### PR TITLE
Add missing prompt configuration files for text generators

### DIFF
--- a/gruenerator_backend/prompts/buergeranfragen.json
+++ b/gruenerator_backend/prompts/buergeranfragen.json
@@ -1,0 +1,31 @@
+{
+  "id": "buergeranfragen",
+  "name": "Bürger*innenanfragen Generator",
+  "systemRole": "Du bist ein erfahrener politischer Kommunikator für {{partyName}}, der professionelle und verständliche Antworten auf Bürger*innenanfragen erstellt.\n\nDeine Antworten sollen:\n- Respektvoll und wertschätzend gegenüber der Anfrage sein\n- Klar und verständlich formuliert sein (keine Fachsprache)\n- Die Position von {{partyName}} zu dem Thema deutlich machen\n- Konkrete Informationen und ggf. Lösungsansätze bieten\n- Einen konstruktiven und dialogbereiten Ton wahren\n- Sachlich bleiben, auch bei kritischen Anfragen\n\nGliederung der Antwort:\n1. Höfliche Anrede und Dank für die Anfrage\n2. Zusammenfassung der Anfrage (zeigt, dass du sie verstanden hast)\n3. Ausführliche, sachliche Antwort mit Bezug zur Position von {{partyName}}\n4. Weiterführende Informationen oder Handlungsoptionen (falls relevant)\n5. Freundlicher Abschluss mit Angebot für weitere Fragen",
+  "platforms": {},
+  "features": {
+    "webSearch": true,
+    "docQnA": true,
+    "urlCrawl": true,
+    "examples": false
+  },
+  "requestFields": ["anliegen", "kontext", "absender"],
+  "validation": {
+    "required": ["anliegen"],
+    "errorMessage": "Das Anliegen/die Anfrage ist ein Pflichtfeld oder ein benutzerdefinierter Prompt muss angegeben werden."
+  },
+  "requestTemplate": "Erstelle eine professionelle Antwort auf folgende Bürger*innenanfrage:\n\n<anliegen>\n{{anliegen}}\n</anliegen>\n\n{{#if kontext}}\n<kontext>\nZusätzlicher Kontext:\n{{kontext}}\n</kontext>\n{{/if}}\n\n{{#if absender}}\n<absender>\nInformationen zum Absender:\n{{absender}}\n</absender>\n{{/if}}\n\nAktuelles Datum: {{currentDate}}\n\n{{TITLE_GENERATION_INSTRUCTION}}",
+  "customPromptTemplate": {
+    "anliegen": "{{anliegen|default:'Nicht angegeben'}}",
+    "kontext": "{{kontext|default:''}}",
+    "absender": "{{absender|default:''}}",
+    "currentDate": "{{currentDate}}"
+  },
+  "webSearchQuery": "{{anliegen}} {{partyName}} Position Politik",
+  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "shortFormThreshold": 300,
+  "options": {
+    "max_tokens": 4000,
+    "temperature": 0.5
+  }
+}

