### PR TITLE
feat(imagine): add chat imagine generation service

### DIFF
--- a/gruenerator_backend/routes/chat/services/imagineGenerationService.js
+++ b/gruenerator_backend/routes/chat/services/imagineGenerationService.js
@@ -1,0 +1,431 @@
+/**
+ * Imagine Generation Service for Chat Integration
+ * Handles FLUX AI image generation from chat messages
+ * Supports three modes: pure, sharepic (with title), and edit (image-to-image)
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { createLogger } = require('../../../utils/logger.js');
+const log = createLogger('imagineGenService');
+
+// Dynamic imports for ESM modules
+let FluxImageService = null;
+const { buildFluxPrompt, VARIANTS } = require('../../../services/fluxPromptBuilder');
+const { composeImagineCreate, OUTPUT_WIDTH, OUTPUT_HEIGHT } = require('../../../services/imagineCanvasService');
+const { addKiLabel } = require('../../sharepic/sharepic_canvas/imagine_label_canvas');
+const ImageGenerationCounter = require('../../../utils/imageGenerationCounter');
+const redisClient = require('../../../utils/redisClient');
+
+const imageCounter = new ImageGenerationCounter(redisClient);
+
+// Initialize FluxImageService lazily
+async function getFluxImageService() {
+  if (!FluxImageService) {
+    const module = await import('../../../services/fluxImageService.mjs');
+    FluxImageService = module.default;
+  }
+  return new FluxImageService();
+}
+
+/**
+ * Main entry point for imagine generation from chat
+ * @param {Object} expressReq - Express request object
+ * @param {string} mode - Generation mode: 'pure', 'sharepic', or 'edit'
+ * @param {Object} requestBody - Request parameters
+ * @returns {Object} Generation result
+ */
+async function generateImagineForChat(expressReq, mode, requestBody) {
+  const userId = expressReq.user?.id;
+
+  log.debug('[ImagineGeneration] Starting generation:', {
+    mode,
+    userId,
+    hasSubject: !!requestBody.subject,
+    hasVariant: !!requestBody.variant,
+    hasTitle: !!requestBody.title
+  });
+
+  // Check rate limit
+  const limitStatus = await imageCounter.checkLimit(userId);
+  if (!limitStatus.canGenerate) {
+    log.debug('[ImagineGeneration] Rate limit reached for user:', userId);
+    return {
+      success: false,
+      error: 'Daily image generation limit reached',
+      agent: 'imagine',
+      content: {
+        text: `Du hast dein tägliches Limit von ${limitStatus.limit} Bildern erreicht. Versuche es morgen wieder.`,
+        type: 'rate_limit'
+      },
+      usage: limitStatus
+    };
+  }
+
+  try {
+    switch (mode) {
+      case 'pure':
+        return await generatePureImage(expressReq, requestBody);
+      case 'sharepic':
+        return await generateSharepicImage(expressReq, requestBody);
+      case 'edit':
+        return await generateEditImage(expressReq, requestBody);
+      default:
+        throw new Error(`Unknown imagine mode: ${mode}`);
+    }
+  } catch (error) {
+    log.error('[ImagineGeneration] Generation error:', error);
+    return {
+      success: false,
+      agent: 'imagine',
+      content: {
+        text: `Fehler bei der Bilderzeugung: ${error.message || 'Unbekannter Fehler'}`,
+        type: 'error'
+      },
+      error: error.message
+    };
+  }
+}
+
+/**
+ * Generate a pure image (text-to-image without title overlay)
+ */
+async function generatePureImage(expressReq, requestBody) {
+  const { subject, variant = 'illustration-pure' } = requestBody;
+  const userId = expressReq.user?.id;
+
+  log.debug('[ImagineGeneration] Generating pure image:', { subject: subject?.substring(0, 50), variant });
+
+  // Ensure we have a pure variant
+  const pureVariant = ensurePureVariant(variant);
+
+  // Build prompt using fluxPromptBuilder
+  const { prompt, dimensions } = buildFluxPrompt({
+    variant: pureVariant,
+    subject: subject
+  });
+
+  log.debug('[ImagineGeneration] Built prompt:', { prompt: prompt.substring(0, 100), dimensions });
+
+  // Generate image with FLUX
+  const flux = await getFluxImageService();
+  const { stored } = await flux.generateFromPrompt(prompt, {
+    width: dimensions.width,
+    height: dimensions.height,
+    output_format: 'jpeg',
+    safety_tolerance: 2
+  });
+
+  // Add KI label
+  const imageBuffer = fs.readFileSync(stored.filePath);
+  const labeledBuffer = await addKiLabel(imageBuffer);
+
+  // Save labeled image
+  const savedPath = await saveGeneratedImage(labeledBuffer, 'pure');
+
+  // Increment counter
+  const usageStatus = await imageCounter.incrementCount(userId);
+
+  const base64 = `data:image/png;base64,${labeledBuffer.toString('base64')}`;
+  const variantName = VARIANTS[pureVariant]?.name || pureVariant;
+
+  log.debug('[ImagineGeneration] Pure image generated successfully');
+
+  return {
+    success: true,
+    agent: 'imagine_pure',
+    content: {
+      text: `Hier ist dein generiertes Bild im Stil "${variantName}".`,
+      type: 'imagine',
+      sharepic: {
+        image: base64,
+        type: 'imagine_pure'
+      },
+      metadata: {
+        mode: 'pure',
+        variant: pureVariant,
+        prompt: prompt,
+        dimensions: dimensions
+      }
+    },
+    usage: {
+      count: usageStatus.count,
+      remaining: usageStatus.remaining,
+      limit: usageStatus.limit
+    }
+  };
+}
+
+/**
+ * Generate a sharepic image (text-to-image with title overlay)
+ */
+async function generateSharepicImage(expressReq, requestBody) {
+  const { subject, title, variant = 'light-top' } = requestBody;
+  const userId = expressReq.user?.id;
+
+  log.debug('[ImagineGeneration] Generating sharepic image:', {
+    subject: subject?.substring(0, 50),
+    title: title?.substring(0, 30),
+    variant
+  });
+
+  // Ensure variant supports title overlay (non-pure)
+  const sharepicVariant = ensureSharepicVariant(variant);
+
+  // Build prompt
+  const { prompt, dimensions } = buildFluxPrompt({
+    variant: sharepicVariant,
+    subject: subject
+  });
+
+  // Generate base image with dimensions suitable for sharepic composition
+  const flux = await getFluxImageService();
+  const { stored } = await flux.generateFromPrompt(prompt, {
+    width: 768,  // FLUX_WIDTH for sharepic
+    height: 960, // FLUX_HEIGHT for sharepic
+    output_format: 'jpeg',
+    safety_tolerance: 2
+  });
+
+  const fluxImageBuffer = fs.readFileSync(stored.filePath);
+
+  // Compose with title overlay using imagineCanvasService
+  const composedBuffer = await composeImagineCreate(fluxImageBuffer, {
+    title: title,
+    variant: sharepicVariant
+  });
+
+  // Add KI label
+  const labeledBuffer = await addKiLabel(composedBuffer);
+
+  // Save labeled image
+  const savedPath = await saveGeneratedImage(labeledBuffer, 'sharepic');
+
+  // Increment counter
+  const usageStatus = await imageCounter.incrementCount(userId);
+
+  const base64 = `data:image/png;base64,${labeledBuffer.toString('base64')}`;
+
+  log.debug('[ImagineGeneration] Sharepic image generated successfully');
+
+  return {
+    success: true,
+    agent: 'imagine_sharepic',
+    content: {
+      text: `Hier ist dein KI-Sharepic mit dem Titel "${title}".`,
+      type: 'imagine',
+      sharepic: {
+        image: base64,
+        type: 'imagine_sharepic',
+        title: title
+      },
+      metadata: {
+        mode: 'sharepic',
+        variant: sharepicVariant,
+        title: title,
+        dimensions: { width: OUTPUT_WIDTH, height: OUTPUT_HEIGHT }
+      }
+    },
+    usage: {
+      count: usageStatus.count,
+      remaining: usageStatus.remaining,
+      limit: usageStatus.limit
+    }
+  };
+}
+
+/**
+ * Generate an edited image (image-to-image transformation)
+ */
+async function generateEditImage(expressReq, requestBody) {
+  const { action, variant = 'realistic-pure' } = requestBody;
+  const userId = expressReq.user?.id;
+
+  log.debug('[ImagineGeneration] Generating edit image:', {
+    action: action?.substring(0, 50),
+    variant
+  });
+
+  // Get uploaded image from SharepicImageManager
+  const sharepicImageManager = expressReq.app?.locals?.sharepicImageManager;
+  const requestId = requestBody.sharepicRequestId;
+
+  let imageAttachment = null;
+  if (sharepicImageManager && requestId) {
+    imageAttachment = await sharepicImageManager.retrieveAndConsume(requestId);
+  }
+
+  // Fallback to attachments array
+  if (!imageAttachment && requestBody.attachments) {
+    imageAttachment = requestBody.attachments.find(a => a.type?.startsWith('image/'));
+  }
+
+  if (!imageAttachment) {
+    return {
+      success: false,
+      agent: 'imagine_edit',
+      content: {
+        text: 'Für die Bildbearbeitung benötige ich ein Bild. Bitte lade ein Bild hoch und beschreibe, wie es transformiert werden soll.',
+        type: 'error'
+      }
+    };
+  }
+
+  // Build edit prompt
+  const editPrompt = buildEditPrompt(action, variant);
+
+  // Convert attachment to buffer
+  const imageBuffer = extractBufferFromAttachment(imageAttachment);
+
+  log.debug('[ImagineGeneration] Processing image-to-image:', {
+    promptLength: editPrompt.length,
+    imageSize: imageBuffer.length
+  });
+
+  // Generate edited image using image-to-image
+  const flux = await getFluxImageService();
+  const { stored } = await flux.generateFromImage(
+    editPrompt,
+    imageBuffer,
+    imageAttachment.type || 'image/jpeg',
+    { output_format: 'jpeg', safety_tolerance: 2 }
+  );
+
+  // Add KI label
+  const resultBuffer = fs.readFileSync(stored.filePath);
+  const labeledBuffer = await addKiLabel(resultBuffer);
+
+  // Save labeled image
+  await saveGeneratedImage(labeledBuffer, 'edit');
+
+  // Increment counter
+  const usageStatus = await imageCounter.incrementCount(userId);
+
+  const base64 = `data:image/png;base64,${labeledBuffer.toString('base64')}`;
+
+  log.debug('[ImagineGeneration] Edit image generated successfully');
+
+  return {
+    success: true,
+    agent: 'imagine_edit',
+    content: {
+      text: 'Hier ist dein transformiertes Bild.',
+      type: 'imagine',
+      sharepic: {
+        image: base64,
+        type: 'imagine_edit'
+      },
+      metadata: {
+        mode: 'edit',
+        action: action
+      }
+    },
+    usage: {
+      count: usageStatus.count,
+      remaining: usageStatus.remaining,
+      limit: usageStatus.limit
+    }
+  };
+}
+
+/**
+ * Ensure variant is a pure variant (full image without reserved space)
+ */
+function ensurePureVariant(variant) {
+  const pureVariants = ['illustration-pure', 'realistic-pure', 'pixel-pure', 'editorial-pure'];
+  if (pureVariants.includes(variant)) return variant;
+
+  // Map non-pure to pure
+  const mapping = {
+    'light-top': 'illustration-pure',
+    'green-bottom': 'illustration-pure',
+    'realistic-top': 'realistic-pure',
+    'realistic-bottom': 'realistic-pure',
+    'pixel-top': 'pixel-pure',
+    'pixel-bottom': 'pixel-pure',
+    'editorial': 'editorial-pure',
+    'illustration': 'illustration-pure',
+    'realistisch': 'realistic-pure',
+    'pixel': 'pixel-pure'
+  };
+
+  return mapping[variant] || 'illustration-pure';
+}
+
+/**
+ * Ensure variant supports title overlay (non-pure)
+ */
+function ensureSharepicVariant(variant) {
+  const sharepicVariants = ['light-top', 'realistic-top', 'pixel-top', 'editorial'];
+  if (sharepicVariants.includes(variant)) return variant;
+
+  // Map to sharepic variant
+  const mapping = {
+    'illustration-pure': 'light-top',
+    'realistic-pure': 'realistic-top',
+    'pixel-pure': 'pixel-top',
+    'editorial-pure': 'editorial',
+    'illustration': 'light-top',
+    'realistisch': 'realistic-top',
+    'pixel': 'pixel-top'
+  };
+
+  return mapping[variant] || 'light-top';
+}
+
+/**
+ * Build prompt for image-to-image transformation
+ */
+function buildEditPrompt(action, variant) {
+  // Check for specific transformation types
+  const lowerAction = action.toLowerCase();
+
+  // Green infrastructure transformation
+  if (lowerAction.includes('begrün') || lowerAction.includes('grün')) {
+    return `Transform this urban scene to include green infrastructure: add trees, bushes, protected bike lanes, outdoor seating with shade, flower beds. Keep the existing buildings and basic layout, but make the environment greener and more sustainable. Natural lighting, photorealistic style.`;
+  }
+
+  // General transformation - use the action directly
+  return `${action}. Maintain the overall composition and structure of the original image. Photorealistic result, natural lighting.`;
+}
+
+/**
+ * Extract buffer from attachment data
+ */
+function extractBufferFromAttachment(attachment) {
+  if (attachment.data) {
+    // Base64 data URL
+    const base64Data = attachment.data.replace(/^data:image\/[^;]+;base64,/, '');
+    return Buffer.from(base64Data, 'base64');
+  }
+
+  if (attachment.buffer) {
+    return attachment.buffer;
+  }
+
+  throw new Error('Unable to extract image buffer from attachment');
+}
+
+/**
+ * Save generated image to uploads directory
+ */
+async function saveGeneratedImage(buffer, mode) {
+  const now = new Date();
+  const today = now.toISOString().split('T')[0];
+  const baseDir = path.join(process.cwd(), 'uploads', 'imagine', 'chat', mode, today);
+
+  if (!fs.existsSync(baseDir)) {
+    fs.mkdirSync(baseDir, { recursive: true });
+  }
+
+  const filename = `${mode}_${now.toISOString().replace(/[:.]/g, '-')}.png`;
+  const filePath = path.join(baseDir, filename);
+  fs.writeFileSync(filePath, buffer);
+
+  log.debug('[ImagineGeneration] Saved image:', filePath);
+  return filePath;
+}
+
+module.exports = {
+  generateImagineForChat
+};

