### PR TITLE
Release: platform skills, PlusMenu redesign, title generation fix, and UI tweaks

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.vitest.ts
@@ -1,0 +1,669 @@
+/**
+ * Search Documents Tool Tests
+ *
+ * Verifies:
+ * 1. Zod schema validation for the search_documents tool
+ * 2. 5-level collection priority chain (mirrors searchNode's chain in the DeepAgent context)
+ * 3. LLM `collections` parameter override behavior
+ * 4. Document-scoped search via getQdrantDocumentService
+ * 5. Integrated reranking with Mistral + MMR diversity
+ * 6. Edge cases: no results, service failures, URL deduplication
+ *
+ * 7. Real LLM integration: Mistral rerank response parsing (skipped without API key)
+ *
+ * Run with: pnpm --filter @gruenerator/api test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock external dependencies BEFORE any imports that use them ──────────
+
+vi.mock('../../../../routes/chat/agents/directSearch.js', () => ({
+  executeDirectSearch: vi.fn(),
+}));
+
+const mockDocumentSearch = vi.fn();
+vi.mock('../../../../services/document-services/DocumentSearchService/index.js', () => ({
+  getQdrantDocumentService: vi.fn(() => ({
+    search: mockDocumentSearch,
+  })),
+}));
+
+vi.mock('../../../../services/search/DiversityReranker.js', () => ({
+  applyMMR: vi.fn((results: any[]) => results),
+}));
+
+vi.mock('../../../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../nodes/searchNode.js', () => ({
+  getDefaultCollectionsForLocale: vi.fn((locale: string | undefined) => {
+    if (locale === 'de-AT') return ['oesterreich', 'gruene-at'];
+    return ['deutschland', 'bundestagsfraktion', 'gruene-de', 'kommunalwiki'];
+  }),
+}));
+
+// ─── Import modules under test (after mocks) ─────────────────────────────
+
+import { createSearchDocumentsTool } from './searchDocuments.js';
+import { executeDirectSearch } from '../../../../routes/chat/agents/directSearch.js';
+import { getQdrantDocumentService } from '../../../../services/document-services/DocumentSearchService/index.js';
+import { applyMMR } from '../../../../services/search/DiversityReranker.js';
+import { getDefaultCollectionsForLocale } from '../nodes/searchNode.js';
+
+import type { ToolDependencies } from './registry.js';
+
+// ─── Test helpers ─────────────────────────────────────────────────────────
+
+function makeDeps(overrides: Partial<ToolDependencies> = {}): ToolDependencies {
+  return {
+    agentConfig: { id: 'test', systemRole: 'test', name: 'Test' } as any,
+    aiWorkerPool: {
+      processRequest: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          scores: [
+            { index: 0, score: 5 },
+            { index: 1, score: 4 },
+            { index: 2, score: 3 },
+            { index: 3, score: 2 },
+          ],
+        }),
+      }),
+    },
+    enabledTools: {},
+    ...overrides,
+  };
+}
+
+function makeDirectSearchResult(
+  collection: string,
+  results: Array<{ source: string; excerpt: string; url?: string; relevance?: string }>
+) {
+  return { collection, results };
+}
+
+function getSearchedCollections(): string[] {
+  return [
+    ...new Set(vi.mocked(executeDirectSearch).mock.calls.map((call: any[]) => call[0].collection)),
+  ];
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('search_documents tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: executeDirectSearch returns 2 results per collection
+    vi.mocked(executeDirectSearch).mockImplementation(
+      async ({ collection }: { collection: string }) =>
+        makeDirectSearchResult(collection, [
+          {
+            source: 'Grüne Klimapolitik',
+            excerpt: 'Die Grünen setzen auf Klimaneutralität bis 2035.',
+            url: `https://example.com/${collection}/1`,
+            relevance: 'Sehr hoch',
+          },
+          {
+            source: 'Energiewende',
+            excerpt: 'Der Ausbau erneuerbarer Energien ist zentral.',
+            url: `https://example.com/${collection}/2`,
+            relevance: 'Hoch',
+          },
+        ])
+    );
+  });
+
+  // ========================================================================
+  // 1. Schema validation
+  // ========================================================================
+
+  describe('schema', () => {
+    const tool = createSearchDocumentsTool(makeDeps());
+
+    it('has name "search_documents"', () => {
+      expect(tool.name).toBe('search_documents');
+    });
+
+    it('accepts query as required string', () => {
+      const parsed = tool.schema.safeParse({ query: 'Klimapolitik' });
+      expect(parsed.success).toBe(true);
+    });
+
+    it('rejects missing query', () => {
+      const parsed = tool.schema.safeParse({});
+      expect(parsed.success).toBe(false);
+    });
+
+    it('accepts collections as optional string array', () => {
+      const parsed = tool.schema.safeParse({
+        query: 'test',
+        collections: ['deutschland', 'bundestagsfraktion'],
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it('accepts document_ids as optional string array', () => {
+      const parsed = tool.schema.safeParse({
+        query: 'test',
+        document_ids: ['doc-123', 'doc-456'],
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it('accepts topK as optional number', () => {
+      const parsed = tool.schema.safeParse({ query: 'test', topK: 5 });
+      expect(parsed.success).toBe(true);
+    });
+
+    it('accepts all parameters together', () => {
+      const parsed = tool.schema.safeParse({
+        query: 'Energiewende',
+        collections: ['deutschland'],
+        document_ids: ['doc-1'],
+        topK: 3,
+      });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  // ========================================================================
+  // 2. Collection priority chain
+  // ========================================================================
+
+  describe('collection priority chain', () => {
+    it('priority 5 (lowest): locale fallback when no deps set', async () => {
+      const tool = createSearchDocumentsTool(makeDeps());
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(
+        expect.arrayContaining(['deutschland', 'bundestagsfraktion', 'gruene-de', 'kommunalwiki'])
+      );
+      expect(collections).toHaveLength(4);
+      expect(getDefaultCollectionsForLocale).toHaveBeenCalled();
+    });
+
+    it('priority 4: defaultNotebookCollectionIds overrides locale', async () => {
+      const tool = createSearchDocumentsTool(
+        makeDeps({ defaultNotebookCollectionIds: ['hamburg'] })
+      );
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(['hamburg']);
+      expect(getDefaultCollectionsForLocale).not.toHaveBeenCalled();
+    });
+
+    it('priority 3: agent defaultCollection overrides defaultNotebookCollectionIds', async () => {
+      const tool = createSearchDocumentsTool(
+        makeDeps({
+          agentConfig: {
+            id: 'test',
+            systemRole: 'test',
+            name: 'Test',
+            toolRestrictions: { defaultCollection: 'oesterreich' },
+          } as any,
+          defaultNotebookCollectionIds: ['hamburg'],
+        })
+      );
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      const collections = getSearchedCollections();
+      expect(collections).toContain('oesterreich');
+      expect(collections).not.toContain('hamburg');
+      // defaultCollection adds supplementary collections
+      expect(collections).toEqual(
+        expect.arrayContaining(['oesterreich', 'bundestagsfraktion', 'gruene-de', 'kommunalwiki'])
+      );
+    });
+
+    it('priority 2: agent allowedCollections overrides defaultNotebookCollectionIds', async () => {
+      const tool = createSearchDocumentsTool(
+        makeDeps({
+          agentConfig: {
+            id: 'test',
+            systemRole: 'test',
+            name: 'Test',
+            toolRestrictions: { allowedCollections: ['bayern', 'thueringen'] },
+          } as any,
+          defaultNotebookCollectionIds: ['hamburg'],
+        })
+      );
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(expect.arrayContaining(['bayern', 'thueringen']));
+      expect(collections).not.toContain('hamburg');
+    });
+
+    it('LLM collections param overrides all deps-level defaults', async () => {
+      const tool = createSearchDocumentsTool(
+        makeDeps({
+          agentConfig: {
+            id: 'test',
+            systemRole: 'test',
+            name: 'Test',
+            toolRestrictions: { allowedCollections: ['bayern'] },
+          } as any,
+          defaultNotebookCollectionIds: ['hamburg'],
+        })
+      );
+      await tool.invoke({ query: 'Klimapolitik', collections: ['kommunalwiki'] });
+
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(['kommunalwiki']);
+    });
+
+    it('locale de-AT produces Austrian collections', async () => {
+      const tool = createSearchDocumentsTool(makeDeps({ userLocale: 'de-AT' }));
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      expect(getDefaultCollectionsForLocale).toHaveBeenCalledWith('de-AT');
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(expect.arrayContaining(['oesterreich', 'gruene-at']));
+      expect(collections).toHaveLength(2);
+    });
+
+    it('multiple default notebook collections searched in parallel', async () => {
+      const tool = createSearchDocumentsTool(
+        makeDeps({ defaultNotebookCollectionIds: ['hamburg', 'bayern'] })
+      );
+      await tool.invoke({ query: 'Klimapolitik' });
+
+      const collections = getSearchedCollections();
+      expect(collections).toEqual(expect.arrayContaining(['hamburg', 'bayern']));
+      expect(collections).toHaveLength(2);
+      // Each collection searched once
+      expect(executeDirectSearch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ========================================================================
+  // 3. Document-scoped search
+  // ========================================================================
+
+  describe('document-scoped search', () => {
+    it('uses getQdrantDocumentService when document_ids provided', async () => {
+      mockDocumentSearch.mockResolvedValue({
+        results: [
+          {
+            document_id: 'doc-1',
+            title: 'Test Document',
+            chunk_text: 'Document content here.',
+            source_url: 'https://docs.example.com/1',
+            score: 0.85,
+          },
+        ],
+      });
+
+      const tool = createSearchDocumentsTool(
+        makeDeps({
+          agentConfig: { id: 'test', systemRole: 'test', name: 'Test', userId: 'user-1' } as any,
+        })
+      );
+      await tool.invoke({ query: 'test query', document_ids: ['doc-1'] });
+
+      expect(getQdrantDocumentService).toHaveBeenCalled();
+      expect(mockDocumentSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'test query',
+          filters: { documentIds: ['doc-1'] },
+        })
+      );
+      // Should NOT call executeDirectSearch
+      expect(executeDirectSearch).not.toHaveBeenCalled();
+    });
+
+    it('bypasses collection priority chain entirely', async () => {
+      mockDocumentSearch.mockResolvedValue({ results: [] });
+
+      const tool = createSearchDocumentsTool(
+        makeDeps({
+          defaultNotebookCollectionIds: ['hamburg'],
+          agentConfig: {
+            id: 'test',
+            systemRole: 'test',
+            name: 'Test',
+            toolRestrictions: { allowedCollections: ['bayern'] },
+          } as any,
+        })
+      );
+      await tool.invoke({ query: 'test', document_ids: ['doc-1'] });
+
+      expect(executeDirectSearch).not.toHaveBeenCalled();
+      expect(getDefaultCollectionsForLocale).not.toHaveBeenCalled();
+    });
+
+    it('returns error message on service failure (not throw)', async () => {
+      mockDocumentSearch.mockRejectedValue(new Error('Qdrant unavailable'));
+
+      const tool = createSearchDocumentsTool(makeDeps());
+      const result = await tool.invoke({ query: 'test', document_ids: ['doc-1'] });
+
+      expect(result).toBe('Fehler bei der Dokumentensuche. Bitte versuche es erneut.');
+    });
+  });
+
+  // ========================================================================
+  // 4. Reranking integration
+  // ========================================================================
+
+  describe('reranking integration', () => {
+    it('results with ≤3 items skip reranking (returned as-is)', async () => {
+      // Return only 2 results (below the ≤3 threshold)
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) =>
+          makeDirectSearchResult(collection, [
+            {
+              source: 'Single Result',
+              excerpt: 'Only result.',
+              url: `https://example.com/${collection}/1`,
+              relevance: 'Hoch',
+            },
+          ])
+      );
+
+      const deps = makeDeps();
+      const tool = createSearchDocumentsTool(deps);
+      await tool.invoke({ query: 'test', collections: ['deutschland'] });
+
+      // aiWorkerPool.processRequest should NOT be called (rerank skipped)
+      expect(deps.aiWorkerPool.processRequest).not.toHaveBeenCalled();
+      expect(applyMMR).not.toHaveBeenCalled();
+    });
+
+    it('rerank failure degrades gracefully (returns original order)', async () => {
+      // Return 5 results to trigger reranking
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) =>
+          makeDirectSearchResult(collection, [
+            {
+              source: 'R1',
+              excerpt: 'A',
+              url: `https://example.com/${collection}/1`,
+              relevance: 'Sehr hoch',
+            },
+            {
+              source: 'R2',
+              excerpt: 'B',
+              url: `https://example.com/${collection}/2`,
+              relevance: 'Hoch',
+            },
+            {
+              source: 'R3',
+              excerpt: 'C',
+              url: `https://example.com/${collection}/3`,
+              relevance: 'Hoch',
+            },
+          ])
+      );
+
+      const deps = makeDeps({
+        aiWorkerPool: {
+          processRequest: vi.fn().mockRejectedValue(new Error('Mistral timeout')),
+        },
+      });
+      const tool = createSearchDocumentsTool(deps);
+      const result = await tool.invoke({
+        query: 'test',
+        collections: ['deutschland', 'bundestagsfraktion'],
+      });
+
+      // Should still return results despite rerank failure
+      expect(result).toContain('Dokumente gefunden');
+    });
+
+    it('MMR diversity applied when >3 results after filtering', async () => {
+      // Return enough results to trigger reranking AND MMR
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) =>
+          makeDirectSearchResult(collection, [
+            {
+              source: 'R1',
+              excerpt: 'A',
+              url: `https://example.com/${collection}/1`,
+              relevance: 'Sehr hoch',
+            },
+            {
+              source: 'R2',
+              excerpt: 'B',
+              url: `https://example.com/${collection}/2`,
+              relevance: 'Hoch',
+            },
+            {
+              source: 'R3',
+              excerpt: 'C',
+              url: `https://example.com/${collection}/3`,
+              relevance: 'Hoch',
+            },
+          ])
+      );
+
+      const tool = createSearchDocumentsTool(makeDeps());
+      await tool.invoke({ query: 'test', collections: ['deutschland', 'bundestagsfraktion'] });
+
+      // applyMMR should be called (>3 results after rerank + filter)
+      expect(applyMMR).toHaveBeenCalledWith(expect.any(Array), 0.7, 2);
+    });
+  });
+
+  // ========================================================================
+  // 5. Edge cases
+  // ========================================================================
+
+  describe('edge cases', () => {
+    it('no results returns German "not found" message', async () => {
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) => makeDirectSearchResult(collection, [])
+      );
+
+      const deps = makeDeps();
+      // Ensure rerank returns empty too
+      deps.aiWorkerPool.processRequest = vi.fn();
+      const tool = createSearchDocumentsTool(deps);
+      const result = await tool.invoke({
+        query: 'nonexistent topic',
+        collections: ['deutschland'],
+      });
+
+      expect(result).toBe('Keine relevanten Dokumente gefunden.');
+    });
+
+    it('service failure returns empty results gracefully', async () => {
+      vi.mocked(executeDirectSearch).mockRejectedValue(new Error('Connection refused'));
+
+      const deps = makeDeps();
+      deps.aiWorkerPool.processRequest = vi.fn();
+      const tool = createSearchDocumentsTool(deps);
+      const result = await tool.invoke({ query: 'test', collections: ['deutschland'] });
+
+      // All collections failed → no results → "not found" message
+      expect(result).toBe('Keine relevanten Dokumente gefunden.');
+    });
+
+    it('URL deduplication across collections', async () => {
+      // Both collections return the same URL
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) =>
+          makeDirectSearchResult(collection, [
+            {
+              source: 'Shared Article',
+              excerpt: 'Shared content across collections.',
+              url: 'https://example.com/shared',
+              relevance: 'Sehr hoch',
+            },
+          ])
+      );
+
+      const deps = makeDeps();
+      // Skip reranking by ensuring ≤3 unique results
+      deps.aiWorkerPool.processRequest = vi.fn();
+      const tool = createSearchDocumentsTool(deps);
+      const result = await tool.invoke({
+        query: 'test',
+        collections: ['deutschland', 'bundestagsfraktion'],
+      });
+
+      // Should only contain the URL once (deduplicated)
+      const urlMatches = result.match(/https:\/\/example\.com\/shared/g) || [];
+      expect(urlMatches.length).toBe(1);
+    });
+
+    it('topK parameter propagates to executeDirectSearch limit', async () => {
+      const tool = createSearchDocumentsTool(makeDeps());
+      await tool.invoke({ query: 'test', topK: 7, collections: ['deutschland'] });
+
+      expect(executeDirectSearch).toHaveBeenCalledWith(expect.objectContaining({ limit: 7 }));
+    });
+
+    it('defaults topK to 3 when omitted', async () => {
+      const tool = createSearchDocumentsTool(makeDeps());
+      await tool.invoke({ query: 'test', collections: ['deutschland'] });
+
+      expect(executeDirectSearch).toHaveBeenCalledWith(expect.objectContaining({ limit: 3 }));
+    });
+
+    it('deduplicates identical collections in input', async () => {
+      const tool = createSearchDocumentsTool(makeDeps());
+      await tool.invoke({
+        query: 'test',
+        collections: ['deutschland', 'deutschland', 'deutschland'],
+      });
+
+      // Should only search once despite 3 identical entries
+      expect(executeDirectSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('formats output with numbered citations and URLs', async () => {
+      vi.mocked(executeDirectSearch).mockImplementation(
+        async ({ collection }: { collection: string }) =>
+          makeDirectSearchResult(collection, [
+            {
+              source: 'Klimapolitik',
+              excerpt: 'Die Grünen setzen auf Klimaneutralität.',
+              url: 'https://gruene.de/klima',
+              relevance: 'Sehr hoch',
+            },
+          ])
+      );
+
+      const deps = makeDeps();
+      deps.aiWorkerPool.processRequest = vi.fn();
+      const tool = createSearchDocumentsTool(deps);
+      const result = await tool.invoke({ query: 'test', collections: ['deutschland'] });
+
+      expect(result).toContain('[1]');
+      expect(result).toContain('https://gruene.de/klima');
+      expect(result).toContain('Dokumente gefunden');
+    });
+  });
+});
+
+// ==========================================================================
+// Real LLM integration test — calls Mistral API directly
+// Skipped when MISTRAL_API_KEY is not set (CI-safe)
+// ==========================================================================
+
+const MISTRAL_KEY = process.env.MISTRAL_API_KEY;
+
+describe.skipIf(!MISTRAL_KEY)('search_documents – real LLM rerank integration', () => {
+  const RERANK_PROMPT = `Du bewertest die Relevanz von Suchergebnissen für eine Benutzeranfrage.
+
+Für jedes Ergebnis vergib einen Relevanz-Score von 1-5:
+5 = Direkt relevant, beantwortet die Frage
+4 = Sehr relevant, enthält wichtige Informationen
+3 = Teilweise relevant, enthält Hintergrundinformationen
+2 = Wenig relevant, nur am Rande verwandt
+1 = Nicht relevant
+
+Antworte NUR mit JSON:
+{ "scores": [{"index": 0, "score": 5}, {"index": 1, "score": 3}, ...] }`;
+
+  const testPassages = [
+    {
+      index: 0,
+      title: 'Klimaneutralität 2035',
+      content: 'Die Grünen fordern Klimaneutralität bis 2035 mit konkretem Stufenplan.',
+    },
+    {
+      index: 1,
+      title: 'Parteifinanzen 2024',
+      content: 'Bericht über die Einnahmen und Ausgaben der Partei im Geschäftsjahr 2024.',
+    },
+    {
+      index: 2,
+      title: 'Erneuerbare Energien Ausbau',
+      content: 'Windkraft und Solarenergie sollen massiv ausgebaut werden.',
+    },
+    {
+      index: 3,
+      title: 'Vereinssatzung §12',
+      content: 'Regelungen zur Mitgliederversammlung und Abstimmungsverfahren.',
+    },
+  ];
+
+  const passageList = testPassages.map((p) => `[${p.index}] ${p.title}\n${p.content}`).join('\n\n');
+
+  async function callMistralRerank(query: string): Promise<any> {
+    const { Mistral } = await import('@mistralai/mistralai');
+    const client = new Mistral({ apiKey: MISTRAL_KEY! });
+
+    const response = await client.chat.complete({
+      model: 'mistral-small-latest',
+      messages: [
+        { role: 'system', content: RERANK_PROMPT },
+        { role: 'user', content: `Suchanfrage: "${query}"\n\nErgebnisse:\n${passageList}` },
+      ],
+      maxTokens: 200,
+      temperature: 0.0,
+      responseFormat: { type: 'json_object' },
+    });
+
+    const raw = (response.choices?.[0]?.message?.content || '{}') as string;
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, '')
+      .replace(/\s*```\s*$/i, '')
+      .trim();
+    return JSON.parse(cleaned);
+  }
+
+  it('Mistral returns valid rerank JSON with scores array', async () => {
+    const parsed = await callMistralRerank('Klimapolitik der Grünen');
+
+    expect(parsed).toHaveProperty('scores');
+    expect(Array.isArray(parsed.scores)).toBe(true);
+    expect(parsed.scores.length).toBe(testPassages.length);
+
+    for (const entry of parsed.scores) {
+      expect(entry).toHaveProperty('index');
+      expect(entry).toHaveProperty('score');
+      expect(typeof entry.index).toBe('number');
+      expect(typeof entry.score).toBe('number');
+      expect(entry.score).toBeGreaterThanOrEqual(1);
+      expect(entry.score).toBeLessThanOrEqual(5);
+    }
+  }, 15_000);
+
+  it('Mistral ranks climate results higher than unrelated ones for a climate query', async () => {
+    const parsed = await callMistralRerank('Was ist die Klimapolitik der Grünen?');
+
+    const scoreMap = new Map<number, number>();
+    for (const entry of parsed.scores) {
+      scoreMap.set(entry.index, entry.score);
+    }
+
+    // "Klimaneutralität 2035" (index 0) and "Erneuerbare Energien" (index 2)
+    // should score higher than "Parteifinanzen" (index 1) and "Vereinssatzung" (index 3)
+    const climateScore = Math.max(scoreMap.get(0) ?? 0, scoreMap.get(2) ?? 0);
+    const unrelatedScore = Math.min(scoreMap.get(1) ?? 5, scoreMap.get(3) ?? 5);
+
+    expect(climateScore).toBeGreaterThan(unrelatedScore);
+  }, 15_000);
+});

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,4 +1,7 @@
+import { config as dotenvConfig } from 'dotenv';
 import { defineConfig } from 'vitest/config';
+
+dotenvConfig();
 
 export default defineConfig({
   test: {

--- a/apps/docs/src/components/permissions/ShareModal.tsx
+++ b/apps/docs/src/components/permissions/ShareModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+
 import { apiClient } from '../../lib/apiClient';
 import './ShareModal.css';
 
@@ -24,7 +25,10 @@ interface ShareModalProps {
 
 export const ShareModal = ({ documentId, onClose }: ShareModalProps) => {
   const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
-  const [shareSettings, setShareSettings] = useState<ShareSettings>({ is_public: false, share_permission: 'editor' });
+  const [shareSettings, setShareSettings] = useState<ShareSettings>({
+    is_public: false,
+    share_permission: 'editor',
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -54,8 +58,8 @@ export const ShareModal = ({ documentId, onClose }: ShareModalProps) => {
   }, [documentId]);
 
   useEffect(() => {
-    fetchCollaborators();
-    fetchShareSettings();
+    void fetchCollaborators();
+    void fetchShareSettings();
   }, [fetchCollaborators, fetchShareSettings]);
 
   const copyShareLink = async () => {
@@ -162,11 +166,11 @@ export const ShareModal = ({ documentId, onClose }: ShareModalProps) => {
         <div className="share-link-section">
           <div className="public-sharing-toggle">
             <div className="public-sharing-info">
-              <h3>Jeder mit dem Link</h3>
+              <h3>Gastzugang</h3>
               <p className="public-sharing-description">
                 {shareSettings.is_public
-                  ? 'Jeder mit dem Link kann dieses Dokument öffnen'
-                  : 'Nur eingeladene Personen haben Zugriff'}
+                  ? 'Jeder mit dem Link kann ohne Anmeldung zugreifen'
+                  : 'Nur angemeldete Nutzer haben Zugriff'}
               </p>
             </div>
             <label className="toggle-switch">

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -4,10 +4,11 @@ import {
   BlockNoteEditor as BlockNoteEditorComponent,
   useDocsAdapter,
   createDocsApiClient,
+  type Document,
 } from '@gruenerator/docs';
+import { EditorTopBar } from '@gruenerator/shared/tiptap-editor/components';
 import { MantineProvider, SegmentedControl, ScrollArea } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
-import { EditorTopBar } from '@gruenerator/shared/tiptap-editor/components';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -20,7 +21,7 @@ import '@mantine/core/styles.css';
 import './EditorPage.css';
 
 const ShareModal = lazy(() =>
-  import('@gruenerator/shared/tiptap-editor').then((m) => ({ default: m.ShareModal }))
+  import('../components/permissions/ShareModal').then((m) => ({ default: m.ShareModal }))
 );
 const ChatSidebar = lazy(() =>
   import('@gruenerator/docs').then((m) => ({ default: m.ChatSidebar }))
@@ -29,13 +30,33 @@ const ChatSidebar = lazy(() =>
 const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const GUEST_ANIMAL_NAMES = [
-  'Eichhörnchen', 'Igel', 'Fuchs', 'Reh', 'Dachs', 'Hase', 'Eule',
-  'Specht', 'Otter', 'Biber', 'Falke', 'Luchs', 'Marder', 'Drossel',
+  'Eichhörnchen',
+  'Igel',
+  'Fuchs',
+  'Reh',
+  'Dachs',
+  'Hase',
+  'Eule',
+  'Specht',
+  'Otter',
+  'Biber',
+  'Falke',
+  'Luchs',
+  'Marder',
+  'Drossel',
 ];
 
 const GUEST_COLORS = [
-  '#FF6B6B', '#4ECDC4', '#45B7D1', '#FFA07A', '#98D8C8',
-  '#F7DC6F', '#BB8FCE', '#85C1E2', '#F8B739', '#52B788',
+  '#FF6B6B',
+  '#4ECDC4',
+  '#45B7D1',
+  '#FFA07A',
+  '#98D8C8',
+  '#F7DC6F',
+  '#BB8FCE',
+  '#85C1E2',
+  '#F8B739',
+  '#52B788',
 ];
 
 function getOrCreateGuestIdentity(): { guestId: string; guestName: string; guestColor: string } {
@@ -43,7 +64,9 @@ function getOrCreateGuestIdentity(): { guestId: string; guestName: string; guest
   if (stored) {
     try {
       return JSON.parse(stored);
-    } catch { /* regenerate */ }
+    } catch {
+      /* regenerate */
+    }
   }
 
   const identity = {
@@ -74,7 +97,7 @@ export const EditorPage = () => {
         if (!res.ok) return null;
         return res.json();
       }
-      return apiClient.get<any>(`/docs/${id}`);
+      return apiClient.get<Document>(`/docs/${id}`);
     },
     enabled: !!id,
   });
