### PR TITLE
Fix group description not refreshing after save

### DIFF
--- a/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
@@ -82,7 +82,8 @@ const GroupDetailView = memo(({
         data, 
         isLoading: isLoadingDetails, 
         isError: isErrorDetails, 
-        error: errorDetails 
+        error: errorDetails,
+        refetch: refetchGroupData
     } = query;
     
     // Constants for compatibility
@@ -316,6 +317,8 @@ const GroupDetailView = memo(({
             onSuccess: () => {
                 setIsEditingName(false);
                 onSuccessMessage('Gruppenname erfolgreich geändert!');
+                // Refetch group data to update UI with latest changes
+                refetchGroupData();
             },
             onError: (error) => {
                 onErrorMessage('Fehler beim Ändern des Gruppennamens: ' + error.message);
@@ -347,6 +350,8 @@ const GroupDetailView = memo(({
             onSuccess: () => {
                 setIsEditingDescription(false);
                 onSuccessMessage('Gruppenbeschreibung erfolgreich geändert!');
+                // Refetch group data to update UI with latest changes
+                refetchGroupData();
             },
             onError: (error) => {
                 onErrorMessage('Fehler beim Ändern der Gruppenbeschreibung: ' + error.message);


### PR DESCRIPTION
## Summary
- Fix group description and name not updating in UI after successful save
- Add refetch calls to ensure latest data is shown without page reload

## Test plan
- [ ] Edit group description and verify it updates immediately after save
- [ ] Edit group name and verify it updates immediately after save
- [ ] Verify both changes persist after page refresh

🤖 Generated with [Claude Code](https://claude.ai/code)