### PR TITLE
Fix undefined redirect_uri in Keycloak authentication

### DIFF
--- a/gruenerator_backend/config/passportSetup.mjs
+++ b/gruenerator_backend/config/passportSetup.mjs
@@ -12,7 +12,7 @@ const keycloakIssuer = await Issuer.discover(`${process.env.KEYCLOAK_BASE_URL}/r
 const client = new keycloakIssuer.Client({
   client_id: process.env.KEYCLOAK_CLIENT_ID,
   client_secret: process.env.KEYCLOAK_CLIENT_SECRET,
-  redirect_uris: [`${process.env.AUTH_BASE_URL || process.env.BASE_URL}/api/auth/callback`],
+  redirect_uris: [`${process.env.AUTH_BASE_URL || process.env.BASE_URL || 'https://beta.gruenerator.de'}/api/auth/callback`],
   response_types: ['code'],
   token_endpoint_auth_method: 'client_secret_post'
 });


### PR DESCRIPTION
## Summary
- Add fallback to beta.gruenerator.de when AUTH_BASE_URL and BASE_URL are undefined
- Prevents 'undefined/api/auth/callback' redirect URI errors in Keycloak authentication

## Test plan
- [ ] Test authentication flow on server environment where AUTH_BASE_URL is not set
- [ ] Verify redirect URI properly resolves to beta.gruenerator.de/api/auth/callback

🤖 Generated with [Claude Code](https://claude.ai/code)