### PR TITLE
fix: add error handling for share queries and filter fetch retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ services/comfyui/
 
 # Windows Zone.Identifier metadata files
 *:Zone.Identifier
+
+# Remotion build output
+apps/api/services/remotion/out/

--- a/apps/api/routes/share/shareController.ts
+++ b/apps/api/routes/share/shareController.ts
@@ -621,7 +621,18 @@ router.get(
         });
       }
 
-      const allShares = await service.getUserShares(userId, 'image');
+      let allShares;
+      try {
+        allShares = await service.getUserShares(userId, 'image');
+      } catch (queryError) {
+        log.warn('Failed to query user shares, returning empty result:', queryError);
+        return res.json({
+          success: true,
+          shares: [],
+          count: 0,
+          limit,
+        });
+      }
       const recentShares = allShares.slice(0, limit);
 
       res.json({


### PR DESCRIPTION
## Summary
- Gracefully handle `getUserShares` failures in the share controller by returning an empty result instead of crashing
- Add retry logic with cooldown (max 3 retries, 30s cooldown) to `fetchFilterValues` in the notebook store to prevent infinite fetch loops on failure
- Add `apps/api/services/remotion/out/` to `.gitignore`

## Test plan
- [ ] Verify share image endpoint returns empty array when DB query fails
- [ ] Verify filter fetching stops retrying after 3 failures
- [ ] Verify filter fetching resumes after cooldown period
- [ ] Verify successful filter fetch clears previous error state