### PR TITLE
feat(web): gate Docs export on beta feature

### DIFF
--- a/apps/web/src/components/common/ExportDropdown.tsx
+++ b/apps/web/src/components/common/ExportDropdown.tsx
@@ -108,6 +108,7 @@ const ExportDropdown = ({
   const navigate = useNavigate();
   const { getBetaFeatureState } = useBetaFeatures();
   const hasChatAccess = isAuthenticated && getBetaFeatureState('chat');
+  const hasDocsAccess = isAuthenticated && getBetaFeatureState('docs');
   const { submitForm: submitEtherpad, loading: etherpadLoading } = useApiSubmit('etherpad/create');
   const getGeneratedText = useGeneratedTextStore((state) => state.getGeneratedText);
 
@@ -510,7 +511,7 @@ const ExportDropdown = ({
 
             {!hideDefaultOptions && (
               <>
-                {onEditInDocs && isAuthenticated && (
+                {onEditInDocs && hasDocsAccess && (
                   <DropdownMenuItem onSelect={handleEditInDocsClick} disabled={editInDocsLoading}>
                     <HiOutlineDocumentText />
                     {editInDocsLoading ? 'Exportiere...' : 'In Docs exportieren'}


### PR DESCRIPTION
## Summary
- Gates the "In Docs exportieren" dropdown menu item behind the `docs` beta feature flag
- Previously visible to all authenticated users, now requires `getBetaFeatureState('docs')` — matching the existing `hasChatAccess` pattern

## Test plan
- [ ] Enable `docs` beta feature in settings → "In Docs exportieren" appears in export dropdown
- [ ] Disable `docs` beta feature → menu item is hidden
- [ ] Verify `hasChatAccess` (chat-related items) still works independently