### PR TITLE
feat: Improve subtitler UX and add cancellation support

### DIFF
--- a/gruenerator_frontend/src/assets/styles/features/auth/login-page.css
+++ b/gruenerator_frontend/src/assets/styles/features/auth/login-page.css
@@ -223,6 +223,10 @@
   animation: slideUp 0.3s ease-out;
 }
 
+.auth-container--modal .auth-header h1 {
+  padding-right: calc(36px + var(--spacing-medium));
+}
+
 /* Modal close button */
 .auth-modal-close {
   position: absolute;
@@ -469,6 +473,11 @@
 @media (max-width: 767px) {
   .auth-container--modal {
     padding: var(--spacing-large);
+  }
+
+  .auth-container--modal .auth-header,
+  .auth-container--modal .auth-header h1 {
+    text-align: left;
   }
 
   .auth-content-wrapper {

--- a/gruenerator_frontend/src/features/subtitler/components/ProjectSelector.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/ProjectSelector.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { FaPlus, FaTrash, FaClock, FaVideo, FaShare } from 'react-icons/fa';
-import { useSubtitlerProjectStore } from '../../../stores/subtitlerProjectStore';
 import ShareVideoModal from './ShareVideoModal';
 import Spinner from '../../../components/common/Spinner';
 import '../styles/ProjectSelector.css';
@@ -207,24 +206,22 @@ const ProjectCard = ({ project, onSelect, onDelete, onShare, isLoading }) => {
     );
 };
 
-const ProjectSelector = ({ onSelectProject, onNewProject, loadingProjectId }) => {
-    const {
-        projects,
-        fetchProjects,
-        deleteProject,
-        isLoading,
-        error
-    } = useSubtitlerProjectStore();
-
+const ProjectSelector = ({
+    onSelectProject,
+    onNewProject,
+    loadingProjectId,
+    projects = [],
+    isLoading = false,
+    error = null,
+    onDeleteProject
+}) => {
     const [shareProject, setShareProject] = useState(null);
 
-    useEffect(() => {
-        fetchProjects();
-    }, [fetchProjects]);
-
     const handleDelete = useCallback(async (projectId) => {
-        await deleteProject(projectId);
-    }, [deleteProject]);
+        if (onDeleteProject) {
+            await onDeleteProject(projectId);
+        }
+    }, [onDeleteProject]);
 
     const handleShare = useCallback((project) => {
         setShareProject(project);

--- a/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
@@ -549,6 +549,6 @@ const SubtitlerPage = () => {
 };
 
 export default withAuthRequired(SubtitlerPage, {
-  title: 'Grünerator Reel-Studio',
-  message: 'Anmeldung erforderlich für das Grünerator Reel-Studio'
+  title: 'Reel-Studio',
+  message: 'Anmeldung für Reel-Studio erforderlich'
 });

--- a/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
@@ -28,7 +28,7 @@ import '../styles/ProjectSelector.css';
 const IS_SUBTITLER_UNDER_MAINTENANCE = false;
 // ------------------------
 
-const SubtitlerPage = () => {
+const SubtitlerPage = ({ user }) => {
   const [step, setStep] = useState('select');
   const [originalVideoFile, setOriginalVideoFile] = useState(null); // Original File-Objekt
   const [uploadInfo, setUploadInfo] = useState(null); // Upload-ID, Metadaten und Präferenz
@@ -55,9 +55,9 @@ const SubtitlerPage = () => {
   // Get Igel mode status from auth store
   const { igelModus } = useAuthStore();
 
-  // Skip to upload if no projects exist
+  // Skip to upload if no projects exist (only fetch when authenticated)
   useEffect(() => {
-    if (step === 'select') {
+    if (step === 'select' && user) {
       fetchProjects().then(() => {
         const { projects: currentProjects } = useSubtitlerProjectStore.getState();
         if (currentProjects.length === 0) {
@@ -65,7 +65,7 @@ const SubtitlerPage = () => {
         }
       });
     }
-  }, [step, fetchProjects]);
+  }, [step, fetchProjects, user]);
 
   // Browser history navigation - push state when step changes
   const isInitialMount = useRef(true);

--- a/gruenerator_frontend/src/features/subtitler/hooks/useSubtitlerProjects.js
+++ b/gruenerator_frontend/src/features/subtitler/hooks/useSubtitlerProjects.js
@@ -1,0 +1,95 @@
+import { useEffect, useCallback } from 'react';
+import { useSubtitlerProjectStore } from '../../../stores/subtitlerProjectStore';
+import { useOptimizedAuth } from '../../../hooks/useAuth';
+
+/**
+ * Hook for managing subtitler projects with built-in auth guards.
+ * Centralizes all project-related API calls and ensures they only
+ * execute when the user is authenticated.
+ */
+export const useSubtitlerProjects = () => {
+  const { isAuthenticated, isAuthResolved } = useOptimizedAuth();
+
+  const {
+    projects,
+    currentProject,
+    isLoading,
+    isSaving,
+    error,
+    saveSuccess,
+    fetchProjects: storeFetchProjects,
+    loadProject: storeLoadProject,
+    saveProject: storeSaveProject,
+    updateProject: storeUpdateProject,
+    deleteProject: storeDeleteProject,
+    setCurrentProject,
+    clearCurrentProject,
+    clearError,
+    reset
+  } = useSubtitlerProjectStore();
+
+  const isReady = isAuthenticated && isAuthResolved;
+
+  // Auto-fetch projects when auth is ready
+  useEffect(() => {
+    if (isReady) {
+      storeFetchProjects();
+    }
+  }, [isReady, storeFetchProjects]);
+
+  // Guarded fetch projects
+  const fetchProjects = useCallback(async () => {
+    if (!isReady) return Promise.resolve();
+    return storeFetchProjects();
+  }, [isReady, storeFetchProjects]);
+
+  // Guarded load project
+  const loadProject = useCallback(async (projectId) => {
+    if (!isReady) return Promise.resolve(null);
+    return storeLoadProject(projectId);
+  }, [isReady, storeLoadProject]);
+
+  // Guarded save project
+  const saveProject = useCallback(async (projectData) => {
+    if (!isReady) return Promise.resolve(null);
+    return storeSaveProject(projectData);
+  }, [isReady, storeSaveProject]);
+
+  // Guarded update project
+  const updateProject = useCallback(async (projectId, updates) => {
+    if (!isReady) return Promise.resolve(null);
+    return storeUpdateProject(projectId, updates);
+  }, [isReady, storeUpdateProject]);
+
+  // Guarded delete project
+  const deleteProject = useCallback(async (projectId) => {
+    if (!isReady) return Promise.resolve();
+    return storeDeleteProject(projectId);
+  }, [isReady, storeDeleteProject]);
+
+  return {
+    // State
+    projects,
+    currentProject,
+    isLoading,
+    isSaving,
+    error,
+    saveSuccess,
+    isReady,
+
+    // Actions (all auth-guarded)
+    fetchProjects,
+    loadProject,
+    saveProject,
+    updateProject,
+    deleteProject,
+
+    // Direct store actions (no API calls)
+    setCurrentProject,
+    clearCurrentProject,
+    clearError,
+    reset
+  };
+};
+
+export default useSubtitlerProjects;

--- a/gruenerator_frontend/src/features/subtitler/styles/VideoUploader.css
+++ b/gruenerator_frontend/src/features/subtitler/styles/VideoUploader.css
@@ -4,7 +4,6 @@
   width: 100%;
   max-width: 800px;
   margin: 0 auto;
-  margin-top: -1rem;
   animation: fadeIn 0.3s ease-out;
 }
 
@@ -344,4 +343,32 @@
   font-size: 1rem;
   color: var(--font-color);
   font-weight: bold;
-} 
+}
+
+/* Cancel button */
+.cancel-btn {
+  margin-top: var(--spacing-medium);
+  width: 100%;
+}
+
+/* Error state */
+.dropzone.error {
+  border-color: var(--error-red);
+}
+
+.upload-icon.error-icon {
+  color: var(--error-red);
+}
+
+/* AI notice styling in uploader */
+.upload-container .ai-notice {
+  margin-top: var(--spacing-medium);
+  padding: var(--spacing-small);
+  background-color: var(--background-color-alt);
+  border-radius: var(--spacing-xsmall);
+}
+
+.upload-container .ai-notice a {
+  color: var(--link-color, var(--primary));
+  text-decoration: underline;
+}

--- a/gruenerator_frontend/src/features/subtitler/styles/subtitler.css
+++ b/gruenerator_frontend/src/features/subtitler/styles/subtitler.css
@@ -58,6 +58,7 @@
   width: 100%;
   max-width: 600px;
   margin: 0 auto;
+  margin-top: var(--spacing-large);
 }
 
 .dropzone {


### PR DESCRIPTION
## Summary
- Skip the confirm step in subtitler - auto-start processing after upload
- Add cancel functionality during upload and processing phases
- Implement backend cancellation via Redis flags to stop AssemblyAI polling
- Fix auth redirect loop in Reel Studio for unauthenticated users
- Centralize subtitler API calls with auth guards
- Improve login modal layout and simplify Reel-Studio title

## Test plan
- [ ] Upload a video and verify processing starts automatically
- [ ] Test cancel button during upload phase
- [ ] Test cancel button during processing phase
- [ ] Verify unauthenticated users don't get stuck in redirect loop
- [ ] Test login modal appearance on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)