### PR TITLE
Remove Node.js Memory Limit - Allow Dynamic Allocation

### DIFF
--- a/gruenerator_frontend/package.json
+++ b/gruenerator_frontend/package.json
@@ -70,7 +70,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "NODE_OPTIONS=--max-old-space-size=6144 vite build",
+    "build": "vite build",
     "preview": "vite preview",
     "test": "jest",
     "release": "semantic-release",


### PR DESCRIPTION
## 🚨 Critical Server Fix: Remove Artificial Memory Limit

This PR removes the Node.js memory limit to allow dynamic allocation, fixing server deployment build failures.

## Problem
Server builds still failing with OOM kills (retcode 137) even with 6GB heap allocation:
```
> NODE_OPTIONS=--max-old-space-size=6144 vite build
✓ 2356 modules transformed.
Killed
```

## Root Cause Analysis
The 6GB memory limit was **too restrictive** for Vite's chunk rendering phase:
- ❌ **Artificial cap**: Prevented Node.js from using available system RAM  
- ❌ **Memory spike**: Chunking phase needs temporary burst above 6GB
- ❌ **System has more RAM**: Server being limited by our configuration, not actual memory

## Solution: Let System Decide
```diff
- "build": "NODE_OPTIONS=--max-old-space-size=6144 vite build"
+ "build": "vite build"
```

**Benefits:**
- ✅ **Dynamic allocation**: Node.js uses whatever memory needed up to system limits
- ✅ **Memory bursting**: Can temporarily spike during chunking, then release
- ✅ **System-aware**: Respects actual available RAM vs artificial limit

## Local Test Results ✅
Build completes successfully without memory limit:
```
✓ 2356 modules transformed.
rendering chunks...
computing gzip size...
✓ built in 27.19s
```

## Expected Server Impact
- 🟢 **Build Success**: Should complete without OOM kills
- 🟢 **Deployment Unblocked**: Server can finally build and deploy
- 🟢 **Optimal Memory Usage**: Node.js manages memory efficiently

**Priority**: CRITICAL - Server deployment currently broken without this fix

🤖 Generated with [Claude Code](https://claude.ai/code)