### PR TITLE
feat: Add /weihnachten route for Christmas campaign

### DIFF
--- a/gruenerator_frontend/src/config/routes.js
+++ b/gruenerator_frontend/src/config/routes.js
@@ -130,6 +130,7 @@ const standardRoutes = [
   { path: '/antrag', component: GrueneratorenBundle.Antrag, withForm: true },
   { path: '/presse-social', component: GrueneratorenBundle.PresseSocial, withForm: true },
   { path: '/kampagnen', component: GrueneratorenBundle.Kampagnen, withForm: true },
+  { path: '/weihnachten', component: GrueneratorenBundle.Kampagnen, withForm: true },
   { path: '/imagine', component: GrueneratorenBundle.Imagine, withForm: true },
   { path: '/barrierefreiheit', component: GrueneratorenBundle.Accessibility, withForm: true },
   { path: '/alttext', component: GrueneratorenBundle.AltText, withForm: true },


### PR DESCRIPTION
## Summary
- Adds `/weihnachten` route that leads directly to the Christmas campaign in KampagnenGenerator
- The KampagnenGenerator already defaults to the 'weihnachten' campaign

## Test plan
- [ ] Navigate to `/weihnachten` and verify the Christmas campaign loads
- [ ] Verify `/kampagnen` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)