### PR TITLE
fix: Synchronize document loading state between stores

### DIFF
--- a/gruenerator_frontend/src/components/hooks/useKnowledge.js
+++ b/gruenerator_frontend/src/components/hooks/useKnowledge.js
@@ -55,7 +55,8 @@ const useKnowledge = ({
     fetchDocuments,
     fetchCombinedContent,
     documents: documentsFromStore,
-    texts: textsFromStore
+    texts: textsFromStore,
+    isLoading: isLoadingDocumentsFromStore
   } = useDocumentsStore();
 
   // Reset store on component mount to ensure clean state
@@ -250,16 +251,25 @@ const useKnowledge = ({
   // CRITICAL: Synchronize documents and texts from documentsStore to generatorKnowledgeStore
   // This fixes the bug where availableDocuments was always empty
   useEffect(() => {
-    if (documentsFromStore && documentsFromStore.length > 0) {
+    // Always sync documents, even if empty array (to handle 0 documents case)
+    if (documentsFromStore) {
       setAvailableDocuments(documentsFromStore);
     }
   }, [documentsFromStore, setAvailableDocuments]);
 
   useEffect(() => {
-    if (textsFromStore && textsFromStore.length > 0) {
+    // Always sync texts, even if empty array (to handle 0 texts case)
+    if (textsFromStore) {
       setAvailableTexts(textsFromStore);
     }
   }, [textsFromStore, setAvailableTexts]);
+
+  // CRITICAL: Synchronize loading state from documentsStore to generatorKnowledgeStore
+  // This fixes the bug where "Lade verfügbare Inhalte..." was shown even after loading completed
+  useEffect(() => {
+    const { setLoadingDocuments } = useGeneratorKnowledgeStore.getState();
+    setLoadingDocuments(isLoadingDocumentsFromStore);
+  }, [isLoadingDocumentsFromStore]);
 
   // Track if initial fetch has been done to prevent duplicate fetches
   const hasFetchedDocuments = useRef(false);


### PR DESCRIPTION
Fixed bug where KnowledgeSelector showed "Lade verfügbare Inhalte..." indefinitely when 0 documents were returned.

Root cause: isLoadingDocuments in generatorKnowledgeStore was never synchronized with documentsStore's isLoading state.

Changes:
- Extract isLoading state from documentsStore in useKnowledge hook
- Add synchronization effect to keep loading states in sync
- Fix document/text syncing to handle empty arrays (0 items case)
- Remove length check - always sync documents/texts even if empty

Now loading state properly transitions from true to false when fetch completes, regardless of result count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)