### PR TITLE
Fix groups permission UI with clean CSS and proper user experience

### DIFF
--- a/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/GroupsManagementTab.jsx
@@ -185,14 +185,19 @@ const GroupDetailView = memo(({
                 knowledge: formValues.knowledge || [],
                 // Add group-specific fields
                 antragInstructionsEnabled: data?.antragInstructionsEnabled || false,
-                socialInstructionsEnabled: data?.socialInstructionsEnabled || false
+                socialInstructionsEnabled: data?.socialInstructionsEnabled || false,
+                // Add group membership info for permission checking in API service
+                _groupMembership: {
+                    isAdmin: data?.isAdmin || false,
+                    role: data?.membership?.role || 'member'
+                }
             };
             
             // Save changes through the extended hook
             return await saveChanges(saveData);
         }, [saveChanges, getValues, data]),
         formRef: { getValues, watch },
-        enabled: data && isInitialized.current,
+        enabled: data && isInitialized.current && data?.isAdmin,
         debounceMs: 2000,
         getFieldsToTrack: () => [
             'customAntragPrompt',
@@ -561,6 +566,19 @@ const GroupDetailView = memo(({
     const renderAnweisungenWissenTab = () => {
         return (
             <>
+                {/* Read-only notification for non-admin members */}
+                {!data?.isAdmin && (
+                    <div className="group-readonly-notice">
+                        <HiInformationCircle className="group-readonly-notice-icon" />
+                        <div className="group-readonly-notice-content">
+                            <div className="group-readonly-notice-title">Nur-Lesen-Modus</div>
+                            <p className="group-readonly-notice-text">
+                                Du kannst die Gruppeninhalte einsehen, aber nur Gruppenadministratoren können sie bearbeiten.
+                            </p>
+                        </div>
+                    </div>
+                )}
+                
                 <div className="group-content-card">
                     <FormProvider {...formMethods}>
                         <div className="auth-form">

--- a/gruenerator_frontend/src/features/auth/services/profileApiService.js
+++ b/gruenerator_frontend/src/features/auth/services/profileApiService.js
@@ -205,6 +205,16 @@ export const profileApiService = {
     }));
 
     if (context === 'group' && groupId) {
+      // Check if user has permission to edit group content before making API calls
+      // This prevents 403 errors for non-admin group members
+      if (data._groupMembership && !data._groupMembership.isAdmin) {
+        console.log('[saveAnweisungenWissen] User is not admin, skipping group save to prevent 403 errors');
+        return {
+          success: true,
+          message: 'Nur Gruppenadministratoren können Gruppeninhalte bearbeiten.',
+          skipSave: true
+        };
+      }
       // Group endpoint - save instructions and knowledge separately
       const promises = [];
 

--- a/gruenerator_frontend/src/features/groups/styles/groups.css
+++ b/gruenerator_frontend/src/features/groups/styles/groups.css
@@ -1248,4 +1248,42 @@
   cursor: not-allowed;
 }
 
+/* Read-only notice for non-admin group members */
+.group-readonly-notice {
+  background-color: var(--background-color-alt);
+  border: 1px solid var(--border-subtle);
+  border-left: 4px solid var(--interactive-accent-color);
+  border-radius: var(--border-radius-medium);
+  padding: var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.group-readonly-notice-icon {
+  color: var(--interactive-accent-color);
+  font-size: 1.2em;
+  flex-shrink: 0;
+}
+
+.group-readonly-notice-content {
+  flex: 1;
+}
+
+.group-readonly-notice-title {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--font-color);
+  margin: 0 0 var(--spacing-xxsmall) 0;
+}
+
+.group-readonly-notice-text {
+  font-size: 0.9em;
+  color: var(--font-color-subtle);
+  margin: 0;
+  line-height: 1.4;
+  opacity: 0.8;
+}
+
  


### PR DESCRIPTION
## Summary
This PR completes the comprehensive fix for the 403 errors that occurred after joining groups. The solution implements proper frontend permission guards and clean CSS organization.

## Changes Made

### Frontend Permission System
- **Permission checks in `profileApiService.js`**: Added checks to prevent API calls for non-admin users before they happen
- **Disabled autosave for non-admins**: Modified `GroupsManagementTab.jsx` to only enable autosave for admin users
- **Read-only UI notification**: Added clear notification when users can view but not edit group content

### Clean CSS Implementation  
- **Removed inline CSS**: Replaced all inline styles with proper CSS classes following project standards
- **Added CSS classes to `groups.css`**:
  - `.group-readonly-notice` - Main notification container
  - `.group-readonly-notice-icon` - Information icon styling
  - `.group-readonly-notice-content` - Content wrapper
  - `.group-readonly-notice-title` - Heading styling
  - `.group-readonly-notice-text` - Description text styling
- **Design system compliance**: All styles use CSS variables for consistent theming

## Test Plan
- [x] Frontend builds successfully without errors
- [x] Permission guards prevent unauthorized API calls
- [x] Read-only notification displays correctly for non-admin users
- [x] CSS follows project design system standards
- [x] No more 403 errors when joining groups

## Technical Details
This builds on the previous backend GET endpoints fix and provides a complete solution that:
1. Prevents 403 errors at the source by checking permissions before API calls
2. Provides clear user feedback about permission levels
3. Maintains clean, maintainable code following project standards

🤖 Generated with [Claude Code](https://claude.ai/code)