### PR TITLE
feat: Temporarily hide Wolke upload option

### DIFF
--- a/gruenerator_frontend/src/components/common/DocumentUpload.jsx
+++ b/gruenerator_frontend/src/components/common/DocumentUpload.jsx
@@ -541,6 +541,7 @@ const DocumentUpload = forwardRef(({
                         <HiOutlineLink className="icon" />
                         URL
                       </button>
+                      {/* Wolke tab temporarily hidden
                       <button
                         type="button"
                         className={`mode-tab ${uploadMode === 'wolke' ? 'active' : ''}`}
@@ -551,6 +552,7 @@ const DocumentUpload = forwardRef(({
                         <HiOutlineCloudDownload className="icon" />
                         Wolke
                       </button>
+                      */}
                     </div>
                   </div>
 
@@ -734,6 +736,7 @@ const DocumentUpload = forwardRef(({
                     <HiOutlineLink className="icon" />
                     URL
                   </button>
+                  {/* Wolke tab temporarily hidden
                   <button
                     type="button"
                     className={`mode-tab ${uploadMode === 'wolke' ? 'active' : ''}`}
@@ -744,6 +747,7 @@ const DocumentUpload = forwardRef(({
                     <HiOutlineCloudDownload className="icon" />
                     Wolke
                   </button>
+                  */}
                 </div>
               </div>
 

--- a/gruenerator_frontend/src/features/auth/components/profile/tabs/ContentManagement/ContentManagementView.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/tabs/ContentManagement/ContentManagementView.jsx
@@ -44,7 +44,7 @@ const ContentManagementView = ({
     // Available tabs - content plus integrations
     const availableTabs = [
         { key: 'inhalte', label: 'Inhalte' },
-        { key: 'wolke', label: 'Wolke' },
+        // { key: 'wolke', label: 'Wolke' }, // Temporarily hidden
         ...(canAccessBetaFeature('canva') ? [{ key: 'canva', label: 'Canva' }] : []),
         { key: 'anweisungen', label: 'Anweisungen' },
         { key: 'einstellungen', label: 'Weitere Einstellungen' }


### PR DESCRIPTION
## Summary
- Hide the Wolke (cloud) upload tab from ContentManagement tabs
- Hide the Wolke upload mode option from DocumentUpload component (both modal and inline views)
- Underlying functionality preserved for easy re-enablement

## Test plan
- [ ] Verify Wolke tab no longer appears in ContentManagement navigation
- [ ] Verify Wolke option no longer appears when uploading documents
- [ ] Confirm File and URL upload modes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)