--- a/gruenerator_backend/services/fluxPromptBuilder.js
+++ b/gruenerator_backend/services/fluxPromptBuilder.js
@@ -1,0 +1,264 @@
+/**
+ * FLUX.2 Prompt Builder
+ * Based on official FLUX.2 Prompting Guide
+ *
+ * Framework: Subject + Action + Style + Context
+ * Priority Order: Main subject → Key action → Critical style → Essential context → Secondary details
+ * No negative prompts - describe what you want, not what you don't want
+ */
+
+const BRAND_COLORS = {
+  TANNE: '#005538',
+  KLEE: '#008939',
+  SAND: '#F5F1E9',
+  WHITE: '#FFFFFF'
+};
+
+/**
+ * Aspect Ratios with recommended dimensions
+ * FLUX limits: Min 64x64, Max 4MP, multiples of 16
+ */
+const ASPECT_RATIOS = {
+  'square': { ratio: '1:1', width: 1024, height: 1024, useCase: 'Social media, product shots' },
+  'portrait': { ratio: '9:16', width: 768, height: 1360, useCase: 'Mobile content, stories, infographics' },
+  'landscape': { ratio: '16:9', width: 1360, height: 768, useCase: 'Landscapes, cinematic shots' },
+  'classic': { ratio: '4:3', width: 1152, height: 864, useCase: 'Magazine layouts, presentations' },
+  'ultrawide': { ratio: '21:9', width: 1680, height: 720, useCase: 'Panoramas, wide scenes' },
+  'instagram': { ratio: '4:5', width: 1080, height: 1350, useCase: 'Instagram posts' }
+};
+
+const VARIANTS = {
+  'light-top': {
+    name: 'Soft Illustration (Light Top)',
+    style: 'soft painterly illustration with gentle textures, warm atmospheric tones, subtle watercolor quality',
+    composition: 'upper 25% light/white sky background smoothly fading into the scene below',
+    aspectRatio: 'instagram',
+    defaultAction: 'depicted in a warm inviting scene'
+  },
+
+  'green-bottom': {
+    name: 'Soft Illustration (Green Bottom)',
+    style: 'soft painterly illustration with gentle textures, warm atmospheric tones, subtle watercolor quality',
+    composition: 'lower 25% dark green area naturally blending from the scene above',
+    aspectRatio: 'instagram',
+    defaultAction: 'depicted in a warm inviting scene'
+  },
+
+  'realistic-top': {
+    name: 'Realistic Photo (Light Top)',
+    style: 'photorealistic, natural photography, authentic documentary style, real people, genuine moment',
+    composition: 'upper 25% bright sky or light background fading into the scene below',
+    aspectRatio: 'instagram',
+    defaultAction: 'captured in an authentic candid moment',
+    isPhoto: true
+  },
+
+  'realistic-bottom': {
+    name: 'Realistic Photo (Green Bottom)',
+    style: 'photorealistic, natural photography, authentic documentary style, real people, genuine moment',
+    composition: 'lower 25% dark green area naturally blending from the scene above',
+    aspectRatio: 'instagram',
+    defaultAction: 'captured in an authentic candid moment',
+    isPhoto: true
+  },
+
+  'pixel-top': {
+    name: 'Pixel Art (Light Top)',
+    style: 'beautiful detailed pixel art, 16-bit retro game aesthetic, rich colors, intricate pixel-perfect details, nostalgic video game art style',
+    composition: 'upper 25% light sky with pixel clouds fading into the scene below',
+    aspectRatio: 'instagram',
+    defaultAction: 'rendered in stunning pixel art',
+    isPixel: true
+  },
+
+  'pixel-bottom': {
+    name: 'Pixel Art (Green Bottom)',
+    style: 'beautiful detailed pixel art, 16-bit retro game aesthetic, rich colors, intricate pixel-perfect details, nostalgic video game art style',
+    composition: 'lower 25% dark green pixel area blending from the scene above',
+    aspectRatio: 'instagram',
+    defaultAction: 'rendered in stunning pixel art',
+    isPixel: true
+  },
+
+  'editorial': {
+    name: 'Editorial',
+    style: 'editorial photography, magazine quality, professional studio lighting',
+    composition: 'centered subject, clean background',
+    aspectRatio: 'portrait',
+    defaultAction: 'posed for editorial shoot'
+  },
+
+  // Pure variants (no composition hints - full image without reserved space)
+  'illustration-pure': {
+    name: 'Illustration (Pure)',
+    style: 'soft painterly illustration with gentle textures, warm atmospheric tones, subtle watercolor quality, soft diffused lighting',
+    aspectRatio: 'instagram',
+    defaultAction: 'depicted in a warm inviting scene'
+  },
+
+  'realistic-pure': {
+    name: 'Realistic (Pure)',
+    style: 'photorealistic, natural photography, authentic documentary style, real people, genuine moment, shot on Sony A7IV, 35mm lens, natural daylight',
+    aspectRatio: 'instagram',
+    defaultAction: 'captured in an authentic candid moment',
+    isPhoto: true
+  },
+
+  'pixel-pure': {
+    name: 'Pixel Art (Pure)',
+    style: 'beautiful detailed pixel art, 16-bit retro game aesthetic, rich colors, intricate pixel-perfect details, nostalgic video game art style, inspired by classic SNES and Genesis games',
+    aspectRatio: 'instagram',
+    defaultAction: 'rendered in stunning pixel art',
+    isPixel: true
+  },
+
+  'editorial-pure': {
+    name: 'Editorial (Pure)',
+    style: 'editorial photography, magazine quality, professional studio lighting, centered subject, clean background',
+    aspectRatio: 'instagram',
+    defaultAction: 'posed for editorial shoot'
+  }
+};
+
+/**
+ * Build prompt for illustration variants (light-top, green-bottom)
+ */
+function buildIllustrationPrompt(subject, action, variant) {
+  const config = VARIANTS[variant];
+
+  if (config.isPhoto) {
+    return {
+      subject: subject,
+      action: action || config.defaultAction,
+      style: `${config.style}, shot on Sony A7IV, 35mm lens, natural daylight`,
+      composition: config.composition,
+      mood: 'authentic, hopeful, community spirit',
+      rendering: 'Real photograph. No illustration. Natural colors, genuine atmosphere.'
+    };
+  }
+
+  if (config.isPixel) {
+    return {
+      subject: subject,
+      action: action || config.defaultAction,
+      style: `${config.style}, inspired by classic SNES and Genesis games`,
+      composition: config.composition,
+      color_palette: ['rich greens', 'warm earth tones', 'vibrant accents'],
+      rendering: 'Pure pixel art. Every pixel carefully placed. Dithering for gradients. Retro gaming masterpiece.'
+    };
+  }
+
+  return {
+    subject: subject,
+    action: action || config.defaultAction,
+    style: `${config.style}, soft diffused lighting`,
+    composition: config.composition,
+    color_palette: ['muted forest green', 'soft sage green', 'warm cream'],
+    rendering: 'Pure visual illustration. Wordless artistic scene. Soft edges, gentle atmosphere.'
+  };
+}
+
+/**
+ * Flatten prompt object to natural language string
+ * Optimized Priority Order: Subject → Action → Style → Context → Details
+ */
+function flattenPromptToString(promptData) {
+  const parts = [
+    promptData.subject,
+    promptData.action,
+    promptData.style,
+    promptData.composition ? `Composition: ${promptData.composition}` : null,
+    promptData.color_palette ? `Colors: ${Array.isArray(promptData.color_palette) ? promptData.color_palette.join(', ') : promptData.color_palette}` : null,
+    promptData.mood ? `Mood: ${promptData.mood}` : null,
+    promptData.lighting ? `Lighting: ${promptData.lighting}` : null,
+    promptData.rendering
+  ].filter(Boolean);
+
+  return parts.join('. ');
+}
+
+/**
+ * Main prompt builder function
+ * Returns formatted prompt string based on variant
+ *
+ * @param {Object} options
+ * @param {string} options.variant - Variant ID
+ * @param {string} options.subject - Main subject
+ * @param {string} options.action - What subject is doing (optional)
+ * @returns {Object} { prompt: string, dimensions: {width, height} }
+ */
+function buildFluxPrompt(options) {
+  const {
+    variant = 'light-top',
+    subject,
+    action
+  } = options;
+
+  const variantConfig = VARIANTS[variant] || VARIANTS['light-top'];
+  const aspectConfig = ASPECT_RATIOS[variantConfig.aspectRatio] || ASPECT_RATIOS['instagram'];
+
+  let promptData;
+
+  switch (variant) {
+    case 'light-top':
+    case 'green-bottom':
+    case 'realistic-top':
+    case 'realistic-bottom':
+    case 'pixel-top':
+    case 'pixel-bottom':
+    case 'editorial':
+    case 'illustration-pure':
+    case 'realistic-pure':
+    case 'pixel-pure':
+    case 'editorial-pure':
+    default:
+      promptData = buildIllustrationPrompt(subject, action, variant);
+      break;
+  }
+
+  const prompt = flattenPromptToString(promptData);
+
+  return {
+    prompt,
+    dimensions: {
+      width: aspectConfig.width,
+      height: aspectConfig.height,
+      ratio: aspectConfig.ratio
+    }
+  };
+}
+
+/**
+ * Get available variants with their configurations
+ */
+function getVariants() {
+  return Object.keys(VARIANTS).map(key => {
+    const config = VARIANTS[key];
+    const aspect = ASPECT_RATIOS[config.aspectRatio];
+    return {
+      id: key,
+      name: config.name,
+      aspectRatio: aspect?.ratio,
+      dimensions: aspect ? `${aspect.width}x${aspect.height}` : null,
+      useCase: aspect?.useCase
+    };
+  });
+}
+
+/**
+ * Get aspect ratio configurations
+ */
+function getAspectRatios() {
+  return ASPECT_RATIOS;
+}
+
+module.exports = {
+  buildFluxPrompt,
+  buildIllustrationPrompt,
+  flattenPromptToString,
+  getVariants,
+  getAspectRatios,
+  VARIANTS,
+  ASPECT_RATIOS,
+  BRAND_COLORS
+};

