### PR TITLE
fix(web): resolve 403 on direct navigation to /imagine/

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -78,7 +78,7 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
 
     # Cache static assets
-    location ~* \.(css|js|map|jpe?g|gif|png|svg|ico|woff|woff2)$ {
+    location ~* \.(css|js|map|jpe?g|gif|png|webp|svg|ico|woff|woff2)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
         try_files $uri =404;
@@ -86,7 +86,7 @@ server {
 
     # SPA fallback - serve index.html for client-side routing
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 
     # Health check

--- a/apps/web/src/components/utils/apiClient.js
+++ b/apps/web/src/components/utils/apiClient.js
@@ -16,10 +16,8 @@ const sharedApiClient = createApiClient({
   authMode: isDesktopApp() ? 'bearer' : 'cookie',
   getAuthToken: isDesktopApp() ? async () => getDesktopToken() : undefined,
   onUnauthorized: () => {
-    console.log('[apiClient:shared] onUnauthorized fired — pathname:', window.location.pathname);
     if (!isPublicPage() && window.location.pathname !== '/login') {
       const currentPath = window.location.pathname + window.location.search;
-      console.log('[apiClient:shared] Redirecting to login with redirect:', currentPath);
       window.location.href = buildLoginUrl(currentPath);
     }
   },
@@ -79,16 +77,9 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response && error.response.status === 401) {
-      console.log(
-        '[apiClient:legacy] 401 interceptor — pathname:',
-        window.location.pathname,
-        'url:',
-        error.config?.url
-      );
       if (!isPublicPage() && window.location.pathname !== '/login') {
         const currentPath = window.location.pathname + window.location.search;
         const loginUrl = buildLoginUrl(currentPath);
-        console.log('[apiClient:legacy] Redirecting to login with redirect:', currentPath);
         window.location.href = loginUrl;
       }
     }

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -89,13 +89,8 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
   const chatConfig = useMemo(
     () => ({
       onUnauthorized: () => {
-        console.log(
-          '[GlobalChatProvider] custom onUnauthorized fired — pathname:',
-          window.location.pathname
-        );
         if (!isPublicPage() && window.location.pathname !== '/login') {
           const currentPath = window.location.pathname + window.location.search;
-          console.log('[GlobalChatProvider] Redirecting to login with redirect:', currentPath);
           window.location.href = buildLoginUrl(currentPath);
         }
       },

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -7,14 +7,10 @@ const PUBLIC_PATHS = ['/datenschutz', '/impressum', '/support', '/login', '/auth
 
 const PUBLIC_PREFIXES = ['/auth/', '/shared/', '/subtitler/shared/'];
 
-export const isPublicPage = (pathname: string = window.location.pathname): boolean => {
-  const result =
-    pathname === '/' ||
-    PUBLIC_PATHS.includes(pathname) ||
-    PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
-  console.log(`[AuthRedirect] isPublicPage("${pathname}") → ${result}`);
-  return result;
-};
+export const isPublicPage = (pathname: string = window.location.pathname): boolean =>
+  pathname === '/' ||
+  PUBLIC_PATHS.includes(pathname) ||
+  PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
 
 /**
  * Build login URL with proper redirectTo parameter

--- a/packages/chat/src/context/ChatContext.tsx
+++ b/packages/chat/src/context/ChatContext.tsx
@@ -29,7 +29,6 @@ export function createChatApiClient(
     });
 
     if (response.status === 401) {
-      console.log('[ChatContext] 401 detected — endpoint:', endpoint, '— calling onUnauthorized');
       onUnauthorized();
       throw new Error('Unauthorized');
     }

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -346,19 +346,15 @@ export function GrueneratorChatProvider({
   const prevConfigRef = useRef<ChatConfig | undefined>(undefined);
   if (config !== prevConfigRef.current) {
     prevConfigRef.current = config;
-    console.log('[GrueneratorChatProvider] Synchronous configure() during render');
     useChatConfigStore.getState().configure(config);
   }
 
   const fetchFn = useChatConfigStore((s) => s.fetch);
   const onUnauthorized = useChatConfigStore((s) => s.onUnauthorized);
-  const providerApiClient = useMemo(() => {
-    console.log(
-      '[GrueneratorChatProvider] Creating providerApiClient — custom onUnauthorized:',
-      onUnauthorized !== undefined
-    );
-    return createChatApiClient(fetchFn, onUnauthorized);
-  }, [fetchFn, onUnauthorized]);
+  const providerApiClient = useMemo(
+    () => createChatApiClient(fetchFn, onUnauthorized),
+    [fetchFn, onUnauthorized]
+  );
 
   // Load user's custom prompts for @mention support
   useEffect(() => {

--- a/packages/chat/src/runtime/GrueneratorThreadListAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorThreadListAdapter.ts
@@ -42,7 +42,6 @@ export function createGrueneratorThreadListAdapter(
 ): RemoteThreadListAdapter {
   return {
     async list() {
-      console.log('[ThreadListAdapter] list() called');
       try {
         const threads = await apiClient.get<ApiThread[]>('/api/chat-service/threads');
         const external = callbacks?.getExternalThreads?.() ?? [];

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -82,10 +82,8 @@ function isPublicPath(pathname: string): boolean {
 function defaultOnUnauthorized(): void {
   if (typeof window === 'undefined') return;
   const p = window.location.pathname;
-  console.log('[chatConfigStore] defaultOnUnauthorized fired — pathname:', p);
   if (isPublicPath(p)) return;
   const currentPath = p + window.location.search;
-  console.log('[chatConfigStore] defaultOnUnauthorized redirecting — redirect:', currentPath);
   window.location.href = `/login?redirectTo=${encodeURIComponent(currentPath)}`;
 }
 
@@ -96,10 +94,6 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
   docsBaseUrl: undefined,
 
   configure: (config?: ChatConfig) => {
-    console.log(
-      '[chatConfigStore] configure() called — has custom onUnauthorized:',
-      !!config?.onUnauthorized
-    );
     set({
       fetch: config?.fetch ?? defaultFetch,
       onUnauthorized: config?.onUnauthorized ?? defaultOnUnauthorized,


### PR DESCRIPTION
## Summary
- Remove `$uri/` from nginx `try_files` so physical directories (e.g. `imagine/`) fall through to `/index.html` instead of triggering a 403 directory listing error
- Add `webp` to the static asset cache location block for proper caching headers

## Test plan
- [ ] `curl -I https://beta.gruenerator.eu/imagine/` returns 200
- [ ] `curl -I https://beta.gruenerator.eu/imagine` returns 200
- [ ] Static assets like `/imagine/previews/headline-preview.webp` still load with cache headers