### PR TITLE
Update Y.js WebSocket URL fallback to production endpoint

### DIFF
--- a/gruenerator_frontend/src/stores/collabEditorStore.js
+++ b/gruenerator_frontend/src/stores/collabEditorStore.js
@@ -52,11 +52,8 @@ const useCollabEditorStore = create((set, get) => ({
     const ytext = ydoc.getText('quill');
     const yChatHistory = ydoc.getArray('chatHistory');
     
-    // Get WebSocket URL from environment or use defaults based on environment
-    const websocketUrl = import.meta.env.VITE_YJS_WEBSOCKET_URL || 
-      (import.meta.env.VITE_APP_ENV === 'development' 
-        ? 'ws://localhost:1234' 
-        : 'wss://gruenerator.de/yjs');
+    // Get WebSocket URL from environment or use backup URL
+    const websocketUrl = import.meta.env.VITE_YJS_WEBSOCKET_URL || 'wss://gruenerator.de/yjs';
     
     if (!websocketUrl) {
       console.error('[CollabEditorStore] Failed to determine Y.js WebSocket URL');


### PR DESCRIPTION
## Summary
- Updated Y.js WebSocket URL fallback logic to use `wss://gruenerator.de/yjs` as backup instead of localhost
- Simplified configuration by removing environment-specific localhost fallback

## Changes
- Modified `gruenerator_frontend/src/stores/collabEditorStore.js` to use production WebSocket URL as fallback
- Ensures consistent behavior across all environments when `VITE_YJS_WEBSOCKET_URL` is not set

## Test plan
- [ ] Verify collaborative editing works when `VITE_YJS_WEBSOCKET_URL` is not set
- [ ] Test real-time synchronization between multiple users
- [ ] Confirm WebSocket connection stability

🤖 Generated with [Claude Code](https://claude.ai/code)