### PR TITLE
fix: Update universal route prompts to use markdown formatting

### DIFF
--- a/gruenerator_backend/prompts/buergeranfragen.json
+++ b/gruenerator_backend/prompts/buergeranfragen.json
@@ -22,7 +22,7 @@
     "currentDate": "{{currentDate}}"
   },
   "webSearchQuery": "{{anliegen}} {{partyName}} Position Politik",
-  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "formatting": "MARKDOWN_FORMATTING_INSTRUCTIONS",
   "shortFormThreshold": 300,
   "options": {
     "max_tokens": 4000,

--- a/gruenerator_backend/prompts/rede.json
+++ b/gruenerator_backend/prompts/rede.json
@@ -24,7 +24,7 @@
     "currentDate": "{{currentDate}}"
   },
   "webSearchQuery": "{{thema}} {{schwerpunkte}} {{partyName}} Politik Rede",
-  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "formatting": "MARKDOWN_FORMATTING_INSTRUCTIONS",
   "shortFormThreshold": 300,
   "options": {
     "max_tokens": 4000,

--- a/gruenerator_backend/prompts/wahlprogramm.json
+++ b/gruenerator_backend/prompts/wahlprogramm.json
@@ -22,7 +22,7 @@
     "currentDate": "{{currentDate}}"
   },
   "webSearchQuery": "{{thema}} {{partyName}} Wahlprogramm Politik",
-  "formatting": "HTML_FORMATTING_INSTRUCTIONS",
+  "formatting": "MARKDOWN_FORMATTING_INSTRUCTIONS",
   "shortFormThreshold": 300,
   "options": {
     "max_tokens": 4000,


### PR DESCRIPTION
## Summary
Updated formatting configuration in prompt JSON files for claude_universal.js routes to use markdown instead of HTML.

## Changes
- **rede.json**: Changed `formatting` from `HTML_FORMATTING_INSTRUCTIONS` to `MARKDOWN_FORMATTING_INSTRUCTIONS`
- **wahlprogramm.json**: Changed `formatting` from `HTML_FORMATTING_INSTRUCTIONS` to `MARKDOWN_FORMATTING_INSTRUCTIONS`
- **buergeranfragen.json**: Changed `formatting` from `HTML_FORMATTING_INSTRUCTIONS` to `MARKDOWN_FORMATTING_INSTRUCTIONS`

## Impact
All 4 text generation endpoints handled by `claude_universal.js` now consistently use markdown formatting:
- `/api/claude_universal` (Universal Text Generator) - already had markdown
- `/api/claude_rede` (Speech Generator) - updated
- `/api/claude_wahlprogramm` (Election Program Generator) - updated
- `/api/claude_buergeranfragen` (Citizen Inquiry Generator) - updated

The changes are automatically processed by the centralized `promptProcessor.js` system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)