### PR TITLE
fix: docs asset loading + hide broken edit mode button

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -1,12 +1,13 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react({ jsxRuntime: 'automatic' })],
   resolve: {
     alias: {

--- a/apps/web/src/components/common/ActionButtons.tsx
+++ b/apps/web/src/components/common/ActionButtons.tsx
@@ -86,7 +86,7 @@ const ActionButtons = ({
   showRegenerate = false,
   showSave = false,
   showSaveToLibrary = true,
-  showEditMode = false,
+  showEditMode: _showEditMode = false,
   showUndo = true,
   showRedo = true,
   onEditModeToggle,
@@ -393,26 +393,8 @@ const ActionButtons = ({
           <IoRefreshOutline size={16} />
         </button>
       ),
-      edit: showEditMode && activeContent && (onRequestEdit || onEditModeToggle) && (
-        <button
-          key="edit"
-          onClick={() => {
-            if (onRequestEdit) {
-              onRequestEdit();
-            } else if (onEditModeToggle) {
-              onEditModeToggle();
-            }
-          }}
-          className={`action-button ${isEditModeActive ? 'active' : ''}`}
-          aria-label={isEditModeActive ? 'Edit Mode schließen' : 'Edit Mode umschalten'}
-          {...(!isMobileView && {
-            'data-tooltip-id': 'action-tooltip',
-            'data-tooltip-content': isEditModeActive ? 'Schließen' : 'Edit Mode',
-          })}
-        >
-          {isEditModeActive ? <IoCloseOutline size={16} /> : <HiPencil size={16} />}
-        </button>
-      ),
+      // TODO: re-enable when suggest_edits backend parsing is fixed
+      edit: null,
       more: (showExport || showDownload || showExportDropdown) && isAuthenticated && (
         <ExportDropdown
           key="more"


### PR DESCRIPTION
## Summary
- **fix(docs):** Change Vite base path from `'./'` to `'/'` to fix JS/CSS assets returning `text/html` MIME type on deep routes like `/document/:id`
- **fix(web):** Temporarily hide the edit mode pencil button — the `suggest_edits` Mistral endpoint returns unparseable JSON, causing repeated `JSON parsing failed` errors

## Test plan
- [ ] Verify docs.gruenerator.eu loads correctly on `/document/:id` routes (no MIME type errors in console)
- [ ] Verify the edit mode pencil button is no longer visible in the action buttons bar