### PR TITLE
chore: Switch Antrag generator to Magistral model

### DIFF
--- a/gruenerator_backend/prompts/antrag_simple.json
+++ b/gruenerator_backend/prompts/antrag_simple.json
@@ -40,6 +40,8 @@
   "shortFormThreshold": 300,
   "options": {
     "max_tokens": 3000,
-    "temperature": 0.6
+    "temperature": 0.6,
+    "model": "magistral-medium-latest",
+    "provider": "mistral"
   }
 }


### PR DESCRIPTION
## Summary
- Updates the Antrag generator to use `magistral-medium-latest` model from Mistral
- This change improves German text generation quality for Antrag documents

## Changes
- Modified `gruenerator_backend/prompts/antrag_simple.json` to specify:
  - `model`: `magistral-medium-latest`
  - `provider`: `mistral`

## Test plan
- [ ] Test Antrag generation with the new Magistral model
- [ ] Verify output quality meets requirements
- [ ] Ensure no breaking changes in API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)