### PR TITLE
fix(web): prevent grid item overflow on mobile

### DIFF
--- a/apps/web/src/components/common/TabbedLayout/TabbedLayout.css
+++ b/apps/web/src/components/common/TabbedLayout/TabbedLayout.css
@@ -142,6 +142,7 @@
   grid-column: 1;
   grid-row: 1;
   width: 100%;
+  min-width: 0;
 }
 
 /* Hidden panels */


### PR DESCRIPTION
## Summary
- Adds `min-width: 0` to `.tabbed-layout__panel` to fix mobile layout overflow
- Grid items default to `min-width: auto`, which let `white-space: nowrap` text in recent cards inflate the panel to ~577px instead of fitting the ~175px mobile viewport
- With this fix, `overflow: hidden` + `text-overflow: ellipsis` on card titles/previews correctly truncates as intended

## Test plan
- [ ] Verify tabbed layout renders correctly on mobile viewports (≤400px)
- [ ] Check that recent card titles and previews truncate with ellipsis
- [ ] Confirm no horizontal overflow on the page
- [ ] Verify desktop layout is unaffected