### PR TITLE
fix(docker): remove docs dependency from nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -125,8 +125,6 @@ services:
         condition: service_started
       api:
         condition: service_healthy
-      docs:
-        condition: service_started
       mcp:
         condition: service_started
       doku:


### PR DESCRIPTION
## Summary
Remove `docs` from nginx `depends_on` so a crashing docs container doesn't take down the entire platform.

## Test plan
- [ ] `docker compose up -d` starts nginx even if docs is unhealthy