### PR TITLE
feat(api): add Docling-Serve sidecar for self-hosted document OCR

### DIFF
--- a/apps/api/services/OcrService/doclingIntegration.ts
+++ b/apps/api/services/OcrService/doclingIntegration.ts
@@ -1,0 +1,117 @@
+/**
+ * Docling-Serve integration
+ * Calls the self-hosted docling-serve sidecar container for document-to-markdown conversion.
+ * See: https://github.com/docling-project/docling-serve
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import type { ExtractionResult } from './types.js';
+
+const DOCLING_BASE_URL = process.env.DOCLING_URL || 'http://ocr:5001';
+
+/**
+ * Extract text from a document using the Docling-Serve sidecar.
+ * Sends the file as multipart/form-data to /v1/convert/file and
+ * requests Markdown output (matching the format Mistral OCR produces).
+ */
+export async function extractTextWithDocling(filePath: string): Promise<ExtractionResult> {
+  const startTime = Date.now();
+
+  try {
+    console.log(`[DoclingOCR] Starting extraction:`, { filePath });
+
+    const fileBuffer = await fs.readFile(filePath);
+    const fileName = path.basename(filePath);
+
+    // Build multipart form with the file and conversion options
+    const formData = new FormData();
+    formData.append('files', new Blob([fileBuffer]), fileName);
+
+    // Request markdown output to match the existing pipeline format
+    const optionsPayload = JSON.stringify({
+      to_formats: ['md'],
+      image_export_mode: 'placeholder',
+      do_ocr: true,
+      force_ocr: false,
+    });
+    formData.append('options', new Blob([optionsPayload], { type: 'application/json' }));
+
+    console.log(
+      `[DoclingOCR] Sending to ${DOCLING_BASE_URL}/v1/convert/file (${fileBuffer.length} bytes)`
+    );
+
+    const response = await fetch(`${DOCLING_BASE_URL}/v1/convert/file`, {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => 'unknown');
+      throw new Error(`Docling API returned ${response.status}: ${errorText}`);
+    }
+
+    const result = await response.json();
+
+    // docling-serve returns { document: { md_content, filename, ... }, status, processing_time }
+    const documents = result?.document ?? result?.documents ?? [result];
+    const markdownParts: string[] = [];
+    let totalPages = 0;
+
+    for (const doc of Array.isArray(documents) ? documents : [documents]) {
+      // The markdown content can be in different fields depending on the version
+      const md = doc?.md_content ?? doc?.markdown ?? doc?.md ?? doc?.text ?? '';
+      if (md.trim()) {
+        markdownParts.push(md.trim());
+      }
+      totalPages += doc?.num_pages ?? doc?.page_count ?? 1;
+    }
+
+    const allText = markdownParts.join('\n\n---\n\n');
+
+    if (!allText.trim()) {
+      throw new Error('Docling returned no text content');
+    }
+
+    const processingTimeMs = Date.now() - startTime;
+    console.log(
+      `[DoclingOCR] Extraction completed in ${processingTimeMs}ms: ${totalPages} pages, ${allText.length} characters`
+    );
+
+    return {
+      text: allText.trim(),
+      pageCount: totalPages,
+      method: 'docling',
+      confidence: 0.9,
+      stats: {
+        pages: totalPages,
+        successfulPages: totalPages,
+        processingTimeMs,
+        method: 'docling-serve',
+      },
+    };
+  } catch (error: any) {
+    const elapsed = Date.now() - startTime;
+    console.error(`[DoclingOCR] Extraction FAILED after ${elapsed}ms:`, {
+      errorMessage: error?.message,
+      errorType: error?.constructor?.name,
+      filePath,
+    });
+    throw new Error(`Docling extraction failed: ${error?.message}`);
+  }
+}
+
+/**
+ * Check if the Docling-Serve sidecar is healthy and reachable.
+ */
+export async function isDoclingAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch(`${DOCLING_BASE_URL}/health`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/apps/api/services/OcrService/types.ts
+++ b/apps/api/services/OcrService/types.ts
@@ -26,7 +26,7 @@ export interface ParseabilityCheck {
 export interface ExtractionResult {
   text: string;
   pageCount: number;
-  method: 'mistral-ocr' | 'direct' | 'pdfjs-dist';
+  method: 'mistral-ocr' | 'docling' | 'direct' | 'pdfjs-dist';
   confidence?: number;
   stats?: {
     pages?: number;

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -141,6 +141,27 @@ services:
       timeout: 10s
       retries: 3
 
+  # Docling-Serve - Self-hosted document OCR/conversion (PDF, DOCX, PPTX, images → Markdown)
+  # Pre-built image from quay.io, no custom build needed
+  ocr:
+    image: quay.io/docling-project/docling-serve-cpu:latest
+    restart: unless-stopped
+    environment:
+      - DOCLING_SERVE_MAX_NUM_PAGES=1000
+      - DOCLING_SERVE_MAX_FILE_SIZE=104857600
+      - DOCLING_NUM_THREADS=4
+      - DOCLING_SERVE_LOAD_MODELS_AT_BOOT=true
+    networks:
+      - gruenerator
+    labels:
+      - 'com.gruenerator.service=ocr'
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:5001/health']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+
   # ComfyUI - Local GPU-based image generation (optional, requires NVIDIA GPU)
   # Start with: docker compose --profile gpu up -d comfyui
   comfyui:


### PR DESCRIPTION
## Summary
- Add docling-serve (pre-built CPU image from quay.io) as a Docker sidecar for local PDF/DOCX/PPTX/image-to-Markdown conversion
- Route OCR via `OCR_PROVIDER` env var (default: `mistral`), with automatic fallback to Mistral when Docling is unavailable or errors
- Fix PDF.js worker path using `createRequire` for monorepo hoisting

## Non-breaking
- Default provider remains `mistral` — existing deployments are unaffected
- Health check gates Docling usage; try/catch provides error fallback to Mistral

## Test plan
- [ ] Deploy with `OCR_PROVIDER=mistral` (default) — verify existing Mistral OCR still works
- [ ] Deploy with `OCR_PROVIDER=docling` but no sidecar — verify fallback to Mistral
- [ ] Deploy with `OCR_PROVIDER=docling` and sidecar running — verify Docling processes documents
- [ ] Upload PDF, DOCX, and image files through the web UI — verify end-to-end pipeline