### PR TITLE
Fix mem0 production deployment with graceful fallback handling

### DIFF
--- a/gruenerator_backend/routes.js
+++ b/gruenerator_backend/routes.js
@@ -73,8 +73,14 @@ async function setupRoutes(app) {
   const { default: mobileAuthRoutes } = await import('./routes/auth/mobile.mjs');
   const { default: documentsRouter } = await import('./routes/documents.mjs');
   const { default: bundestagRouter } = await import('./routes/bundestag.mjs');
-  // Import mem0Router directly with Node.js SDK
-  const { default: mem0Router } = await import('./routes/mem0.mjs');
+  // Try to import mem0Router, handle gracefully if dependencies missing
+  let mem0Router = null;
+  try {
+    const mem0Module = await import('./routes/mem0.mjs');
+    mem0Router = mem0Module.default;
+  } catch (error) {
+    console.log('[Setup] Mem0 router import failed, skipping mem0 routes:', error.message);
+  }
   
   // Import claude_social as ES6 module
   const { default: claudeSocialRoute } = await import('./routes/claude_social.js');
@@ -162,9 +168,13 @@ async function setupRoutes(app) {
   // app.use('/api/canva/webhooks', canvaWebhooksRouter); // Optional - uncomment if you need real-time webhook updates
   console.log('[Setup] Canva basic routes registered');
 
-  // Add Mem0 routes with Node.js SDK
-  app.use('/api/mem0', mem0Router);
-  console.log('[Setup] Mem0 routes registered with Node.js SDK');
+  // Add Mem0 routes if available
+  if (mem0Router) {
+    app.use('/api/mem0', mem0Router);
+    console.log('[Setup] Mem0 routes registered with Node.js SDK');
+  } else {
+    console.log('[Setup] Mem0 routes skipped - dependencies not available');
+  }
 }
 
 module.exports = { setupRoutes };

--- a/gruenerator_backend/routes/mem0.mjs
+++ b/gruenerator_backend/routes/mem0.mjs
@@ -5,8 +5,53 @@ import { createRequire } from 'module';
 // Use createRequire for CommonJS modules
 const require = createRequire(import.meta.url);
 
-// Import the simplified Node.js SDK mem0Service directly
-const mem0Service = require('../services/mem0Service');
+// Try to import mem0Service, provide fallback if dependencies missing
+let mem0Service;
+try {
+  mem0Service = require('../services/mem0Service');
+} catch (error) {
+  console.log('[mem0.mjs] Mem0Service dependencies not available, using fallback implementation');
+  console.log('[mem0.mjs] Error:', error.message);
+  // Fallback service for when mem0ai package is not installed
+  mem0Service = {
+    async healthCheck() {
+      return {
+        status: 'disabled',
+        message: 'Mem0 Node.js SDK dependencies not installed',
+        provider: 'fallback'
+      };
+    },
+    async addMemory(messages, userId, metadata) {
+      console.log('[mem0.mjs] addMemory called but dependencies missing - skipping');
+      return {
+        success: false,
+        message: 'Mem0 dependencies not available',
+        data: null
+      };
+    },
+    async getMemories(userId) {
+      return {
+        success: true,
+        data: { results: [] },
+        message: 'Mem0 dependencies not available - no memories'
+      };
+    },
+    async searchMemories(query, userId) {
+      return {
+        success: true,
+        data: { results: [] },
+        message: 'Mem0 dependencies not available - no search results'
+      };
+    },
+    async deleteMemory(memoryId) {
+      return {
+        success: false,
+        message: 'Mem0 dependencies not available'
+      };
+    }
+  };
+}
+
 const authMiddlewareModule = require('../middleware/authMiddleware');
 
 const { requireAuth } = authMiddlewareModule;


### PR DESCRIPTION
## Summary
- Fix production deployment issue where mem0ai Node.js SDK dependencies are missing
- Add graceful fallback handling for servers without mem0ai package installed
- Ensure server starts successfully even when Node.js SDK unavailable

## Problem
Production server was failing with `MODULE_NOT_FOUND` error:
```
Error: Cannot find module '../services/mem0Service'
```

## Solution
- **Added try/catch logic** in `mem0.mjs` to handle missing dependencies gracefully
- **Restored fallback service object** that provides disabled functionality when package missing
- **Updated routes.js** to skip mem0 routes if dependencies unavailable
- **Maintains backward compatibility** with servers that don't have mem0ai installed

## Key Changes
- ✅ **Graceful degradation**: Server starts without mem0ai package
- ✅ **Fallback service**: Provides disabled mem0 functionality with proper messaging
- ✅ **Production ready**: No more MODULE_NOT_FOUND errors
- ✅ **Optional enhancement**: Full functionality when mem0ai package installed

## Test Plan
- [x] Server starts successfully without mem0ai package
- [x] Fallback endpoints return appropriate disabled messages
- [x] No breaking changes to existing functionality
- [x] Routes properly skipped when dependencies missing

## Installation
To enable full mem0 functionality on production:
```bash
npm install mem0ai
```

🤖 Generated with [Claude Code](https://claude.ai/code)