### PR TITLE
fix(docker): fix docs container crash — missing production deps

### DIFF
--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -85,12 +85,13 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 
 # Copy only package.json files for production install
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/docs/package.json ./packages/docs/
 COPY apps/docs/package.json ./apps/docs/
 COPY apps/api/package.json ./apps/api/
 
 # Install production dependencies (include api for hocuspocus service)
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
-    pnpm install --prod --frozen-lockfile --ignore-scripts --filter @gruenerator/docs --filter @gruenerator/api
+    pnpm install --prod --frozen-lockfile --ignore-scripts --filter @gruenerator/apps-docs --filter @gruenerator/api
 
 # Copy built assets and server
 COPY --from=builder /app/apps/docs/dist ./apps/docs/dist


### PR DESCRIPTION
## Summary
- Add `packages/docs/package.json` to production stage so workspace dep resolves
- Fix pnpm filter: `@gruenerator/docs` → `@gruenerator/apps-docs` so `express`, `helmet`, etc. are installed

Without this fix, the docs container crashes on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'express'`.

## Test plan
- [ ] Docs container starts and passes healthcheck