### PR TITLE
fix(web): unify KI navigation under /imagine sub-routes

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -1,5 +1,5 @@
 import { lazy, type ComponentType, type LazyExoticComponent, type FC, createElement } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import { isDesktopApp } from '../utils/platform';
 
@@ -86,6 +86,15 @@ const ImageStudioKiRedirect = lazy(() =>
   Promise.resolve({
     default: createRedirect('/imagine'),
   })
+);
+
+// Dynamic redirect: /image-studio/ki/:type → /imagine/:type
+const ImageStudioKiTypeRedirectComponent: FC<Record<string, unknown>> = () => {
+  const { type } = useParams();
+  return createElement(Navigate, { to: `/imagine/${type || ''}`, replace: true });
+};
+const ImageStudioKiTypeRedirect = lazy(() =>
+  Promise.resolve({ default: ImageStudioKiTypeRedirectComponent })
 );
 
 // Direct Imagine page (renders ImageStudio with 'ki' category pre-selected)
@@ -349,9 +358,10 @@ const standardRoutes: RouteConfig[] = [
   { path: '/media-library', component: MediaLibraryPage },
   // Image Studio Routes - KI routes redirect to /imagine
   { path: '/imagine', component: ImaginePage, withForm: true },
+  { path: '/imagine/:type', component: ImaginePage, withForm: true },
   { path: '/image-studio', component: ImageStudioKiRedirect },
   { path: '/image-studio/ki', component: ImageStudioKiRedirect },
-  { path: '/image-studio/ki/:type', component: ImageStudioKiRedirect },
+  { path: '/image-studio/ki/:type', component: ImageStudioKiTypeRedirect },
   { path: '/image-studio/gallery', component: GrueneratorenBundle.ImageGallery },
   { path: '/image-studio/:category', component: GrueneratorenBundle.ImageStudio, withForm: true },
   {

--- a/apps/web/src/features/image-studio/ImageStudioPage.tsx
+++ b/apps/web/src/features/image-studio/ImageStudioPage.tsx
@@ -237,23 +237,42 @@ const ImageStudioPageContent: React.FC<ImageStudioPageContentProps> = ({
     };
   }, []);
 
+  const isImagineRoute = location.pathname.startsWith('/imagine');
+
   const handleBack = useCallback(() => {
     if (currentStep === FORM_STEPS.TYPE_SELECT) {
       setCategory(null, null);
-      navigate('/image-studio');
+      navigate(isImagineRoute ? '/imagine' : '/image-studio');
     } else if (currentStep === FORM_STEPS.IMAGE_UPLOAD) {
-      navigate(`/image-studio/${category}${subcategory ? `/${subcategory}` : ''}`);
+      if (isImagineRoute) {
+        navigate('/imagine');
+      } else {
+        navigate(`/image-studio/${category}${subcategory ? `/${subcategory}` : ''}`);
+      }
       goBack();
     } else if (currentStep === FORM_STEPS.INPUT) {
       const prevStep = typeConfig?.steps?.[typeConfig.steps.indexOf(currentStep) - 1];
       if (prevStep === FORM_STEPS.TYPE_SELECT || !prevStep) {
-        navigate(`/image-studio/${category}${subcategory ? `/${subcategory}` : ''}`);
+        if (isImagineRoute) {
+          navigate('/imagine');
+        } else {
+          navigate(`/image-studio/${category}${subcategory ? `/${subcategory}` : ''}`);
+        }
       }
       goBack();
     } else {
       goBack();
     }
-  }, [currentStep, category, subcategory, typeConfig, goBack, setCategory, navigate]);
+  }, [
+    currentStep,
+    category,
+    subcategory,
+    typeConfig,
+    goBack,
+    setCategory,
+    navigate,
+    isImagineRoute,
+  ]);
 
   const validateForm = useCallback(() => {
     const errors: FormErrors = {};

--- a/apps/web/src/features/image-studio/ImaginePage.tsx
+++ b/apps/web/src/features/image-studio/ImaginePage.tsx
@@ -1,21 +1,36 @@
 import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 
 import useImageStudioStore from '../../stores/imageStudioStore';
 
 import ImageStudioPage from './ImageStudioPage';
+import { URL_TYPE_MAP } from './utils/typeConfig';
+
+import type { UrlTypeMapKey } from './types/componentTypes';
 
 /**
- * Wrapper component for the /imagine route.
- * Pre-selects the 'ki' category before rendering ImageStudioPage.
+ * Wrapper component for the /imagine and /imagine/:type routes.
+ * Pre-selects the 'ki' category and optionally sets the type from the URL.
  */
 const ImaginePage: React.FC = () => {
-  const { category, setCategory } = useImageStudioStore();
+  const { type: urlType } = useParams();
+  const { category, setCategory, setType } = useImageStudioStore();
 
   useEffect(() => {
     if (!category) {
       setCategory('ki');
     }
   }, [category, setCategory]);
+
+  useEffect(() => {
+    if (urlType) {
+      const mappedType = urlType in URL_TYPE_MAP ? URL_TYPE_MAP[urlType as UrlTypeMapKey] : urlType;
+      if (mappedType) {
+        setCategory('ki');
+        setType(mappedType);
+      }
+    }
+  }, [urlType, setCategory, setType]);
 
   return <ImageStudioPage />;
 };

--- a/apps/web/src/features/image-studio/components/ImageStudioCategorySelector.tsx
+++ b/apps/web/src/features/image-studio/components/ImageStudioCategorySelector.tsx
@@ -71,6 +71,9 @@ const ImageStudioCategorySelector: React.FC = () => {
       if (directType) {
         void setType(directType);
         void navigate(`/image-studio/templates/${directType}`);
+      } else if (cat === IMAGE_STUDIO_CATEGORIES.KI) {
+        void setCategory(cat, subcat);
+        void navigate('/imagine');
       } else if (cat) {
         void setCategory(cat, subcat);
         void navigate(`/image-studio/${cat}`);
@@ -150,7 +153,7 @@ const ImageStudioCategorySelector: React.FC = () => {
 
         // Handle KI types - navigate to KI creation flow
         if (result.isKiType) {
-          void navigate(`/image-studio/ki/create/pure-create`);
+          void navigate(`/imagine/pure-create`);
           return;
         }
 

--- a/apps/web/src/features/image-studio/components/ImageStudioTypeSelector.tsx
+++ b/apps/web/src/features/image-studio/components/ImageStudioTypeSelector.tsx
@@ -38,7 +38,11 @@ const ImageStudioTypeSelector: React.FC = () => {
       setType(selectedType);
       const config = getTypeConfig(selectedType) as TypeConfig | null;
       const urlSegment = config?.urlSlug || selectedType;
-      navigate(`/image-studio/${config?.category || category}/${urlSegment}`);
+      if (category === IMAGE_STUDIO_CATEGORIES.KI) {
+        navigate(`/imagine/${urlSegment}`);
+      } else {
+        navigate(`/image-studio/${config?.category || category}/${urlSegment}`);
+      }
     },
     [setType, navigate, category]
   );
@@ -59,7 +63,7 @@ const ImageStudioTypeSelector: React.FC = () => {
       setType(IMAGE_STUDIO_TYPES.PURE_CREATE);
       const store = useImageStudioStore.getState();
       store.updateFormData({ variant: selectedVariant });
-      navigate(`/image-studio/ki/pure-create`);
+      navigate(`/imagine/pure-create`);
     };
 
     return (


### PR DESCRIPTION
## Summary
- Add `/imagine/:type` route so clicking a KI type (e.g. green-edit) navigates to `/imagine/green-edit` instead of causing a page reload / 404
- Update all KI navigation (type selector, variant selector, category selector, prompt submit) to use `/imagine/...` URLs instead of `/image-studio/ki/...`
- Old `/image-studio/ki/:type` URLs now dynamically redirect to `/imagine/:type` preserving the type param
- Back navigation is context-aware, returning to `/imagine` when within the `/imagine` route

## Test plan
- [ ] Navigate to `/imagine` → shows KI type selector
- [ ] Click a KI type (e.g. green-edit) → URL becomes `/imagine/green-edit`, no page reload, correct flow loads
- [ ] Click back → returns to `/imagine` type selector
- [ ] Direct deep-link `/imagine/green-edit` → loads green-edit flow directly
- [ ] Old URL `/image-studio/ki/green-edit` → redirects to `/imagine/green-edit`
- [ ] Template routes `/image-studio/templates/dreizeilen` → still work unchanged
- [ ] Gallery route `/image-studio/gallery` → still works unchanged