### PR TITLE
fix(docs): merge Mantine into vendor-editor chunk to fix useLayoutEffect crash

### DIFF
--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -78,11 +78,12 @@ export default defineConfig(({ command }) => ({
         assetFileNames: 'assets/[name].[hash][extname]',
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-mantine': ['@mantine/core', '@mantine/hooks'],
           'vendor-editor': [
             '@blocknote/core',
             '@blocknote/react',
             '@blocknote/mantine',
+            '@mantine/core',
+            '@mantine/hooks',
             'yjs',
             'y-websocket',
             '@hocuspocus/provider',


### PR DESCRIPTION
## Summary
- Merges `@mantine/core` and `@mantine/hooks` from the separate `vendor-mantine` chunk into `vendor-editor` in `apps/docs/vite.config.ts`
- Fixes `TypeError: Cannot read properties of undefined (reading 'useLayoutEffect')` that crashes the docs app in production when the user is not logged in

## Root cause
Mantine's `useIsomorphicEffect` captures `useLayoutEffect` at **module scope** (not inside a component). When `@mantine/core` was in a separate `vendor-mantine` chunk from `vendor-react`, Rollup's cross-chunk initialization order could leave React uninitialized — the named import resolves to `undefined`, causing the crash on the login page.

## Test plan
- [x] `pnpm build` in `apps/docs` succeeds, no `vendor-mantine` chunk in output
- [ ] Visit beta.gruenerator.de/docs while logged out — no console errors
- [ ] Visit while logged in — editor loads normally