### PR TITLE
fix(docs): API proxy + ShareModal toggle fix

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,6 +31,10 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@react-pdf/renderer": "^4.3.2",
     "@tanstack/react-query": "^5.90.16",
+    "@tauri-apps/api": "^2.9.0",
+    "@tauri-apps/plugin-fs": "^2",
+    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-shell": "^2",
     "@tiptap/core": "^3.15.3",
     "@tiptap/extension-collaboration": "^2.10.0",
     "@tiptap/extension-collaboration-cursor": "^2.10.0",
@@ -58,6 +62,7 @@
     "dotenv": "^17.0.0",
     "express": "^5",
     "helmet": "^8.1.0",
+    "http-proxy-middleware": "^3.0.5",
     "lodash.throttle": "^4.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -66,11 +71,7 @@
     "react-router-dom": "^7.12.0",
     "y-websocket": "^2.0.4",
     "yjs": "^13.6.20",
-    "zustand": "^5.0.9",
-    "@tauri-apps/api": "^2.9.0",
-    "@tauri-apps/plugin-fs": "^2",
-    "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-shell": "^2"
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@gruenerator/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,6 +493,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      http-proxy-middleware:
+        specifier: ^3.0.5
+        version: 3.0.5
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
@@ -11060,6 +11063,10 @@ packages:
       '@types/express':
         optional: true
 
+  http-proxy-middleware@3.0.5:
+    resolution: {integrity: sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
@@ -11474,6 +11481,10 @@ packages:
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
@@ -30144,6 +30155,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  http-proxy-middleware@3.0.5:
+    dependencies:
+      '@types/http-proxy': 1.17.17
+      debug: 4.4.3
+      http-proxy: 1.18.1(debug@4.4.3)
+      is-glob: 4.0.3
+      is-plain-object: 5.0.0
+      micromatch: 4.0.8
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
@@ -30534,6 +30556,8 @@ snapshots:
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- **Fix ShareModal toggle**: EditorPage was importing the shared ShareModal (requires `apiClient` prop) but never passed one — all API calls silently returned. Switched to the local ShareModal that imports `apiClient` directly.
- **Fix misleading descriptions**: Updated share toggle text from "Nur eingeladene Personen" (no invite system exists) to accurately describe login-required access control.
- **Add API proxy to docs server**: The docs Express server had no `/api` proxy — requests hit the SPA fallback returning `index.html` instead of reaching the API backend. This is the root cause of 404s on `docs.gruenerator.eu`. Added `http-proxy-middleware` using `VITE_API_TARGET` env var (defaults to `http://api:3001`).
- **ESLint**: Added `packages/shared/src/tiptap-editor/**` to global ignores (excluded from tsconfig, can't be parsed). Fixed pre-existing floating promises and `any` type warnings.

## Test plan
- [ ] Deploy docs image to test environment
- [ ] Set `VITE_API_TARGET` env var on docs container (e.g., `http://api:3001`)
- [ ] Open a document on `docs.gruenerator.eu` → click share button
- [ ] Verify toggle calls POST `/api/docs/:id/share/enable` or `/share/disable` (check network tab)
- [ ] Verify text reads "Gastzugang" / "Nur angemeldete Nutzer haben Zugriff"
- [ ] Verify font loading errors are resolved