### PR TITLE
chore: Bayern notebook dev-only, scanner dev-only, remove deploy workflow

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -100,6 +100,7 @@ export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuI
     },
     scanner: {
       id: 'scanner',
+      path: '/scanner',
       title: 'Scanner',
       description: 'Text aus Dokumenten extrahieren (OCR)',
       icon: getIcon('navigation', 'scanner'),

--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -98,14 +98,16 @@ export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuI
       icon: getIcon('ui', 'notebook'),
       badge: 'early-access',
     },
-    scanner: {
-      id: 'scanner',
-      path: '/scanner',
-      title: 'Scanner',
-      description: 'Text aus Dokumenten extrahieren (OCR)',
-      icon: getIcon('navigation', 'scanner'),
-      badge: 'early-access',
-    },
+    ...(import.meta.env.DEV && {
+      scanner: {
+        id: 'scanner',
+        path: '/scanner',
+        title: 'Scanner',
+        description: 'Text aus Dokumenten extrahieren (OCR)',
+        icon: getIcon('navigation', 'scanner'),
+        badge: 'early-access',
+      },
+    }),
     // TEMPORARILY HIDDEN - Datenbank menu item
     // datenbank: {
     //   id: 'datenbank',

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -346,8 +346,8 @@ const standardRoutes: RouteConfig[] = [
   { path: '/notebooks', component: GrueneratorenBundle.NotebooksGallery },
   { path: '/documents/:documentId', component: GrueneratorenBundle.DocumentView },
   { path: '/reel', component: GrueneratorenBundle.Reel },
-  // Scanner Route (Beta Feature)
-  { path: '/scanner', component: GrueneratorenBundle.Scanner },
+  // Scanner Route (dev only)
+  ...(import.meta.env.DEV ? [{ path: '/scanner', component: GrueneratorenBundle.Scanner }] : []),
   { path: '/subtitler/share/:shareToken', component: SharedVideoPage, showHeaderFooter: false },
   { path: '/share/:shareToken', component: SharedMediaPage, showHeaderFooter: false },
   { path: '/gruenerator/erstellen', component: CreateCustomGeneratorPage, withForm: true },

--- a/apps/web/src/features/notebook/config/notebooksConfig.js
+++ b/apps/web/src/features/notebook/config/notebooksConfig.js
@@ -52,16 +52,6 @@ const PRODUCTION_NOTEBOOKS = [
     category: 'landesebene',
   },
   {
-    id: 'bayern-notebook',
-    path: '/gruene-bayern',
-    title: 'Frag Grüne Bayern',
-    description: 'Durchsuchbar ist das Regierungsprogramm der Grünen Bayern zur Landtagswahl.',
-    meta: '1 Programm',
-    tags: ['Bayern', 'Regierungsprogramm'],
-    order: 6,
-    category: 'landesebene',
-  },
-  {
     id: 'oesterreich-notebook',
     path: '/gruene-oesterreich',
     title: 'Frag Die Grünen Österreich',
@@ -75,6 +65,16 @@ const PRODUCTION_NOTEBOOKS = [
 ];
 
 const DEV_ONLY_NOTEBOOKS = [
+  {
+    id: 'bayern-notebook',
+    path: '/gruene-bayern',
+    title: 'Frag Grüne Bayern',
+    description: 'Durchsuchbar ist das Regierungsprogramm der Grünen Bayern zur Landtagswahl.',
+    meta: '1 Programm',
+    tags: ['Bayern', 'Regierungsprogramm'],
+    order: 6,
+    category: 'landesebene',
+  },
   {
     id: 'kommunalwiki-notebook',
     path: '/kommunalwiki',


### PR DESCRIPTION
## Summary
- Make Bayern notebook dev-only in frontend gallery
- Make scanner dev-only until further testing
- Restore scanner path in sidebar menu item
- Remove deploy-test workflow