### PR TITLE
feat: notebook labels, KommunalWiki, gruen-o-mat auth, TTS & docs settings

### DIFF
--- a/apps/api/config/domains.ts
+++ b/apps/api/config/domains.ts
@@ -26,6 +26,8 @@ export const ALLOWED_DOMAINS: string[] = [
   'sites.beta.gruenerator.eu',
   'gruenerator.at',
   'www.gruenerator.at',
+  'gruen-o-mat.eu',
+  'www.gruen-o-mat.eu',
   'gruenerator.eu',
   'www.gruenerator.eu',
   'gruenerator-test.de',

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -61,6 +61,7 @@ import {
   leichteSpracheRouter as leichteSpracheRoute,
 } from './routes/texte/index.js';
 import { recentValuesRouter } from './routes/user/index.js';
+import ttsRouter from './routes/voice/ttsController.js';
 import voiceRouter from './routes/voice/voiceController.js';
 import * as sharepicGenerationService from './services/chat/sharepicGenerationService.js';
 import * as tusServiceModule from './services/subtitler/tusService.js';
@@ -276,6 +277,7 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/docs', requireAuth, docsRouter);
   app.use('/api/users', requireAuth, usersRouter);
   app.use('/api/voice', voiceRouter);
+  app.use('/api/voice/tts', requireAuth, ttsRouter);
   app.use('/api/search', searchRouter);
   app.use('/api/analyze', searchRouter);
   app.use('/api/image-picker', imagePickerRoute);

--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -138,6 +138,9 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
           }
         }
 
+        const settings = (collection.settings as Record<string, unknown>) || {};
+        const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+
         return {
           ...collection,
           documents,
@@ -148,6 +151,7 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
           documents_from_wolke: documents.filter((doc) => doc.source_type === 'wolke').length,
           auto_sync: !!collection.auto_sync,
           remove_missing_on_sync: !!collection.remove_missing_on_sync,
+          labels,
         };
       })
     );
@@ -180,6 +184,7 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       wolke_share_link_ids = [],
       auto_sync = false,
       remove_missing_on_sync = false,
+      labels,
     } = req.body as CreateCollectionBody;
 
     if (!name || !name.trim()) {
@@ -242,6 +247,9 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       wolke_share_link_ids: selection_mode === 'wolke' ? wolke_share_link_ids : null,
       auto_sync: selection_mode === 'wolke' ? !!auto_sync : false,
       remove_missing_on_sync: selection_mode === 'wolke' ? !!remove_missing_on_sync : false,
+      settings: {
+        ...(Array.isArray(labels) ? { labels: labels.map((l) => l.trim()).filter(Boolean) } : {}),
+      },
     };
 
     const result = await notebookHelper.storeNotebookCollection(collectionData);
