### PR TITLE
Beta features and settings updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,102 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Reusable drag-drop hook (`useDragDropFiles`) with overlay styles
+- ChatGPT-like start page layout with centered input experience
+- Mobile chat experience with full text messages in edit mode
+- Interactive generator and text improver
+- Autocomplete and platform detection hooks
+- Qdrant collections schema configuration
+- Edit mode pencil on mobile with simplified MDX editor
+- Sharepic sharing modal component with file sharing and clipboard utilities
+- Enhanced sharing features for SharedVideoPage (QR code, native Instagram share)
+- Multi-domain support for .de, .at, .eu domains
+- Export buttons restructured with native share and 3-dot menu
+- Video editor with auto-processing and Remotion integration
+- Inline ghost text tag autocomplete for template modals
+- OParl API integration and Website generator
+- Gladia transcription service
+- GrueneratorGPTIcon and mode icons
+- Interactive antrag enabled by default
+- Mistral reasoning mode for Pro Mode
+- Alttext migration to Mistral Large 3 vision
+- Auto-save exports as projects
+- Christmas campaign popup and /weihnachten route
+- Background video rendering for share links
+- Loading overlay when selecting subtitler project
+- Floating play/pause button for mobile subtitle editor
+- Video sharing with on-demand social text generation
+- New subtitler editor with project management
+- Two download buttons for subtitler (Instagram/Full quality)
+- FFmpeg process pool for concurrent video processing
+
+### Changed
+- ContentSelector simplified to popup-based selection (~450 lines removed)
+- FeatureIcons: Remove ValidationBanner and simplify (~160 lines removed)
+- BaseForm components: Update and simplify layout styles
+- Chat: Extract shared components, display results as inline messages
+- Form: Add start mode, example prompts, and input tips
+- Rename QA feature to Notebook
+- Simplify profile settings UI and merge sections
+- Sharepic generation switched from Mistral to GPT-OSS (LiteLLM)
+- Privacy mode always uses litellm (gpt-oss) provider
+- Markdown heading instructions improved for AI text generation
+- Sharepic text generation migrated from AWS Bedrock to Mistral
+- Centralize domain configuration in domainUtils.js
+- Centralize subtitler API calls with auth guards
+- Rename Reel-Grünerator to Grünerator Reel-Studio
+- Replace fluent-ffmpeg with custom wrapper
+- Convert console.log to Winston logger in routes/
+- Default subtitle height changed from standard to tief
+
+### Fixed
+- Backend: Remove privacy mode check from enableDocQnA
+- AI: Reorder fallback chain to prioritize Mistral after LiteLLM
+- Auth: Add graceful fallback for database errors during login
+- Mobile: Improve start page layout, hide edit button, fix touch targets
+- Edit mode: Fix z-index stacking, platform selector overlap
+- Form: Change validation mode to onSubmit to prevent errors during editing
+- Store: Read latest store value in getEditableText
+- Chat: Use proper assistant avatar in GrueneratorChatMessage
+- Mobile styling for ActionButtons, MDXEditor toolbar, and forms
+- Restore chatMemoryService.js accidentally deleted in refactor
+- Dark mode: Make gradient title white
+- CSP: Add Matomo domain to connectSrc, imgSrc, scriptSrc
+- AI worker: Add fallback for empty AI responses
+- Spinner sizing for primary buttons
+- CSS secondary color variable mapping
+- Subtitler: CSS naming conflicts, pixelated subtitles, race condition
+- Canva domains added to CSP img-src directive
+- Missing fetchUrl method in urlCrawlerService
+- Auth redirect loop in Reel Studio for unauthenticated users
+- Login modal layout and mobile padding
+- Mobile popups full height like Instagram stories
+- Auto-reload on chunk load failures after deployment
+- Subtitle font sizes for HD+ resolutions
+- Subtitle line breaking (balanced 50/50 split, max 4 words)
+- Subtitle vertical centering with \an5\pos
+- Video bitrate matching input file size
+- Font family names in ASS subtitle generation
+- URL sanitization for unbalanced trailing punctuation
+- ES module imports in route files
+
+### Performance
+- Subtitler style optimizations
+- Form layout optimizations
+- FFmpeg encoding with VAAPI hardware acceleration
+- Video streaming URL instead of blob download
+- Deferred video loading for faster project selection
+- Subtitle export with faster preset and ASS caching
+
+### Removed
+- E-Learning feature
+- You feature
+- Bundestag feature
+- Chat memory service (old implementation)
+- Word highlight subtitle feature
+- Wolke upload option (temporarily hidden)
+
 ## [2.5.0] - 2025-12-03
 
 ### Added

