### PR TITLE
Fix API URL construction and backend URL references

### DIFF
--- a/gruenerator_frontend/src/features/groups/hooks/useGroupDetails.js
+++ b/gruenerator_frontend/src/features/groups/hooks/useGroupDetails.js
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 const MAX_KNOWLEDGE_ENTRIES = 3;
 const MAX_CONTENT_LENGTH = 1000;
-const AUTH_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001';
+const AUTH_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 // Helper to clean up knowledge entry
 const cleanKnowledgeEntry = (entry) => {

--- a/gruenerator_frontend/src/features/groups/pages/JoinGroupPage.jsx
+++ b/gruenerator_frontend/src/features/groups/pages/JoinGroupPage.jsx
@@ -28,7 +28,7 @@ const JoinGroupPage = () => {
       
       try {
         // Use backend API to verify join token
-        const response = await fetch(`${import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001'}/auth/groups/verify-token/${joinToken}`, {
+        const response = await fetch(`${import.meta.env.VITE_API_BASE_URL || '/api'}/auth/groups/verify-token/${joinToken}`, {
           method: 'GET',
           credentials: 'include',
           headers: {

--- a/gruenerator_frontend/src/stores/documentsStore.js
+++ b/gruenerator_frontend/src/stores/documentsStore.js
@@ -49,7 +49,7 @@ export const useDocumentsStore = create(immer((set, get) => {
       try {
         console.log('[DocumentsStore] Fetching user documents');
         
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/user`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/user`, {
           method: 'GET',
           credentials: 'include',
           headers: {
@@ -102,7 +102,7 @@ export const useDocumentsStore = create(immer((set, get) => {
         }
 
         // Upload with progress tracking
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/upload`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/upload`, {
           method: 'POST',
           credentials: 'include',
           body: formData,
@@ -143,7 +143,7 @@ export const useDocumentsStore = create(immer((set, get) => {
       try {
         console.log('[DocumentsStore] Deleting document:', documentId);
 
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/${documentId}`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/${documentId}`, {
           method: 'DELETE',
           credentials: 'include',
           headers: {
@@ -187,7 +187,7 @@ export const useDocumentsStore = create(immer((set, get) => {
       try {
         console.log('[DocumentsStore] Searching documents:', { query, limit });
 
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/search`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/search`, {
           method: 'POST',
           credentials: 'include',
           headers: {
@@ -264,7 +264,7 @@ export const useDocumentsStore = create(immer((set, get) => {
       try {
         console.log('[DocumentsStore] Updating document title:', { documentId, newTitle });
 
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/${documentId}/metadata`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/${documentId}/metadata`, {
           method: 'POST',
           credentials: 'include',
           headers: {
@@ -306,7 +306,7 @@ export const useDocumentsStore = create(immer((set, get) => {
       try {
         console.log('[DocumentsStore] Refreshing document:', documentId);
 
-        const response = await fetch(`${AUTH_BASE_URL}/api/documents/${documentId}/content`, {
+        const response = await fetch(`${AUTH_BASE_URL}/documents/${documentId}/content`, {
           method: 'GET',
           credentials: 'include',
           headers: {


### PR DESCRIPTION
- Fix useGroupDetails.js to use VITE_API_BASE_URL instead of VITE_BACKEND_URL
- Fix JoinGroupPage.jsx to use VITE_API_BASE_URL instead of VITE_BACKEND_URL
- Remove extra /api prefixes from documentsStore.js endpoints
- Resolves double /api issue and localhost connection errors

🤖 Generated with [Claude Code](https://claude.ai/code)