### PR TITLE
feat(mobile): Scroll to top when entering edit mode

### DIFF
--- a/gruenerator_frontend/src/components/common/Form/BaseForm/BaseForm.jsx
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/BaseForm.jsx
@@ -502,6 +502,13 @@ const BaseFormInternal = ({
     getDisplayTitle
   } = useResponsive();
 
+  // Scroll to top when edit mode is activated on mobile
+  React.useEffect(() => {
+    if (isEditModeActive && isMobileView) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [isEditModeActive, isMobileView]);
+
   // Enhanced accessibility hook with Phase 5 features
   const { 
     setupKeyboardNav, 


### PR DESCRIPTION
## Summary
- Add smooth scroll-to-top behavior when user activates edit mode on mobile
- Improves UX by ensuring user sees the edit interface from the top

## Test plan
- [ ] Open generator page on mobile viewport
- [ ] Generate content and click edit button
- [ ] Verify page scrolls smoothly to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)