### PR TITLE
fix(ui): Hide FeatureIcons in Imagine and Accessibility generators

### DIFF
--- a/gruenerator_frontend/src/features/imagine/GrueneratorImagine.jsx
+++ b/gruenerator_frontend/src/features/imagine/GrueneratorImagine.jsx
@@ -187,9 +187,10 @@ const GrueneratorImagine = ({ showHeaderFooter = true }) => {
     componentName: componentName,
     endpoint: '/flux/green-edit/prompt',
     disableKnowledgeSystem: true,
-    features: [], // No webSearch or privacyMode for image generation
+    features: [],
     tabIndexKey: 'IMAGINE',
-    helpContent: helpContent
+    helpContent: helpContent,
+    useFeatureIcons: false
   });
 
   // Use local loading state for manual management

--- a/gruenerator_frontend/src/features/texte/accessibility/AccessibilityTextGenerator.jsx
+++ b/gruenerator_frontend/src/features/texte/accessibility/AccessibilityTextGenerator.jsx
@@ -337,7 +337,7 @@ const AccessibilityTextGenerator = ({ showHeaderFooter = true }) => {
           firstExtrasChildren={renderTypeSelector()}
           submitButtonText={selectedType === ACCESSIBILITY_TYPES.ALT_TEXT ? "Alt-Text generieren" : "In Leichte Sprache übersetzen"}
           isSubmitDisabled={!formRef.current?.isValid?.()}
-          useFeatureIcons={true}
+          useFeatureIcons={false}
           loading={combinedLoading}
           success={combinedSuccess}
           error={combinedError}


### PR DESCRIPTION
## Summary
- Hide FeatureIcons component in GrueneratorImagine
- Hide FeatureIcons component in AccessibilityTextGenerator

These features (Websuche, Privacy mode, Content, Anweisungen) are not relevant for image generation and accessibility text generation.

## Test plan
- [ ] Verify Imagine feature no longer shows FeatureIcons
- [ ] Verify Accessibility feature no longer shows FeatureIcons
- [ ] Verify both features still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)