### PR TITLE
fix: correct type name check for zitat sharepic editing

### DIFF
--- a/gruenerator_frontend/src/components/pages/Grüneratoren/Sharepicgenerator.jsx
+++ b/gruenerator_frontend/src/components/pages/Grüneratoren/Sharepicgenerator.jsx
@@ -355,7 +355,7 @@ function SharepicGeneratorContent({ showHeaderFooter = true, darkMode }) {
                 line2: lines[1] || '',
                 line3: lines[2] || ''
               });
-            } else if (data.type === 'quote' || data.type === 'quote_pure') {
+            } else if (data.type === 'zitat' || data.type === 'zitat_pure') {
               // For quotes, extract quote and name from text - handle both formats
               let quote = '';
               let name = '';


### PR DESCRIPTION
Changed condition from 'quote'/'quote_pure' to 'zitat'/'zitat_pure' to match backend response, enabling edit functionality for quote sharepics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)