### PR TITLE
fix(gruen-o-mat): remove host port binding from Coolify compose

### DIFF
--- a/apps/gruen-o-mat/docker-compose.coolify.yml
+++ b/apps/gruen-o-mat/docker-compose.coolify.yml
@@ -12,8 +12,6 @@
 services:
   gruen-o-mat:
     image: ghcr.io/netzbegruenung/gruenerator-gruen-o-mat:${TAG:-latest}
-    ports:
-      - '80:80'
     environment:
       - API_BASE_URL=${API_BASE_URL:-https://gruenerator.eu}
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Removes `ports: '80:80'` from `docker-compose.coolify.yml` — Coolify's reverse proxy already binds to port 80/443, so the explicit host mapping causes "port is already allocated" on deployment.

## Test plan
- [ ] Deploy Grün-O-Mat via Coolify using `docker-compose.coolify.yml`
- [ ] Verify container starts without port conflict
- [ ] Verify Coolify proxy routes traffic to the container's port 80