### PR TITLE
Fix Y.js WebSocket connection CSP and host binding issues

### DIFF
--- a/gruenerator_backend/server.mjs
+++ b/gruenerator_backend/server.mjs
@@ -253,6 +253,9 @@ if (cluster.isMaster) {
           // Weiterhin lokale Entwicklungs-URLs
           "http://localhost:*",
           "http://127.0.0.1:*",
+          // WebSocket connections for Y.js collaborative editing
+          "ws://localhost:*",
+          "ws://127.0.0.1:*",
           // Falls *.netzbegruenung* genutzt wird
           "http://*.netzbegruenung.verdigado.net",
           "https://*.netzbegruenung.verdigado.net",

--- a/gruenerator_backend/yjsServer.mjs
+++ b/gruenerator_backend/yjsServer.mjs
@@ -30,7 +30,7 @@ async function start() {
     // For now, we proceed assuming setupWSConnection might pick it up or that a similar mechanism is in place.
   }
 
-  const host = process.env.HOST || '127.0.0.1'
+  const host = process.env.HOST || 'localhost'
   const port = process.env.YJS_PORT || 1234
 
   const server = http.createServer((req, res) => {


### PR DESCRIPTION
## Summary
- Fixed Content Security Policy blocking WebSocket connections for Y.js collaborative editing
- Updated Y.js server host binding from 127.0.0.1 to localhost for consistency with frontend
- Resolves CSP violation error preventing collaborative editor WebSocket connections

## Changes Made
- Added `ws://localhost:*` and `ws://127.0.0.1:*` to CSP `connectSrc` directive in server.mjs
- Changed Y.js server host binding to use `localhost` instead of `127.0.0.1` for consistency

## Test Plan
- [ ] Restart Y.js server to apply host binding changes
- [ ] Verify WebSocket connection works in browser console
- [ ] Test collaborative editing functionality
- [ ] Confirm no CSP violations in browser network tab

🤖 Generated with [Claude Code](https://claude.ai/code)