### PR TITLE
Fix double /api URLs in profile tab components

### DIFF
--- a/gruenerator_frontend/src/features/auth/components/profile/IntelligenceTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/IntelligenceTab.jsx
@@ -154,7 +154,7 @@ const IntelligenceTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
         
         try {
             console.log('[IntelligenceTab] Fetching memories for user:', user.id);
-            const response = await fetch(`${AUTH_BASE_URL}/api/mem0/user/${user.id}`, {
+            const response = await fetch(`${AUTH_BASE_URL}/mem0/user/${user.id}`, {
                 method: 'GET',
                 credentials: 'include',
                 headers: {
@@ -195,7 +195,7 @@ const IntelligenceTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
 
         setAddingMemory(true);
         try {
-            const response = await fetch(`${AUTH_BASE_URL}/api/mem0/add-text`, {
+            const response = await fetch(`${AUTH_BASE_URL}/mem0/add-text`, {
                 method: 'POST',
                 credentials: 'include',
                 headers: {
@@ -233,7 +233,7 @@ const IntelligenceTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
 
     const deleteMemory = async (memoryId) => {
         try {
-            const response = await fetch(`${AUTH_BASE_URL}/api/mem0/${memoryId}`, {
+            const response = await fetch(`${AUTH_BASE_URL}/mem0/${memoryId}`, {
                 method: 'DELETE',
                 credentials: 'include',
                 headers: {
@@ -266,7 +266,7 @@ const IntelligenceTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
 
         try {
             const deletePromises = memories.map(memory => 
-                fetch(`${AUTH_BASE_URL}/api/mem0/${memory.id}`, {
+                fetch(`${AUTH_BASE_URL}/mem0/${memory.id}`, {
                     method: 'DELETE',
                     credentials: 'include',
                     headers: {

--- a/gruenerator_frontend/src/features/auth/components/profile/MeineTexteTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/MeineTexteTab.jsx
@@ -26,7 +26,7 @@ const MeineTexteTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
         if (!isAuthenticated || !user?.id) return;
 
         try {
-            const response = await fetch(`${AUTH_BASE_URL}/api/user-texts`, {
+            const response = await fetch(`${AUTH_BASE_URL}/user-texts`, {
                 method: 'GET',
                 credentials: 'include',
                 headers: {
@@ -59,7 +59,7 @@ const MeineTexteTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
 
     // Update document title
     const updateTitle = async (documentId, newTitleValue) => {
-        const response = await fetch(`${AUTH_BASE_URL}/api/user-texts/${documentId}/metadata`, {
+        const response = await fetch(`${AUTH_BASE_URL}/user-texts/${documentId}/metadata`, {
             method: 'POST',
             credentials: 'include',
             headers: {
@@ -87,7 +87,7 @@ const MeineTexteTab = ({ isActive, onSuccessMessage, onErrorMessage }) => {
 
     // Delete document
     const deleteDocument = async (documentId) => {
-        const response = await fetch(`${AUTH_BASE_URL}/api/user-texts/${documentId}`, {
+        const response = await fetch(`${AUTH_BASE_URL}/user-texts/${documentId}`, {
             method: 'DELETE',
             credentials: 'include',
             headers: {


### PR DESCRIPTION
- IntelligenceTab.jsx: Remove /api prefix from mem0 endpoints (4 instances)
- MeineTexteTab.jsx: Remove /api prefix from user-texts endpoints (3 instances)

This prevents double /api/api/ patterns when AUTH_BASE_URL already contains /api.

🤖 Generated with [Claude Code](https://claude.ai/code)