### PR TITLE
Fix Button Alignment in Groups Management

### DIFF
--- a/gruenerator_frontend/src/assets/styles/features/auth/auth.css
+++ b/gruenerator_frontend/src/assets/styles/features/auth/auth.css
@@ -622,6 +622,11 @@
   margin-top: var(--spacing-small);
 }
 
+/* Override vertical margin for horizontal button layouts in profile-actions */
+.auth-form .profile-actions button + button {
+  margin-top: 0;
+}
+
 .auth-form button.auth-submit-button:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);


### PR DESCRIPTION
Fixed CSS conflict causing misaligned 'Abbrechen' button in GroupsManagementTab. Added override rule to ensure horizontal button alignment.