### PR TITLE
Complete group knowledge integration and KnowledgeSelector fixes

### DIFF
--- a/gruenerator_backend/routes/auth/userGroups.mjs
+++ b/gruenerator_backend/routes/auth/userGroups.mjs
@@ -1384,6 +1384,17 @@ router.get('/groups/:groupId/content', ensureAuthenticated, async (req, res) => 
       });
     }
 
+    // Fetch group knowledge entries
+    const { data: groupKnowledge, error: knowledgeError } = await supabaseService
+      .from('group_knowledge')
+      .select('id, title, content, created_by, created_at, updated_at')
+      .eq('group_id', groupId)
+      .order('created_at', { ascending: true });
+
+    if (knowledgeError) {
+      console.error('[User Groups /groups/:groupId/content GET] Knowledge error:', knowledgeError);
+    }
+
     // Fetch shared content using junction table
     const { data: sharedContent, error: fetchError } = await supabaseService
       .from('group_content_shares')
@@ -1486,6 +1497,7 @@ router.get('/groups/:groupId/content', ensureAuthenticated, async (req, res) => 
 
     // Process and format results
     const groupContent = {
+      knowledge: groupKnowledge || [],
       documents: [],
       generators: [],
       qas: [],

--- a/gruenerator_frontend/src/components/common/KnowledgeSelector/KnowledgeSelector.jsx
+++ b/gruenerator_frontend/src/components/common/KnowledgeSelector/KnowledgeSelector.jsx
@@ -29,6 +29,7 @@ const KnowledgeIcon = memo(({ type, size = 16 }) => {
       );
     case 'knowledge':
     case 'wissen':
+    case 'group_knowledge':
       return (
         <FaBrain className={iconClass} size={size} />
       );
@@ -226,7 +227,7 @@ const EnhancedKnowledgeSelector = ({
     errorAllGroupsContent
   } = useAllGroupsContent({ 
     isActive: true,
-    enabled: enableKnowledge // Only load group content when knowledge is enabled
+    enabled: true // Always load group content
   });
   
   // For backwards compatibility, alias the loading state

--- a/gruenerator_frontend/src/components/hooks/useKnowledge.js
+++ b/gruenerator_frontend/src/components/hooks/useKnowledge.js
@@ -184,41 +184,35 @@ const useKnowledge = ({
   useEffect(() => {
     // Source changed
     
+    // ALWAYS load user knowledge regardless of source selection
+    if (userData) {
+      setAvailableKnowledge(userData.knowledge);
+    } else {
+      setAvailableKnowledge([]);
+    }
+    
+    // Trigger refetch if needed (for any source type)
+    if (!!user && !userData && !isLoadingUserData) {
+      // Triggering refetch - no data
+      refreshUserData();
+    }
+    
+    // ONLY change instructions based on source selection
     if (source.type === 'neutral') {
-      // For neutral source, still load user knowledge but no instructions
-      if (userData) {
-        setAvailableKnowledge(userData.knowledge);
-        setInstructions({ antrag: null, antragGliederung: null, social: null, universal: null, gruenejugend: null });
-        setInstructionsActive(false);
-      } else {
-        clearKnowledge();
-      }
-      setLoading(isLoadingUserData);
+      setInstructions({ antrag: null, antragGliederung: null, social: null, universal: null, gruenejugend: null });
+      setInstructionsActive(false);
     } else if (source.type === 'user') {
-      // Trigger refetch if needed
-      if (!!user && !userData && !isLoadingUserData) {
-        // Triggering refetch - no data
-        refreshUserData();
-      }
-      // Update knowledge when data is available
       if (userData) {
-        updateUserKnowledge(userData.knowledge, userData.instructions);
-      }
-      // Update loading state
-      setLoading(isLoadingUserData);
-    } else if (source.type === 'group') {
-      // For group source, load user knowledge but use group instructions (if any)
-      if (userData) {
-        setAvailableKnowledge(userData.knowledge);
-      }
-      if (groupKnowledge && groupKnowledge.length >= 0) {
-        // Group knowledge is handled separately in the KnowledgeSelector via useAllGroupsContent
-        // We just need to activate instructions
+        setInstructions(userData.instructions);
         setInstructionsActive(true);
       }
-      // Update loading state
-      setLoading(isLoadingUserData || isLoadingGroupKnowledge);
+    } else if (source.type === 'group') {
+      // Group instructions come from groupDetailsData, knowledge comes from allGroupContent in KnowledgeSelector
+      setInstructionsActive(true);
     }
+    
+    // Update loading state
+    setLoading(isLoadingUserData || isLoadingGroupKnowledge);
   }, [
     source, 
     user, 

--- a/gruenerator_frontend/src/utils/knowledgeFormUtils.jsx
+++ b/gruenerator_frontend/src/utils/knowledgeFormUtils.jsx
@@ -131,11 +131,6 @@ export const createKnowledgeFormNotice = ({
 
   const hasLoadedKnowledge = availableKnowledge.length > 0;
 
-  if (source.type !== 'neutral' && hasLoadedKnowledge) {
-    if (source.type === 'group') {
-      noticeParts.push(`gesamtes Wissen der Gruppe "${sourceNameForNotice}"`);
-    }
-  }
   
 
   if (noticeParts.length === 0 && source.type === 'neutral') {


### PR DESCRIPTION
## Summary
- Fix all group knowledge integration issues in KnowledgeSelector
- Ensure group knowledge is always visible regardless of source selection
- Add individual group knowledge entries with proper icons and functionality

## Frontend Changes
- ✅ Fix `useGroupDetails` undefined error by replacing with `useAnweisungenWissen`
- ✅ Decouple knowledge availability from source selection - always show all knowledge
- ✅ Always load group content in KnowledgeSelector regardless of `enableKnowledge` flag
- ✅ Fix group knowledge icon to show brain icon (🧠) like regular knowledge
- ✅ Remove misleading "gesamtes Wissen der Gruppe" notice text

## Backend Changes
- ✅ Add group knowledge fetching to `/groups/:groupId/content` endpoint
- ✅ Return individual group knowledge entries from `group_knowledge` table

## Test Plan
- [ ] Test that all Grünerator components load without errors (PresseSocialGenerator, AntragGenerator, UniversalTextGenerator, GrueneJugendGenerator)
- [ ] Verify KnowledgeSelector shows user knowledge + all group knowledge regardless of source selection
- [ ] Confirm individual group knowledge entries appear with brain icons
- [ ] Test that source selection only affects instructions, not knowledge visibility
- [ ] Verify no automatic knowledge selection occurs
- [ ] Check that no misleading "gesamtes Wissen" notice appears

## Result
KnowledgeSelector now properly shows ALL available knowledge (personal + all groups) with individual selectable entries, consistent icons, and clean UX without misleading notices.

🤖 Generated with [Claude Code](https://claude.ai/code)