### PR TITLE
Fix server build memory issues (OOM)

### DIFF
--- a/gruenerator_frontend/package.json
+++ b/gruenerator_frontend/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "start": "vite",
     "start:debug": "NODE_OPTIONS=\"--inspect --max-old-space-size=4096\" vite",
-    "build": "vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=1024 --max-semi-space-size=32' vite build",
     "build:server": "node --max-semi-space-size=32 --gc-global ./node_modules/.bin/vite build",
     "build:debug": "NODE_OPTIONS=\"--inspect --max-old-space-size=6144\" vite build",
     "build:profile": "NODE_OPTIONS=\"--prof --max-old-space-size=6144\" vite build",

--- a/gruenerator_frontend/vite.config.js
+++ b/gruenerator_frontend/vite.config.js
@@ -27,8 +27,8 @@ export default defineConfig(({ command }) => ({
   build: {
     target: ['es2022', 'chrome88', 'firefox86', 'safari14'],
     sourcemap: false,
-    cssCodeSplit: true,
-    assetsInlineLimit: 4096, // Inline small assets to reduce HTTP requests
+    cssCodeSplit: false, // Disable CSS code splitting to reduce memory usage
+    assetsInlineLimit: 8192, // Increase inline limit to reduce file operations
     chunkSizeWarningLimit: 300, // Smaller chunks to reduce memory pressure
     outDir: 'build',
     // Memory-optimized build settings for server compatibility
@@ -44,6 +44,9 @@ export default defineConfig(({ command }) => ({
       },
       // Sequential processing to prevent memory spikes on server
       maxParallelFileOps: 1,
+      // Additional memory optimizations
+      experimentalMinChunkSize: 100, // Prevent tiny chunks that increase memory overhead
+      shimMissingExports: false, // Reduce analysis overhead
       // Manual vendor chunking for memory efficiency
       output: {
         entryFileNames: 'assets/js/[name].[hash].js',


### PR DESCRIPTION
## Summary
- Optimize Vite build configuration for server memory constraints
- Add Node.js memory limits to prevent OOM crashes during build
- Reduce memory overhead through build optimizations

## Changes Made
- Set `--max-old-space-size=1024` and `--max-semi-space-size=32` in build script
- Disabled CSS code splitting to reduce memory usage
- Increased assets inline limit from 4KB to 8KB
- Added `experimentalMinChunkSize: 100` to prevent tiny chunks
- Disabled `shimMissingExports` to reduce Rollup analysis overhead

## Test Plan
- [ ] Verify build succeeds on server without OOM (exit code 137)
- [ ] Test local build still works correctly
- [ ] Confirm application functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)