### PR TITLE
Fix AWS Bedrock PDF document processing

### DIFF
--- a/gruenerator_backend/utils/attachmentUtils.js
+++ b/gruenerator_backend/utils/attachmentUtils.js
@@ -318,8 +318,7 @@ const buildDocumentsForPromptBuilder = (attachments, usePrivacyMode = false) => 
         source: {
           type: 'base64',
           media_type: att.type,
-          data: att.data,
-          name: att.name || att.displayName || 'unknown'
+          data: att.data
         }
       };
     }


### PR DESCRIPTION
## Summary
- Fixed AWS Bedrock validation error when processing PDF documents
- Removed unnecessary `name` field from document source structure
- Resolves "Extra inputs are not permitted" error that prevented PDF uploads

## Root Cause
AWS Bedrock has stricter validation than Claude API and rejects the `name` field in `document.source.base64` structure, causing PDF document processing to fail.

## Solution
Removed the `name` field from document source in `attachmentUtils.js` as it's not required by either Claude API or Bedrock API.

## Test plan
- [ ] Upload PDF document to social media generator
- [ ] Verify AWS Bedrock processes the document successfully
- [ ] Test with multiple document types (PDF, images)
- [ ] Ensure no regression with Claude API fallback

🤖 Generated with [Claude Code](https://claude.ai/code)