### PR TITLE
Fix LiteLLM API key typo

### DIFF
--- a/gruenerator_backend/workers/aiWorker.js
+++ b/gruenerator_backend/workers/aiWorker.js
@@ -580,11 +580,11 @@ async function processWithLiteLLM(requestId, data) {
   const { messages, systemPrompt, options = {}, type, metadata: requestMetadata = {} } = data;
   
   // LiteLLM configuration
-  const litellmApiKey = process.env.LITTELLM_API_KEY;
+  const litellmApiKey = process.env.LITELLM_API_KEY;
   const model = options.model || 'llama3.3';
   
   if (!litellmApiKey) {
-    throw new Error('LITTELLM_API_KEY environment variable is required for LiteLLM requests');
+    throw new Error('LITELLM_API_KEY environment variable is required for LiteLLM requests');
   }
 
   console.log(`[AI Worker] Processing with LiteLLM. Request ID: ${requestId}, Type: ${type}, Model: ${model}`);


### PR DESCRIPTION
## Summary
- Fixed typo in environment variable name: `LITTELLM_API_KEY` → `LITELLM_API_KEY`
- Updated both the variable reference and error message

## Test plan
- [ ] Verify LiteLLM provider works correctly with proper environment variable
- [ ] Test error handling when API key is missing

🤖 Generated with [Claude Code](https://claude.ai/code)