### PR TITLE
fix: persist uploaded image across all imagine modes including ally-m…

### DIFF
--- a/gruenerator_frontend/src/features/imagine/AllyMakerForm.jsx
+++ b/gruenerator_frontend/src/features/imagine/AllyMakerForm.jsx
@@ -1,11 +1,11 @@
 import React, { forwardRef, useImperativeHandle, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import CreatableSelect from 'react-select/creatable';
 import FileUpload from '../../components/common/FileUpload';
 import FormFieldWrapper from '../../components/common/Form/Input/FormFieldWrapper';
 import TextAreaInput from '../../components/common/Form/Input/TextAreaInput';
 
-const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false }, ref) => {
-  const [uploadedImage, setUploadedImage] = useState(null);
+const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false, uploadedImage, onImageChange }, ref) => {
   const [selectedPlacement, setSelectedPlacement] = useState([]);
   const [precisionPlacement, setPrecisionPlacement] = useState('');
 
@@ -17,10 +17,6 @@ const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false }, ref) => 
     { value: 'oberarm', label: 'Oberarm' },
     { value: 'handgelenk', label: 'Handgelenk' }
   ];
-
-  const handleImageChange = useCallback((file) => {
-    setUploadedImage(file);
-  }, []);
 
   const handlePlacementChange = useCallback((newValues) => {
     const selectedValues = newValues || [];
@@ -37,7 +33,6 @@ const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false }, ref) => 
             : '')
     }),
     resetForm: () => {
-      setUploadedImage(null);
       setSelectedPlacement([]);
       setPrecisionPlacement('');
     },
@@ -48,12 +43,12 @@ const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false }, ref) => 
       }
       return true;
     }
-  }));
+  }), [uploadedImage, isPrecisionMode, precisionPlacement, selectedPlacement]);
 
   return (
     <>
       <FileUpload
-        handleChange={handleImageChange}
+        handleChange={onImageChange}
         allowedTypes={['.jpg', '.jpeg', '.png', '.webp']}
         file={uploadedImage}
         loading={loading}
@@ -129,5 +124,12 @@ const AllyMakerForm = forwardRef(({ loading, isPrecisionMode = false }, ref) => 
 });
 
 AllyMakerForm.displayName = 'AllyMakerForm';
+
+AllyMakerForm.propTypes = {
+  loading: PropTypes.bool,
+  isPrecisionMode: PropTypes.bool,
+  uploadedImage: PropTypes.object,
+  onImageChange: PropTypes.func.isRequired
+};
 
 export default AllyMakerForm;

--- a/gruenerator_frontend/src/features/imagine/GrueneratorImagine.jsx
+++ b/gruenerator_frontend/src/features/imagine/GrueneratorImagine.jsx
@@ -558,6 +558,8 @@ const GrueneratorImagine = ({ showHeaderFooter = true }) => {
         ref={allyMakerFormRef}
         loading={isLoading}
         isPrecisionMode={isPrecisionMode}
+        uploadedImage={uploadedImage}
+        onImageChange={handleImageChange}
       />
     </>
   );


### PR DESCRIPTION
…aker

Lifted uploadedImage state from AllyMakerForm to parent component to ensure images persist when switching between all imagine modes (green-edit, ally-maker, universal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)