### PR TITLE
feat(mobile-edit): Add close button and fix z-index for mobile edit mode

### DIFF
--- a/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
+++ b/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
@@ -309,11 +309,20 @@ body:has(.base-container.edit-mode-active) .container.with-header {
 
 /* Mobile chat container - simple wrapper, ChatWorkbenchLayout handles layout */
 .universal-edit-form.mobile-chat {
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   width: 100%;
-  min-height: calc(100vh - 60px);
-  min-height: calc(100dvh - 60px);
+  z-index: 9990;
+  padding-top: var(--spacing-xlarge);
   background: var(--background-color);
+}
+
+/* Override form-section stacking context to allow mobile edit mode to appear above header */
+.form-section:has(.universal-edit-form.mobile-chat) {
+  z-index: 9980;
 }
 
 /* Edit result message styling */
@@ -406,4 +415,40 @@ body:has(.base-container.edit-mode-active) .container.with-header {
   }
 }
 
+/* Mobile Edit Close Button */
+.mobile-edit-close-button {
+  position: fixed;
+  top: var(--spacing-medium);
+  right: var(--spacing-medium);
+  z-index: 9995;
+  background-color: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--font-color);
+  box-shadow: var(--shadow-md);
+  transition: transform 0.15s ease, background-color 0.15s ease;
+}
 
+.mobile-edit-close-button:hover {
+  background-color: var(--background-color-hover);
+  transform: scale(1.05);
+}
+
+.mobile-edit-close-button:active {
+  transform: scale(0.95);
+}
+
+[data-theme="dark"] .mobile-edit-close-button {
+  background-color: var(--dunkelgrau);
+  border-color: var(--border-color);
+}
+
+[data-theme="dark"] .mobile-edit-close-button:hover {
+  background-color: var(--mittelgrau);
+}

--- a/gruenerator_frontend/src/components/common/Form/BaseForm/BaseForm.jsx
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/BaseForm.jsx
@@ -810,6 +810,7 @@ const BaseFormInternal = ({
                 componentName={componentName}
                 onWebSearchInfoClick={handleWebSearchInfoClick}
                 useEditMode={isEditModeActive}
+                onCloseEditMode={handleToggleEditMode}
                 isImageEditActive={isImageEditActive}
                 customEditContent={customEditContent}
                 registerEditHandler={(fn) => { editSubmitHandlerRef.current = fn; }}

--- a/gruenerator_frontend/src/components/common/Form/BaseForm/FormSection.jsx
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/FormSection.jsx
@@ -104,6 +104,7 @@ const FormSection = forwardRef(({
   onWebSearchInfoClick,
   componentName,
   useEditMode = false,
+  onCloseEditMode = null,
   isImageEditActive = false,
   registerEditHandler = null,
   enableKnowledgeSelector = false,
@@ -252,7 +253,7 @@ const FormSection = forwardRef(({
               {isImageEditActive ? (
                 customEditContent
               ) : useEditMode ? (
-                <UniversalEditForm componentName={componentName} />
+                <UniversalEditForm componentName={componentName} onClose={onCloseEditMode} />
               ) : (
                 children
               )}
@@ -370,6 +371,7 @@ FormSection.propTypes = {
   documentSelectorTabIndex: PropTypes.number,
   submitButtonTabIndex: PropTypes.number,
   useEditMode: PropTypes.bool,
+  onCloseEditMode: PropTypes.func,
   isStartMode: PropTypes.bool,
   startPageDescription: PropTypes.string,
   examplePrompts: PropTypes.arrayOf(PropTypes.shape({

--- a/gruenerator_frontend/src/components/common/Form/EditMode/UniversalEditForm.jsx
+++ b/gruenerator_frontend/src/components/common/Form/EditMode/UniversalEditForm.jsx
@@ -14,9 +14,10 @@ import useHeaderStore from '../../../../stores/headerStore';
 import useResponsive from '../hooks/useResponsive';
 import ActionButtons from '../../ActionButtons';
 import ReactMarkdown from 'react-markdown';
+import { IoClose } from 'react-icons/io5';
 import '../../../../assets/styles/components/edit-mode/edit-mode-overlay.css';
 
-const UniversalEditForm = ({ componentName }) => {
+const UniversalEditForm = ({ componentName, onClose }) => {
   const { getEditableText, applyEdits } = useTextEditActions(componentName);
   const storeContent = useGeneratedTextStore(state => state.generatedTexts[componentName] || null);
 
@@ -342,6 +343,15 @@ const UniversalEditForm = ({ componentName }) => {
   if (stableIsMobileView) {
     return (
       <div className="universal-edit-form mobile-chat">
+        {onClose && (
+          <button
+            className="mobile-edit-close-button"
+            onClick={onClose}
+            aria-label="Edit Mode schließen"
+          >
+            <IoClose size={24} />
+          </button>
+        )}
         <ChatWorkbenchLayout
           mode="chat"
           modes={{ chat: { label: 'Edit' } }}
@@ -403,7 +413,8 @@ const UniversalEditForm = ({ componentName }) => {
 };
 
 UniversalEditForm.propTypes = {
-  componentName: PropTypes.string.isRequired
+  componentName: PropTypes.string.isRequired,
+  onClose: PropTypes.func
 };
 
 export default UniversalEditForm;


### PR DESCRIPTION
## Summary
- Add close button (X) to mobile edit mode overlay for easy exit
- Fix z-index stacking context issue where header was appearing above edit overlay
- Make mobile edit form full-screen fixed overlay with proper z-index (9990)
- Add top padding for better spacing in mobile edit view

## Test plan
- [ ] Open presse-social on mobile viewport
- [ ] Generate text and enter edit mode
- [ ] Verify close button appears in top-right corner
- [ ] Verify edit overlay covers the entire screen including header
- [ ] Verify close button closes edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)