### PR TITLE
Update browser tab title to Grünerator - Grüne KI

### DIFF
--- a/gruenerator_frontend/index.html
+++ b/gruenerator_frontend/index.html
@@ -13,7 +13,7 @@
     <meta name="author" content="Moritz Wächter" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Grünerator - KI-Assistent für grüne Politik | Anträge, Reden & mehr</title>
+    <title>Grünerator - Grüne KI</title>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/gruenerator_frontend/public/index.html
+++ b/gruenerator_frontend/public/index.html
@@ -17,7 +17,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Grünerator - KI-Assistent für grüne Politik | Anträge, Reden & mehr</title>
+    <title>Grünerator - Grüne KI</title>
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />


### PR DESCRIPTION
## Summary
- Updates the browser tab title from "Grünerator - KI-Assistent für grüne Politik | Anträge, Reden & mehr" to "Grünerator - Grüne KI"
- Changed in both `index.html` files (Vite entry and public template)

## Test plan
- [ ] Verify browser tab shows "Grünerator - Grüne KI"

🤖 Generated with [Claude Code](https://claude.com/claude-code)