### PR TITLE
Fix group creation form flickering back to overview

### DIFF
--- a/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
@@ -885,7 +885,7 @@ const GroupsManagementTab = ({ onSuccessMessage, onErrorMessage, isActive }) => 
         // Handle the case where user has no groups
         if (userGroups.length === 0) {
             setSelectedGroupId(null);
-            if (currentView !== 'overview') {
+            if (currentView !== 'overview' && currentView !== 'create') {
                 setCurrentView('overview');
             }
         }


### PR DESCRIPTION
## Summary
- Fixed critical view state flickering issue in group creation
- Modified useEffect condition to prevent automatic view reset during group creation
- Resolves the sub-second flicker that prevented users from accessing the create form

## Problem Solved
User reported: "I never see the group creating site, it flashes for just a second and then I see the übersicht page"

**Root Cause**: useEffect hook was automatically resetting `currentView` from 'create' to 'overview' when `userGroups.length === 0`

**Flow**: Click button → set to 'create' → useEffect triggers → immediately resets to 'overview'

## Solution
Modified the condition at line 888 to exclude 'create' view from auto-reset:

**Before:**
```javascript
if (currentView \!== 'overview') {
    setCurrentView('overview');
}
```

**After:**
```javascript
if (currentView \!== 'overview' && currentView \!== 'create') {
    setCurrentView('overview');
}
```

## Test Plan
- [x] Click "Gruppe hinzufügen" - form should display without flickering
- [x] Form should remain visible and functional
- [ ] Verify group creation completes successfully
- [ ] Ensure group deletion still returns to overview correctly

🤖 Generated with [Claude Code](https://claude.ai/code)