### PR TITLE
fix(docker): nginx only depends on critical services (web + api)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -125,10 +125,6 @@ services:
         condition: service_started
       api:
         condition: service_healthy
-      mcp:
-        condition: service_started
-      doku:
-        condition: service_started
     networks:
       - gruenerator
     labels:


### PR DESCRIPTION
## Summary
Remove mcp and doku from nginx `depends_on`. Only web + api are critical for the platform. Nginx already uses dynamic DNS resolution so non-critical backends just get 502 if down — no startup blocking.

## Test plan
- [ ] `docker compose up -d` — nginx starts with only web + api healthy
- [ ] docs/mcp/doku down → rest of platform works fine