### PR TITLE
fix: Prevent Qdrant validation error when scrolling with limit=0

### DIFF
--- a/gruenerator_backend/database/services/QdrantOperations.js
+++ b/gruenerator_backend/database/services/QdrantOperations.js
@@ -753,6 +753,12 @@ class QdrantOperations {
     async scrollDocuments(collection, filter = {}, options = {}) {
         const { limit = 100, withPayload = true, withVector = false, offset = null } = options;
 
+        // Defensive validation: Qdrant requires limit >= 1
+        if (limit <= 0) {
+            console.warn(`[QdrantOperations] Invalid limit value: ${limit}. Returning empty array.`);
+            return [];
+        }
+
         try {
             const scrollParams = {
                 filter: Object.keys(filter).length > 0 ? filter : undefined,

--- a/gruenerator_backend/services/DocumentSearchService.js
+++ b/gruenerator_backend/services/DocumentSearchService.js
@@ -976,6 +976,15 @@ class DocumentSearchService extends BaseSearchService {
         try {
             await this.ensureInitialized();
 
+            // Early return if no documents to avoid Qdrant API call with limit=0
+            if (!documentIds || documentIds.length === 0) {
+                return {
+                    success: true,
+                    chunks: {},
+                    foundCount: 0
+                };
+            }
+
             const filter = {
                 must: [
                     { key: 'user_id', match: { value: userId } },


### PR DESCRIPTION
## Summary
This PR fixes three related bugs around loading states and empty data handling:

### 1. Backend: Qdrant validation error with limit=0
- Fixed API error when users have no documents
- Added defensive validation to prevent `limit=0` being passed to Qdrant scroll API

### 2. Frontend: KnowledgeSelector incorrect empty state
- Fixed race condition where "Keine Inhalte verfügbar" appeared during loading
- Added derived state combining all three loading states (groups, texts, documents)

### 3. Frontend: Document loading state synchronization
- Fixed infinite "Lade verfügbare Inhalte..." message when 0 documents returned
- Synchronized loading state between documentsStore and generatorKnowledgeStore

## Changes

### Backend
- **QdrantOperations.js**: Defensive validation for `limit <= 0`
- **DocumentSearchService.js**: Early return when documentIds array is empty

### Frontend
- **KnowledgeSelector.jsx**: Extract `isLoadingDocuments`, create `isLoadingAnyContent` derived state
- **useKnowledge.js**: Synchronize loading states between stores, handle empty arrays

## Root Causes

### Backend Issue
When `/api/documents/combined-content` was called for users with no documents, `documentIds.length = 0` was passed directly as limit to Qdrant, causing validation error.

### Frontend Issues
1. `isLoadingDocuments` was not extracted from store, causing incomplete loading state checks
2. Loading states from documentsStore were never synchronized to generatorKnowledgeStore
3. Empty arrays were not synced, preventing proper "0 items" state

## Test Plan
- [x] Verified no error when user has 0 documents (backend)
- [x] Confirmed loading message appears during fetch (frontend)
- [x] Confirmed empty message appears after fetch completes with 0 items (frontend)
- [x] Tested that users with documents still receive correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)