### PR TITLE
fix(ci): fetch 2 commits for paths-filter on workflow_dispatch

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,6 +62,8 @@ jobs:
       shared: ${{ steps.filter.outputs.shared }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - uses: dorny/paths-filter@v3
         id: filter


### PR DESCRIPTION
## Summary
- Fix `'before' field is missing in event payload` warning from `dorny/paths-filter`
- Add `fetch-depth: 2` to checkout step so there's a previous commit to diff against on manual `workflow_dispatch` triggers

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` — verify no `'before' field is missing` warning