### PR TITLE
fix(api): symlink uploads/logs inside dist/ for __dirname path resolution

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -124,6 +124,11 @@ RUN ln -s dist/static-data static-data && \
 # Create runtime directories owned by app user
 RUN mkdir -p uploads logs && chown gruenerator:gruenerator uploads logs
 
+# Symlink uploads/logs inside dist/ for code using __dirname-relative paths
+# (compiled JS runs from dist/, so __dirname resolves inside dist/)
+RUN ln -s /app/apps/api/uploads dist/uploads && \
+    ln -s /app/apps/api/logs dist/logs
+
 ENV NODE_ENV=production
 ENV PORT=3001
 


### PR DESCRIPTION
## Summary
- Fixes API container crash-loop caused by `__dirname`-relative paths resolving inside `dist/` after the compiled JS Dockerfile change (`397e624e`)
- Symlinks `dist/uploads` → `/app/apps/api/uploads` and `dist/logs` → `/app/apps/api/logs` so TusService and other services find their runtime directories

## Root cause
Commit `397e624e` switched the API Dockerfile from `tsx` to `node dist/server.js`. This changed `__dirname` from pointing at source dirs to pointing inside `dist/`, breaking ~15 files that use `__dirname`-relative paths to `uploads/`.

## Test plan
- [x] Container starts without `ENOENT: mkdir dist/uploads` crash
- [x] TUS file uploads work (symlink redirects to real uploads dir)
- [x] Docker volume mount `api-uploads:/app/apps/api/uploads` still works