--- a/gruenerator_backend/services/imagineCanvasService.js
+++ b/gruenerator_backend/services/imagineCanvasService.js
@@ -1,0 +1,251 @@
+const { createCanvas, loadImage } = require('canvas');
+const { checkFiles, registerFonts } = require('../routes/sharepic/sharepic_canvas/fileManagement');
+const { COLORS } = require('../routes/sharepic/sharepic_canvas/config');
+const { createLogger } = require('../utils/logger.js');
+
+const log = createLogger('imagineCanvasService');
+
+let fontsRegistered = false;
+
+function ensureFontsRegistered() {
+  if (!fontsRegistered) {
+    registerFonts();
+    fontsRegistered = true;
+    log.debug('Fonts registered for canvas rendering');
+  }
+}
+
+ensureFontsRegistered();
+
+const OUTPUT_WIDTH = 1080;
+const OUTPUT_HEIGHT = 1350;
+const FLUX_WIDTH = 768;
+const FLUX_HEIGHT = 960;
+
+const BRAND_COLORS = {
+  TANNE: COLORS.TANNE || '#005538',
+  SAND: COLORS.SAND || '#F5F1E9',
+  WHITE: '#FFFFFF',
+  KLEE: COLORS.KLEE || '#008939'
+};
+
+const VARIANT_CONFIGS = {
+  'light-top': {
+    name: 'Light Top',
+    textArea: { y: 0, height: 0.20 },
+    defaultTextColor: BRAND_COLORS.TANNE
+  },
+  'green-bottom': {
+    name: 'Green Bottom',
+    textArea: { y: 0.80, height: 0.20 },
+    defaultTextColor: BRAND_COLORS.WHITE
+  }
+};
+
+function wrapText(ctx, text, maxWidth) {
+  const words = text.split(' ');
+  const lines = [];
+  let currentLine = '';
+
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i];
+    const testLine = currentLine ? currentLine + ' ' + word : word;
+    const testWidth = ctx.measureText(testLine).width;
+
+    if (testWidth > maxWidth && currentLine) {
+      lines.push(currentLine);
+      currentLine = word;
+    } else {
+      currentLine = testLine;
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+}
+
+function calculateFontSize(ctx, text, maxWidth, maxHeight, fontFamily, minSize = 40, maxSize = 140) {
+  let fontSize = maxSize;
+  const lineHeightMultiplier = 1.15;
+
+  while (fontSize >= minSize) {
+    ctx.font = `${fontSize}px ${fontFamily}`;
+    const lines = wrapText(ctx, text, maxWidth * 0.92);
+    const totalHeight = lines.length * fontSize * lineHeightMultiplier;
+
+    if (totalHeight <= maxHeight && lines.every(line => ctx.measureText(line).width <= maxWidth * 0.95)) {
+      return { fontSize, lines };
+    }
+    fontSize -= 4;
+  }
+
+  ctx.font = `${minSize}px ${fontFamily}`;
+  return { fontSize: minSize, lines: wrapText(ctx, text, maxWidth * 0.92) };
+}
+
+function renderFluxImage(ctx, image, templateConfig, outputWidth, outputHeight) {
+  const { imageArea } = templateConfig;
+  const destY = Math.round(imageArea.y * outputHeight);
+  const destHeight = Math.round(imageArea.height * outputHeight);
+
+  const imageAspectRatio = image.width / image.height;
+  const areaAspectRatio = outputWidth / destHeight;
+
+  let sx = 0, sy = 0, sWidth = image.width, sHeight = image.height;
+
+  if (imageAspectRatio > areaAspectRatio) {
+    sWidth = image.height * areaAspectRatio;
+    sx = (image.width - sWidth) / 2;
+  } else {
+    sHeight = image.width / areaAspectRatio;
+    sy = (image.height - sHeight) / 2;
+  }
+
+  ctx.drawImage(image, sx, sy, sWidth, sHeight, 0, destY, outputWidth, destHeight);
+  log.debug(`Rendered FLUX image: area y=${destY}, height=${destHeight}`);
+}
+
+function renderGradientOverlay(ctx, gradientConfig, outputWidth, outputHeight) {
+  const { direction, startY, endY, centerY, spread, opacity } = gradientConfig;
+
+  let gradient;
+
+  if (direction === 'top') {
+    const gradStartY = Math.round(startY * outputHeight);
+    const gradEndY = Math.round(endY * outputHeight);
+    gradient = ctx.createLinearGradient(0, gradStartY, 0, gradEndY);
+    gradient.addColorStop(0, `rgba(0, 0, 0, ${opacity})`);
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, gradStartY, outputWidth, gradEndY - gradStartY);
+  } else if (direction === 'bottom') {
+    const gradStartY = Math.round(startY * outputHeight);
+    const gradEndY = Math.round(endY * outputHeight);
+    gradient = ctx.createLinearGradient(0, gradStartY, 0, gradEndY);
+    gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+    gradient.addColorStop(1, `rgba(0, 0, 0, ${opacity})`);
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, gradStartY, outputWidth, gradEndY - gradStartY);
+  } else if (direction === 'center') {
+    const center = Math.round((centerY || 0.5) * outputHeight);
+    const spreadPx = Math.round((spread || 0.3) * outputHeight);
+    const topY = center - spreadPx;
+    const bottomY = center + spreadPx;
+
+    gradient = ctx.createLinearGradient(0, topY, 0, bottomY);
+    gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+    gradient.addColorStop(0.3, `rgba(0, 0, 0, ${opacity})`);
+    gradient.addColorStop(0.7, `rgba(0, 0, 0, ${opacity})`);
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, topY, outputWidth, bottomY - topY);
+  }
+
+  log.debug(`Rendered gradient overlay: direction=${direction}`);
+}
+
+function renderSolidBar(ctx, barConfig, outputWidth, outputHeight) {
+  const { y, height, color } = barConfig;
+  const barY = Math.round(y * outputHeight);
+  const barHeight = Math.round(height * outputHeight);
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, barY, outputWidth, barHeight);
+  log.debug(`Rendered solid bar: y=${barY}, height=${barHeight}, color=${color}`);
+}
+
+function renderTitle(ctx, title, templateConfig, outputWidth, outputHeight, color) {
+  const { textArea } = templateConfig;
+  const textY = textArea.y * outputHeight;
+  const textHeight = textArea.height * outputHeight;
+  const maxWidth = outputWidth * 0.90;
+  const fontFamily = 'GrueneTypeNeue';
+
+  const { fontSize, lines } = calculateFontSize(
+    ctx,
+    title,
+    maxWidth,
+    textHeight * 0.85,
+    fontFamily,
+    48,
+    120
+  );
+
+  ctx.font = `${fontSize}px ${fontFamily}`;
+  ctx.fillStyle = color;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  const lineHeight = fontSize * 1.15;
+  const totalTextHeight = lines.length * lineHeight;
+  const startY = textY + (textHeight * 0.5) - (totalTextHeight / 2) + lineHeight / 2;
+
+  lines.forEach((line, index) => {
+    const lineY = startY + index * lineHeight;
+    ctx.fillText(line, outputWidth / 2, lineY);
+  });
+
+  log.debug(`Rendered title: "${title.substring(0, 30)}..." fontSize=${fontSize}, lines=${lines.length}`);
+}
+
+
+
+async function composeImagineCreate(fluxImageBuffer, options) {
+  await checkFiles();
+  ensureFontsRegistered();
+
+  const {
+    title,
+    titleColor,
+    variant = 'light-top',
+    outputWidth = OUTPUT_WIDTH,
+    outputHeight = OUTPUT_HEIGHT
+  } = options;
+
+  const variantConfig = VARIANT_CONFIGS[variant] || VARIANT_CONFIGS['light-top'];
+
+  log.debug(`Composing imagine create: variant="${variant}", title="${title?.substring(0, 30)}..."`);
+
+  const canvas = createCanvas(outputWidth, outputHeight);
+  const ctx = canvas.getContext('2d');
+
+  const fluxImage = await loadImage(fluxImageBuffer);
+  log.debug(`Loaded FLUX image: ${fluxImage.width}x${fluxImage.height}`);
+
+  // Draw FLUX image scaled to fill entire canvas
+  const imageAspectRatio = fluxImage.width / fluxImage.height;
+  const canvasAspectRatio = outputWidth / outputHeight;
+
+  let sx = 0, sy = 0, sWidth = fluxImage.width, sHeight = fluxImage.height;
+
+  if (imageAspectRatio > canvasAspectRatio) {
+    sWidth = fluxImage.height * canvasAspectRatio;
+    sx = (fluxImage.width - sWidth) / 2;
+  } else {
+    sHeight = fluxImage.width / canvasAspectRatio;
+    sy = (fluxImage.height - sHeight) / 2;
+  }
+
+  ctx.drawImage(fluxImage, sx, sy, sWidth, sHeight, 0, 0, outputWidth, outputHeight);
+
+  const finalTitleColor = titleColor || variantConfig.defaultTextColor;
+  renderTitle(ctx, title, variantConfig, outputWidth, outputHeight, finalTitleColor);
+
+  const buffer = canvas.toBuffer('image/png');
+  log.debug(`Canvas composition complete: ${buffer.length} bytes`);
+
+  return buffer;
+}
+
+module.exports = {
+  composeImagineCreate,
+  VARIANT_CONFIGS,
+  FLUX_WIDTH,
+  FLUX_HEIGHT,
+  OUTPUT_WIDTH,
+  OUTPUT_HEIGHT,
+  BRAND_COLORS
+};


### PR DESCRIPTION
## Summary
- Add missing imagine generation files required by grueneratorChat
- Fixes server crash: `Cannot find module './services/imagineGenerationService'`
- Includes fluxPromptBuilder and imagineCanvasService dependencies

## Files Added
- `routes/chat/services/imagineGenerationService.js`
- `services/fluxPromptBuilder.js`
- `services/imagineCanvasService.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)