### PR TITLE
feat(mobile): Enable edit mode on mobile devices

### DIFF
--- a/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
+++ b/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
@@ -8,7 +8,7 @@
   width: 100vw;
   height: calc(100vh - 60px);
   background-color: var(--background-color-pure);
-  z-index: 1500;
+  z-index: 9990;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -52,7 +52,7 @@
   border-radius: var(--card-border-radius-large);
   box-shadow: var(--shadow-lg);
   padding: var(--spacing-small);
-  z-index: 1600;
+  z-index: 9995;
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   display: flex;
@@ -384,15 +384,25 @@ body:has(.base-container.edit-mode-active) .container.with-header {
     margin: var(--spacing-xxsmall);
   }
 
+  .edit-result-content {
+    padding-top: var(--spacing-xlarge);
+  }
+
   .edit-result-text {
     font-size: 0.95rem;
     max-height: 50vh;
   }
 
   /* Mobile button sizing for edit actions */
+  .chat-message.edit-result-message > .edit-message-actions {
+    top: var(--spacing-xsmall);
+    right: var(--spacing-xsmall);
+    gap: var(--spacing-xsmall);
+  }
+
   .chat-message.edit-result-message > .edit-message-actions button {
     font-size: var(--font-size-small);
-    padding: var(--spacing-xxsmall) var(--spacing-xsmall);
+    padding: var(--spacing-xsmall);
   }
 }
 

--- a/gruenerator_frontend/src/components/common/ActionButtons.jsx
+++ b/gruenerator_frontend/src/components/common/ActionButtons.jsx
@@ -314,7 +314,7 @@ const ActionButtons = ({
           {getIcon('actions', 'refresh')({ size: 16 })}
         </button>
       ),
-      edit: !isMobileView && showEditMode && activeContent && (onRequestEdit || onEditModeToggle) && (
+      edit: showEditMode && activeContent && (onRequestEdit || onEditModeToggle) && (
         <button
           key="edit"
           onClick={() => {

--- a/gruenerator_frontend/src/components/common/Chat/ChatUI.css
+++ b/gruenerator_frontend/src/components/common/Chat/ChatUI.css
@@ -130,6 +130,7 @@
 .chat-messages-fullscreen .chat-message.assistant {
   background: var(--white);
   color: var(--font-color);
+  border-radius: var(--card-border-radius-medium);
 }
 
 .chat-messages-fullscreen .chat-message.assistant p,
@@ -812,7 +813,13 @@
 
 @media (max-width: 768px) {
   .chat-messages {
-    padding: 16px 16px 120px 16px;
+    padding: var(--spacing-small) var(--spacing-medium) var(--spacing-large) var(--spacing-medium);
+  }
+
+  /* Better readability on mobile - 16px minimum, 1.6 line-height */
+  .chat-message.assistant p {
+    font-size: 1rem;
+    line-height: 1.6;
   }
 
   /* Fullscreen mode mobile adjustments - remove excessive left space */

--- a/gruenerator_frontend/src/components/common/Form/BaseForm/FormSection.jsx
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/FormSection.jsx
@@ -216,8 +216,8 @@ const FormSection = forwardRef(({
           onSubmit();
         }} className="form-section__form">
           
-          {/* Mobile: firstExtrasChildren above everything (except in start mode where it goes in extras section) */}
-          {isMobileView && firstExtrasChildren && !isStartMode && (
+          {/* Mobile: firstExtrasChildren above everything (except in start mode or edit mode) */}
+          {isMobileView && firstExtrasChildren && !isStartMode && !useEditMode && (
             <div className="form-section__mobile-first-extras">
               {firstExtrasChildren}
             </div>


### PR DESCRIPTION
## Summary
- Enable edit button on mobile devices (previously hidden)
- Hide platform selector dropdown when in mobile edit mode for cleaner UI
- Fix z-index hierarchy so edit mode overlay appears above react-select controls
- Improve mobile chat readability with 16px font and 1.6 line-height
- Add rounded corners to fullscreen assistant messages
- Optimize mobile spacing with CSS variables

## Test plan
- [ ] Open /presse-social on mobile viewport
- [ ] Generate text and verify edit button is visible
- [ ] Enter edit mode and verify platform dropdown is hidden
- [ ] Verify chat messages are readable with improved typography
- [ ] Test z-index by interacting with dropdowns in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)