### PR TITLE
fix(docker): add procps to API image to stop Crawlee log spam

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     fontconfig \
     fonts-dejavu-core \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g 1001 gruenerator && \


### PR DESCRIPTION
## Summary
- Adds `procps` package to the API Docker production stage
- Fixes the repeated `ERROR Memory snapshot failed. spawn ps ENOENT` log spam on beta.gruenerator.de
- Crawlee's `LocalEventManager` spawns `ps` for memory monitoring, which requires `procps` (not included in `node:20-slim`)

## Test plan
- [ ] Rebuild API Docker image and deploy to test
- [ ] Verify `docker exec <container> ps --version` works
- [ ] Confirm "Memory snapshot failed" errors no longer appear in logs