### PR TITLE
fix(web): revert notebook Q&A to non-streaming

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookChat.tsx
+++ b/apps/web/src/features/notebook/components/NotebookChat.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { HiDocumentText, HiInformationCircle } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 
@@ -7,7 +7,7 @@ import { CitationModal } from '../../../components/common/Citation';
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import { useOptimizedAuth } from '../../../hooks/useAuth';
 import { type NotebookCollection } from '../../../types/notebook';
-import useNotebookStreamChat from '../hooks/useNotebookStreamChat';
+import useNotebookChat from '../hooks/useNotebookChat';
 import useNotebookStore from '../stores/notebookStore';
 
 import ActiveFiltersDisplay from './ActiveFiltersDisplay';
@@ -47,35 +47,16 @@ const NotebookChat = () => {
     chatMessages,
     inputValue,
     submitLoading,
-    streamingText,
     isMobileView,
     setInputValue,
     handleSubmitQuestion,
-  } = useNotebookStreamChat({
+  } = useNotebookChat({
     collections: collection ? [{ id: collection.id, name: collection.name }] : [],
     welcomeMessage: collection
       ? `Hallo! Ich bin bereit, Fragen zu Ihrem Notebook "${collection.name}" zu beantworten. Stellen Sie mir gerne eine Frage zu den Dokumenten.`
       : undefined,
     persistMessages: true,
   });
-
-  // Combine chat messages with streaming text for display
-  const displayMessages = useMemo(() => {
-    if (submitLoading && streamingText) {
-      // Add a temporary streaming message at the end
-      return [
-        ...chatMessages,
-        {
-          type: 'assistant' as const,
-          content: streamingText,
-          timestamp: Date.now(),
-          id: 'streaming',
-          isStreaming: true,
-        },
-      ];
-    }
-    return chatMessages;
-  }, [chatMessages, submitLoading, streamingText]);
 
   // Hooks must be called before early returns (Rules of Hooks)
   const renderMessage = useCallback((msg: unknown, i: number) => {
@@ -146,7 +127,7 @@ const NotebookChat = () => {
         modes={{ chat: { label: 'Chat' } }}
         onModeChange={() => {}}
         title={collection?.name || ''}
-        messages={displayMessages}
+        messages={chatMessages}
         onSubmit={(value) => {
           if (typeof value === 'string') handleSubmitQuestion(value);
         }}

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -7,7 +7,7 @@ import withAuthRequired from '../../../components/common/LoginRequired/withAuthR
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useAuthStore } from '../../../stores/authStore';
 import { getNotebookConfig } from '../config/notebookPagesConfig';
-import useNotebookStreamChat from '../hooks/useNotebookStreamChat';
+import useNotebookChat from '../hooks/useNotebookChat';
 
 import ActiveFiltersDisplay from './ActiveFiltersDisplay';
 import FilterDropdownButton from './FilterDropdownButton';
@@ -123,33 +123,15 @@ const NotebookPageContent = ({ config }: NotebookPageContentProps): React.ReactE
     chatMessages,
     inputValue,
     submitLoading,
-    streamingText,
     isMobileView,
     activeCollections,
     setInputValue,
     handleSubmitQuestion,
-  } = useNotebookStreamChat({
+  } = useNotebookChat({
     collections: selectedCollections,
     persistMessages: config.persistMessages,
     extraApiParams,
   });
-
-  // Combine chat messages with streaming text for display
-  const displayMessages = useMemo(() => {
-    if (submitLoading && streamingText) {
-      return [
-        ...chatMessages,
-        {
-          type: 'assistant' as const,
-          content: streamingText,
-          timestamp: Date.now(),
-          id: 'streaming',
-          isStreaming: true,
-        },
-      ];
-    }
-    return chatMessages;
-  }, [chatMessages, submitLoading, streamingText]);
 
   const HeaderIcon = config.headerIcon;
 
@@ -249,7 +231,7 @@ const NotebookPageContent = ({ config }: NotebookPageContentProps): React.ReactE
         modes={{ chat: { label: 'Chat' } }}
         onModeChange={() => {}}
         title={config.title}
-        messages={displayMessages}
+        messages={chatMessages}
         onSubmit={(value) => {
           if (typeof value === 'string') handleSubmitQuestion(value);
         }}


### PR DESCRIPTION
## Summary
- Reverts notebook Q&A from the broken SSE streaming hook (`useNotebookStreamChat`) back to the working non-streaming hook (`useNotebookChat`)
- Removes `streamingText` and `displayMessages` memo from both `NotebookChat.tsx` and `NotebookPage.tsx`
- No backend changes needed — the non-streaming endpoints (`/api/auth/notebook/:id/ask`, `/api/auth/notebook/multi/ask`) are already live and working

## Test plan
- [ ] Open a single-collection notebook → ask a question → verify answer appears with citations
- [ ] Open a multi-collection page (e.g., Grundsatzprogramm) → ask a question → verify answer + sources
- [ ] Confirm no streaming cursor (▋) appears — responses should appear all at once
- [ ] Verify `pnpm build:web` passes cleanly