### PR TITLE
fix(subtitler): prevent old video download after editing

### DIFF
--- a/gruenerator_frontend/src/features/subtitler/components/SubtitleEditor.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/SubtitleEditor.jsx
@@ -168,9 +168,10 @@ const SubtitleEditor = ({
   
   // Watch for export start and completion
   useEffect(() => {
-    if (exportStatus === 'starting' || exportStatus === 'exporting') {
-      // Move to success screen immediately when export starts
-      console.log('[SubtitleEditor] Export started, calling success callback with token:', exportToken);
+    // Only navigate to success when we have a valid NEW token (not null)
+    // This prevents race condition where old token is used before API response
+    if (exportStatus === 'exporting' && exportToken) {
+      console.log('[SubtitleEditor] Export started with new token:', exportToken);
       onExportSuccess && onExportSuccess(exportToken);
     } else if (exportStatus === 'complete') {
       console.log('[SubtitleEditor] Export completed');

--- a/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
+++ b/gruenerator_frontend/src/features/subtitler/components/SubtitlerPage.jsx
@@ -367,9 +367,11 @@ const SubtitlerPage = () => {
 
   // Function to go back to the editor without resetting everything
   const handleEditAgain = useCallback(() => {
+    // Reset export state so user must re-export after making changes
+    // This prevents downloading old video after editing
+    resetExport();
     setStep('edit');
-    // No reset of other states like videoFile, subtitles, etc.
-  }, []);
+  }, [resetExport]);
 
   // New handlers for styling step
   const handleStyleSelect = useCallback((style) => {

--- a/gruenerator_frontend/src/stores/subtitlerExportStore.js
+++ b/gruenerator_frontend/src/stores/subtitlerExportStore.js
@@ -73,6 +73,7 @@ export const useSubtitlerExportStore = create((set, get) => ({
       exportParams,
       retryCount: 0,
       pollingStartTime: Date.now(),
+      exportToken: null,
     });
 
     try {
@@ -186,6 +187,7 @@ export const useSubtitlerExportStore = create((set, get) => ({
       exportParams,
       retryCount: 0,
       pollingStartTime: Date.now(),
+      exportToken: null,
     });
 
     try {


### PR DESCRIPTION
## Summary
- Fix race condition where downloading after "Edit Again" would get the old video instead of re-exported video with new subtitles
- Reset `exportToken` to null when starting new export in store
- Only navigate to success screen when new token is received (not when status is just 'starting')
- Reset export state when clicking "Edit Again" button

## Root Cause
The SubtitleEditor was navigating to success screen when `exportStatus === 'starting'`, but at that point the `exportToken` was still the OLD token from the previous export. The new token only arrives after the API response.

## Test plan
- [ ] Export a video with subtitles
- [ ] Click "Edit Again" (Bearbeiten)
- [ ] Change the subtitle text
- [ ] Click Download button in Editor
- [ ] Wait for export to complete
- [ ] Download the video
- [ ] Verify the downloaded video has the NEW subtitles

🤖 Generated with [Claude Code](https://claude.com/claude-code)