### PR TITLE
fix(docs): derive Hocuspocus WebSocket URL from window.location

### DIFF
--- a/apps/docs/src/lib/docsAdapter.ts
+++ b/apps/docs/src/lib/docsAdapter.ts
@@ -1,6 +1,8 @@
 import type { DocsAdapter } from '@gruenerator/docs';
 
-const HOCUSPOCUS_URL = import.meta.env.VITE_HOCUSPOCUS_URL || 'ws://localhost:1240';
+const HOCUSPOCUS_URL =
+  import.meta.env.VITE_HOCUSPOCUS_URL ||
+  `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`;
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 /**


### PR DESCRIPTION
## Summary
- The `VITE_HOCUSPOCUS_URL` env var is not set during Docker builds, so the hardcoded fallback `ws://localhost:1240` was baked into the production bundle
- This caused the browser to attempt WebSocket connections to the user's local machine instead of the server, leaving the collaboration status indicator permanently yellow (syncing)
- Changed the fallback to derive the URL from `window.location`, using `wss://` for HTTPS and the `/ws` nginx proxy path

## Test plan
- [x] Verified on https://docs.gruenerator.eu/ — status dot turns green, documents sync correctly
- [ ] Confirm local dev still works (Vite proxy forwards `/ws` to hocuspocus on port 1240)