### PR TITLE
fix: exclude beta subdomain from user sites routing

### DIFF
--- a/gruenerator_backend/middleware/subdomainHandler.js
+++ b/gruenerator_backend/middleware/subdomainHandler.js
@@ -9,7 +9,7 @@ export const getSubdomain = (host) => {
 
     if (parts.length >= 3) {
         const subdomain = parts[0];
-        if (subdomain !== 'www' && subdomain !== 'api' && subdomain !== 'app') {
+        if (subdomain !== 'www' && subdomain !== 'api' && subdomain !== 'app' && subdomain !== 'beta') {
             return subdomain;
         }
     }


### PR DESCRIPTION
Adds 'beta' to the list of reserved subdomains in subdomainHandler to prevent beta.gruenerator.de from being treated as a user site subdomain. This fixes 403 errors on the beta domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)