### PR TITLE
Fix production JSX injection errors by disabling ReactQueryDevtools

### DIFF
--- a/gruenerator_frontend/src/App.jsx
+++ b/gruenerator_frontend/src/App.jsx
@@ -146,7 +146,7 @@ function App() {
                   </Routes>
                 </SuspenseWrapper>
               </Router>
-          <ReactQueryDevtools initialIsOpen={false} />
+          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
         </QueryClientProvider>
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
- Fixed JSX injection errors in production by disabling ReactQueryDevtools
- Resolved MIME type mismatch: "Expected JavaScript module but got text/jsx"  
- Added environment check to only load devtools in development

## Problem
Production was experiencing:
- JSX module injection via data URLs from ReactQueryDevtools
- Browser rejecting modules with "text/jsx" MIME type
- Group creation functionality breaking due to failed script loading

## Solution
Wrapped ReactQueryDevtools component with development environment check:
```jsx
{process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
```

## Test Plan
- [x] Verify no JSX injection errors in production
- [x] Confirm group creation works without flickering
- [x] Ensure devtools still work in development

🤖 Generated with [Claude Code](https://claude.ai/code)