--- a/gruenerator_frontend/src/components/layout/Footer/Footer.jsx
+++ b/gruenerator_frontend/src/components/layout/Footer/Footer.jsx
@@ -53,6 +53,7 @@ const Footer = () => {
                                     <li><Link to="/support">Support</Link></li>
                                     <li><Link to="/impressum">Impressum</Link></li>
                                     <li><Link to="/datenschutz">Datenschutz</Link></li>
+                                    <li><Link to="/changelog">Changelog</Link></li>
                                     <li><a href="https://896ca129.sibforms.com/serve/MUIFAFnH3lov98jrw3d75u_DFByChA39XRS6JkBKqjTsN9gx0MxCvDn1FMnkvHLgzxEh1JBcEOiyHEkyzRC-XUO2DffKsVccZ4r7CCaYiugoiLf1a-yoTxDwoctxuzCsmDuodwrVwEwnofr7K42jQc-saIKeVuB_8UxrwS18QIaahZml1qMExNno2sEC7HyMy9Nz4f2f8-UJ4QmW" target="_blank" rel="noopener noreferrer">Newsletter</a></li>
                                 </ul>
                             </section>

--- a/gruenerator_frontend/src/components/pages/Impressum_Datenschutz_Terms/Changelog.jsx
+++ b/gruenerator_frontend/src/components/pages/Impressum_Datenschutz_Terms/Changelog.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import changelogContent from '../../../../../CHANGELOG.md?raw';
+import '../../../assets/styles/pages/Impressum_datenschutz.css';
+
+const Changelog = () => {
+  return (
+    <div className="page-container">
+      <ReactMarkdown>{changelogContent}</ReactMarkdown>
+    </div>
+  );
+};
+
+export default Changelog;

--- a/gruenerator_frontend/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.jsx
+++ b/gruenerator_frontend/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.jsx
@@ -52,6 +52,8 @@ const BETA_VIEWS = {
     CHAT: 'chat',
     GROUPS: 'groups',
     WEBSITE: 'website',
+    VORLAGEN: 'vorlagen',
+    VIDEO_EDITOR: 'videoEditor',
 };
 
 const SettingsSection = ({
@@ -170,6 +172,30 @@ const SettingsSection = ({
                     linkTo: '/website',
                     linkText: 'Zum Website Generator',
                     icon: getIcon('navigation', 'website')
+                };
+            case BETA_VIEWS.VORLAGEN:
+                return {
+                    title: 'Vorlagen & Galerie',
+                    description: 'Zugang zu deinen persönlichen Vorlagen und der öffentlichen Vorlagen-Galerie.',
+                    checked: getBetaFeatureState('vorlagen'),
+                    setter: (value) => updateUserBetaFeatures('vorlagen', value),
+                    featureName: 'Vorlagen & Galerie',
+                    checkboxLabel: 'Meine Vorlagen und Vorlagen-Galerie aktivieren',
+                    linkTo: '/profile/inhalte/vorlagen',
+                    linkText: 'Zu Meine Vorlagen',
+                    icon: HiOutlineDatabase
+                };
+            case BETA_VIEWS.VIDEO_EDITOR:
+                return {
+                    title: 'Video Editor',
+                    description: 'Volle Video-Bearbeitung im Reel-Studio: Video schneiden, Text-Overlays und Untertitel.',
+                    checked: getBetaFeatureState('videoEditor'),
+                    setter: (value) => updateUserBetaFeatures('videoEditor', value),
+                    featureName: 'Video Editor',
+                    checkboxLabel: 'Volle Video-Bearbeitung im Reel-Studio aktivieren',
+                    linkTo: '/reel',
+                    linkText: 'Zum Reel-Studio',
+                    icon: getIcon('navigation', 'reel')
                 };
             default:
                 return null;

--- a/gruenerator_frontend/src/hooks/useBetaFeatures.js
+++ b/gruenerator_frontend/src/hooks/useBetaFeatures.js
@@ -4,7 +4,7 @@ import { useBetaFeaturesStore } from '../stores/betaFeaturesStore';
 
 // Beta features configuration - single source of truth
 const BETA_FEATURES_CONFIG = [
-  { key: 'sharepic', label: 'Sharepic', isAdminOnly: false },
+  { key: 'sharepic', label: 'Sharepic', isAdminOnly: false, devOnly: true },
   { key: 'aiSharepic', label: 'KI-Sharepic', isAdminOnly: false, devOnly: true },
   { key: 'groups', label: 'Gruppen', isAdminOnly: false, devOnly: true },
   { key: 'vorlagen', label: 'Vorlagen & Galerie', isAdminOnly: false, devOnly: true },
@@ -12,7 +12,7 @@ const BETA_FEATURES_CONFIG = [
   { key: 'notebook', label: 'Notebooks', isAdminOnly: false },
   // { key: 'canva', label: 'Canva Integration', isAdminOnly: false },
   { key: 'chat', label: 'Grünerator Chat', isAdminOnly: false, devOnly: true },
-  { key: 'sites', label: 'Web-Visitenkarte', isAdminOnly: false, devOnly: true },
+  // { key: 'sites', label: 'Web-Visitenkarte', isAdminOnly: false, devOnly: true }, // Removed - outdated
   { key: 'website', label: 'Website Generator', isAdminOnly: false, devOnly: true },
   { key: 'interactiveAntrag', label: 'Interaktiver Antrag', isAdminOnly: false, defaultEnabled: true },
   { key: 'autoSaveOnExport', label: 'Auto-Speichern bei Export', isAdminOnly: false },


### PR DESCRIPTION
## Summary
- Add vorlagen as dev-only beta feature
- Add videoEditor as toggleable beta feature  
- Update Labor settings with new beta feature toggles
- Make sharepic dev-only
- Remove outdated sites feature

## Recent commits
- refactor(beta): Update Labor settings and beta feature configs
- feat(beta): Add videoEditor as toggleable beta feature
- feat(beta): Add vorlagen as dev-only beta feature

## Test plan
- [ ] Verify vorlagen is hidden in production, visible in dev
- [ ] Verify videoEditor toggle appears in Labor settings
- [ ] Verify full-edit mode in Reel shows only when videoEditor enabled
- [ ] Verify sharepic is dev-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)