### PR TITLE
fix: Make mobile popups full height like Instagram stories

### DIFF
--- a/gruenerator_frontend/src/components/common/Popup/base-popup.css
+++ b/gruenerator_frontend/src/components/common/Popup/base-popup.css
@@ -720,6 +720,15 @@
     margin: 0;
   }
 
+  .popup-single-container {
+    min-height: 100vh;
+    min-height: var(--app-height, 100vh);
+    height: 100vh;
+    height: var(--app-height, 100vh);
+    max-height: 100vh;
+    max-height: var(--app-height, 100vh);
+  }
+
   .popup-slider-dots {
     top: env(safe-area-inset-top, 10px);
     left: 10px;


### PR DESCRIPTION
## Summary
- Add mobile override for `.popup-single-container` to fill full viewport height on mobile
- Ensures all single-variant popups (Christmas, custom grueneratoren, etc.) display like Instagram stories

## Test plan
- [ ] Open any single popup on mobile device or mobile viewport
- [ ] Verify popup fills entire screen height
- [ ] Test on both iOS and Android if possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)