### PR TITLE
fix(subtitler): Video share and libx265 encoding fixes

### DIFF
--- a/gruenerator_backend/routes/subtitler/services/ffmpegExportUtils.js
+++ b/gruenerator_backend/routes/subtitler/services/ffmpegExportUtils.js
@@ -131,7 +131,7 @@ function buildFFmpegOutputOptions(params) {
       '-c:v', videoCodec,
       '-preset', preset,
       ...bitrateOptions,
-      ...(includeTune ? ['-tune', 'film'] : []),
+      ...(includeTune && videoCodec === 'libx264' ? ['-tune', 'film'] : []),
       '-profile:v', isLargeFile ? 'main' : (videoCodec === 'libx264' ? 'high' : 'main'),
       '-level', videoCodec === 'libx264' ? '4.1' : '4.0',
       '-c:a', audioCodec,

--- a/gruenerator_frontend/src/components/common/ShareMediaModal/ShareMediaModal.css
+++ b/gruenerator_frontend/src/components/common/ShareMediaModal/ShareMediaModal.css
@@ -1,0 +1,258 @@
+.share-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--spacing-medium);
+  animation: shareModalFadeIn 0.2s ease;
+}
+
+@keyframes shareModalFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.share-modal {
+  background: var(--background-color);
+  border-radius: var(--card-border-radius-large);
+  padding: var(--spacing-large);
+  max-width: 640px;
+  width: 100%;
+  position: relative;
+  box-shadow: var(--shadow-xl);
+  border: var(--border-subtle);
+}
+
+.share-modal-close {
+  position: absolute;
+  top: var(--spacing-medium);
+  right: var(--spacing-medium);
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--font-color);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: var(--spacing-xxsmall);
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.share-modal-close:hover {
+  opacity: 1;
+  background-color: var(--background-color-alt);
+}
+
+.share-modal h2 {
+  margin: 0 0 var(--spacing-small) 0;
+  font-size: 1.25rem;
+  color: var(--font-color-h);
+}
+
+.share-modal-description {
+  color: var(--font-color-disabled);
+  margin-bottom: var(--spacing-large);
+  line-height: 1.5;
+}
+
+.share-modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+  margin-bottom: var(--spacing-large);
+}
+
+.share-modal-form .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+
+.share-modal-form label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--font-color);
+}
+
+.share-modal-form input,
+.share-modal-form select {
+  padding: var(--spacing-small) var(--spacing-medium);
+  border: var(--border-subtle);
+  border-radius: var(--card-border-radius-small);
+  background: var(--input-background);
+  color: var(--font-color);
+  font-size: 1rem;
+  min-height: var(--form-element-min-height);
+  transition: var(--input-transition);
+}
+
+.share-modal-form input:focus,
+.share-modal-form select:focus {
+  outline: none;
+  border: var(--input-border-focus);
+  box-shadow: var(--input-shadow-focus);
+}
+
+.share-modal-error {
+  background: rgba(211, 47, 47, 0.1);
+  color: var(--error-red);
+  padding: var(--spacing-small) var(--spacing-medium);
+  border-radius: var(--card-border-radius-small);
+  margin-bottom: var(--spacing-medium);
+  font-size: 0.875rem;
+}
+
+.share-modal-error.export-required {
+  background: rgba(255, 193, 7, 0.15);
+  color: #856404;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+
+.share-modal-error.export-required svg {
+  flex-shrink: 0;
+}
+
+.share-modal-actions {
+  display: flex;
+  gap: var(--spacing-medium);
+  justify-content: flex-end;
+}
+
+.share-modal-success-layout {
+  display: flex;
+  gap: var(--spacing-large);
+  align-items: center;
+}
+
+.share-modal-left {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.share-qr-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: var(--spacing-medium);
+  background: white;
+  border-radius: var(--card-border-radius-small);
+}
+
+.share-modal-right {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.share-link-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--font-color);
+  margin-bottom: var(--spacing-xsmall);
+}
+
+.share-link-container {
+  display: flex;
+  gap: var(--spacing-small);
+  margin: 0 0 var(--spacing-medium);
+}
+
+.share-link-input {
+  flex: 1;
+  padding: var(--spacing-small) var(--spacing-medium);
+  border: var(--border-subtle);
+  border-radius: var(--card-border-radius-small);
+  background: var(--input-background);
+  color: var(--font-color);
+  font-size: 0.875rem;
+  font-family: monospace;
+  min-height: var(--form-element-min-height);
+}
+
+.share-copy-button,
+.share-native-button {
+  padding: var(--spacing-small) var(--spacing-medium);
+  background: var(--primary-600);
+  border: none;
+  border-radius: var(--card-border-radius-small);
+  color: var(--white);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s ease;
+}
+
+.share-copy-button:hover,
+.share-native-button:hover {
+  background: var(--primary-700);
+}
+
+.share-modal-info {
+  font-size: 0.875rem;
+  color: var(--font-color-disabled);
+  text-align: center;
+  margin-bottom: var(--spacing-large);
+}
+
+.share-modal-rendering-info {
+  background: rgba(33, 150, 243, 0.1);
+  padding: var(--spacing-small) var(--spacing-medium);
+  border-radius: var(--card-border-radius-small);
+}
+
+.share-modal-actions-centered {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-medium);
+}
+
+@media (max-width: 600px) {
+  .share-modal-success-layout {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .share-modal-left,
+  .share-modal-right {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .share-modal {
+    padding: var(--spacing-medium);
+    border-radius: var(--card-border-radius-medium);
+  }
+
+  .share-modal-actions {
+    flex-direction: column-reverse;
+  }
+
+  .share-modal-actions button {
+    width: 100%;
+  }
+
+  .share-link-container {
+    flex-direction: column;
+  }
+}

--- a/gruenerator_frontend/src/components/common/ShareMediaModal/ShareMediaModal.jsx
+++ b/gruenerator_frontend/src/components/common/ShareMediaModal/ShareMediaModal.jsx
@@ -1,0 +1,259 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import QRCode from 'react-qr-code';
+import { useMediaShareStore, getShareUrl } from '../../../stores/mediaShareStore';
+import { canShare, shareContent } from '../../../utils/shareUtils';
+import './ShareMediaModal.css';
+
+const ShareMediaModal = ({
+  isOpen,
+  onClose,
+  mediaType,
+  projectId,
+  exportToken,
+  imageData,
+  defaultTitle,
+  onShareCreated,
+  getOriginalImage,
+}) => {
+  const [shareTitle, setShareTitle] = useState(defaultTitle || '');
+  const [copied, setCopied] = useState(false);
+
+  const {
+    createVideoShare,
+    createVideoShareFromToken,
+    createImageShare,
+    currentShare,
+    isCreating,
+    error,
+    errorCode,
+    clearError,
+    clearCurrentShare,
+  } = useMediaShareStore();
+
+  useEffect(() => {
+    if (isOpen) {
+      clearCurrentShare();
+      clearError();
+      setShareTitle(defaultTitle || '');
+      setCopied(false);
+    }
+  }, [isOpen, defaultTitle, clearCurrentShare, clearError]);
+
+  const handleCreateShare = async () => {
+    try {
+      clearError();
+      let share;
+
+      if (mediaType === 'video') {
+        if (exportToken) {
+          share = await createVideoShareFromToken(exportToken, shareTitle || null, projectId);
+        } else if (projectId) {
+          share = await createVideoShare(projectId, shareTitle || null);
+        }
+      } else if (mediaType === 'image' && imageData) {
+        // Get the original image if a getter function was provided
+        let originalImage = imageData.originalImage;
+        if (originalImage === 'pending' && getOriginalImage) {
+          originalImage = await getOriginalImage();
+        }
+
+        share = await createImageShare(
+          imageData.image,
+          shareTitle || null,
+          imageData.type || null,
+          imageData.metadata || {},
+          originalImage || null
+        );
+      }
+
+      if (share && onShareCreated) {
+        onShareCreated(share);
+      }
+    } catch (err) {
+      console.error('Failed to create share:', err);
+    }
+  };
+
+  const handleCopyLink = () => {
+    if (currentShare?.shareToken) {
+      const url = getShareUrl(currentShare.shareToken);
+      navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleNativeShare = async () => {
+    if (currentShare?.shareToken) {
+      const url = getShareUrl(currentShare.shareToken);
+      await shareContent({
+        title: shareTitle || (mediaType === 'video' ? 'Geteiltes Video' : 'Geteiltes Bild'),
+        text: mediaType === 'video' ? 'Schau dir dieses Video an!' : 'Schau dir dieses Bild an!',
+        url,
+      });
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const mediaLabel = mediaType === 'video' ? 'Video' : 'Bild';
+
+  return (
+    <div className="share-modal-overlay" onClick={onClose}>
+      <div className="share-modal" onClick={(e) => e.stopPropagation()}>
+        <button className="share-modal-close" onClick={onClose}>
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+
+        <h2>{mediaLabel} teilen</h2>
+
+        {!currentShare ? (
+          <>
+            <p className="share-modal-description">
+              Erstelle einen Link, den du mit anderen teilen kannst.
+            </p>
+
+            <div className="share-modal-form">
+              <div className="form-group">
+                <label htmlFor="shareTitle">Titel</label>
+                <input
+                  id="shareTitle"
+                  type="text"
+                  value={shareTitle}
+                  onChange={(e) => setShareTitle(e.target.value)}
+                  placeholder={`Titel für ${mediaType === 'video' ? 'das geteilte Video' : 'das geteilte Bild'}`}
+                />
+              </div>
+            </div>
+
+            {error && (
+              <div className={`share-modal-error ${errorCode === 'NO_SUBTITLES' ? 'export-required' : ''}`}>
+                {errorCode === 'NO_SUBTITLES' ? (
+                  <>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="12" cy="12" r="10" />
+                      <line x1="12" y1="8" x2="12" y2="12" />
+                      <line x1="12" y1="16" x2="12.01" y2="16" />
+                    </svg>
+                    <span>{error}</span>
+                  </>
+                ) : error}
+              </div>
+            )}
+
+            <div className="share-modal-actions">
+              <button
+                className="btn-secondary"
+                onClick={onClose}
+                disabled={isCreating}
+              >
+                Abbrechen
+              </button>
+              <button
+                className="btn-primary"
+                onClick={handleCreateShare}
+                disabled={isCreating}
+              >
+                {isCreating ? 'Wird erstellt...' : 'Link erstellen'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            {currentShare.status === 'processing' && (
+              <p className="share-modal-info share-modal-rendering-info">
+                {mediaType === 'video'
+                  ? 'Das Video wird im Hintergrund gerendert. Der Empfänger kann es herunterladen, sobald es fertig ist.'
+                  : 'Das Bild wird verarbeitet...'}
+              </p>
+            )}
+
+            <div className="share-modal-success-layout">
+              <div className="share-modal-left">
+                <div className="share-qr-container">
+                  <QRCode
+                    value={getShareUrl(currentShare.shareToken)}
+                    size={160}
+                    level="M"
+                  />
+                </div>
+              </div>
+
+              <div className="share-modal-right">
+                <label className="share-link-label">Link kopieren</label>
+                <div className="share-link-container">
+                  <input
+                    type="text"
+                    readOnly
+                    value={getShareUrl(currentShare.shareToken)}
+                    className="share-link-input"
+                  />
+                  <button
+                    className="share-copy-button"
+                    onClick={handleCopyLink}
+                  >
+                    {copied ? (
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <polyline points="20,6 9,17 4,12" />
+                      </svg>
+                    ) : (
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                      </svg>
+                    )}
+                  </button>
+                  {canShare() && (
+                    <button
+                      className="share-native-button"
+                      onClick={handleNativeShare}
+                    >
+                      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                        <circle cx="18" cy="5" r="3" />
+                        <circle cx="6" cy="12" r="3" />
+                        <circle cx="18" cy="19" r="3" />
+                        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                        <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="share-modal-actions-centered">
+              <button
+                className="btn-primary"
+                onClick={onClose}
+              >
+                Fertig
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+ShareMediaModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  mediaType: PropTypes.oneOf(['video', 'image']).isRequired,
+  projectId: PropTypes.string,
+  exportToken: PropTypes.string,
+  imageData: PropTypes.shape({
+    image: PropTypes.string.isRequired,
+    type: PropTypes.string,
+    metadata: PropTypes.object,
+    originalImage: PropTypes.string,
+  }),
+  defaultTitle: PropTypes.string,
+  onShareCreated: PropTypes.func,
+  getOriginalImage: PropTypes.func,
+};
+
+export default ShareMediaModal;

--- a/gruenerator_frontend/src/components/common/ShareMediaModal/index.js
+++ b/gruenerator_frontend/src/components/common/ShareMediaModal/index.js
@@ -1,0 +1,2 @@
+export { default } from './ShareMediaModal';
+export { default as ShareMediaModal } from './ShareMediaModal';

--- a/gruenerator_frontend/src/features/subtitler/components/VideoSuccessScreen.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/VideoSuccessScreen.jsx
@@ -4,7 +4,7 @@ import { motion } from 'motion/react';
 import { FaPlus, FaEdit, FaShareAlt, FaInstagram, FaTimes, FaDownload, FaFileAlt } from 'react-icons/fa';
 import CopyButton from '../../../components/common/CopyButton';
 import { useSubtitlerExportStore } from '../../../stores/subtitlerExportStore';
-import ShareVideoModal from './ShareVideoModal';
+import { ShareMediaModal } from '../../../components/common/ShareMediaModal';
 import '../../../assets/styles/components/ui/button.css';
 import '../styles/VideoSuccessScreen.css';
 
@@ -271,10 +271,13 @@ const VideoSuccessScreen = ({ onReset, onEditAgain, isLoading, socialText, uploa
       </div>
 
       {showShareModal && (exportStore.projectId || projectId) && (
-        <ShareVideoModal
-          projectId={exportStore.projectId || projectId}
-          title={projectTitle}
+        <ShareMediaModal
+          isOpen={showShareModal}
           onClose={() => setShowShareModal(false)}
+          mediaType="video"
+          projectId={exportStore.projectId || projectId}
+          exportToken={exportStore.exportToken}
+          defaultTitle={projectTitle}
         />
       )}
     </div>

--- a/gruenerator_frontend/src/stores/mediaShareStore.js
+++ b/gruenerator_frontend/src/stores/mediaShareStore.js
@@ -1,0 +1,210 @@
+import { create } from 'zustand';
+import apiClient from '../components/utils/apiClient';
+
+const initialState = {
+  shares: [],
+  isLoading: false,
+  error: null,
+  errorCode: null,
+  currentShare: null,
+  isCreating: false,
+  count: 0,
+  limit: 50,
+};
+
+export const useMediaShareStore = create((set, get) => ({
+  ...initialState,
+
+  createVideoShare: async (projectId, title = null) => {
+    set({ isCreating: true, error: null, errorCode: null });
+
+    try {
+      const response = await apiClient.post('/share/video/from-project', {
+        projectId,
+        title,
+      });
+
+      if (response.data.success) {
+        const newShare = response.data.share;
+        set((state) => ({
+          isCreating: false,
+          currentShare: newShare,
+          shares: [newShare, ...state.shares],
+          count: state.count + 1,
+        }));
+        return newShare;
+      } else {
+        throw new Error(response.data.error || 'Failed to create video share');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to create video share';
+      const errorCode = error.response?.data?.code || null;
+      set({ isCreating: false, error: errorMessage, errorCode });
+      throw new Error(errorMessage);
+    }
+  },
+
+  createVideoShareFromToken: async (exportToken, title = null, projectId = null) => {
+    set({ isCreating: true, error: null, errorCode: null });
+
+    try {
+      const response = await apiClient.post('/share/video', {
+        exportToken,
+        title,
+        projectId,
+      });
+
+      if (response.data.success) {
+        const newShare = response.data.share;
+        set((state) => ({
+          isCreating: false,
+          currentShare: newShare,
+          shares: [newShare, ...state.shares],
+          count: state.count + 1,
+        }));
+        return newShare;
+      } else {
+        throw new Error(response.data.error || 'Failed to create video share');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to create video share';
+      const errorCode = error.response?.data?.code || null;
+      set({ isCreating: false, error: errorMessage, errorCode });
+      throw new Error(errorMessage);
+    }
+  },
+
+  createImageShare: async (imageData, title = null, imageType = null, metadata = {}, originalImage = null) => {
+    set({ isCreating: true, error: null, errorCode: null });
+
+    try {
+      const response = await apiClient.post('/share/image', {
+        imageData,
+        title,
+        imageType,
+        metadata,
+        originalImage,
+      });
+
+      if (response.data.success) {
+        const newShare = response.data.share;
+        set((state) => ({
+          isCreating: false,
+          currentShare: newShare,
+          shares: [newShare, ...state.shares],
+          count: state.count + 1,
+        }));
+        return newShare;
+      } else {
+        throw new Error(response.data.error || 'Failed to create image share');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to create image share';
+      set({ isCreating: false, error: errorMessage });
+      throw new Error(errorMessage);
+    }
+  },
+
+  updateImageShare: async (shareToken, imageData, title = null, metadata = {}, originalImage = null) => {
+    set({ isCreating: true, error: null, errorCode: null });
+
+    try {
+      const response = await apiClient.put(`/share/${shareToken}/image`, {
+        imageBase64: imageData,
+        title,
+        metadata,
+        originalImage,
+      });
+
+      if (response.data.success) {
+        const updatedShare = response.data.share;
+        set((state) => ({
+          isCreating: false,
+          currentShare: updatedShare,
+          shares: state.shares.map((s) =>
+            s.shareToken === shareToken ? { ...s, ...updatedShare } : s
+          ),
+        }));
+        return updatedShare;
+      } else {
+        throw new Error(response.data.error || 'Failed to update image share');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to update image share';
+      set({ isCreating: false, error: errorMessage });
+      throw new Error(errorMessage);
+    }
+  },
+
+  fetchUserShares: async (mediaType = null) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const url = mediaType ? `/share/my?type=${mediaType}` : '/share/my';
+      const response = await apiClient.get(url);
+
+      if (response.data.success) {
+        set({
+          isLoading: false,
+          shares: response.data.shares,
+          count: response.data.count || response.data.shares.length,
+          limit: response.data.limit || 50,
+        });
+        return response.data.shares;
+      } else {
+        throw new Error(response.data.error || 'Failed to fetch shares');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to fetch shares';
+      set({ isLoading: false, error: errorMessage });
+      throw new Error(errorMessage);
+    }
+  },
+
+  fetchImageShares: async () => {
+    return get().fetchUserShares('image');
+  },
+
+  fetchVideoShares: async () => {
+    return get().fetchUserShares('video');
+  },
+
+  deleteShare: async (shareToken) => {
+    try {
+      const response = await apiClient.delete(`/share/${shareToken}`);
+
+      if (response.data.success) {
+        set((state) => ({
+          shares: state.shares.filter((s) => s.shareToken !== shareToken),
+          currentShare: state.currentShare?.shareToken === shareToken ? null : state.currentShare,
+          count: Math.max(0, state.count - 1),
+        }));
+        return true;
+      } else {
+        throw new Error(response.data.error || 'Failed to delete share');
+      }
+    } catch (error) {
+      const errorMessage = error.response?.data?.error || error.message || 'Failed to delete share';
+      set({ error: errorMessage });
+      throw new Error(errorMessage);
+    }
+  },
+
+  clearCurrentShare: () => {
+    set({ currentShare: null });
+  },
+
+  clearError: () => {
+    set({ error: null, errorCode: null });
+  },
+
+  reset: () => {
+    set(initialState);
+  },
+}));
+
+export const getShareUrl = (shareToken) => {
+  return `${window.location.origin}/share/${shareToken}`;
+};
+
+export default useMediaShareStore;


### PR DESCRIPTION
## Summary
- Fix video share re-render issue by using exportToken
- Fix FFmpeg export failure for 4K HEVC videos by only applying `-tune film` for libx264 codec

## Changes
- **Video Share Fix**: Use exportToken to prevent unnecessary re-renders when sharing videos
- **libx265 Fix**: The `-tune film` option is only valid for libx264, not libx265. This was causing export failures for 4K HEVC sources

## Test plan
- [ ] Test video export with 4K HEVC source files
- [ ] Test video sharing functionality
- [ ] Verify no regressions in standard video exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)