### PR TITLE
Add AWS deployment security to .gitignore

### DIFF
--- a/gruenerator_frontend/.gitignore
+++ b/gruenerator_frontend/.gitignore
@@ -42,3 +42,14 @@ gruenerator_frontend/node_modules/.cache
 #claudecode files
 .claude
 
+# AWS deployment
+aws/
+.aws/
+*.pem
+*.key
+aws-*.json
+aws-*.yaml
+aws-*.yml
+.aws-credentials
+aws-exports.js
+


### PR DESCRIPTION
## Summary
Add comprehensive AWS deployment file exclusions to .gitignore to prevent committing sensitive deployment artifacts and credentials.

## Changes
- **AWS folder exclusion**: Ignore `aws/` and `.aws/` directories
- **Security keys**: Exclude `*.pem` and `*.key` files (SSH keys, certificates)
- **Configuration files**: Ignore AWS config files (`aws-*.json`, `aws-*.yaml`, `aws-*.yml`)
- **Credentials**: Exclude `.aws-credentials` and `aws-exports.js`

## Security Benefits
- Prevents accidental commits of AWS access keys and secrets
- Protects SSH private keys and certificates from being exposed
- Excludes deployment configuration that might contain sensitive data
- Maintains clean repository without deployment artifacts

## Files Affected
- `.gitignore` - Added AWS deployment exclusions

🤖 Generated with [Claude Code](https://claude.ai/code)