### PR TITLE
Fix double /api in Keycloak callback URL construction

### DIFF
--- a/gruenerator_backend/config/passportSetup.mjs
+++ b/gruenerator_backend/config/passportSetup.mjs
@@ -12,7 +12,7 @@ const keycloakIssuer = await Issuer.discover(`${process.env.KEYCLOAK_BASE_URL}/r
 const client = new keycloakIssuer.Client({
   client_id: process.env.KEYCLOAK_CLIENT_ID,
   client_secret: process.env.KEYCLOAK_CLIENT_SECRET,
-  redirect_uris: [`${process.env.AUTH_BASE_URL || process.env.BASE_URL || 'https://beta.gruenerator.de'}/api/auth/callback`],
+  redirect_uris: [`${process.env.AUTH_BASE_URL || process.env.BASE_URL || 'https://beta.gruenerator.de'}/auth/callback`],
   response_types: ['code'],
   token_endpoint_auth_method: 'client_secret_post'
 });


### PR DESCRIPTION
- Remove /api prefix from callback URL in passportSetup.mjs
- AUTH_BASE_URL already includes /api, so /api/auth/callback was creating /api/api/auth/callback
- Now constructs correct URL: AUTH_BASE_URL + /auth/callback = /api/auth/callback

🤖 Generated with [Claude Code](https://claude.ai/code)