### PR TITLE
fix(chat): use existing MCP_REPO_PAT for mirror workflow

### DIFF
--- a/.github/workflows/mirror-chat.yml
+++ b/.github/workflows/mirror-chat.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Movm/Gruenerator-Chat
-          token: ${{ secrets.CHAT_REPO_PAT }}
+          token: ${{ secrets.MCP_REPO_PAT }}
           fetch-depth: 0
           path: chat-standalone
 


### PR DESCRIPTION
Reuse the existing MCP_REPO_PAT secret instead of a missing CHAT_REPO_PAT — same Movm account, same token.