### PR TITLE
feat: Auto-save exports as projects and fix share functionality

### DIFF
--- a/gruenerator_backend/services/subtitlerProjectService.js
+++ b/gruenerator_backend/services/subtitlerProjectService.js
@@ -113,6 +113,25 @@ class SubtitlerProjectService {
         }
     }
 
+    async findProjectByVideoFilename(userId, videoFilename) {
+        await this.ensureInitialized();
+
+        try {
+            const query = `
+                SELECT id, title, status, video_path, video_filename, subtitled_video_path
+                FROM subtitler_projects
+                WHERE user_id = $1 AND video_filename = $2
+                ORDER BY updated_at DESC
+                LIMIT 1
+            `;
+            const result = await this.postgres.queryOne(query, [userId, videoFilename]);
+            return result || null;
+        } catch (error) {
+            console.error('[SubtitlerProjectService] Failed to find project by filename:', error);
+            return null;
+        }
+    }
+
     async getVideoPathOnly(userId, projectId) {
         await this.ensureInitialized();
 

--- a/gruenerator_frontend/src/features/subtitler/components/ShareVideoModal.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/ShareVideoModal.jsx
@@ -11,27 +11,23 @@ const expirationOptions = [
   { value: 30, label: '30 Tage' },
 ];
 
-const ShareVideoModal = ({ exportToken, projectId, title, onClose }) => {
+const ShareVideoModal = ({ projectId, title, onClose }) => {
   const [shareTitle, setShareTitle] = useState(title || 'Untertiteltes Video');
   const [expiresInDays, setExpiresInDays] = useState(expirationOptions[1]);
   const [copied, setCopied] = useState(false);
 
-  const { createShare, createShareFromProject, currentShare, isCreatingShare, error, errorCode, clearError, clearCurrentShare } = useSubtitlerShareStore();
+  const { createShareFromProject, currentShare, isCreatingShare, error, errorCode, clearError, clearCurrentShare } = useSubtitlerShareStore();
 
-  // Clear any previous share state when modal opens
   useEffect(() => {
     clearCurrentShare();
     clearError();
   }, [clearCurrentShare, clearError]);
 
   const handleCreateShare = async () => {
+    if (!projectId) return;
     try {
       clearError();
-      if (projectId) {
-        await createShareFromProject(projectId, shareTitle, expiresInDays.value);
-      } else {
-        await createShare(exportToken, shareTitle, null, expiresInDays.value);
-      }
+      await createShareFromProject(projectId, shareTitle, expiresInDays.value);
     } catch (err) {
       console.error('Failed to create share:', err);
     }
@@ -188,8 +184,7 @@ const ShareVideoModal = ({ exportToken, projectId, title, onClose }) => {
 };
 
 ShareVideoModal.propTypes = {
-  exportToken: PropTypes.string,
-  projectId: PropTypes.string,
+  projectId: PropTypes.string.isRequired,
   title: PropTypes.string,
   onClose: PropTypes.func.isRequired,
 };

--- a/gruenerator_frontend/src/features/subtitler/components/SuccessScreen.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/SuccessScreen.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import { motion } from 'motion/react';
-import { FaPlus, FaEdit, FaShareAlt, FaInstagram } from 'react-icons/fa';
+import { FaPlus, FaEdit, FaShareAlt, FaInstagram, FaTimes } from 'react-icons/fa';
 import CopyButton from '../../../components/common/CopyButton';
 import { useSubtitlerExportStore } from '../../../stores/subtitlerExportStore';
 import ShareVideoModal from './ShareVideoModal';
@@ -95,7 +95,7 @@ const SuccessScreen = ({ onReset, onEditAgain, isLoading, socialText, uploadId, 
     <div className="success-screen">
       <div className="success-content">
         <div className="success-main">
-          <div className={`success-icon ${showSpinner ? 'loading' : ''}`}>
+          <div className={`success-icon ${showSpinner ? 'loading' : ''} ${exportError ? 'error' : ''}`}>
             {showSpinner ? (
               <div className="spinner-container">
                 <div className="spinner" />
@@ -105,23 +105,26 @@ const SuccessScreen = ({ onReset, onEditAgain, isLoading, socialText, uploadId, 
                   </div>
                 )}
               </div>
+            ) : exportError ? (
+              <FaTimes style={{ fontSize: '60px', color: 'var(--error-red)' }} />
             ) : (
               <AnimatedCheckmark />
             )}
           </div>
-          <h2>{showSpinner ? 'Dein Video wird verarbeitet' : 'Dein Video wurde heruntergeladen'}</h2>
+          <h2>
+            {showSpinner
+              ? 'Dein Video wird verarbeitet'
+              : exportError
+                ? 'Export fehlgeschlagen'
+                : 'Dein Video wurde heruntergeladen'}
+          </h2>
           <p>
             {showSpinner
               ? 'Dein Video wird mit Untertiteln versehen...'
-              : 'Dein Video wurde erfolgreich mit Untertiteln versehen und heruntergeladen.'}
+              : exportError
+                ? exportError
+                : 'Dein Video wurde erfolgreich mit Untertiteln versehen und heruntergeladen.'}
           </p>
-          
-          {/* Show error if export failed */}
-          {exportError && (
-            <div className="error-message" style={{ marginBottom: 'var(--spacing-medium)' }}>
-              <p>Fehler beim Export: {exportError}</p>
-            </div>
-          )}
           
 
           {!showSpinner && (
@@ -140,7 +143,7 @@ const SuccessScreen = ({ onReset, onEditAgain, isLoading, socialText, uploadId, 
               >
                 <FaEdit />
               </button>
-              {(exportStore.exportToken || projectId) && (
+              {(exportStore.projectId || projectId) && (
                 <button
                   className="btn-icon btn-secondary"
                   onClick={() => setShowShareModal(true)}
@@ -178,10 +181,9 @@ const SuccessScreen = ({ onReset, onEditAgain, isLoading, socialText, uploadId, 
         )}
       </div>
 
-      {showShareModal && (exportStore.exportToken || projectId) && (
+      {showShareModal && (exportStore.projectId || projectId) && (
         <ShareVideoModal
-          exportToken={exportStore.exportToken}
-          projectId={projectId}
+          projectId={exportStore.projectId || projectId}
           title={projectTitle}
           onClose={() => setShowShareModal(false)}
         />

--- a/gruenerator_frontend/src/features/subtitler/components/VideoUploader.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/VideoUploader.jsx
@@ -180,7 +180,7 @@ const VideoUploader = ({ onUpload, onBack, isProcessing = false, onCancel, proce
                 <div className="spinner" />
                 <div className="upload-text">
                   <h3>Video wird verarbeitet...</h3>
-                  <p>Die KI erstellt jetzt deine Untertitel</p>
+                  <p>Der Grünerator erstellt jetzt deine Untertitel</p>
                 </div>
               </>
             ) : (

--- a/gruenerator_frontend/src/stores/subtitlerExportStore.js
+++ b/gruenerator_frontend/src/stores/subtitlerExportStore.js
@@ -27,6 +27,7 @@ const initialState = {
   status: EXPORT_STATUS.IDLE,
   progress: 0, // 0-100
   exportToken: null,
+  projectId: null,
   error: null,
   timeRemaining: null,
   
@@ -216,6 +217,7 @@ export const useSubtitlerExportStore = create((set, get) => ({
           set({
             status: EXPORT_STATUS.COMPLETE,
             progress: 100,
+            projectId: progressData.projectId || null,
           });
           get().stopPolling();
           

--- a/gruenerator_frontend/src/stores/subtitlerShareStore.js
+++ b/gruenerator_frontend/src/stores/subtitlerShareStore.js
@@ -13,36 +13,6 @@ const initialState = {
 export const useSubtitlerShareStore = create((set, get) => ({
   ...initialState,
 
-  createShare: async (exportToken, title = null, projectId = null, expiresInDays = 7) => {
-    set({ isCreatingShare: true, error: null, errorCode: null });
-
-    try {
-      const response = await apiClient.post('/subtitler/share', {
-        exportToken,
-        title,
-        projectId,
-        expiresInDays,
-      });
-
-      if (response.data.success) {
-        const newShare = response.data.share;
-        set((state) => ({
-          isCreatingShare: false,
-          currentShare: newShare,
-          shares: [newShare, ...state.shares],
-        }));
-        return newShare;
-      } else {
-        throw new Error(response.data.error || 'Failed to create share');
-      }
-    } catch (error) {
-      const errorMessage = error.response?.data?.error || error.message || 'Failed to create share';
-      const errorCode = error.response?.data?.code || null;
-      set({ isCreatingShare: false, error: errorMessage, errorCode });
-      throw new Error(errorMessage);
-    }
-  },
-
   createShareFromProject: async (projectId, title = null, expiresInDays = 7) => {
     set({ isCreatingShare: true, error: null, errorCode: null });
 


### PR DESCRIPTION
## Summary
- Fix race condition in share functionality that caused 404 errors
- Auto-save exports as projects for reliable sharing
- Check for existing project before creating duplicates
- Remove old exportToken-based sharing, use projectId path only

## Changes
- **Backend**: Set Redis key before response, auto-create/update projects on export
- **Frontend**: Remove exportToken, only use projectId for sharing
- **Project Service**: Add `findProjectByVideoFilename` method

## Test plan
- [ ] Export a video without saving project first
- [ ] Verify project is auto-created
- [ ] Export same video again, verify existing project is updated (not duplicated)
- [ ] Click share button, verify it works without 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)