### PR TITLE
fix(docs): use mobile formatting toolbar on touch devices

### DIFF
--- a/apps/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/apps/docs/src/components/editor/BlockNoteEditor.tsx
@@ -15,6 +15,7 @@ import {
   useCreateBlockNote,
   FormattingToolbar,
   FormattingToolbarController,
+  ExperimentalMobileFormattingToolbarController,
   SuggestionMenuController,
   getDefaultReactSlashMenuItems,
   getFormattingToolbarItems,
@@ -37,6 +38,7 @@ import { DefaultChatTransport } from 'ai';
 import type * as Y from 'yjs';
 
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
+import { useIsTouchDevice } from '@/hooks/use-is-touch-device';
 import { useBlockNoteComments } from '@/hooks/useBlockNoteComments';
 import { useResolveUsers } from '@/hooks/useResolveUsers';
 import { isEditorEmpty } from '@/lib/blockNoteUtils';
@@ -139,6 +141,7 @@ const BlockNoteEditorInner = ({
   onEditorReady,
 }: BlockNoteEditorProps) => {
   const { setEditor: setEditorInStore, removeEditor } = useEditorStore();
+  const isTouchDevice = useIsTouchDevice();
   const hasInitialized = useRef(false);
   const [isReady, setIsReady] = useState(false);
   const [syncTimedOut, setSyncTimedOut] = useState(false);
@@ -326,14 +329,25 @@ const BlockNoteEditorInner = ({
       <ErrorBoundary>
         <BlockNoteView editor={editor} theme="light" formattingToolbar={false} slashMenu={false}>
           <AIMenuController />
-          <FormattingToolbarController
-            formattingToolbar={() => (
-              <FormattingToolbar>
-                {getFormattingToolbarItems()}
-                <AIToolbarButton />
-              </FormattingToolbar>
-            )}
-          />
+          {isTouchDevice ? (
+            <ExperimentalMobileFormattingToolbarController
+              formattingToolbar={() => (
+                <FormattingToolbar>
+                  {getFormattingToolbarItems()}
+                  <AIToolbarButton />
+                </FormattingToolbar>
+              )}
+            />
+          ) : (
+            <FormattingToolbarController
+              formattingToolbar={() => (
+                <FormattingToolbar>
+                  {getFormattingToolbarItems()}
+                  <AIToolbarButton />
+                </FormattingToolbar>
+              )}
+            />
+          )}
           <SuggestionMenuController
             triggerCharacter="/"
             getItems={async (query) =>

--- a/apps/docs/src/hooks/use-is-touch-device.ts
+++ b/apps/docs/src/hooks/use-is-touch-device.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+const TOUCH_QUERY = '(pointer: coarse)';
+
+export function useIsTouchDevice(): boolean {
+  const [isTouch, setIsTouch] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(TOUCH_QUERY).matches
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(TOUCH_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsTouch(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isTouch;
+}


### PR DESCRIPTION
## Summary
- Adds `useIsTouchDevice` hook to `apps/docs` (reactive `(pointer: coarse)` media query)
- Conditionally renders `ExperimentalMobileFormattingToolbarController` on touch devices instead of the standard `FormattingToolbarController`
- Matches the pattern already implemented in `packages/docs` (used by docs-expo)

## Test plan
- [ ] Open apps/docs on desktop browser → select text → floating toolbar appears above selection (standard behavior)
- [ ] Open apps/docs on mobile/touch device → select text → toolbar pinned above keyboard at screen bottom
- [ ] Toggle Chrome DevTools device emulation to verify `(pointer: coarse)` detection reactivity