### PR TITLE
fix: restore help text display before content generation

### DIFF
--- a/gruenerator_frontend/src/components/common/Form/BaseForm/DisplaySection.jsx
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/DisplaySection.jsx
@@ -181,9 +181,9 @@ const DisplaySection = forwardRef(({
   return (
     <div className="display-container" id="display-section-container" ref={ref}>
       {actionsNode}
-      {hasRenderableContent && helpContent && (
+      {!hasRenderableContent && helpContent && (
         <div className="help-section">
-          <HelpDisplay 
+          <HelpDisplay
             content={helpContent.content}
             tips={helpContent.tips}
             hasGeneratedContent={!!activeContent}


### PR DESCRIPTION
Help texts now appear when no content is generated yet to guide users, and disappear once content is generated. Previously help texts only showed when content already existed, which was backwards.

🤖 Generated with [Claude Code](https://claude.ai/code)