### PR TITLE
fix(auth): add docs.gruenerator.eu to allowed domains

### DIFF
--- a/apps/api/config/domains.ts
+++ b/apps/api/config/domains.ts
@@ -15,6 +15,7 @@ export const ALLOWED_DOMAINS: string[] = [
   `www.${PRIMARY_DOMAIN}`,
   `beta.${PRIMARY_DOMAIN}`,
   `chat.${PRIMARY_DOMAIN}`,
+  `docs.${PRIMARY_DOMAIN}`,
   'gruenerator.de',
   'www.gruenerator.de',
   'beta.gruenerator.de',


### PR DESCRIPTION
## Summary
- Adds `docs.gruenerator.eu` to `ALLOWED_DOMAINS` in `apps/api/config/domains.ts`
- Fixes Keycloak "Ungültiger Parameter: redirect_uri" error when logging in from `docs.gruenerator.eu`
- The missing subdomain caused the OIDC strategy to fall back to the primary domain's callback URL, which Keycloak rejected

## Keycloak Admin (manual step)
After deploying, ensure the Keycloak client has:
- **Valid Redirect URIs**: `https://docs.gruenerator.eu/*`
- **Web Origins**: `https://docs.gruenerator.eu`

## Test plan
- [ ] Deploy to test environment
- [ ] Confirm Keycloak client has the new redirect URI configured
- [ ] Visit `docs.gruenerator.eu` → click login → verify redirect to Keycloak and back succeeds
- [ ] Check API logs for `Using origin domain for redirect_uri: https://docs.gruenerator.eu/api/auth/callback`