### PR TITLE
fix: Align dark mode background-color-alt with prefers-color-scheme

### DIFF
--- a/gruenerator_frontend/src/assets/styles/common/variables.css
+++ b/gruenerator_frontend/src/assets/styles/common/variables.css
@@ -158,7 +158,7 @@
 [data-theme="dark"] {
     --background-color: var(--grey-950);
     --background-color-pure: var(--grey-900);
-    --background-color-alt: var(--grey-950);
+    --background-color-alt: var(--grey-800);
     --background-color-sand: var(--grey-950);
     --hover-color-alt: var(--grey-700);
     --font-color: var(--neutral-600);


### PR DESCRIPTION
## Summary
- Fixed `--background-color-alt` in `[data-theme="dark"]` from `var(--grey-950)` to `var(--grey-800)`
- This aligns with the `prefers-color-scheme: dark` behavior and provides proper visual hierarchy in dark mode

## Test plan
- [ ] Verify dark mode has visible contrast between background and alt-background elements
- [ ] Check that explicit dark mode (`data-theme="dark"`) matches system dark mode preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)