### PR TITLE
fix(docs): reduce excessive mobile side spacing

### DIFF
--- a/apps/docs/src/components/editor/BlockNoteEditor.css
+++ b/apps/docs/src/components/editor/BlockNoteEditor.css
@@ -28,7 +28,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 767px) {
   .blocknote-wrapper {
     margin: 0;
     padding: 1.5rem 1rem;

--- a/apps/docs/src/pages/EditorPage.css
+++ b/apps/docs/src/pages/EditorPage.css
@@ -32,6 +32,19 @@
   }
 }
 
+@media (max-width: 640px) {
+  .editor-content .editor-main {
+    padding-left: 0;
+    padding-right: 0;
+    padding-top: 0;
+    background-color: var(--background, #fff);
+  }
+
+  [data-theme="dark"] .editor-content .editor-main {
+    background-color: var(--background-color, #1f2937);
+  }
+}
+
 /* Guest Banner */
 .guest-banner {
   display: flex;

--- a/apps/docs/src/pages/HomePage.css
+++ b/apps/docs/src/pages/HomePage.css
@@ -69,6 +69,14 @@
   }
 }
 
+/* Small phones - tighter side padding */
+@media (max-width: 380px) {
+  .home-page-container {
+    padding-left: var(--spacing-small);
+    padding-right: var(--spacing-small);
+  }
+}
+
 /* Desktop - more spacing */
 @media (min-width: 769px) {
   .home-page-container {

--- a/packages/docs/src/components/editor/BlockNoteEditor.css
+++ b/packages/docs/src/components/editor/BlockNoteEditor.css
@@ -28,7 +28,7 @@
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 767px) {
   .blocknote-wrapper {
     margin: 0;
     padding: 1.5rem 1rem;


### PR DESCRIPTION
## Summary
- Remove `.editor-main` side/top padding on phones (≤640px) so the editor card fills the screen width instead of floating on a grey canvas
- Widen BlockNote wrapper mobile breakpoint from 640px → 767px to close the gap where mid-size phones (641–767px) got 40px side padding instead of the slim 16px
- Tighten HomePage container padding on very small screens (≤380px) from 16px → 12px

**Result:** Editor total side padding drops from ~56px → ~32px on phones, giving significantly more content space.

## Test plan
- [ ] Test at 375px width (iPhone SE): editor text fills more of the screen
- [ ] Test at 700px width: gets slim mobile layout instead of fat 40px padding
- [ ] Test at 1024px+: no visual change (desktop unaffected)
- [ ] HomePage at 360px: slightly tighter side margins
- [ ] Verify dark mode looks correct at all breakpoints