### PR TITLE
fix(web): add loading state and per-subtype display to UniversalTab

### DIFF
--- a/apps/web/src/features/texte/TexteGenerator.tsx
+++ b/apps/web/src/features/texte/TexteGenerator.tsx
@@ -64,6 +64,8 @@ const TAB_COMPONENT_NAMES: Record<TabId, string> = {
   eigene: 'eigene-generators',
 };
 
+const UNIVERSAL_SUB_TYPES = ['rede', 'wahlprogramm', 'buergeranfragen', 'leichte_sprache'];
+
 /**
  * TexteGenerator - Main text generation interface with tabbed navigation.
  *
@@ -92,8 +94,15 @@ const TexteGenerator: React.FC<TexteGeneratorProps> = ({ showHeaderFooter = true
   }, [profile?.first_name, user?.display_name, user?.name]);
 
   const hasGeneratedContent = useMemo(() => {
-    return Object.values(TAB_COMPONENT_NAMES).some((componentName) => {
+    const baseCheck = Object.values(TAB_COMPONENT_NAMES).some((componentName) => {
       const content = generatedTexts[componentName];
+      if (!content) return false;
+      if (typeof content === 'string') return content.trim().length > 0;
+      return Object.keys(content).length > 0;
+    });
+    if (baseCheck) return true;
+    return UNIVERSAL_SUB_TYPES.some((subType) => {
+      const content = generatedTexts[`universal-text-${subType}`];
       if (!content) return false;
       if (typeof content === 'string') return content.trim().length > 0;
       return Object.keys(content).length > 0;
@@ -120,7 +129,9 @@ const TexteGenerator: React.FC<TexteGeneratorProps> = ({ showHeaderFooter = true
 
   const wrapperClassName = useMemo(
     () =>
-      ['tabbed-layout', hasGeneratedContent && 'tabbed-layout--full-width'].filter(Boolean).join(' '),
+      ['tabbed-layout', hasGeneratedContent && 'tabbed-layout--full-width']
+        .filter(Boolean)
+        .join(' '),
     [hasGeneratedContent]
   );
 

--- a/apps/web/src/features/texte/tabs/UniversalTab.tsx
+++ b/apps/web/src/features/texte/tabs/UniversalTab.tsx
@@ -82,7 +82,7 @@ const EXTRAS_CONFIG: Partial<Record<UniversalSubType, ExtrasInputConfig>> = {
 };
 
 const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType }) => {
-  const componentName = 'universal-text';
+  const componentName = `universal-text-${selectedType}`;
 
   const redeFormRef = useRef<FormRef>(null);
   const wahlprogrammFormRef = useRef<FormRef>(null);
@@ -90,6 +90,7 @@ const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType
   const leichteSpracheFormRef = useRef<FormRef>(null);
 
   const [extrasValue, setExtrasValue] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(false);
 
   const getCurrentFormRef = (): RefObject<FormRef | null> | null => {
     switch (selectedType) {
@@ -129,7 +130,7 @@ const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType
 
   const setup = useGeneratorSetup({
     instructionType: currentInstructionType,
-    componentName: 'universal-text',
+    componentName,
   });
 
   useEffect(() => {
@@ -202,6 +203,7 @@ const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType
 
     const formDataToSubmit = builder.buildSubmissionData(dataWithExtras);
 
+    setIsLoading(true);
     try {
       const { default: apiClient } = await import('../../../components/utils/apiClient');
 
@@ -221,6 +223,8 @@ const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType
       } else {
         form.handleSubmitError(new Error(String(error)));
       }
+    } finally {
+      setIsLoading(false);
     }
   }, [selectedType, form, currentFormRef, builder, extrasValue]);
 
@@ -293,11 +297,11 @@ const UniversalTab: React.FC<UniversalTabProps> = memo(({ isActive, selectedType
     <>
       {form.generator && (
         <BaseForm
-          key={selectedType}
           {...restBaseFormProps}
           componentName={componentName}
           enableEditMode={true}
           onSubmit={handleSubmit}
+          loading={isLoading}
           firstExtrasChildren={renderExtrasInput()}
         >
           {renderForm()}


### PR DESCRIPTION
## Summary
- **Loading spinner**: Add `isLoading` state to `UniversalTab` with `try/finally` in `handleSubmit`, and pass `loading={isLoading}` to `BaseForm` so the submit button spinner works
- **Per-subtype content storage**: Change `componentName` from static `'universal-text'` to dynamic `universal-text-${selectedType}` so each sub-type (Rede, Wahlprogramm, etc.) gets its own slot in the generated text store — display section now correctly shows/hides content when switching sub-types
- **Remove forced remount**: Remove `key={selectedType}` on `BaseForm` since distinct `componentName` values handle isolation naturally
- **hasGeneratedContent check**: Extend the check in `TexteGenerator` to also look at per-subtype keys so the layout detects content from any universal sub-type

## Test plan
- [ ] Navigate to Sonstige tab, select "Rede", submit → loading spinner appears
- [ ] Generated content appears in display section after submit
- [ ] Switch to "Bürger*innenanfragen" → display section clears
- [ ] Submit for "Bürger*innenanfragen" → loading + display works
- [ ] Switch back to "Rede" → previously generated content reappears