### PR TITLE
Additional fix: Conservative feature bundling to prevent circular dependencies

### DIFF
--- a/gruenerator_frontend/vite.config.js
+++ b/gruenerator_frontend/vite.config.js
@@ -64,15 +64,17 @@ export default defineConfig(({ command }) => ({
             
             return 'misc-vendor';
           }
+          // Be more conservative with feature splitting to prevent circular dependencies
           if (id.includes('src/features/auth')) return 'auth-feature';
-          if (id.includes('src/features/texte')) return 'texte-feature';
-          if (id.includes('src/features/groups')) return 'groups-feature';
-          if (id.includes('src/features/sharepic')) return 'sharepic-feature';
-          if (id.includes('src/features/templates')) return 'templates-feature';
-          if (id.includes('src/features/generators')) return 'generators-feature';
-          if (id.includes('src/components/common')) return 'common-ui';
-          if (id.includes('src/components/layout')) return 'layout';
-          if (id.includes('src/hooks') || id.includes('src/stores')) return 'core-logic';
+          if (id.includes('src/features/texte') || 
+              id.includes('src/features/templates') ||
+              id.includes('src/features/generators')) return 'content-features';
+          if (id.includes('src/features/sharepic') ||
+              id.includes('src/features/groups')) return 'ui-features';
+          if (id.includes('src/components/common') ||
+              id.includes('src/components/layout') ||
+              id.includes('src/hooks') || 
+              id.includes('src/stores')) return 'core-ui';
         },
         entryFileNames: 'assets/js/[name].[hash].js',
         chunkFileNames: 'assets/js/[name].[hash].js',


### PR DESCRIPTION
## Summary
- Further fix for circular dependency errors in feature chunks
- More conservative bundling strategy to prevent "Cannot access before initialization" errors

## Changes
- Consolidate content features (texte, templates, generators) into `content-features` chunk
- Group UI features (sharepic, groups) into `ui-features` chunk  
- Merge common components, layout, hooks, and stores into `core-ui` chunk
- Prevents circular dependencies between interdependent features

## Fixes
- Resolves `sharepic-feature.js: Cannot access 'se' before initialization` error
- Prevents similar circular dependency issues in other feature chunks

## Test plan
- [ ] No circular dependency errors in any feature chunks
- [ ] Sharepic feature loads without initialization errors
- [ ] All features work correctly with consolidated bundling

🤖 Generated with [Claude Code](https://claude.ai/code)