### PR TITLE
fix: Enable delete confirmation buttons in reel studio

### DIFF
--- a/gruenerator_frontend/src/features/subtitler/components/ProjectSelector.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/ProjectSelector.jsx
@@ -80,10 +80,10 @@ const ProjectCard = ({ project, onSelect, onDelete, onShare, isLoading }) => {
         e.stopPropagation();
         try {
             await onDelete(project.id);
+            setConfirmDelete(false);
         } catch (err) {
             console.error('Failed to delete project:', err);
         }
-        setConfirmDelete(false);
     };
 
     const handleCancelDelete = (e) => {

--- a/gruenerator_frontend/src/features/subtitler/styles/ProjectSelector.css
+++ b/gruenerator_frontend/src/features/subtitler/styles/ProjectSelector.css
@@ -266,10 +266,6 @@
     font-size: 0.9rem;
 }
 
-.project-card.deleting {
-    pointer-events: none;
-}
-
 .project-card.deleting .project-thumbnail,
 .project-card.deleting .project-info {
     filter: blur(2px);


### PR DESCRIPTION
## Summary
- Fixed bug where clicking "Ja" (confirm delete) button did nothing in the reel studio project selector
- Root cause: CSS `pointer-events: none` on `.project-card.deleting` blocked all clicks including confirmation buttons
- Also fixed error handling so delete dialog stays open if deletion fails

## Test plan
- [ ] Open reel studio with existing projects
- [ ] Click delete button on a project
- [ ] Click "Ja" to confirm - should now work and delete the project
- [ ] Verify "Nein" button still cancels

🤖 Generated with [Claude Code](https://claude.com/claude-code)