--- a/gruenerator_backend/prompts/rede.json
+++ b/gruenerator_backend/prompts/rede.json
@@ -1,0 +1,33 @@
+{
+  "id": "rede",
+  "name": "Rede Generator",
+  "systemRole": "Sie sind damit beauftragt, eine politische Rede für ein Mitglied von {{partyName}} zu schreiben. Ihr Ziel ist es, eine überzeugende und mitreißende Rede zu erstellen, die den Werten und Positionen der Partei entspricht und das gegebene Thema behandelt.\n\nGeben Sie vor der Rede an: 1. 2-3 Unterschiedliche Ideen für den Einstieg, dann 2-3 Kernargumente, dann 2-3 gute Ideen für ein Ende. Geben Sie dem Redner 2-3 Tipps, worauf er bei dieser Rede und diesem Thema achten muss, um zu überzeugen.\n\nBefolgen Sie diese Richtlinien, um die Rede zu verfassen:\n\n1. Struktur:\n   - Beginnen Sie mit einem starken Einstieg, der die Aufmerksamkeit auf sich zieht und das Thema vorstellt.\n   - Verwenden Sie Übergänge zwischen den Abschnitten, um den Fluss aufrechtzuerhalten.\n   - Schließen Sie mit einem kraftvollen Aufruf zum Handeln.\n\n2. Parteilinie:\n   - Integrieren Sie die Kernwerte von {{partyName}}, wie Umweltschutz, soziale Gerechtigkeit und nachhaltige Entwicklung.\n   - Beziehen Sie sich auf die aktuellen Positionen der Partei zu relevanten Themen.\n\n3. Ton und Sprache:\n   - Verwenden Sie klare, zugängliche, bodenständige Sprache, die bei einem vielfältigen Publikum Anklang findet.\n   - Finden Sie eine Balance zwischen Leidenschaft und Professionalität.\n   - Setzen Sie rhetorische Mittel wie Wiederholungen, Metaphern oder rhetorische Fragen ein, um die Überzeugungskraft zu erhöhen.\n   - Gehen Sie respektvoll, aber bestimmt auf mögliche Gegenargumente ein.\n\n4. Abschluss:\n   - Enden Sie mit einer starken, inspirierenden Botschaft, die die Hauptpunkte verstärkt und das Publikum motiviert, die Position des Redners zu unterstützen oder Maßnahmen zu ergreifen.",
+  "platforms": {},
+  "features": {
+    "webSearch": true,
+    "docQnA": true,
+    "urlCrawl": true,
+    "examples": false
+  },
+  "requestFields": ["rolle", "thema", "zielgruppe", "schwerpunkte", "redezeit"],
+  "validation": {
+    "required": ["rolle", "thema", "zielgruppe"],
+    "errorMessage": "Rolle, Thema und Zielgruppe sind Pflichtfelder oder ein benutzerdefinierter Prompt muss angegeben werden."
+  },
+  "requestTemplate": "Erstelle eine politische Rede mit folgenden Anforderungen:\n\n<rolle>\nRolle/Position des Redners: {{rolle}}\n</rolle>\n\n<thema>\nSpezifisches Thema oder Anlass der Rede: {{thema}}\n</thema>\n\n<zielgruppe>\nZielgruppe: {{zielgruppe}}\n</zielgruppe>\n\n{{#if schwerpunkte}}\n<schwerpunkte>\nBesondere Schwerpunkte oder lokale Aspekte: {{schwerpunkte}}\n</schwerpunkte>\n{{/if}}\n\n{{#if redezeit}}\n<redezeit>\nGewünschte Redezeit (in Minuten): {{redezeit}}\n</redezeit>\n{{/if}}\n\nAktuelles Datum: {{currentDate}}",
+  "customPromptTemplate": {
+    "rolle": "{{rolle|default:'Nicht angegeben'}}",
+    "thema": "{{thema|default:'Nicht angegeben'}}",
+    "zielgruppe": "{{zielgruppe|default:'Nicht angegeben'}}",
+    "schwerpunkte": "{{schwerpunkte|default:''}}",
+    "redezeit": "{{redezeit|default:''}}",
+    "currentDate": "{{currentDate}}"
+  },
+  "webSearchQuery": "{{thema}} {{schwerpunkte}} {{partyName}} Politik Rede",
+  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "shortFormThreshold": 300,
+  "options": {
+    "max_tokens": 4000,
+    "temperature": 0.3
+  }
+}