@@ -317,6 +325,7 @@ router.put(
         wolke_share_link_ids = [],
         auto_sync,
         remove_missing_on_sync,
+        labels,
       } = req.body as UpdateCollectionBody;
 
       if (!name || !name.trim()) {
@@ -383,6 +392,14 @@ router.put(
         document_count: allDocumentIds.length,
         wolke_share_link_ids: selection_mode === 'wolke' ? wolke_share_link_ids : null,
       };
+
+      if (Array.isArray(labels)) {
+        const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
+        updateData.settings = {
+          ...existingSettings,
+          labels: labels.map((l) => l.trim()).filter(Boolean),
+        };
+      }
 
       if (selection_mode === 'wolke') {
         if (typeof auto_sync === 'boolean') updateData.auto_sync = auto_sync;

--- a/apps/api/routes/notebook/types.ts
+++ b/apps/api/routes/notebook/types.ts
@@ -22,6 +22,7 @@ export interface CreateCollectionBody {
   wolke_share_link_ids?: string[];
   auto_sync?: boolean;
   remove_missing_on_sync?: boolean;
+  labels?: string[];
 }
 
 /**
@@ -36,6 +37,7 @@ export interface UpdateCollectionBody {
   wolke_share_link_ids?: string[];
   auto_sync?: boolean;
   remove_missing_on_sync?: boolean;
+  labels?: string[];
 }
 
 /**
@@ -222,6 +224,7 @@ export interface NotebookCollectionFromQdrant {
   remove_missing_on_sync?: boolean;
   created_at: string;
   updated_at: string;
+  settings?: Record<string, unknown>;
   notebook_collection_documents?: Array<{ document_id: string }>;
 }
 

--- a/apps/api/routes/voice/ttsController.ts
+++ b/apps/api/routes/voice/ttsController.ts
@@ -1,0 +1,141 @@
+import express, { type Request, type Response, type Router } from 'express';
+
+import ttsService from '../../services/voice/ttsService.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('ttsController');
+
+const router: Router = express.Router();
+
+const MAX_TEXT_LENGTH = 8192;
+
+interface GenerateRequest extends Request {
+  body: {
+    text?: string;
+    modelId?: string;
+    voiceId?: number;
+    cfgScale?: number;
+    language?: string;
+  };
+}
+
+router.post('/generate', async (req: GenerateRequest, res: Response) => {
+  const { text, modelId, voiceId, cfgScale, language } = req.body;
+
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ success: false, error: 'Text ist erforderlich' });
+  }
+
+  if (text.length > MAX_TEXT_LENGTH) {
+    return res.status(400).json({
+      success: false,
+      error: `Text darf maximal ${MAX_TEXT_LENGTH} Zeichen lang sein`,
+    });
+  }
+
+  try {
+    const wavBuffer = await ttsService.generateSpeech(text, {
+      modelId,
+      voiceId,
+      cfgScale,
+      language,
+    });
+
+    res.set({
+      'Content-Type': 'audio/wav',
+      'Content-Length': String(wavBuffer.length),
+      'Content-Disposition': 'inline; filename="speech.wav"',
+    });
+    return res.send(wavBuffer);
+  } catch (error) {
+    log.error('[TTS] Generate error:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Fehler bei der Sprachsynthese: ' + (error as Error).message,
+    });
+  }
+});
+
+router.post('/stream', async (req: GenerateRequest, res: Response) => {
+  const { text, modelId, voiceId, cfgScale, language } = req.body;
+
+  if (!text || typeof text !== 'string') {
+    return res.status(400).json({ success: false, error: 'Text ist erforderlich' });
+  }
+
+  if (text.length > MAX_TEXT_LENGTH) {
+    return res.status(400).json({
+      success: false,
+      error: `Text darf maximal ${MAX_TEXT_LENGTH} Zeichen lang sein`,
+    });
+  }
+
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.flushHeaders();
+
+  try {
+    await ttsService.streamSpeech(
+      text,
+      { modelId, voiceId, cfgScale, language },
+      {
+        onChunk: (chunk) => {
+          res.write(
+            `event: audio_chunk\ndata: ${JSON.stringify({
+              audio: chunk.audio,
+              index: chunk.index,
+              sampleRate: chunk.sampleRate,
+            })}\n\n`
+          );
+        },
+        onDone: (stats) => {
+          res.write(`event: done\ndata: ${JSON.stringify(stats)}\n\n`);
+          res.end();
+        },
+        onError: (error) => {
+          res.write(`event: error\ndata: ${JSON.stringify({ error: error.message })}\n\n`);
+          res.end();
+        },
+      }
+    );
+  } catch (error) {
+    log.error('[TTS] Stream error:', error);
+    if (!res.writableEnded) {
+      res.write(`event: error\ndata: ${JSON.stringify({ error: (error as Error).message })}\n\n`);
+      res.end();
+    }
+  }
+});
+
+router.get('/voices', async (req: Request, res: Response) => {
+  const language = req.query.language as string | undefined;
+
+  try {
+    const voices = await ttsService.listVoices(language);
+    return res.json({ success: true, voices });
+  } catch (error) {
+    log.error('[TTS] List voices error:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Fehler beim Abrufen der Stimmen: ' + (error as Error).message,
+    });
+  }
+});
+
+router.get('/models', async (_req: Request, res: Response) => {
+  try {
+    const models = await ttsService.listModels();
+    return res.json({ success: true, models });
+  } catch (error) {
+    log.error('[TTS] List models error:', error);
+    return res.status(500).json({
+      success: false,
+      error: 'Fehler beim Abrufen der Modelle: ' + (error as Error).message,
+    });
+  }
+});
+
+export default router;

--- a/apps/api/services/voice/ttsService.ts
+++ b/apps/api/services/voice/ttsService.ts
@@ -1,0 +1,154 @@
+import {
+  KugelAudio,
+  createWavFile,
+  type Voice as SDKVoice,
+  type Model as SDKModel,
+} from 'kugelaudio';
+
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('tts');
+
+interface TTSOptions {
+  modelId?: string;
+  voiceId?: number;
+  cfgScale?: number;
+  language?: string;
+}
+
+interface TTSStreamCallbacks {
+  onChunk?: (chunk: { audio: string; index: number; sampleRate: number }) => void;
+  onDone?: (stats: { chunks: number; durationMs: number; generationMs: number }) => void;
+  onError?: (error: Error) => void;
+}
+
+type Voice = SDKVoice;
+type Model = SDKModel;
+
+const DEFAULT_MODEL = 'kugel-1-turbo';
+const DEFAULT_LANGUAGE = 'de';
+const DEFAULT_CFG_SCALE = 2.0;
+
+class TTSService {
+  private client: KugelAudio | null = null;
+
+  private getClient(): KugelAudio {
+    if (!this.client) {
+      const apiKey = process.env.KUGELAUDIO_API_KEY;
+      if (!apiKey) {
+        throw new Error('KUGELAUDIO_API_KEY is not configured');
+      }
+      this.client = new KugelAudio({ apiKey });
+      log.info('[TTS] KugelAudio client initialized');
+    }
+    return this.client;
+  }
+
+  async generateSpeech(text: string, options: TTSOptions = {}): Promise<Buffer> {
+    const client = this.getClient();
+    const {
+      modelId = DEFAULT_MODEL,
+      voiceId,
+      cfgScale = DEFAULT_CFG_SCALE,
+      language = DEFAULT_LANGUAGE,
+    } = options;
+
+    log.debug('[TTS] Generating speech', {
+      textLength: text.length,
+      modelId,
+      voiceId,
+      language,
+    });
+
+    const audio = await client.tts.generate({
+      text,
+      modelId,
+      voiceId,
+      cfgScale,
+      language,
+    });
+
+    const wavBytes = createWavFile(audio.audio, audio.sampleRate);
+
+    log.debug('[TTS] Speech generated', {
+      durationMs: audio.durationMs,
+      generationMs: audio.generationMs,
+      sampleRate: audio.sampleRate,
+    });
+
+    return Buffer.from(wavBytes);
+  }
+
+  async streamSpeech(
+    text: string,
+    options: TTSOptions = {},
+    callbacks: TTSStreamCallbacks = {}
+  ): Promise<void> {
+    const client = this.getClient();
+    const {
+      modelId = DEFAULT_MODEL,
+      voiceId,
+      cfgScale = DEFAULT_CFG_SCALE,
+      language = DEFAULT_LANGUAGE,
+    } = options;
+
+    if (!client.tts.isConnected()) {
+      await client.tts.connect();
+    }
+
+    log.debug('[TTS] Starting speech stream', {
+      textLength: text.length,
+      modelId,
+      voiceId,
+      language,
+    });
+
+    await client.tts.stream(
+      { text, modelId, voiceId, cfgScale, language },
+      {
+        onChunk: (chunk) => {
+          callbacks.onChunk?.({
+            audio: chunk.audio,
+            index: chunk.index,
+            sampleRate: chunk.sampleRate,
+          });
+        },
+        onFinal: (stats) => {
+          log.debug('[TTS] Stream completed', {
+            chunks: stats.chunks,
+            durationMs: stats.durationMs,
+            generationMs: stats.generationMs,
+          });
+          callbacks.onDone?.({
+            chunks: stats.chunks,
+            durationMs: stats.durationMs,
+            generationMs: stats.generationMs,
+          });
+        },
+        onError: (error) => {
+          log.error('[TTS] Stream error:', error);
+          callbacks.onError?.(error);
+        },
+      }
+    );
+  }
+
+  async listVoices(language?: string): Promise<Voice[]> {
+    const client = this.getClient();
+    log.debug('[TTS] Listing voices', { language });
+    const voices = await client.voices.list({ language });
+    return voices as Voice[];
+  }
+
+  async listModels(): Promise<Model[]> {
+    const client = this.getClient();
+    log.debug('[TTS] Listing models');
+    const models = await client.models.list();
+    return models as Model[];
+  }
+}
+
+const instance = new TTSService();
+export default instance;
+export { TTSService };
+export type { TTSOptions, TTSStreamCallbacks, Voice, Model };

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -11,6 +11,9 @@ const EditorPage = lazy(() =>
 );
 const HomePage = lazy(() => import('./pages/HomePage').then((m) => ({ default: m.HomePage })));
 const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })));
+const SettingsPage = lazy(() =>
+  import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage }))
+);
 
 // Initialize API client (side-effect: sets up shared API client)
 import './lib/apiClient';
@@ -53,6 +56,16 @@ function App() {
                   <ProtectedRoute>
                     <ErrorBoundary showHomeLink>
                       <EditorPage />
+                    </ErrorBoundary>
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <ProtectedRoute>
+                    <ErrorBoundary showHomeLink>
+                      <SettingsPage />
                     </ErrorBoundary>
                   </ProtectedRoute>
                 }

--- a/apps/docs/src/components/settings/WolkeConnectionCard.tsx
+++ b/apps/docs/src/components/settings/WolkeConnectionCard.tsx
@@ -1,0 +1,144 @@
+import { ActionIcon, Badge, Tooltip } from '@mantine/core';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import { FiExternalLink, FiTrash2, FiWifi } from 'react-icons/fi';
+
+import { type ShareLink, deleteShareLink, testConnection } from '../../lib/wolkeApi';
+
+type TestStatus = 'idle' | 'loading' | 'success' | 'error';
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+}
+
+function extractHostname(url: string | null): string {
+  if (!url) return 'Unbekannt';
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+interface WolkeConnectionCardProps {
+  link: ShareLink;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export function WolkeConnectionCard({ link, onError, onSuccess }: WolkeConnectionCardProps) {
+  const queryClient = useQueryClient();
+  const [testStatus, setTestStatus] = useState<TestStatus>('idle');
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteShareLink(link.id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['wolke-share-links'] });
+      onSuccess('Verbindung wurde entfernt.');
+    },
+    onError: () => onError('Verbindung konnte nicht entfernt werden.'),
+  });
+
+  const handleTest = async () => {
+    setTestStatus('loading');
+    try {
+      const result = await testConnection(link.share_link);
+      setTestStatus(result.success ? 'success' : 'error');
+      if (result.success) {
+        onSuccess('Verbindung erfolgreich!');
+      } else {
+        onError(result.message || 'Verbindung fehlgeschlagen.');
+      }
+    } catch {
+      setTestStatus('error');
+      onError('Verbindungstest fehlgeschlagen.');
+    }
+    timerRef.current = setTimeout(() => setTestStatus('idle'), 4000);
+  };
+
+  const handleDelete = () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true);
+      timerRef.current = setTimeout(() => setConfirmDelete(false), 3000);
+      return;
+    }
+    deleteMutation.mutate();
+    setConfirmDelete(false);
+  };
+
+  const hostname = extractHostname(link.base_url || link.share_link);
+  const displayLabel = link.label || hostname;
+
+  const testIconColor =
+    testStatus === 'success' ? 'green' : testStatus === 'error' ? 'red' : 'gray';
+
+  return (
+    <div className="wolke-connection-row">
+      <div className="wolke-connection-info">
+        <span className="wolke-connection-label">{displayLabel}</span>
+        <span className="wolke-connection-host">{hostname}</span>
+        <span className="wolke-connection-date">Hinzugefügt am {formatDate(link.created_at)}</span>
+      </div>
+
+      <div className="wolke-connection-actions">
+        <Badge color={link.is_active ? 'green' : 'gray'} variant="light" size="sm">
+          {link.is_active ? 'Aktiv' : 'Inaktiv'}
+        </Badge>
+
+        <Tooltip label="Verbindung testen">
+          <ActionIcon
+            variant="subtle"
+            color={testIconColor}
+            size="md"
+            onClick={handleTest}
+            loading={testStatus === 'loading'}
+            aria-label="Verbindung testen"
+          >
+            <FiWifi size={16} />
+          </ActionIcon>
+        </Tooltip>
+
+        <Tooltip label="In Nextcloud öffnen">
+          <ActionIcon
+            variant="subtle"
+            color="gray"
+            size="md"
+            component="a"
+            href={link.share_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="In Nextcloud öffnen"
+          >
+            <FiExternalLink size={16} />
+          </ActionIcon>
+        </Tooltip>
+
+        <Tooltip label={confirmDelete ? 'Nochmal klicken zum Bestätigen' : 'Verbindung entfernen'}>
+          <ActionIcon
+            variant="subtle"
+            color="red"
+            size="md"
+            onClick={handleDelete}
+            loading={deleteMutation.isPending}
+            aria-label="Verbindung entfernen"
+            style={confirmDelete ? { background: 'var(--mantine-color-red-1)' } : undefined}
+          >
+            <FiTrash2 size={16} />
+          </ActionIcon>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/settings/WolkeConnectionSection.tsx
+++ b/apps/docs/src/components/settings/WolkeConnectionSection.tsx
@@ -1,0 +1,175 @@
+import { Alert, Button, Loader, TextInput } from '@mantine/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type AxiosError } from 'axios';
+import { type FormEvent, useEffect, useRef, useState } from 'react';
+import { FiAlertCircle, FiCheckCircle, FiCloud, FiPlus } from 'react-icons/fi';
+
+import { addShareLink, fetchShareLinks, validateShareLink } from '../../lib/wolkeApi';
+
+import { WolkeConnectionCard } from './WolkeConnectionCard';
+
+export function WolkeConnectionSection() {
+  const queryClient = useQueryClient();
+
+  const [linkUrl, setLinkUrl] = useState('');
+  const [label, setLabel] = useState('');
+  const [linkError, setLinkError] = useState('');
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(
+    null
+  );
+  const feedbackTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    };
+  }, []);
+
+  const showFeedback = (type: 'success' | 'error', message: string) => {
+    setFeedback({ type, message });
+    if (feedbackTimer.current) clearTimeout(feedbackTimer.current);
+    feedbackTimer.current = setTimeout(() => setFeedback(null), 5000);
+  };
+
+  const {
+    data: shareLinks,
+    isLoading,
+    error: queryError,
+  } = useQuery({
+    queryKey: ['wolke-share-links'],
+    queryFn: fetchShareLinks,
+  });
+
+  const addMutation = useMutation({
+    mutationFn: ({ url, lbl }: { url: string; lbl?: string }) => addShareLink(url, lbl),
+    onSuccess: (data) => {
+      void queryClient.invalidateQueries({ queryKey: ['wolke-share-links'] });
+      setLinkUrl('');
+      setLabel('');
+      setLinkError('');
+      const testMsg = data.connectionTest?.success
+        ? ' Verbindung erfolgreich getestet.'
+        : ' Verbindungstest fehlgeschlagen — bitte prüfe den Link.';
+      showFeedback(
+        data.connectionTest?.success ? 'success' : 'error',
+        'Share-Link hinzugefügt.' + testMsg
+      );
+    },
+    onError: (error: AxiosError) => {
+      if (error.response?.status === 409) {
+        showFeedback('error', 'Dieser Share-Link ist bereits vorhanden.');
+      } else {
+        showFeedback('error', 'Share-Link konnte nicht hinzugefügt werden.');
+      }
+    },
+  });
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validation = validateShareLink(linkUrl);
+    if (!validation.valid) {
+      setLinkError(validation.error || 'Ungültiger Link.');
+      return;
+    }
+    setLinkError('');
+    addMutation.mutate({ url: linkUrl, lbl: label });
+  };
+
+  return (
+    <section className="settings-section">
+      <div className="settings-section-header">
+        <div className="settings-section-icon">
+          <FiCloud size={20} />
+        </div>
+        <div>
+          <h2 className="settings-section-title">Wolke-Verbindungen</h2>
+          <p className="settings-section-description">
+            Verbinde deine Nextcloud (Grüne Wolke), um Dokumente direkt dorthin zu exportieren.
+          </p>
+        </div>
+      </div>
+
+      {feedback && (
+        <Alert
+          color={feedback.type === 'success' ? 'green' : 'red'}
+          icon={
+            feedback.type === 'success' ? <FiCheckCircle size={16} /> : <FiAlertCircle size={16} />
+          }
+          withCloseButton
+          onClose={() => setFeedback(null)}
+          className="settings-alert"
+        >
+          {feedback.message}
+        </Alert>
+      )}
+
+      <div className="settings-card">
+        <form onSubmit={handleSubmit} className="wolke-add-form">
+          <TextInput
+            label="Share-Link"
+            placeholder="https://wolke.netzbegruenung.de/s/AbCdEf123"
+            value={linkUrl}
+            onChange={(e) => {
+              setLinkUrl(e.currentTarget.value);
+              if (linkError) setLinkError('');
+            }}
+            error={linkError}
+            required
+          />
+          <TextInput
+            label="Bezeichnung"
+            placeholder="z.B. Ortsverband, Mein Ordner…"
+            value={label}
+            onChange={(e) => setLabel(e.currentTarget.value)}
+          />
+          <Button
+            type="submit"
+            color="var(--primary-600)"
+            leftSection={<FiPlus size={16} />}
+            loading={addMutation.isPending}
+          >
+            Verbindung hinzufügen
+          </Button>
+        </form>
+      </div>
+
+      <div className="settings-card">
+        {isLoading && (
+          <div className="wolke-empty-state">
+            <Loader size="sm" color="var(--primary-600)" />
+          </div>
+        )}
+
+        {queryError && (
+          <div className="wolke-empty-state">
+            <FiAlertCircle size={24} className="wolke-empty-icon" />
+            <p>Verbindungen konnten nicht geladen werden.</p>
+          </div>
+        )}
+
+        {!isLoading && !queryError && shareLinks?.length === 0 && (
+          <div className="wolke-empty-state">
+            <FiCloud size={24} className="wolke-empty-icon" />
+            <p>Noch keine Wolke-Verbindungen vorhanden.</p>
+            <p className="wolke-empty-hint">
+              Füge einen Nextcloud Share-Link hinzu, um Dokumente zu exportieren.
+            </p>
+          </div>
+        )}
+
+        {!isLoading &&
+          !queryError &&
+          shareLinks &&
+          shareLinks.length > 0 &&
+          shareLinks.map((link) => (
+            <WolkeConnectionCard
+              key={link.id}
+              link={link}
+              onError={(msg) => showFeedback('error', msg)}
+              onSuccess={(msg) => showFeedback('success', msg)}
+            />
+          ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/lib/wolkeApi.ts
+++ b/apps/docs/src/lib/wolkeApi.ts
@@ -1,0 +1,71 @@
+import { apiClient } from './apiClient';
+
+export interface ShareLink {
+  id: string;
+  share_link: string;
+  label: string | null;
+  base_url: string | null;
+  share_token: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at?: string;
+}
+
+interface ConnectionTestResult {
+  success: boolean;
+  message: string;
+  writable?: boolean;
+}
+
+interface AddShareLinkResponse {
+  success: boolean;
+  shareLink: ShareLink;
+  connectionTest: ConnectionTestResult;
+}
+
+const SHARE_LINK_PATTERN = /\/s\/[A-Za-z0-9]+/;
+
+export function validateShareLink(url: string): { valid: boolean; error?: string } {
+  if (!url.trim()) return { valid: false, error: 'Share-Link ist erforderlich.' };
+  try {
+    new URL(url);
+  } catch {
+    return { valid: false, error: 'Ungültiges URL-Format.' };
+  }
+  if (!SHARE_LINK_PATTERN.test(url)) {
+    return {
+      valid: false,
+      error: 'Ungültiges Nextcloud Share-Link-Format. Der Link muss "/s/" enthalten.',
+    };
+  }
+  return { valid: true };
+}
+
+export async function fetchShareLinks(): Promise<ShareLink[]> {
+  const { data } = await apiClient.get<{ success: boolean; shareLinks: ShareLink[] }>(
+    '/nextcloud/share-links'
+  );
+  return data.shareLinks;
+}
+
+export async function addShareLink(
+  shareLink: string,
+  label?: string
+): Promise<AddShareLinkResponse> {
+  const { data } = await apiClient.post<AddShareLinkResponse>('/nextcloud/share-links', {
+    shareLink,
+    ...(label?.trim() ? { label: label.trim() } : {}),
+  });
+  return data;
+}
+
+export async function deleteShareLink(id: string): Promise<void> {
+  await apiClient.delete(`/nextcloud/share-links/${id}`);
+}
+
+export async function testConnection(shareLink: string): Promise<ConnectionTestResult> {
+  const { data } = await apiClient.post<ConnectionTestResult>('/nextcloud/test-connection', {
+    shareLink,
+  });
+  return data;
+}

--- a/apps/docs/src/pages/HomePage.tsx
+++ b/apps/docs/src/pages/HomePage.tsx
@@ -2,7 +2,8 @@ import { DocumentList } from '@gruenerator/docs';
 import { getAvatarDisplayProps, getRobotAvatarPath } from '@gruenerator/shared/avatar';
 import { MantineProvider, Menu, ActionIcon, TextInput } from '@mantine/core';
 import { useState } from 'react';
-import { FiLogOut, FiSearch, FiX } from 'react-icons/fi';
+import { FiLogOut, FiSearch, FiSettings, FiX } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
 
 import { useAuth } from '../hooks/useAuth';
 import { useColorScheme } from '../hooks/useColorScheme';
@@ -34,6 +35,7 @@ export const HomePage = () => {
   const { user } = useAuth();
   const { logout } = useAuthStore();
   const colorScheme = useColorScheme();
+  const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState('');
 
   return (
@@ -82,6 +84,13 @@ export const HomePage = () => {
                 </Menu.Target>
                 <Menu.Dropdown>
                   <Menu.Label>{user?.display_name || user?.email}</Menu.Label>
+                  <Menu.Item
+                    leftSection={<FiSettings size={14} />}
+                    onClick={() => navigate('/settings')}
+                  >
+                    Einstellungen
+                  </Menu.Item>
+                  <Menu.Divider />
                   <Menu.Item
                     leftSection={<FiLogOut size={14} />}
                     onClick={() => logout()}

--- a/apps/docs/src/pages/SettingsPage.css
+++ b/apps/docs/src/pages/SettingsPage.css
@@ -1,0 +1,191 @@
+@import '../../../web/src/assets/styles/common/variables.css';
+
+.settings-page {
+  min-height: 100vh;
+  background-color: var(--background-color);
+  color: var(--font-color);
+}
+
+.settings-container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--spacing-large) var(--spacing-medium);
+}
+
+/* Header */
+.settings-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  margin-bottom: var(--spacing-xlarge);
+}
+
+.settings-header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+/* Section */
+.settings-section {
+  margin-bottom: var(--spacing-xlarge);
+}
+
+.settings-section-header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-small);
+  margin-bottom: var(--spacing-medium);
+}
+
+.settings-section-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--primary-100);
+  color: var(--primary-700);
+  flex-shrink: 0;
+}
+
+.settings-section-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+
+.settings-section-description {
+  font-size: 0.875rem;
+  color: var(--grey-500);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* Alert */
+.settings-alert {
+  margin-bottom: var(--spacing-medium);
+}
+
+/* Card */
+.settings-card {
+  background: var(--card-background, #fff);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+}
+
+/* Add form */
+.wolke-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-small);
+}
+
+.wolke-add-form button[type='submit'] {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+/* Connection row */
+.wolke-connection-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) 0;
+}
+
+.wolke-connection-row + .wolke-connection-row {
+  border-top: 1px solid var(--border-color);
+}
+
+.wolke-connection-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.wolke-connection-label {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wolke-connection-host {
+  font-size: 0.8125rem;
+  color: var(--grey-500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wolke-connection-date {
+  font-size: 0.75rem;
+  color: var(--grey-400);
+}
+
+.wolke-connection-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Empty state */
+.wolke-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: var(--spacing-large) var(--spacing-medium);
+  text-align: center;
+  color: var(--grey-500);
+}
+
+.wolke-empty-icon {
+  color: var(--grey-300);
+}
+
+.wolke-empty-hint {
+  font-size: 0.8125rem;
+  color: var(--grey-400);
+  margin: 0;
+}
+
+/* Dark mode */
+[data-theme='dark'] .settings-section-icon {
+  background: var(--primary-900);
+  color: var(--primary-300);
+}
+
+[data-theme='dark'] .settings-card {
+  background: var(--grey-900);
+}
+
+[data-theme='dark'] .wolke-empty-icon {
+  color: var(--grey-600);
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+  .settings-container {
+    padding: var(--spacing-medium) var(--spacing-small);
+  }
+
+  .wolke-connection-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .wolke-connection-actions {
+    align-self: flex-end;
+    margin-top: 4px;
+  }
+}

--- a/apps/docs/src/pages/SettingsPage.tsx
+++ b/apps/docs/src/pages/SettingsPage.tsx
@@ -1,0 +1,37 @@
+import { ActionIcon, MantineProvider } from '@mantine/core';
+import { FiArrowLeft } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
+
+import { WolkeConnectionSection } from '../components/settings/WolkeConnectionSection';
+import { useColorScheme } from '../hooks/useColorScheme';
+
+import '@mantine/core/styles.css';
+import './SettingsPage.css';
+
+export const SettingsPage = () => {
+  const colorScheme = useColorScheme();
+  const navigate = useNavigate();
+
+  return (
+    <MantineProvider forceColorScheme={colorScheme}>
+      <div className="settings-page">
+        <div className="settings-container">
+          <header className="settings-header">
+            <ActionIcon
+              variant="subtle"
+              color="gray"
+              size="lg"
+              onClick={() => navigate('/')}
+              aria-label="Zurück zur Übersicht"
+            >
+              <FiArrowLeft size={20} />
+            </ActionIcon>
+            <h1>Einstellungen</h1>
+          </header>
+
+          <WolkeConnectionSection />
+        </div>
+      </div>
+    </MantineProvider>
+  );
+};

--- a/apps/gruen-o-mat/Dockerfile
+++ b/apps/gruen-o-mat/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.title="Gruen-O-Mat"
 LABEL org.opencontainers.image.description="Public Green Party Q&A Bot Frontend"
 LABEL org.opencontainers.image.source="https://github.com/netzbegruenung/Gruenerator"
 
-RUN apk add --no-cache curl gettext
+RUN apk add --no-cache curl gettext apache2-utils
 
 # Remove default nginx config
 RUN rm -rf /usr/share/nginx/html/* /etc/nginx/conf.d/default.conf

--- a/apps/gruen-o-mat/docker-compose.coolify.yml
+++ b/apps/gruen-o-mat/docker-compose.coolify.yml
@@ -14,6 +14,8 @@ services:
     image: ghcr.io/netzbegruenung/gruenerator-gruen-o-mat:${TAG:-latest}
     environment:
       - API_BASE_URL=${API_BASE_URL:-https://gruenerator.eu}
+      - AUTH_USERNAME=${AUTH_USERNAME:-}
+      - AUTH_PASSWORD=${AUTH_PASSWORD:-}
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost/health']

--- a/apps/gruen-o-mat/docker-entrypoint.sh
+++ b/apps/gruen-o-mat/docker-entrypoint.sh
@@ -5,6 +5,16 @@ set -e
 # Restricted to ${API_BASE_URL} so nginx variables ($host, $uri, etc.) are untouched.
 envsubst '${API_BASE_URL}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
 
+# Optional basic auth (set AUTH_USERNAME + AUTH_PASSWORD to enable)
+if [ -n "$AUTH_USERNAME" ] && [ -n "$AUTH_PASSWORD" ]; then
+  htpasswd -cb /etc/nginx/.htpasswd "$AUTH_USERNAME" "$AUTH_PASSWORD"
+  sed -i 's|# __AUTH_PLACEHOLDER__|auth_basic "Gruen-O-Mat"; auth_basic_user_file /etc/nginx/.htpasswd;|g' \
+    /etc/nginx/conf.d/default.conf
+  echo "Basic auth enabled for user: ${AUTH_USERNAME}"
+else
+  echo "Basic auth disabled (AUTH_USERNAME not set)"
+fi
+
 echo "Starting nginx — API proxy target: ${API_BASE_URL}"
 
 # Execute the main command (nginx)

--- a/apps/gruen-o-mat/nginx.conf.template
+++ b/apps/gruen-o-mat/nginx.conf.template
@@ -20,6 +20,7 @@ server {
     # Reverse proxy API requests to the backend
     # SSE streaming requires buffering off + long timeouts
     location /api/ {
+        # __AUTH_PLACEHOLDER__
         proxy_pass ${API_BASE_URL}/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -37,10 +38,11 @@ server {
 
     # SPA fallback — serve index.html for client-side routing
     location / {
+        # __AUTH_PLACEHOLDER__
         try_files $uri /index.html;
     }
 
-    # Health check
+    # Health check (no auth — needed for Docker/Coolify health probes)
     location /health {
         access_log off;
         return 200 "healthy\n";

--- a/apps/web/src/components/pages/Impressum_Datenschutz_Terms/Datenschutz.tsx
+++ b/apps/web/src/components/pages/Impressum_Datenschutz_Terms/Datenschutz.tsx
@@ -176,8 +176,11 @@ const Datenschutz = () => {
       </p>
 
       <p>
-        Darüber hinaus nutzen wir für die Bereitstellung der KI-Funktionen und der Suchfunktion
-        spezialisierte technische Dienstleister, die als unsere Auftragsverarbeiter agieren.
+        Darüber hinaus nutzen wir für die Bereitstellung der KI-Funktionen, der Suchfunktion und der
+        Fehlerüberwachung spezialisierte technische Dienstleister, die als unsere
+        Auftragsverarbeiter agieren. Für die Anwendungsüberwachung nutzen wir{' '}
+        <strong>GlitchTip</strong> (Burke Software and Consulting LLC, USA) mit EU-Serverstandort in
+        Frankfurt, Deutschland.
       </p>
 
       <h3>Auftragsverarbeitung durch technische Dienstleister</h3>
@@ -284,6 +287,28 @@ const Datenschutz = () => {
         <li>Zweck: Suchfunktion (Metasuchmaschine für Web-Informationen)</li>
         <li>Server: Eigene Server (Deutschland)</li>
         <li>Besonderheit: Keine Weitergabe an externe Suchanbieter, vollständige Datenkontrolle</li>
+      </ul>
+
+      <p>
+        <strong>7. GlitchTip</strong> (Burke Software and Consulting LLC, New York, USA)
+      </p>
+      <ul>
+        <li>Zweck: Fehlerüberwachung und Anwendungsmonitoring (Error Tracking)</li>
+        <li>Server: EU (DigitalOcean Frankfurt, Deutschland)</li>
+        <li>Verarbeitete Daten: Fehlerberichte, Stack-Traces, Browserinformationen, IP-Adressen</li>
+        <li>Speicherdauer: Automatische Löschung nach 90 Tagen</li>
+        <li>Sicherheit: TLS 1.2+, Verschlüsselung im Ruhezustand, A+ Mozilla Observatory Rating</li>
+        <li>
+          Besonderheit: Open-Source-Alternative zu Sentry, Daten werden nicht zum KI-Training
+          verwendet, EU-Datenresidenz trotz US-Firmensitz
+        </li>
+        <li>Rechtsgrundlage Drittlandtransfer: EU-US Data Privacy Framework (Art. 45 DSGVO)</li>
+        <li>
+          Details: <a href="https://glitchtip.com/legal/privacy/">Datenschutzerklärung</a> und{' '}
+          <a href="https://glitchtip.com/documentation/hosted-architecture/">
+            Architektur &amp; Sicherheit
+          </a>
+        </li>
       </ul>
 
       <h3 id="webanalyse">Webanalyse mit Umami</h3>
@@ -428,6 +453,10 @@ const Datenschutz = () => {
           <tr>
             <td>KI-Anfragen (Mistral/Claude)</td>
             <td>Max. 30 Tage (Missbrauchserkennung)</td>
+          </tr>
+          <tr>
+            <td>Fehlerberichte (GlitchTip)</td>
+            <td>90 Tage (automatische Löschung)</td>
           </tr>
           <tr>
             <td>Video-Transkription (Gladia)</td>

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -6,11 +6,13 @@ import {
   useRef,
   type ComponentType,
   type DragEvent,
+  type KeyboardEvent,
 } from 'react';
 import { useForm } from 'react-hook-form';
-import { HiCheckCircle, HiArrowLeft, HiUpload, HiX } from 'react-icons/hi';
+import { HiCheckCircle, HiArrowLeft, HiUpload, HiX, HiPlus } from 'react-icons/hi';
 
 import { useFormFields } from '../../../components/common/Form/hooks';
+import { Badge } from '../../../components/ui/badge';
 import { Button } from '../../../components/ui/button';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
@@ -20,6 +22,7 @@ interface NotebookCollection {
   name: string;
   description?: string;
   documents?: { id: string; title?: string }[];
+  labels?: string[];
 }
 
 interface NotebookEditorFormData {
@@ -75,6 +78,8 @@ const NotebookEditor = ({
   const [isUploading, setIsUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [labels, setLabels] = useState<string[]>([]);
+  const [newLabel, setNewLabel] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { Input, Textarea } = useFormFields() as unknown as FormFieldComponents;
@@ -93,6 +98,7 @@ const NotebookEditor = ({
         name: editingCollection.name || '',
         description: editingCollection.description || '',
       });
+      setLabels(editingCollection.labels || []);
       if (editingCollection.documents?.length) {
         const doc = editingCollection.documents[0];
         setUploadedDocument({ id: doc.id, title: doc.title || 'Dokument' });
@@ -100,6 +106,7 @@ const NotebookEditor = ({
       }
     } else {
       reset({ name: '', description: '' });
+      setLabels([]);
       setUploadedDocument(null);
       setStep(1);
     }
@@ -156,7 +163,32 @@ const NotebookEditor = ({
     setUploadedDocument(null);
     setStep(1);
     reset({ name: '', description: '' });
+    setLabels([]);
   }, [reset]);
+
+  const handleAddLabel = useCallback(() => {
+    const trimmed = newLabel.trim();
+    if (!trimmed || labels.includes(trimmed) || labels.length >= 10) {
+      setNewLabel('');
+      return;
+    }
+    setLabels((prev) => [...prev, trimmed]);
+    setNewLabel('');
+  }, [newLabel, labels]);
+
+  const handleRemoveLabel = useCallback((labelToRemove: string) => {
+    setLabels((prev) => prev.filter((l) => l !== labelToRemove));
+  }, []);
+
+  const handleLabelKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleAddLabel();
+      }
+    },
+    [handleAddLabel]
+  );
 
   const onSubmit = async (data: NotebookEditorFormData): Promise<void> => {
     if (!uploadedDocument) return;
@@ -166,6 +198,7 @@ const NotebookEditor = ({
       selectionMode: 'documents',
       documents: [uploadedDocument.id],
       id: editingCollection?.id,
+      labels,
     };
 
     await onSave(qaData);
@@ -174,6 +207,8 @@ const NotebookEditor = ({
   const handleCancel = (): void => {
     reset();
     setUploadedDocument(null);
+    setLabels([]);
+    setNewLabel('');
     setStep(1);
     if (onCancel) onCancel();
   };
@@ -354,6 +389,52 @@ const NotebookEditor = ({
                         },
                       }}
                     />
+                  </div>
+
+                  <div>
+                    <label className="text-sm font-medium text-foreground">Labels (optional)</label>
+                    <div className="mt-xs flex items-center gap-xs">
+                      <input
+                        type="text"
+                        value={newLabel}
+                        onChange={(e) => setNewLabel(e.target.value)}
+                        onKeyDown={handleLabelKeyDown}
+                        placeholder="Label hinzufügen…"
+                        maxLength={30}
+                        disabled={loading || labels.length >= 10}
+                        className="flex-1 rounded-md border border-grey-300 dark:border-grey-600 bg-background px-sm py-xs text-sm text-foreground placeholder:text-grey-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={handleAddLabel}
+                        disabled={loading || !newLabel.trim() || labels.length >= 10}
+                      >
+                        <HiPlus size={14} />
+                      </Button>
+                    </div>
+                    {labels.length > 0 && (
+                      <div className="mt-xs flex flex-wrap gap-xs">
+                        {labels.map((label) => (
+                          <Badge
+                            key={label}
+                            variant="secondary"
+                            className="bg-secondary-600 text-white border-transparent gap-1"
+                          >
+                            {label}
+                            <button
+                              type="button"
+                              className="ml-0.5 inline-flex items-center hover:text-grey-200"
+                              onClick={() => handleRemoveLabel(label)}
+                              aria-label={`Label "${label}" entfernen`}
+                            >
+                              <HiX size={12} />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/apps/web/src/features/notebook/components/NotebookList.tsx
+++ b/apps/web/src/features/notebook/components/NotebookList.tsx
@@ -64,7 +64,7 @@ const NotebookList: React.FC<NotebookListProps> = ({
   return (
     <div className={gridClasses}>
       {qaCollections.map((collection) => {
-        const tags: string[] = [];
+        const tags: string[] = [...(collection.labels || [])];
         if (collection.is_public) tags.push('Öffentlich');
         if (processingCollectionIds.has(collection.id)) tags.push('Wird verarbeitet…');
 

--- a/apps/web/src/features/notebook/config/notebooksConfig.js
+++ b/apps/web/src/features/notebook/config/notebooksConfig.js
@@ -36,7 +36,7 @@ const PRODUCTION_NOTEBOOKS = [
     title: 'Frag Grüne Hamburg',
     description: 'Durchsuchbar sind Beschlüsse und Pressemitteilungen der Grünen Hamburg.',
     meta: 'Archiv',
-    tags: ['Hamburg', 'Beschlüsse', 'Presse'],
+    tags: ['Test', 'Hamburg', 'Beschlüsse', 'Presse'],
     order: 4,
     category: 'landesebene',
   },
@@ -47,7 +47,7 @@ const PRODUCTION_NOTEBOOKS = [
     description:
       'Durchsuchbar ist das Wahlprogramm der Grünen Schleswig-Holstein zur Landtagswahl.',
     meta: '1 Programm',
-    tags: ['Schleswig-Holstein', 'Wahlprogramm'],
+    tags: ['Test', 'Schleswig-Holstein', 'Wahlprogramm'],
     order: 5,
     category: 'landesebene',
   },
@@ -58,7 +58,7 @@ const PRODUCTION_NOTEBOOKS = [
     description:
       'Durchsuchbar sind Beschlüsse, Wahlprogramme und Pressemitteilungen der Grünen Thüringen.',
     meta: 'Archiv',
-    tags: ['Thüringen', 'Beschlüsse', 'Wahlprogramme', 'Presse'],
+    tags: ['Offiziell', 'Thüringen', 'Beschlüsse', 'Wahlprogramme', 'Presse'],
     order: 6,
     category: 'landesebene',
   },
@@ -73,6 +73,17 @@ const PRODUCTION_NOTEBOOKS = [
     order: 3,
     category: 'oesterreich',
   },
+  {
+    id: 'kommunalwiki-notebook',
+    path: '/kommunalwiki',
+    title: 'Frag KommunalWiki',
+    description:
+      'Fachwissen zur Kommunalpolitik – durchsuchbar über das KommunalWiki der Heinrich-Böll-Stiftung.',
+    meta: 'Wiki',
+    tags: ['Kommunalpolitik', 'Böll-Stiftung'],
+    order: 6,
+    category: 'weitere',
+  },
 ];
 
 const DEV_ONLY_NOTEBOOKS = [
@@ -85,17 +96,6 @@ const DEV_ONLY_NOTEBOOKS = [
     tags: ['Bayern', 'Regierungsprogramm'],
     order: 6,
     category: 'landesebene',
-  },
-  {
-    id: 'kommunalwiki-notebook',
-    path: '/kommunalwiki',
-    title: 'Frag KommunalWiki',
-    description:
-      'Fachwissen zur Kommunalpolitik – durchsuchbar über das KommunalWiki der Heinrich-Böll-Stiftung.',
-    meta: 'Wiki',
-    tags: ['Kommunalpolitik', 'Böll-Stiftung'],
-    order: 6,
-    category: 'weitere',
   },
   {
     id: 'boell-stiftung-notebook',

--- a/apps/web/src/features/notebook/pages/NotebooksGalleryPage.tsx
+++ b/apps/web/src/features/notebook/pages/NotebooksGalleryPage.tsx
@@ -23,6 +23,7 @@ interface EditorSaveData {
   selectionMode?: 'documents' | 'wolke';
   documents?: string[];
   wolkeShareLinks?: string[];
+  labels?: string[];
 }
 
 const gridClasses = 'grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-2xl';
@@ -134,6 +135,7 @@ const NotebooksGalleryPage = () => {
           selectionMode: saveData.selectionMode,
           documents: saveData.documents,
           wolkeShareLinks: saveData.wolkeShareLinks,
+          labels: saveData.labels,
         });
       } else {
         const result = await createQACollection({
@@ -142,6 +144,7 @@ const NotebooksGalleryPage = () => {
           selectionMode: saveData.selectionMode,
           documents: saveData.documents,
           wolkeShareLinks: saveData.wolkeShareLinks,
+          labels: saveData.labels,
         });
 
         if (result?.id && saveData.documents?.length) {

--- a/apps/web/src/features/notebook/stores/notebookStore.ts
+++ b/apps/web/src/features/notebook/stores/notebookStore.ts
@@ -47,6 +47,7 @@ interface NotebookState {
     selectionMode?: 'documents' | 'wolke';
     documents?: string[];
     wolkeShareLinks?: string[];
+    labels?: string[];
   }) => Promise<NotebookCollection>;
   updateQACollection: (
     collectionId: string,
@@ -57,6 +58,7 @@ interface NotebookState {
       selectionMode?: 'documents' | 'wolke';
       documents?: string[];
       wolkeShareLinks?: string[];
+      labels?: string[];
     }
   ) => Promise<void>;
   deleteQACollection: (collectionId: string) => Promise<void>;
@@ -145,6 +147,7 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
         selection_mode: string;
         document_ids?: string[];
         wolke_share_link_ids?: string[];
+        labels?: string[];
       } = {
         name: collectionData.name,
         description: collectionData.description,
@@ -157,6 +160,10 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
         requestData.wolke_share_link_ids = collectionData.wolkeShareLinks || [];
       } else {
         requestData.document_ids = collectionData.documents || [];
+      }
+
+      if (collectionData.labels) {
+        requestData.labels = collectionData.labels;
       }
 
       const response = await apiClient.post('/auth/notebook-collections', requestData);
@@ -191,6 +198,7 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
         selection_mode: string;
         document_ids?: string[];
         wolke_share_link_ids?: string[];
+        labels?: string[];
       } = {
         name: collectionData.name,
         description: collectionData.description,
@@ -203,6 +211,10 @@ const useNotebookStore = create<NotebookState>((set, get) => ({
         requestData.wolke_share_link_ids = collectionData.wolkeShareLinks || [];
       } else {
         requestData.document_ids = collectionData.documents || [];
+      }
+
+      if (collectionData.labels) {
+        requestData.labels = collectionData.labels;
       }
 
       const response = await apiClient.put(

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -37,6 +37,7 @@ export interface NotebookCollection {
   documents?: Document[];
   wolke_share_links?: WolkeShareLink[];
   selection_mode?: 'documents' | 'wolke' | 'mixed';
+  labels?: string[];
 }
 
 /**
@@ -62,6 +63,7 @@ export interface NotebookCollectionInput {
   selectionMode?: 'documents' | 'wolke' | 'mixed';
   documents?: string[];
   wolkeShareLinks?: string[];
+  labels?: string[];
 }
 
 /**

--- a/packages/docs/src/components/document/DocumentList.tsx
+++ b/packages/docs/src/components/document/DocumentList.tsx
@@ -183,7 +183,9 @@ export const DocumentList = ({ searchQuery }: DocumentListProps) => {
                     </Menu>
                   </div>
                   {doc.access_type && doc.access_type !== 'owner' && (
-                    <div className="document-card-sharing">Mit dir geteilt</div>
+                    <div className="document-card-sharing">
+                      {doc.creator_name ? `Von ${doc.creator_name}` : 'Mit dir geteilt'}
+                    </div>
                   )}
                   <div className="document-card-meta">
                     {new Date(doc.updated_at).toLocaleDateString('de-DE', {

--- a/packages/docs/src/stores/documentStore.ts
+++ b/packages/docs/src/stores/documentStore.ts
@@ -19,6 +19,7 @@ export interface Document {
   permissions: Record<string, { level: string; granted_at: string }>;
   metadata?: Record<string, unknown>;
   access_type?: 'owner' | 'direct' | 'group' | 'public';
+  creator_name?: string;
 }
 
 interface DocumentStore {


### PR DESCRIPTION
## Summary
- **Notebook labels**: Add label CRUD (stored in settings JSONB), label editor UI in NotebookEditor, display on notebook cards. Add "Test" to Hamburg/Schleswig-Holstein, "Offiziell" to Thüringen
- **KommunalWiki**: Promote from dev-only to production notebooks
- **Gruen-o-mat**: Add basic auth via nginx, update Dockerfile/compose
- **TTS endpoint**: New text-to-speech API route and service
- **Docs settings**: Add settings page with Wolke connection UI
- **Privacy**: Update Datenschutz page
- **Docs app**: Show creator name on shared documents

## Test plan
- [ ] Verify notebook labels display on cards in gallery
- [ ] Create/edit notebook with labels, confirm persistence
- [ ] Confirm KommunalWiki appears in production notebook gallery under "Weitere"
- [ ] Test gruen-o-mat basic auth in Docker
- [ ] Test TTS endpoint
- [ ] Verify docs settings page renders