### PR TITLE
Mobile improvements, edit mode, and presse-social updates

### DIFF
--- a/gruenerator_frontend/src/assets/styles/components/baseform/start-page.css
+++ b/gruenerator_frontend/src/assets/styles/components/baseform/start-page.css
@@ -160,13 +160,13 @@
 
 @media (max-width: 768px) {
   /* Container mobile adjustments */
-  .base-container--start-mode {
+  .base-container.base-container--start-mode {
     padding: var(--spacing-small);
-    padding-top: 4vh;
-    gap: var(--spacing-large);
+    padding-top: 2vh;
+    gap: var(--spacing-medium);
   }
 
-  .base-container--start-mode .form-section-motion-wrapper {
+  .base-container.base-container--start-mode .form-section-motion-wrapper {
     max-width: 100%;
   }
 
@@ -196,9 +196,20 @@
    =========================================== */
 
 @media (max-width: 480px) {
+  /* Remove min-height on content wrapper for start mode on phones */
+  .content-wrapper:has(.base-container--start-mode) {
+    min-height: auto;
+  }
+
+  .base-container.base-container--start-mode {
+    padding-top: var(--spacing-small);
+    gap: var(--spacing-small);
+  }
+
   .form-card--start-mode {
-    border-radius: 16px;
+    border-radius: 16px 16px 0 0;
     border: var(--border-subtle);
+    border-bottom: none;
     box-shadow: var(--shadow-md);
   }
 }

--- a/gruenerator_frontend/src/assets/styles/components/baseform/start-page.css
+++ b/gruenerator_frontend/src/assets/styles/components/baseform/start-page.css
@@ -122,14 +122,12 @@
 
 .form-section__start-title {
   text-align: left;
-  color: var(--tanne);
   font-size: 1.5rem;
   font-weight: 600;
   margin-bottom: var(--spacing-small);
 }
 
 .form-section__start-description {
-  color: var(--text-secondary);
   font-size: 1rem;
   line-height: 1.5;
   max-width: 100%;

--- a/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
+++ b/gruenerator_frontend/src/assets/styles/components/edit-mode/edit-mode-overlay.css
@@ -104,6 +104,9 @@
     top: var(--spacing-medium);
     right: var(--spacing-medium);
     left: auto;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background-color: var(--background-color);
   }
 
   .edit-mode-floating-input {
@@ -315,6 +318,11 @@ body:has(.base-container.edit-mode-active) .container.with-header {
   right: 0;
   bottom: 0;
   width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   z-index: 9990;
   padding-top: var(--spacing-xlarge);
   background: var(--background-color);
@@ -358,9 +366,6 @@ body:has(.base-container.edit-mode-active) .container.with-header {
   font-size: var(--font-size-md, 1rem);
   line-height: 1.6;
   white-space: pre-wrap;
-  max-height: 60vh;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 /* Scrollbar styling for edit result text */

--- a/gruenerator_frontend/src/assets/styles/components/ui/react-select.css
+++ b/gruenerator_frontend/src/assets/styles/components/ui/react-select.css
@@ -678,6 +678,100 @@
   .form-section--start-mode .react-select__value-container {
     padding: 0 0 0 var(--spacing-small) !important;
   }
+
+  .form-section--start-mode .react-select__multi-value {
+    border-radius: 10px !important;
+    margin: 1px 2px 1px 0 !important;
+  }
+
+  .form-section--start-mode .react-select__multi-value__label-wrapper {
+    padding: 2px;
+    padding-left: 6px;
+  }
+
+  .form-section--start-mode .react-select__multi-value__icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  .form-section--start-mode .react-select__multi-value__remove {
+    position: relative;
+    padding: 0 4px !important;
+    min-width: 22px;
+    min-height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Expanded touch target for tablet */
+  .form-section--start-mode .react-select__multi-value__remove::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 40px;
+    height: 40px;
+  }
+
+  /* Visual feedback on touch */
+  .form-section--start-mode .react-select__multi-value__remove:active {
+    background-color: var(--hover-color-alt) !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .form-section--start-mode .react-select__multi-value {
+    border-radius: 8px !important;
+    margin: 1px 1px 1px 0 !important;
+    border-width: 0.5px !important;
+  }
+
+  .form-section--start-mode .react-select__multi-value__label-wrapper {
+    padding: 1px;
+    padding-left: 4px;
+  }
+
+  .form-section--start-mode .react-select__multi-value__icon {
+    width: 14px;
+    height: 14px;
+  }
+
+  .form-section--start-mode .react-select__multi-value__remove {
+    position: relative;
+    padding: 0 4px !important;
+    border-radius: 0 8px 8px 0 !important;
+    min-width: 20px;
+    min-height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Invisible expanded touch target (44x44px WCAG minimum) */
+  .form-section--start-mode .react-select__multi-value__remove::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+  }
+
+  /* Visual feedback on touch */
+  .form-section--start-mode .react-select__multi-value__remove:active {
+    background-color: var(--hover-color-alt) !important;
+    opacity: 0.8;
+  }
+
+  .form-section--start-mode .react-select__multi-value__remove svg {
+    width: 12px;
+    height: 12px;
+  }
 }
 
 body > .react-select__menu-portal {

--- a/gruenerator_frontend/src/components/common/Chat/ChatUI.css
+++ b/gruenerator_frontend/src/components/common/Chat/ChatUI.css
@@ -99,6 +99,7 @@
   scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
   min-height: 0;
   height: 100%;
+  contain: layout;
 }
 
 /* Dossier mode: messages don't scroll individually - parent panel scrolls */

--- a/gruenerator_frontend/src/components/common/Form/BaseForm/ExamplePrompts.css
+++ b/gruenerator_frontend/src/components/common/Form/BaseForm/ExamplePrompts.css
@@ -36,6 +36,9 @@
 
 .example-prompts__icon {
   font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .example-prompts__text {

--- a/gruenerator_frontend/src/features/texte/presse/PresseSocialGenerator.jsx
+++ b/gruenerator_frontend/src/features/texte/presse/PresseSocialGenerator.jsx
@@ -106,7 +106,7 @@ const PresseSocialGenerator = ({ showHeaderFooter = true }) => {
     instructionType: 'social',
     features: ['webSearch', 'privacyMode', 'proMode'],
     tabIndexKey: 'PRESS_SOCIAL',
-    defaultMode: 'privacy',
+    defaultMode: 'balanced',
     disableKnowledgeSystem: false  // Enable knowledge system for document/text fetching
   });
 

--- a/gruenerator_frontend/src/features/texte/presse/SharepicConfigPopup.css
+++ b/gruenerator_frontend/src/features/texte/presse/SharepicConfigPopup.css
@@ -1,0 +1,121 @@
+.sharepic-config-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xsmall);
+  background: var(--background-color-alt);
+  border: var(--border-subtle);
+  border-radius: var(--card-border-radius-small);
+  cursor: pointer;
+  color: var(--font-color-disabled);
+  transition: var(--input-transition);
+}
+
+.sharepic-config-button:hover {
+  background: var(--hover-color-alt);
+  color: var(--font-color);
+}
+
+.sharepic-config-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: var(--spacing-medium);
+}
+
+.sharepic-config-modal {
+  background: var(--card-background);
+  border-radius: var(--card-border-radius-large);
+  border: var(--border-subtle);
+  box-shadow: var(--shadow-lg);
+  width: 100%;
+  max-width: 420px;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.sharepic-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-medium);
+  border-bottom: var(--border-subtle);
+}
+
+.sharepic-config-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--font-color);
+}
+
+.sharepic-config-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  border-radius: var(--card-border-radius-small);
+  color: var(--font-color-disabled);
+  cursor: pointer;
+  transition: var(--input-transition);
+}
+
+.sharepic-config-close:hover {
+  background: var(--background-color-alt);
+  color: var(--font-color);
+}
+
+.sharepic-config-content {
+  padding: var(--spacing-medium);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.sharepic-config-footer {
+  padding: var(--spacing-medium);
+  border-top: var(--border-subtle);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.sharepic-config-done {
+  padding: var(--spacing-xsmall) var(--spacing-medium);
+  background: var(--klee);
+  color: var(--white);
+  border: none;
+  border-radius: var(--card-border-radius-small);
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--input-transition);
+}
+
+.sharepic-config-done:hover {
+  background: var(--primary-700);
+}
+
+@media (max-width: 480px) {
+  .sharepic-config-overlay {
+    padding: var(--spacing-small);
+    align-items: flex-end;
+  }
+
+  .sharepic-config-modal {
+    max-width: 100%;
+    border-radius: var(--card-border-radius-large) var(--card-border-radius-large) 0 0;
+    max-height: 80vh;
+  }
+}

--- a/gruenerator_frontend/src/features/texte/presse/SharepicConfigPopup.jsx
+++ b/gruenerator_frontend/src/features/texte/presse/SharepicConfigPopup.jsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'motion/react';
+import { Controller } from 'react-hook-form';
+import ReactSelect from 'react-select';
+import { HiX } from 'react-icons/hi';
+import FormFieldWrapper from '../../../components/common/Form/Input/FormFieldWrapper';
+import SmartInput from '../../../components/common/Form/SmartInput';
+import FileUpload from '../../../components/common/FileUpload';
+import './SharepicConfigPopup.css';
+
+const SharepicConfigPopup = ({
+  isOpen,
+  onClose,
+  control,
+  setValue,
+  getValues,
+  sharepicTypeOptions,
+  watchSharepicType,
+  uploadedImage,
+  handleImageChange,
+  loading,
+  success
+}) => {
+  if (!isOpen) return null;
+
+  const showAuthorField = watchSharepicType === 'quote' || watchSharepicType === 'quote_pure';
+  const showImageUpload = watchSharepicType === 'dreizeilen' || watchSharepicType === 'quote';
+
+  const modalContent = (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="sharepic-config-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        >
+          <motion.div
+            className="sharepic-config-modal"
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: "spring", stiffness: 300, damping: 25 }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="sharepic-config-header">
+              <h3>Sharepic konfigurieren</h3>
+              <button
+                type="button"
+                className="sharepic-config-close"
+                onClick={onClose}
+                aria-label="Schließen"
+              >
+                <HiX size={20} />
+              </button>
+            </div>
+
+            <div className="sharepic-config-content">
+              <Controller
+                name="sharepicType"
+                control={control}
+                rules={{}}
+                defaultValue="default"
+                render={({ field, fieldState: { error } }) => (
+                  <FormFieldWrapper
+                    label="Sharepic Art"
+                    required={false}
+                    error={error?.message}
+                    htmlFor="sharepicType-select-popup"
+                  >
+                    <ReactSelect
+                      {...field}
+                      inputId="sharepicType-select-popup"
+                      className={`react-select ${error ? 'error' : ''}`.trim()}
+                      classNamePrefix="react-select"
+                      options={sharepicTypeOptions}
+                      value={sharepicTypeOptions.find(option => option.value === field.value)}
+                      onChange={(selectedOption) => {
+                        field.onChange(selectedOption ? selectedOption.value : '');
+                      }}
+                      onBlur={field.onBlur}
+                      placeholder="Sharepic Art auswählen..."
+                      isClearable={false}
+                      isSearchable={false}
+                      noOptionsMessage={() => 'Keine Optionen verfügbar'}
+                      menuPortalTarget={document.body}
+                      menuPosition="fixed"
+                      styles={{
+                        menuPortal: (base) => ({ ...base, zIndex: 10001 })
+                      }}
+                    />
+                  </FormFieldWrapper>
+                )}
+              />
+
+              <AnimatePresence>
+                {showAuthorField && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <SmartInput
+                      fieldType="zitatAuthor"
+                      formName="presseSocial"
+                      name="zitatAuthor"
+                      control={control}
+                      setValue={setValue}
+                      getValues={getValues}
+                      label="Autor/Urheber des Zitats"
+                      placeholder="z.B. Anton Hofreiter"
+                      rules={{ required: 'Autor ist für Zitat-Sharepics erforderlich' }}
+                      onSubmitSuccess={success ? getValues('zitatAuthor') : null}
+                      shouldSave={success}
+                    />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              <AnimatePresence>
+                {showImageUpload && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <FileUpload
+                      handleChange={handleImageChange}
+                      allowedTypes={['.jpg', '.jpeg', '.png', '.webp']}
+                      file={uploadedImage}
+                      loading={loading}
+                      label="Bild für Sharepic (optional)"
+                    />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            <div className="sharepic-config-footer">
+              <button
+                type="button"
+                className="sharepic-config-done"
+                onClick={onClose}
+              >
+                Fertig
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+
+  return createPortal(modalContent, document.body);
+};
+
+export default SharepicConfigPopup;


### PR DESCRIPTION
## Summary
- Mobile edit mode with improved touch targets and performance
- Start page layout improvements for mobile and desktop
- Presse-social generator enhancements with mobile-optimized example prompts
- Default AI mode switched from privacy to kreativ (Mistral Medium)
- Theme color fixes for better dark/light mode support
- Auth fix for multi-domain session handling

## Key Changes
- **Mobile Edit Mode**: New edit experience with close button, fixed z-index stacking, scroll-to-top behavior
- **Performance**: Fixed scrolling lag and improved mobile edit performance
- **Presse-Social**: Added mobile-optimized example prompts and sharepic config popup
- **Default Mode**: Changed default from Gruenerator-GPT to Kreativ (Mistral Medium)
- **Styling**: Removed hardcoded colors for better theme consistency

## Test plan
- [ ] Test mobile edit mode on iOS and Android
- [ ] Verify start page layout on various screen sizes
- [ ] Check presse-social generator with different platforms selected
- [ ] Confirm default mode shows "Kreativ" on first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)