### PR TITLE
Test branch rollup: popup auth-gating, docs sharing, ESLint fixes, dependency updates

### DIFF
--- a/apps/web/src/components/Popups/popup_austria_launch.tsx
+++ b/apps/web/src/components/Popups/popup_austria_launch.tsx
@@ -5,7 +5,7 @@ import './popup_austria_launch.css';
 
 const PopupAustriaLaunch = () => {
   return (
-    <BasePopup storageKey="austriaLaunchVideo2025Shown" variant="single">
+    <BasePopup storageKey="austriaLaunchVideo2025Shown" variant="single" requireAuth>
       {({ onClose }) => (
         <div className="popup-single-container">
           <div className="popup-slide video-popup">

--- a/apps/web/src/hooks/usePopupDismiss.ts
+++ b/apps/web/src/hooks/usePopupDismiss.ts
@@ -5,6 +5,11 @@ import { useUserDefaultsStore } from '../stores/userDefaultsStore';
 
 const POPUP_GENERATOR = 'popups';
 
+/**
+ * Registry of all popup storageKeys that participate in cross-device sync.
+ * When adding a new popup with `usePopupDismiss`, register its storageKey here
+ * so that dismiss state is synced to the server via `user_defaults` on login.
+ */
 const POPUP_KEYS = ['termsAccepted', 'austriaLaunchVideo2025Shown'] as const;
 
 interface UsePopupDismissReturn {


### PR DESCRIPTION
## Summary

Rollup of test-branch changes for promotion to production:

- **Popup auth-gating & keyboard dismiss**: `BasePopup` gains `requireAuth` and `closeOnAnyKey` props; Austria Launch popup now only shows for logged-in users
- **Docs sharing & permissions**: Login-required share mode, auto-add link users to document permissions, fix 404s on sharing/export endpoints
- **Express 5 & ESLint cleanup**: Fix all `req.params` types for Express 5, resolve ESLint errors across the API
- **Docker build fix**: Copy `.npmrc` into API build to fix missing `express-serve-static-core` types
- **Auth stability**: Increase OIDC staleness threshold to 15min, auto-redirect on expiry
- **UI improvements**: Path-based routing for texte tabs, Mantine migration for ShareModal, semantic color tokens in chat
- **Dependency updates**: Bulk dependency update across all packages
- **Docs & conventions**: Express 5 route typing, Mantine conventions, CLAUDE.md updates
- **Misc fixes**: Race condition in RecentValuesService, orphaned Canva re-exports, notebook Q&A streaming revert, merge conflict cleanup

## Test plan

- [ ] Verify Austria popup only appears for authenticated users on beta.gruenerator.de
- [ ] Press any key to dismiss popup — confirm it tracks as dismissed
- [ ] Cookie consent bar still shows for all users (not affected)
- [ ] Docs sharing with login-required mode works end-to-end
- [ ] Texte tab navigation works with keyboard and URL changes
- [ ] API builds successfully in Docker
- [ ] No TypeScript or ESLint regressions