### PR TITLE
fix: Ensure Canva button text is always white

### DIFF
--- a/gruenerator_frontend/src/assets/styles/components/common/canva-template-modal.css
+++ b/gruenerator_frontend/src/assets/styles/components/common/canva-template-modal.css
@@ -135,7 +135,7 @@
   justify-content: center;
   gap: var(--spacing-small);
   background: linear-gradient(135deg, #7d2ae8 0%, #00c4cc 100%);
-  color: var(--weiss);
+  color: white;
   border: none;
   padding: var(--spacing-small) var(--spacing-large);
   border-radius: var(--card-border-radius-small);


### PR DESCRIPTION
## Summary
- Fixed the "In Canva öffnen" button text color to always be white
- Changed from `var(--weiss)` to explicit `white` to ensure visibility regardless of theme

## Test plan
- [ ] Open Kampagnen Generator
- [ ] Generate a sharepic
- [ ] Click the Canva button on the generated image
- [ ] Verify the "In Canva öffnen" button has white text in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)