### PR TITLE
Rename groups tab label for better clarity

### DIFF
--- a/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
@@ -1189,7 +1189,7 @@ const GroupsManagementTab = ({ onSuccessMessage, onErrorMessage, isActive }) => 
                             aria-selected={groupDetailView === 'anweisungen-wissen'}
                             aria-controls="anweisungen-wissen-panel"
                         >
-                            Profil auswählen
+                            Anweisungen & Wissen
                         </button>
                         <button
                             className={`groups-vertical-tab ${groupDetailView === 'shared' ? 'active' : ''}`}


### PR DESCRIPTION
## Summary
- Rename groups tab from "Profil auswählen" to "Anweisungen & Wissen"
- Improves user interface clarity and navigation

## Test plan
- [ ] Verify tab label shows "Anweisungen & Wissen" in group navigation
- [ ] Confirm tab functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)