@@ -138,8 +161,7 @@ export const EditorPage = () => {
   const handleExportPDF = useCallback(async () => {
     if (!docData || !editor) return;
     try {
-      const { PDFExporter, pdfDefaultSchemaMappings } =
-        await import('@blocknote/xl-pdf-exporter');
+      const { PDFExporter, pdfDefaultSchemaMappings } = await import('@blocknote/xl-pdf-exporter');
       const { pdf } = await import('@react-pdf/renderer');
 
       const exporter = new PDFExporter(editor.schema, pdfDefaultSchemaMappings);
@@ -161,8 +183,7 @@ export const EditorPage = () => {
   const handleExportODT = useCallback(async () => {
     if (!docData || !editor) return;
     try {
-      const { ODTExporter, odtDefaultSchemaMappings } =
-        await import('@blocknote/xl-odt-exporter');
+      const { ODTExporter, odtDefaultSchemaMappings } = await import('@blocknote/xl-odt-exporter');
       const exporter = new ODTExporter(editor.schema, odtDefaultSchemaMappings);
       const blob = await exporter.toODTDocument(editor.document);
 
@@ -183,7 +204,9 @@ export const EditorPage = () => {
   }, []);
 
   useEffect(() => {
-    setCommentsPortalTarget(sidebarOpen && sidebarTab === 'comments' ? commentsPortalRef.current : null);
+    setCommentsPortalTarget(
+      sidebarOpen && sidebarTab === 'comments' ? commentsPortalRef.current : null
+    );
   }, [sidebarOpen, sidebarTab]);
 
   if (docIsLoading) {

--- a/apps/web/src/assets/styles/components/layout/profile-dropdown.css
+++ b/apps/web/src/assets/styles/components/layout/profile-dropdown.css
@@ -396,7 +396,7 @@
 
 @media (max-width: 768px) {
   .profile-button-container {
-    margin-right: 60px;
+    margin-right: 10px;
   }
 
   .profile-dropdown {

--- a/apps/web/src/assets/styles/pages/homepage.css
+++ b/apps/web/src/assets/styles/pages/homepage.css
@@ -570,7 +570,7 @@
   .mobile-only { display: flex !important; }
 
   .top-section {
-    padding: 16px 1.25rem 2rem;
+    padding: 32px 1.25rem 2rem;
   }
 
   .animated-heading .typing-text,

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -14,7 +14,7 @@ export default function ChatPage() {
 
   return (
     <div className="chat-page-root flex overflow-hidden bg-background">
-      <main className="flex flex-1 flex-col overflow-hidden">
+      <main className="flex flex-1 flex-col overflow-hidden pt-4 md:pt-0">
         <GrueneratorThread />
       </main>
     </div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,6 +68,7 @@ export default [
       '**/.next/**',
       '**/.expo/**',
       '**/coverage/**',
+      'packages/shared/src/tiptap-editor/**',
       'pnpm-lock.yaml',
     ],
   },

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -86,13 +86,15 @@ export function GrueneratorComposer({ isRunning }: GrueneratorComposerProps) {
       const after = mention.mentionStart >= 0 ? currentText.slice(textarea.selectionStart) : '';
       const prefix =
         before.length > 0 && !before.endsWith(' ') && mention.mentionStart < 0 ? ' ' : '';
-      const newText = `${before}${prefix}${trigger}${mentionable.mention} ${after}`;
+      const ctxSuffix = mentionable.contextPrefix ? `${mentionable.contextPrefix} ` : '';
+      const newText = `${before}${prefix}${trigger}${mentionable.mention} ${ctxSuffix}${after}`;
 
       composerRuntime.setText(newText);
       dismissPopover();
 
       requestAnimationFrame(() => {
-        const cursorPos = before.length + prefix.length + mentionable.mention.length + 2; // +2 for trigger and space
+        const cursorPos =
+          before.length + prefix.length + mentionable.mention.length + 2 + ctxSuffix.length; // +2 for trigger and space
         textarea.setSelectionRange(cursorPos, cursorPos);
         textarea.focus();
       });

--- a/packages/chat/src/components/thread/PlusMenu.tsx
+++ b/packages/chat/src/components/thread/PlusMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { PlusIcon, Upload, FileSearch, ChevronRight, ArrowLeft, Check } from 'lucide-react';
+import { PlusIcon, Upload, FileSearch, ChevronRight, Check } from 'lucide-react';
 import { Dropdown, DropdownItem } from '../ui/Dropdown';
 import { useAgentStore } from '../../stores/chatStore';
 import {
@@ -12,7 +12,7 @@ import {
   type Mentionable,
 } from '../../lib/mentionables';
 
-type MenuView = 'main' | 'skills' | 'quellen';
+type Submenu = 'skills' | 'quellen' | 'funktionen' | 'dateien';
 
 interface PlusMenuProps {
   onInsertMention: (mentionable: Mentionable) => void;
@@ -21,15 +21,18 @@ interface PlusMenuProps {
 }
 
 export function PlusMenu({ onInsertMention, onOpenFileBrowser, onUploadFile }: PlusMenuProps) {
-  const [view, setView] = useState<MenuView>('main');
+  const [expandedSubmenu, setExpandedSubmenu] = useState<Submenu | null>(null);
   const customAgents = getCustomAgentMentionables();
   const allSkills = [...agentMentionables, ...customAgents];
   const selectedNotebookId = useAgentStore((s) => s.selectedNotebookId);
   const setSelectedNotebook = useAgentStore((s) => s.setSelectedNotebook);
-  const selectedNotebook = notebookMentionables.find((n) => n.identifier === selectedNotebookId);
 
   const handleOpenChange = (open: boolean) => {
-    if (!open) setView('main');
+    if (!open) setExpandedSubmenu(null);
+  };
+
+  const toggleSubmenu = (menu: Submenu) => {
+    setExpandedSubmenu((prev) => (prev === menu ? null : menu));
   };
 
   return (
@@ -37,123 +40,96 @@ export function PlusMenu({ onInsertMention, onOpenFileBrowser, onUploadFile }: P
       trigger={<PlusIcon className="h-5 w-5 stroke-[1.5px]" />}
       direction="up"
       align="left"
-      width="w-80"
-      maxHeight="24rem"
+      width="min-w-80 w-fit"
       showChevron={false}
       onOpenChange={handleOpenChange}
     >
-      {view === 'main' && (
-        <>
-          {/* Skills → submenu */}
+      <div className="flex">
+        {/* Main menu — always visible */}
+        <div className="w-80 flex-shrink-0">
           <DropdownItem
             icon={<span className="text-base">🎯</span>}
             label="Skills"
-            description={`${allSkills.length} Assistenten`}
-            onClick={() => setView('skills')}
+            selected={expandedSubmenu === 'skills'}
+            onClick={() => toggleSubmenu('skills')}
             trailing={<ChevronRight className="h-4 w-4 text-foreground-muted" />}
           />
-
-          {/* Divider */}
-          <div className="my-1 border-t border-border" />
-
-          {/* Functions section — compact inline */}
-          <div className="px-3 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
-            Funktionen
-          </div>
-          {toolMentionables.map((tool) => (
-            <button
-              key={tool.identifier}
-              onClick={() => onInsertMention(tool)}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors hover:bg-hover-overlay"
-            >
-              <span className="flex h-5 w-5 items-center justify-center text-sm">
-                {tool.avatar}
-              </span>
-              <span className="text-foreground">{tool.title}</span>
-            </button>
-          ))}
-
-          {/* Divider */}
-          <div className="my-1 border-t border-border" />
-
-          {/* Quellen → submenu */}
           <DropdownItem
             icon={<span className="text-base">📚</span>}
             label="Quellen"
-            description={selectedNotebook?.title || 'Alle Quellen'}
-            onClick={() => setView('quellen')}
+            selected={expandedSubmenu === 'quellen'}
+            onClick={() => toggleSubmenu('quellen')}
             trailing={<ChevronRight className="h-4 w-4 text-foreground-muted" />}
           />
-
-          {/* Divider */}
-          <div className="my-1 border-t border-border" />
-
-          {/* File actions */}
           <DropdownItem
-            icon={<Upload className="h-4 w-4 text-foreground-muted" />}
-            label="Datei hochladen"
-            onClick={onUploadFile}
+            icon={<span className="text-base">⚡</span>}
+            label="Funktionen"
+            selected={expandedSubmenu === 'funktionen'}
+            onClick={() => toggleSubmenu('funktionen')}
+            trailing={<ChevronRight className="h-4 w-4 text-foreground-muted" />}
           />
           <DropdownItem
-            icon={<FileSearch className="h-4 w-4 text-foreground-muted" />}
-            label="Dokument referenzieren"
-            onClick={onOpenFileBrowser}
+            icon={<span className="text-base">📎</span>}
+            label="Dateien"
+            selected={expandedSubmenu === 'dateien'}
+            onClick={() => toggleSubmenu('dateien')}
+            trailing={<ChevronRight className="h-4 w-4 text-foreground-muted" />}
           />
-        </>
-      )}
+        </div>
 
-      {view === 'skills' && (
-        <>
-          <button
-            onClick={() => setView('main')}
-            className="flex w-full items-center gap-2 px-3 py-2.5 text-sm font-semibold text-foreground hover:bg-hover-overlay rounded-lg transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Skills
-          </button>
-          <div className="my-1 border-t border-border" />
-          {allSkills.map((agent) => (
-            <button
-              key={agent.identifier}
-              onClick={() => onInsertMention(agent)}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors hover:bg-hover-overlay"
-            >
-              <span className="flex h-5 w-5 items-center justify-center text-sm">
-                {agent.avatar}
-              </span>
-              <span className="text-foreground">{agent.title}</span>
-            </button>
-          ))}
-        </>
-      )}
-
-      {view === 'quellen' && (
-        <>
-          <button
-            onClick={() => setView('main')}
-            className="flex w-full items-center gap-2 px-3 py-2.5 text-sm font-semibold text-foreground hover:bg-hover-overlay rounded-lg transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Quellen
-          </button>
-          <div className="my-1 border-t border-border" />
-          {notebookMentionables.map((notebook) => (
-            <button
-              key={notebook.identifier}
-              onClick={() => setSelectedNotebook(notebook.identifier)}
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors hover:bg-hover-overlay"
-            >
-              <span className="flex h-5 w-5 items-center justify-center text-sm">
-                {notebook.avatar}
-              </span>
-              <span className="flex-1 text-foreground">{notebook.title}</span>
-              {selectedNotebookId === notebook.identifier && (
-                <Check className="h-4 w-4 text-primary-500" />
-              )}
-            </button>
-          ))}
-        </>
-      )}
+        {/* Submenu panel — appears alongside main menu */}
+        {expandedSubmenu && (
+          <div className="w-72 flex-shrink-0 border-l border-border max-h-[24rem] overflow-y-auto">
+            {expandedSubmenu === 'skills' &&
+              allSkills.map((agent) => (
+                <DropdownItem
+                  key={agent.mention}
+                  icon={<span className="text-base">{agent.avatar}</span>}
+                  label={agent.title}
+                  onClick={() => onInsertMention(agent)}
+                />
+              ))}
+            {expandedSubmenu === 'quellen' &&
+              notebookMentionables.map((notebook) => (
+                <DropdownItem
+                  key={notebook.identifier}
+                  icon={<span className="text-base">{notebook.avatar}</span>}
+                  label={notebook.title}
+                  selected={selectedNotebookId === notebook.identifier}
+                  onClick={() => setSelectedNotebook(notebook.identifier)}
+                  trailing={
+                    selectedNotebookId === notebook.identifier ? (
+                      <Check className="h-4 w-4 text-primary-500" />
+                    ) : undefined
+                  }
+                />
+              ))}
+            {expandedSubmenu === 'funktionen' &&
+              toolMentionables.map((tool) => (
+                <DropdownItem
+                  key={tool.identifier}
+                  icon={<span className="text-base">{tool.avatar}</span>}
+                  label={tool.title}
+                  onClick={() => onInsertMention(tool)}
+                />
+              ))}
+            {expandedSubmenu === 'dateien' && (
+              <>
+                <DropdownItem
+                  icon={<Upload className="h-4 w-4 text-foreground-muted" />}
+                  label="Datei hochladen"
+                  onClick={onUploadFile}
+                />
+                <DropdownItem
+                  icon={<FileSearch className="h-4 w-4 text-foreground-muted" />}
+                  label="Dokument referenzieren"
+                  onClick={onOpenFileBrowser}
+                />
+              </>
+            )}
+          </div>
+        )}
+      </div>
     </Dropdown>
   );
 }

--- a/packages/chat/src/components/thread/SkillPopover.tsx
+++ b/packages/chat/src/components/thread/SkillPopover.tsx
@@ -59,7 +59,7 @@ export function SkillPopover({
             const idx = itemIndex++;
             return (
               <SkillItem
-                key={agent.identifier}
+                key={agent.mention}
                 mentionable={agent}
                 isSelected={idx === selectedIndex}
                 onSelect={onSelect}
@@ -77,7 +77,7 @@ export function SkillPopover({
             const idx = itemIndex++;
             return (
               <SkillItem
-                key={agent.identifier}
+                key={agent.mention}
                 mentionable={agent}
                 isSelected={idx === selectedIndex}
                 onSelect={onSelect}

--- a/packages/chat/src/lib/agents.ts
+++ b/packages/chat/src/lib/agents.ts
@@ -30,6 +30,7 @@ export interface AgentListItem {
   avatar: string;
   backgroundColor: string;
   mention: string;
+  contextPrefix?: string;
 }
 
 export const agentsList: AgentListItem[] = [
@@ -59,11 +60,66 @@ export const agentsList: AgentListItem[] = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit',
-    title: 'Öffentlichkeitsarbeit',
-    description: 'Presse & Social Media',
-    avatar: '📢',
+    title: 'Pressemitteilung',
+    description: 'Pressemitteilungen verfassen',
+    avatar: '📰',
     backgroundColor: '#316049',
     mention: 'presse',
+    contextPrefix: '[Plattform: Pressemitteilung]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'Instagram',
+    description: 'Instagram-Posts & Captions',
+    avatar: '📸',
+    backgroundColor: '#E1306C',
+    mention: 'instagram',
+    contextPrefix: '[Plattform: Instagram]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'Facebook',
+    description: 'Facebook-Posts & Beiträge',
+    avatar: '👍',
+    backgroundColor: '#1877F2',
+    mention: 'facebook',
+    contextPrefix: '[Plattform: Facebook]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'Twitter / X',
+    description: 'Tweets & Threads',
+    avatar: '🐦',
+    backgroundColor: '#1DA1F2',
+    mention: 'twitter',
+    contextPrefix: '[Plattform: Twitter]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'LinkedIn',
+    description: 'LinkedIn-Posts & Artikel',
+    avatar: '💼',
+    backgroundColor: '#0A66C2',
+    mention: 'linkedin',
+    contextPrefix: '[Plattform: LinkedIn]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'Reel / TikTok',
+    description: 'Reel- & TikTok-Skripte',
+    avatar: '🎬',
+    backgroundColor: '#FE2C55',
+    mention: 'reel',
+    contextPrefix: '[Plattform: Reel/TikTok-Skript]',
+  },
+  {
+    identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    title: 'Aktionsideen',
+    description: 'Kreative Aktionsideen entwickeln',
+    avatar: '💡',
+    backgroundColor: '#F59E0B',
+    mention: 'aktion',
+    contextPrefix: '[Plattform: Aktionsideen]',
   },
   {
     identifier: 'gruenerator-rede-schreiber',

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -13,6 +13,7 @@ export interface Mentionable {
   avatar: string;
   backgroundColor: string;
   mention: string;
+  contextPrefix?: string;
 }
 
 export interface CustomAgentMentionable {
@@ -33,6 +34,7 @@ export function agentToMentionable(agent: AgentListItem): Mentionable {
     avatar: agent.avatar,
     backgroundColor: agent.backgroundColor,
     mention: agent.mention,
+    contextPrefix: agent.contextPrefix,
   };
 }
 

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -91,6 +91,7 @@ export default tseslint.config(
       '**/.next/**',
       '**/coverage/**',
       '**/*.vitest.ts',
+      'packages/shared/src/tiptap-editor/**',
     ],
   }
 );

--- a/packages/shared/src/tiptap-editor/components/ShareModal.tsx
+++ b/packages/shared/src/tiptap-editor/components/ShareModal.tsx
@@ -30,7 +30,10 @@ interface ShareModalProps {
 
 export const ShareModal = ({ documentId, onClose, apiClient, baseUrl }: ShareModalProps) => {
   const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
-  const [shareSettings, setShareSettings] = useState<ShareSettings>({ is_public: false, share_permission: 'editor' });
+  const [shareSettings, setShareSettings] = useState<ShareSettings>({
+    is_public: false,
+    share_permission: 'editor',
+  });
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -184,11 +187,11 @@ export const ShareModal = ({ documentId, onClose, apiClient, baseUrl }: ShareMod
         <div className="share-link-section">
           <div className="public-sharing-toggle">
             <div className="public-sharing-info">
-              <h3>Jeder mit dem Link</h3>
+              <h3>Gastzugang</h3>
               <p className="public-sharing-description">
                 {shareSettings.is_public
-                  ? 'Jeder mit dem Link kann dieses Dokument öffnen'
-                  : 'Nur eingeladene Personen haben Zugriff'}
+                  ? 'Jeder mit dem Link kann ohne Anmeldung zugreifen'
+                  : 'Nur angemeldete Nutzer haben Zugriff'}
               </p>
             </div>
             <label className="toggle-switch">


### PR DESCRIPTION
## Summary

- **Platform-specific skills**: Split Öffentlichkeitsarbeit into dedicated skills (Instagram, Facebook, Twitter, LinkedIn, Reel/TikTok, Aktionsideen) with `contextPrefix` support
- **PlusMenu redesign**: Refactored from back-navigation to side-by-side submenu layout with 4 categories (Skills, Quellen, Funktionen, Dateien)
- **Thread title generation fix**: Added `ThreadTitleEffect` workaround for Assistant UI's `generateTitle()` never firing + debug logging across the full title pipeline
- **UI tweaks**: Mobile profile dropdown margin, homepage top padding, chat page padding, SkillPopover key fix
- **Test infra**: Added dotenv to vitest config, new searchDocuments test file

## Test plan
- [ ] Verify PlusMenu opens submenus side-by-side (not replacing main menu)
- [ ] Verify platform skills insert correct `@mention [Plattform: ...]` prefix
- [ ] Verify thread titles generate after first message exchange
- [ ] Check mobile layout (profile dropdown, homepage, chat page)