### PR TITLE
fix(web): prevent public pages from redirecting to login on 401

### DIFF
--- a/apps/web/src/components/utils/apiClient.js
+++ b/apps/web/src/components/utils/apiClient.js
@@ -1,7 +1,7 @@
 import { createApiClient, setGlobalApiClient } from '@gruenerator/shared/api';
 import axios from 'axios';
 
-import { buildLoginUrl } from '../../utils/authRedirect';
+import { buildLoginUrl, isPublicPage } from '../../utils/authRedirect';
 import { getDesktopToken } from '../../utils/desktopAuth';
 import { isDesktopApp } from '../../utils/platform';
 
@@ -16,7 +16,7 @@ const sharedApiClient = createApiClient({
   authMode: isDesktopApp() ? 'bearer' : 'cookie',
   getAuthToken: isDesktopApp() ? async () => getDesktopToken() : undefined,
   onUnauthorized: () => {
-    if (window.location.pathname !== '/login') {
+    if (!isPublicPage() && window.location.pathname !== '/login') {
       const currentPath = window.location.pathname + window.location.search;
       window.location.href = buildLoginUrl(currentPath);
     }
@@ -77,8 +77,7 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response && error.response.status === 401) {
-      // Redirect to frontend login page with proper redirectTo parameter
-      if (window.location.pathname !== '/login') {
+      if (!isPublicPage() && window.location.pathname !== '/login') {
         const currentPath = window.location.pathname + window.location.search;
         const loginUrl = buildLoginUrl(currentPath);
         console.log('[apiClient] 401 detected, redirecting to login with redirect:', currentPath);

--- a/apps/web/src/features/notebook/stores/notebookStore.ts
+++ b/apps/web/src/features/notebook/stores/notebookStore.ts
@@ -117,7 +117,9 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
 
     set({ loading: true, error: null });
     try {
-      const response = await apiClient.get('/auth/notebook-collections');
+      const response = await apiClient.get('/auth/notebook-collections', {
+        skipAuthRedirect: true,
+      });
       const data = response.data;
 
       if (!data.success) {
@@ -203,7 +205,10 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
         requestData.document_ids = collectionData.documents || [];
       }
 
-      const response = await apiClient.put(`/auth/notebook-collections/${collectionId}`, requestData);
+      const response = await apiClient.put(
+        `/auth/notebook-collections/${collectionId}`,
+        requestData
+      );
 
       const data = response.data;
 

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -1,5 +1,5 @@
 import { GrueneratorChatProvider, ChatThreadList, TooltipProvider } from '@gruenerator/chat';
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -7,6 +7,7 @@ import { useNotebookChatStore } from '../features/notebook/stores/notebookChatSt
 import useNotebookStore from '../features/notebook/stores/notebookStore';
 import { resolveNotebookChatEntries } from '../features/notebook/utils/notebookChatResolver';
 import { useOptimizedAuth } from '../hooks/useAuth';
+import { buildLoginUrl, isPublicPage } from '../utils/authRedirect';
 
 const PORTAL_SLOT_ID = 'chat-thread-portal-slot';
 
@@ -85,9 +86,22 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
     [navigate]
   );
 
+  const chatConfig = useMemo(
+    () => ({
+      onUnauthorized: () => {
+        if (!isPublicPage() && window.location.pathname !== '/login') {
+          const currentPath = window.location.pathname + window.location.search;
+          window.location.href = buildLoginUrl(currentPath);
+        }
+      },
+    }),
+    []
+  );
+
   return (
     <GrueneratorChatProvider
       userId={user?.id}
+      config={chatConfig}
       getExternalThreads={getExternalThreads}
       onExternalThreadClick={handleExternalClick}
       activePath={location.pathname}

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -3,6 +3,15 @@
  * Handles redirect URLs for authentication flows consistently across the app
  */
 
+const PUBLIC_PATHS = ['/datenschutz', '/impressum', '/support', '/login', '/auth'];
+
+const PUBLIC_PREFIXES = ['/auth/', '/shared/', '/subtitler/shared/'];
+
+export const isPublicPage = (pathname: string = window.location.pathname): boolean =>
+  pathname === '/' ||
+  PUBLIC_PATHS.includes(pathname) ||
+  PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+
 /**
  * Build login URL with proper redirectTo parameter
  * @param {string} redirectTo - URL to redirect to after login

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -353,6 +353,7 @@ export function GrueneratorChatProvider({
 
   // Load user's custom prompts for @mention support
   useEffect(() => {
+    if (!userId) return;
     const loadCustomAgents = async () => {
       try {
         const [ownPrompts, savedPrompts] = await Promise.all([
@@ -375,7 +376,7 @@ export function GrueneratorChatProvider({
       }
     };
     loadCustomAgents();
-  }, [providerApiClient]);
+  }, [providerApiClient, userId]);
 
   const getExternalThreadsRef = useRef(getExternalThreads);
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Add centralized `isPublicPage()` guard in `authRedirect.ts` for paths like `/datenschutz`, `/impressum`, `/support`, `/login`, `/`
- Guard all three `onUnauthorized` handlers (legacy apiClient interceptor, shared API client, chat provider) with `isPublicPage()` check
- Add `userId` guard to `loadCustomAgents` effect in `GrueneratorChatProvider` — prevents unauthenticated API calls that were the primary first-visit redirect trigger
- Add `skipAuthRedirect: true` to `fetchQACollections` as defense-in-depth against stale auth cache

## Test plan

- [ ] Clear all browser data → visit `/datenschutz` → page renders without redirect
- [ ] Visit `/impressum`, `/support`, `/` → same behavior
- [ ] Visit `/profile` (protected) without session → redirects to login
- [ ] Log in → navigate to `/chat` → custom agents load in @mention
- [ ] Log in → log out → visit `/datenschutz` → no redirect (stale cache scenario)