### PR TITLE
fix(chat): restore viewport scrolling by removing wrapper div

### DIFF
--- a/apps/web/src/assets/styles/layout.css
+++ b/apps/web/src/assets/styles/layout.css
@@ -87,5 +87,4 @@ main {
 
 .chat-page-root {
   height: 100%;
-  overflow: hidden;
 } 

--- a/apps/web/src/components/routing/RouteComponent.tsx
+++ b/apps/web/src/components/routing/RouteComponent.tsx
@@ -71,11 +71,9 @@ const RouteComponent = ({
         toggleDarkMode={toggleDarkMode}
         showHeaderFooter={showHeaderFooter}
       >
-        <div>
-          <Suspense fallback={<div />}>
-            <ComponentToRender key={path} darkMode={darkMode} showHeaderFooter={showHeaderFooter} />
-          </Suspense>
-        </div>
+        <Suspense fallback={<div />}>
+          <ComponentToRender key={path} darkMode={darkMode} showHeaderFooter={showHeaderFooter} />
+        </Suspense>
       </PageLayout>
     </AppProviders>
   );

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -13,8 +13,8 @@ export default function ChatPage() {
   }, [searchParams]);
 
   return (
-    <div className="chat-page-root flex overflow-hidden bg-background">
-      <main className="flex flex-1 flex-col overflow-hidden pt-4 md:pt-0">
+    <div className="chat-page-root flex min-h-0 bg-background">
+      <main className="flex min-h-0 flex-1 flex-col pt-4 md:pt-0">
         <GrueneratorThread />
       </main>
     </div>

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -14,7 +14,7 @@ export function GrueneratorThread() {
   const messageComponents = useMemo(() => ({ UserMessage, AssistantMessage }), []);
 
   return (
-    <ThreadPrimitive.Root className="relative flex h-full flex-col bg-background">
+    <ThreadPrimitive.Root className="relative flex h-full min-h-0 flex-col bg-background">
       <div className="floating-controls-wrapper">
         <div className="floating-controls-left">
           <ModelSelector />

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -91,7 +91,6 @@ export default tseslint.config(
       '**/.next/**',
       '**/coverage/**',
       '**/*.vitest.ts',
-      'packages/shared/src/tiptap-editor/**',
     ],
   }
 );


### PR DESCRIPTION
## Summary

- **Root cause**: An unstyled `<div>` wrapper in `RouteComponent.tsx` broke the CSS flex height chain between `content-wrapper` and `chat-page-root`. Since the div had no explicit height, `height: 100%` on `.chat-page-root` resolved to `auto`, making the viewport grow unbounded — so `overflow-y: auto` never activated and the composer disappeared off-screen.
- **Fix**: Removed the wrapper `<div>` (it had no className, ref, or handlers — purely vestigial). Added `min-h-0` to inner flex containers so flex children can shrink below content size.
- Also removed unnecessary `overflow: hidden` from `.chat-page-root` in `layout.css` and an outdated eslint ignore path.

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/components/routing/RouteComponent.tsx` | Remove wrapper `<div>` breaking height chain |
| `apps/web/src/assets/styles/layout.css` | Remove `overflow: hidden` from `.chat-page-root` |
| `apps/web/src/features/chat/ChatPage.tsx` | Replace `overflow-hidden` with `min-h-0` |
| `packages/chat/src/components/thread/GrueneratorThread.tsx` | Add `min-h-0` to ThreadPrimitive.Root |
| `packages/eslint-config/base.js` | Remove outdated tiptap-editor ignore |

## Test plan

- [ ] Open `/chat` — message area scrolls when messages exceed viewport
- [ ] Composer input bar is always visible at bottom
- [ ] Page itself does NOT scroll (only the message area)
- [ ] Other pages (`/`, `/editor`) still render correctly
- [ ] Test in both desktop and mobile viewport widths
- [ ] Test in both light and dark mode