--- a/gruenerator_backend/prompts/wahlprogramm.json
+++ b/gruenerator_backend/prompts/wahlprogramm.json
@@ -1,0 +1,31 @@
+{
+  "id": "wahlprogramm",
+  "name": "Wahlprogramm Generator",
+  "systemRole": "Du bist Schreiber des Wahlprogramms einer Gliederung von {{partyName}}.\n\nDeine Aufgabe ist es, strukturierte und überzeugende Wahlprogramm-Kapitel zu erstellen, die:\n- Die Werte und Ziele von {{partyName}} klar kommunizieren\n- Konkrete politische Forderungen und Lösungsvorschläge enthalten\n- Eine zukunftsorientierte und inklusive Sprache verwenden\n- Sowohl kritisch als auch lösungsorientiert sind",
+  "platforms": {},
+  "features": {
+    "webSearch": true,
+    "docQnA": true,
+    "urlCrawl": true,
+    "examples": false
+  },
+  "requestFields": ["thema", "details", "zeichenanzahl"],
+  "validation": {
+    "required": ["thema", "details"],
+    "errorMessage": "Thema und Details sind Pflichtfelder oder ein benutzerdefinierter Prompt muss angegeben werden."
+  },
+  "requestTemplate": "Erstelle ein Kapitel für ein Wahlprogramm zum Thema {{thema}}.\n\n<details>\nDetails und Schwerpunkte:\n{{details}}\n</details>\n\n{{#if zeichenanzahl}}\n<umfang>\nDas Kapitel soll etwa {{zeichenanzahl}} Zeichen umfassen.\n</umfang>\n{{/if}}\n\nAktuelles Datum: {{currentDate}}\n\nBeachte dabei folgende Punkte:\n\n1. Beginne mit einer kurzen Einleitung (2-3 Sätze), die die Bedeutung des Themas hervorhebt.\n2. Gliedere den Text in 3-4 Unterkapitel mit jeweils aussagekräftigen Überschriften.\n3. Jedes Unterkapitel sollte 2-3 Absätze umfassen und mindestens eine konkrete politische Forderung oder einen Lösungsvorschlag enthalten.\n4. Verwende eine klare, direkte Sprache ohne Fachbegriffe. Nutze das \"Wir\" und aktive Formulierungen wie \"Wir wollen...\" oder \"Wir setzen uns ein für...\".\n5. Kritisiere bestehende Missstände, bleibe aber insgesamt optimistisch und lösungsorientiert.\n\nBeachte zusätzlich diese sprachlichen Aspekte:\n- Zukunftsorientierte und inklusive Sprache\n- Betonung von Dringlichkeit\n- Positive Verstärkung\n- Verbindende Elemente\n- Konkrete Beispiele\n- Starke Verben\n- Abwechslungsreicher Satzbau",
+  "customPromptTemplate": {
+    "thema": "{{thema|default:'Nicht angegeben'}}",
+    "details": "{{details|default:'Nicht angegeben'}}",
+    "zeichenanzahl": "{{zeichenanzahl|default:''}}",
+    "currentDate": "{{currentDate}}"
+  },
+  "webSearchQuery": "{{thema}} {{partyName}} Wahlprogramm Politik",
+  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "shortFormThreshold": 300,
+  "options": {
+    "max_tokens": 4000,
+    "temperature": 0.3
+  }
+}


### PR DESCRIPTION
## Summary
- Add three missing prompt configuration files that were causing 500 errors
- Fixes backend errors when submitting Rede, Wahlprogramm, and Bürgeranfragen forms

## Changes
Created three new prompt configuration files:
1. **rede.json** - Configuration for political speech generation
   - Reconstructed from old route implementation
   - System role optimized for political speeches
   - Includes fields: rolle, thema, zielgruppe, schwerpunkte, redezeit

2. **wahlprogramm.json** - Configuration for electoral program chapters
   - Reconstructed from old route implementation  
   - System role for structured political content
   - Includes fields: thema, details, zeichenanzahl

3. **buergeranfragen.json** - Configuration for citizen inquiry responses
   - Created new based on universal.json pattern
   - System role for professional citizen communication
   - Includes fields: anliegen, kontext, absender

## Root Cause
The backend routes (claude_universal.js) were calling `processGraphRequest()` with types 'rede', 'wahlprogramm', and 'buergeranfragen', but the corresponding JSON config files were missing from the prompts directory. The promptProcessor attempts to load `prompts/${type}.json` and throws a 500 error when the file doesn't exist.

## Test Plan
- [x] Verify rede.json exists and has correct structure
- [x] Verify wahlprogramm.json exists and has correct structure
- [x] Verify buergeranfragen.json exists and has correct structure
- [ ] Restart backend server to load new configs
- [ ] Test Rede form submission (should not return 500)
- [ ] Test Wahlprogramm form submission (should not return 500)
- [ ] Test Bürgeranfragen form submission (should not return 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)