### PR TITLE
fix: Add padding to login modal on mobile devices

### DIFF
--- a/gruenerator_frontend/src/assets/styles/features/auth/login-page.css
+++ b/gruenerator_frontend/src/assets/styles/features/auth/login-page.css
@@ -467,10 +467,14 @@
 
 /* Enhanced Mobile Layout (<768px) */
 @media (max-width: 767px) {
+  .auth-container--modal {
+    padding: var(--spacing-large);
+  }
+
   .auth-content-wrapper {
     display: block;
   }
-  
+
   .auth-content-left,
   .auth-content-right {
     width: 100%;
@@ -513,9 +517,10 @@
   .auth-modal-overlay {
     padding: var(--spacing-medium);
   }
-  
+
   .auth-container--modal {
     max-height: 95vh;
+    padding: var(--spacing-medium);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fixed missing internal padding on login modal for mobile screens
- Added `padding: var(--spacing-large)` for screens ≤767px
- Added `padding: var(--spacing-medium)` for screens ≤480px

## Test plan
- [ ] Open login modal on mobile device or mobile viewport
- [ ] Verify content has proper spacing from modal edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)