### PR TITLE
feat(mobile): enable mobile authentication routes

### DIFF
--- a/gruenerator_backend/routes.js
+++ b/gruenerator_backend/routes.js
@@ -111,8 +111,7 @@ async function setupRoutes(app) {
   const { default: userGroups } = await import('./routes/auth/userGroups.mjs');
   const { default: userCustomGenerators } = await import('./routes/auth/userCustomGenerators.mjs');
   const { default: userTemplates } = await import('./routes/auth/userTemplates.mjs');
-  // MOBILE AUTH DISABLED
-  // const { default: mobileAuthRoutes } = await import('./routes/auth/mobile.mjs');
+  const { default: mobileAuthRoutes } = await import('./routes/auth/mobile.mjs');
   const { default: documentsRouter } = await import('./routes/documents.mjs');
 
   const { default: oparlRouter } = await import('./routes/oparl.mjs');
@@ -153,8 +152,7 @@ async function setupRoutes(app) {
   app.use('/api/auth', userGroups);
   app.use('/api/auth', userCustomGenerators);
   app.use('/api/auth', userTemplates);
-  // MOBILE AUTH DISABLED
-  // app.use('/api/auth/mobile', mobileAuthRoutes);
+  app.use('/api/auth/mobile', mobileAuthRoutes);
   app.use('/api/auth/notebook-collections', notebookCollectionsRouter);
   app.use('/api/auth/notebook', notebookInteractionRouter);
   app.use('/api/documents', documentsRouter);


### PR DESCRIPTION
## Summary
- Enable mobile auth endpoints for JWT token exchange
- Allows mobile apps to authenticate via the `/api/auth/mobile` endpoints
- Required for testing the Expo mobile app

## Test plan
- [ ] Deploy to staging/dev environment
- [ ] Test `/api/auth/mobile/exchange` endpoint with Keycloak token
- [ ] Verify mobile app can authenticate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)