### PR TITLE
fix(custom-generator): Fix field deletion not updating UI

### DIFF
--- a/gruenerator_frontend/src/assets/styles/components/custom-generator/create-custom-generator.css
+++ b/gruenerator_frontend/src/assets/styles/components/custom-generator/create-custom-generator.css
@@ -16,6 +16,7 @@ h3 {
 
 /* Modern list group styles (token-based, dark-mode aware) */
 .list-group {
+  list-style: none;
   padding: 0;
   margin: var(--spacing-large) 0;
   border-radius: var(--card-border-radius-small);

--- a/gruenerator_frontend/src/features/generators/CreateCustomGeneratorPage.jsx
+++ b/gruenerator_frontend/src/features/generators/CreateCustomGeneratorPage.jsx
@@ -394,7 +394,7 @@ const CreateCustomGeneratorPage = ({ onCompleted, onCancel }) => {
         );
 
       case STEPS.FIELDS:
-        const currentFields = getValues('fields');
+        const currentFields = watch('fields');
         return (
           <>
             {/* Heading removed to avoid duplication with FormSection title */}

--- a/gruenerator_frontend/src/features/generators/styles/custom-generators-tab.css
+++ b/gruenerator_frontend/src/features/generators/styles/custom-generators-tab.css
@@ -271,14 +271,6 @@
   line-height: 1.4;
 }
 
-.list-group {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--border-radius-medium);
-  overflow: hidden;
-}
 
 /* Generator Documents Section */
 .generator-documents-section {


### PR DESCRIPTION
## Summary
- Fix form field deletion not updating UI in custom generator creation
- Use `watch('fields')` instead of `getValues('fields')` to subscribe to form changes and trigger re-renders
- Consolidate duplicate `.list-group` CSS definitions (removed `overflow: hidden` that was clipping buttons)

## Test plan
- [ ] Navigate to Profile → Custom Grünerators → Create new
- [ ] Add 2+ fields in "Formularfelder definieren" step
- [ ] Click delete (trash) icon on any field
- [ ] Confirm field disappears immediately from the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)