### PR TITLE
Docs improvements, rename fix, and debug logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -439,6 +439,36 @@ All user-facing German text **must use gender-neutral language** with the **Gend
 4. **Exceptions**: Standard legal text (Impressum, Datenschutz) and compound nouns that aren't role-based (e.g. "Mitgliederversammlung") can remain unchanged
 5. **Email templates**: Permission labels in notification emails must also be gendered (`Eigentümer*in`, not `Eigentümer`)
 
+### Newsletter Writing Style
+
+Newsletters are sent via Brevo (Sendinblue) and archived in Docusaurus at `documentation/docs/newsletter/`. When writing new newsletters, follow the established voice:
+
+#### Tone & Voice
+- **Personal "du"-Ansprache** — direct, informal, like talking to a friend
+- **Mix of "ich" (Moritz) and "wir" (the project/community)** — personal voice for decisions and plans, collective voice for shared goals
+- **Conversational, almost spoken language** — short sentences, rhetorical pauses, sentence fragments for emphasis ("Und dann? Fand TikTok ohne uns statt.")
+- **Sign-off**: First name only ("Moritz"), no formal closing
+
+#### Structure
+- **Rhetorical question headers** — section titles are questions ("Was heißt das?", "Wie machen wir das?", "Warum so schnell?")
+- **Short paragraphs** — many single-sentence paragraphs for dramatic effect
+- **Vision first, then practical** — lead with big-picture motivation, follow with concrete how-to
+- **Clear call-to-action** — each newsletter has a specific ask (beta testing, feedback, conversations)
+
+#### Content Patterns
+- **Political urgency as motivator** — connect features to democratic values and Green principles
+- **Balanced tech optimism** — pro-innovation but acknowledges risks (CO2, KI-Bloat, data privacy)
+- **Technical concepts explained simply** — no jargon without plain-language explanation
+- **Green values woven naturally** — European sovereignty, data privacy, open source, sustainability
+- **Self-aware about project status** — honest about being a "Freizeit-Projekt", acknowledges early-stage bugs
+- **Branded language** — "Grünerieren" as a verb, "Grünerierung" as a noun
+
+#### Formatting
+- **Brevo template variables**: `{{ contact.VORNAME | default : " " }}` for personalization
+- **Emoji**: Used sparingly, only for CTAs (e.g., `👉` before a link)
+- **Links**: Inline where relevant, newsletter subscription at `fax.gruenerator.de`
+- **Archive filename convention**: `YYYY-MM-thema-in-kebab-case.md` (e.g., `2026-01-jahr-der-daten.md`)
+
 ### Code Quality
 
 ESLint (flat config), Prettier, Husky pre-commit hooks (lint-staged), Knip for unused code detection.

--- a/apps/api/routes/docs/documentController.ts
+++ b/apps/api/routes/docs/documentController.ts
@@ -242,7 +242,14 @@ router.put('/:id', async (req: Request, res: Response) => {
     const { title, folder_id, content } = req.body;
     const userId = req.user?.id;
 
+    console.log('[docs-rename] PUT /api/docs/%s — userId=%s, body=%o', id, userId, {
+      title,
+      folder_id,
+      content: content !== undefined ? `(${String(content).length} chars)` : undefined,
+    });
+
     if (!userId) {
+      console.warn('[docs-rename] PUT /api/docs/%s — 401: no userId', id);
       return res.status(401).json({ error: 'User not authenticated' });
     }
 
@@ -252,6 +259,11 @@ router.put('/:id', async (req: Request, res: Response) => {
     )) as CollaborativeDocument[];
 
     if (checkResult.length === 0) {
+      console.warn(
+        '[docs-rename] PUT /api/docs/%s — 404: document not found (userId=%s)',
+        id,
+        userId
+      );
       return res.status(404).json({ error: 'Document not found' });
     }
 
@@ -259,6 +271,11 @@ router.put('/:id', async (req: Request, res: Response) => {
     const userPermission = document.permissions?.[userId];
     const isOwner = document.created_by === userId;
     let canEdit = isOwner || (userPermission && ['owner', 'editor'].includes(userPermission.level));
+    let accessMethod = isOwner
+      ? 'owner'
+      : userPermission
+        ? `direct:${userPermission.level}`
+        : 'none';
 
     if (!canEdit) {
       const groupAccess = (await db.query(
@@ -270,10 +287,19 @@ router.put('/:id', async (req: Request, res: Response) => {
 
       if (groupAccess.length > 0 && groupAccess[0].permissions?.write === true) {
         canEdit = true;
+        accessMethod = 'group:write';
       }
     }
 
     if (!canEdit) {
+      console.warn(
+        '[docs-rename] PUT /api/docs/%s — 403: userId=%s, accessMethod=%s, createdBy=%s, permissions=%o',
+        id,
+        userId,
+        accessMethod,
+        document.created_by,
+        document.permissions
+      );
       return res.status(403).json({ error: 'Insufficient permissions to edit document' });
     }
 
@@ -310,6 +336,12 @@ router.put('/:id', async (req: Request, res: Response) => {
       values
     )) as CollaborativeDocument[];
 
+    console.log(
+      '[docs-rename] PUT /api/docs/%s — success: title="%s", accessMethod=%s',
+      id,
+      result[0]?.title,
+      accessMethod
+    );
     return res.json(result[0]);
   } catch (error: any) {
     console.error('[Docs] Error updating document:', error);

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -117,15 +117,30 @@ export const EditorPage = () => {
 
   const handleTitleChange = useCallback(
     async (newTitle: string) => {
-      if (!id) return;
+      if (!id) {
+        console.warn('[docs-rename] handleTitleChange: no document id, aborting');
+        return;
+      }
+      console.log(
+        '[docs-rename] handleTitleChange: docId=%s, newTitle="%s", isGuest=%s',
+        id,
+        newTitle,
+        isGuest
+      );
       const queryKey = ['document', id, isGuest ? 'public' : 'auth'];
       queryClient.setQueryData(queryKey, (old: Document | undefined) =>
         old ? { ...old, title: newTitle } : old
       );
       document.title = newTitle;
       try {
-        await apiClient.put(`/docs/${id}`, { title: newTitle });
-      } catch {
+        const result = await apiClient.put(`/docs/${id}`, { title: newTitle });
+        console.log(
+          '[docs-rename] handleTitleChange: API success, docId=%s, response=%o',
+          id,
+          result
+        );
+      } catch (error) {
+        console.error('[docs-rename] handleTitleChange: API failed, docId=%s, error=%o', id, error);
         queryClient.setQueryData(queryKey, docData);
       }
     },

--- a/apps/docs/src/stores/documentStore.ts
+++ b/apps/docs/src/stores/documentStore.ts
@@ -80,16 +80,22 @@ export const useDocumentStore = create<DocumentStore>((set, _get) => ({
   },
 
   updateDocument: async (id, updates) => {
+    console.log('[docs-rename] appStore.updateDocument: docId=%s, updates=%o', id, updates);
     set({ error: null });
     try {
       const response = await apiClient.put(`/docs/${id}`, updates);
       const updatedDocument = response.data;
+      console.log(
+        '[docs-rename] appStore.updateDocument: success, docId=%s, returnedTitle="%s"',
+        id,
+        updatedDocument?.title
+      );
 
       set((state) => ({
         documents: state.documents.map((doc) => (doc.id === id ? updatedDocument : doc)),
       }));
     } catch (error) {
-      console.error('Failed to update document:', error);
+      console.error('[docs-rename] appStore.updateDocument: failed, docId=%s, error=%o', id, error);
       set({ error: 'Fehler beim Aktualisieren des Dokuments' });
       throw error;
     }

--- a/documentation/docs/gruenerieren/ki-chat.md
+++ b/documentation/docs/gruenerieren/ki-chat.md
@@ -1,0 +1,111 @@
+---
+sidebar_position: 1
+---
+
+# KI-Chat
+
+Der Grünerator Chat ist dein persönlicher KI-Assistent für grüne Politik. Du kannst Fragen stellen, Texte erstellen lassen, in Parteiprogrammen recherchieren und sogar Bilder generieren — alles in einer Chat-Oberfläche.
+
+## Gespräch starten
+
+Den Chat erreichst du über den Menüpunkt **Chat** in der Seitenleiste oder direkt unter `/chat`. Dort siehst du:
+
+- **Eingabefeld** unten zum Schreiben deiner Nachricht
+- **Seitenleiste** links mit deinem Gesprächsverlauf
+- **Modell-Auswahl** oben links zum Wechseln des Assistenten
+
+Jedes Gespräch wird als eigener **Thread** gespeichert. Du kannst jederzeit über das **+**-Symbol ein neues Gespräch beginnen oder in der Seitenleiste zu einem früheren Gespräch zurückkehren.
+
+## Assistenten auswählen
+
+Assistenten sind spezialisierte KI-Persönlichkeiten, die auf bestimmte Textarten und Aufgaben optimiert sind. Der Standard-Assistent ist ein Allrounder — aber für spezifische Aufgaben lohnt sich ein Wechsel.
+
+**So wählst du einen Assistenten:**
+
+- Tippe `/` im Eingabefeld und wähle aus der Liste, **oder**
+- Klicke auf die Modell-Auswahl oben links
+
+| Befehl           | Assistent                | Beschreibung                                |
+| ---------------- | ------------------------ | ------------------------------------------- |
+| `/antrag`        | 📝 Antrag                | Anträge & Anfragen für kommunale Parlamente |
+| `/presse`        | 📰 Pressemitteilung      | Pressemitteilungen verfassen                |
+| `/instagram`     | 📸 Instagram             | Instagram-Posts & Captions                  |
+| `/facebook`      | 👍 Facebook              | Facebook-Posts & Beiträge                   |
+| `/twitter`       | 🐦 Twitter / X           | Tweets & Threads                            |
+| `/linkedin`      | 💼 LinkedIn              | LinkedIn-Posts & Artikel                    |
+| `/reel`          | 🎬 Reel / TikTok         | Reel- & TikTok-Skripte                      |
+| `/aktion`        | 💡 Aktionsideen          | Kreative Aktionsideen entwickeln            |
+| `/rede`          | 🎙️ Rede                  | Politische Reden schreiben                  |
+| `/wahlprogramm`  | 📋 Wahlprogramm          | Programmkapitel erstellen                   |
+| `/bürgerservice` | 💬 Bürger\*innenanfragen | Bürgeranfragen beantworten                  |
+| `/jugend`        | ✊ Grüne Jugend          | Aktivistischer Content                      |
+
+:::tip Assistenten kombinieren
+Du kannst einen Assistenten mit Quellen und Werkzeugen kombinieren. Zum Beispiel: `/antrag @grundsatz Klimaschutz in Kommunen fördern` erstellt einen Antrag auf Basis des Grundsatzprogramms.
+:::
+
+## Quellen durchsuchen
+
+Der Chat kann gezielt in grünen Parteiprogrammen, Beschlüssen und Dokumenten recherchieren. Tippe `@` im Eingabefeld, um eine Quelle auszuwählen.
+
+| Kürzel          | Quelle                      | Inhalt                                       |
+| --------------- | --------------------------- | -------------------------------------------- |
+| `@alle`         | 🔍 Alle Quellen             | Durchsucht mehrere Quellen parallel          |
+| `@grundsatz`    | 📗 Grundsatzprogramm        | Grundsatzprogramme von Bündnis 90/Die Grünen |
+| `@bundestag`    | 🏛️ Bundestagsfraktion       | Inhalte von gruene-bundestag.de              |
+| `@hamburg`      | ⚓ Grüne Hamburg            | Beschlüsse und Presse der Grünen Hamburg     |
+| `@sh`           | 🌊 Grüne Schleswig-Holstein | Wahlprogramm Schleswig-Holstein              |
+| `@thüringen`    | 🏔️ Grüne Thüringen          | Beschlüsse und Wahlprogramme Thüringen       |
+| `@bayern`       | 🦁 Grüne Bayern             | Regierungsprogramm Bayern                    |
+| `@berlin`       | 🐻 Grüne Berlin             | Pressemitteilungen und Beschlüsse Berlin     |
+| `@at`           | 🇦🇹 Grüne Österreich         | Programme von Die Grünen Österreich          |
+| `@kommunalwiki` | 📚 KommunalWiki             | Fachwissen zur Kommunalpolitik               |
+| `@böll`         | 📖 Heinrich-Böll-Stiftung   | Analysen und Dossiers der Böll-Stiftung      |
+
+:::info Landesverbände
+Weitere Landesverbände werden laufend ergänzt. Wenn dein Landesverband ein [Grünerator Notebook](../ueber-den-gruenerator/notebook) erworben hat, erscheinen eure Daten automatisch als Quelle.
+:::
+
+## Werkzeuge nutzen
+
+Werkzeuge erweitern die Fähigkeiten des Chats über die reine Textgenerierung hinaus. Du kannst sie per `@`-Mention im Eingabefeld aktivieren.
+
+| Kürzel             | Werkzeug           | Beschreibung                             |
+| ------------------ | ------------------ | ---------------------------------------- |
+| `@websearch`       | 🌐 Websuche        | Aktuelle Infos aus dem Internet          |
+| `@recherche`       | 🔬 Recherche       | Tiefgehende Multi-Quellen-Recherche      |
+| `@dokumente`       | 📄 Dokumente       | Parteiprogramme & Beschlüsse durchsuchen |
+| `@dokumentchat`    | 💬 Dokument-Chat   | Mit ausgewählten Dokumenten chatten      |
+| `@zusammenfassung` | 📝 Zusammenfassung | Dokument(e) zusammenfassen               |
+| `@bildgenerieren`  | 🎨 Bildgenerierung | Bild mit KI generieren                   |
+| `@stadtbegruenen`  | 🌳 Stadt begrünen  | Stadtbild mit Grün transformieren        |
+
+:::tip Werkzeuge dauerhaft ein-/ausschalten
+Klicke auf das **Schraubenschlüssel-Symbol** neben dem Eingabefeld, um Werkzeuge dauerhaft zu aktivieren oder zu deaktivieren. So musst du sie nicht bei jeder Nachricht erneut erwähnen. Dort findest du vier Hauptwerkzeuge: Recherche, Dokumente, Web und Beispiele.
+:::
+
+## Dateien im Chat
+
+Du kannst PDFs und Bilder direkt im Chat hochladen, um sie als Kontext für deine Frage zu verwenden. Klicke auf das **📎-Symbol** im Eingabefeld und wähle deine Dateien aus.
+
+Mehr Details zu unterstützten Dateitypen und Einschränkungen findest du unter [Dateien hinzufügen](./dateien-hinzufuegen).
+
+## Quellenangaben
+
+Wenn der Chat in Dokumenten oder im Web recherchiert, zeigt er dir die verwendeten Quellen an:
+
+- **Nummerierte Badges** im Text (z.B. [1], [2]) verweisen auf die genutzten Quellen
+- **Hover** über einen Badge zeigt dir Titel, URL und einen Textauszug
+- **Gruppierte Quellenübersicht** unterhalb der Antwort mit allen verwendeten Dokumenten
+
+:::info Transparenz
+Quellenangaben helfen dir, die Antworten des Grünerators nachzuvollziehen und zu überprüfen. Du kannst jede Quelle direkt anklicken, um das Originaldokument zu öffnen.
+:::
+
+## Tipps für die Nutzung
+
+- **Kombiniere Assistent + Quelle + Thema** für die besten Ergebnisse, z.B. `/presse @bundestag Kindergrundsicherung`
+- **Nutze `@recherche`** für eine tiefgehende Analyse, die mehrere Quellen gleichzeitig durchsucht und vergleicht
+- **Nutze `@websearch`** für aktuelle Nachrichten und Entwicklungen, die noch nicht in den Parteiprogrammen stehen
+- **Starte ein neues Gespräch** für jedes neue Thema — so bleibt der Kontext sauber und die Antworten präziser
+- **Lade relevante Dokumente hoch**, wenn du einen bestehenden Text überarbeiten oder darauf aufbauen möchtest

--- a/documentation/docs/integrationen/mcp-was-kann-ich-fragen.md
+++ b/documentation/docs/integrationen/mcp-was-kann-ich-fragen.md
@@ -28,7 +28,7 @@ Die Kernfunktion des MCP-Servers ist die **semantische Suche** über grüne Part
 
 ### Welche Sammlungen gibt es?
 
-Der Server durchsucht **7 verschiedene Dokumentensammlungen**:
+Der Server durchsucht verschiedene Dokumentensammlungen — darunter **7 bundesweite Sammlungen** und **5 Landesverbände**:
 
 | Sammlung                     | Was ist drin?                                                         | Beispielfrage                            |
 | ---------------------------- | --------------------------------------------------------------------- | ---------------------------------------- |
@@ -39,6 +39,18 @@ Der Server durchsucht **7 verschiedene Dokumentensammlungen**:
 | **gruene.at**                | Aktuelle Positionen und Themen der Grünen Österreich                  | _„Was sagen die Grünen AT zu X?"_        |
 | **KommunalWiki**             | Fachwissen zur Kommunalpolitik (Heinrich-Böll-Stiftung)               | _„Wie macht man X in der Kommune?"_      |
 | **Heinrich-Böll-Stiftung**   | Analysen, Dossiers und Atlanten                                       | _„Analyse zu X"_, _„Hintergründe zu X"_  |
+
+### Landesverbände
+
+Zusätzlich kannst du gezielt in **Dokumenten einzelner Landesverbände** suchen. Diese werden bei einer normalen Landessuche nicht automatisch mitdurchsucht — du musst den Landesverband explizit nennen.
+
+| Sammlung                     | Was ist drin?                        | Beispielfrage                                       |
+| ---------------------------- | ------------------------------------ | --------------------------------------------------- |
+| **Grüne Hamburg**            | Beschlüsse und Pressemitteilungen    | _„Was sagen die Grünen Hamburg zum Thema Verkehr?"_ |
+| **Grüne Schleswig-Holstein** | Wahlprogramm zur Landtagswahl        | _„Wahlprogramm der Grünen SH zu Bildung"_           |
+| **Grüne Thüringen**          | Beschlüsse, Wahlprogramme und Presse | _„Grüne Thüringen Position zu Energie?"_            |
+| **Grüne Bayern**             | Regierungsprogramm zur Landtagswahl  | _„Was steht im Bayern-Programm zur Wirtschaft?"_    |
+| **Grüne Berlin**             | Pressemitteilungen und Beschlüsse    | _„Grüne Berlin Beschlüsse zum Thema Wohnen"_        |
 
 :::tip Mehrere Sammlungen vergleichen
 Du kannst auch nach demselben Thema in verschiedenen Sammlungen suchen lassen, z.B.: _„Vergleiche die Position von Deutschland und Österreich zum Thema Mobilität."_ Die KI sucht dann automatisch in beiden Sammlungen.
@@ -74,6 +86,7 @@ Du kannst die Suchergebnisse nach Kategorien einschränken. Sag der KI einfach, 
 | **KommunalWiki**                             | + Inhaltstyp (z.B. Praxishilfe, Artikel), Unterkategorien          |
 | **Böll-Stiftung**                            | + Inhaltstyp, Unterkategorien, Region (z.B. Europa, Asien, Nahost) |
 | **Bundestagsfraktion, gruene.de, gruene.at** | + Land (DE/AT)                                                     |
+| **Landesverbände**                           | + Inhaltstyp (Typ), Themenbereich (Kategorie)                      |
 
 :::info Filter-Werte nicht raten
 Die KI fragt automatisch die verfügbaren Filterwerte ab, bevor sie filtert. Du musst dir also keine exakten Werte merken — beschreib einfach, was du suchst.

--- a/documentation/docs/newsletter/2025-03-gruugo.md
+++ b/documentation/docs/newsletter/2025-03-gruugo.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 5
+title: 'März 2025: Kennst du schon Gruugo?'
+---
+
+# Kennst du schon Gruugo?
+
+_Newsletter März 2025_
+
+---
+
+Zugegeben, der Betreff klingt wie aus dem letzten Jahrhundert, hat es aber in sich. Denn: Das Grünerator-Universum hat Zuwachs bekommen. Darf ich vorstellen? Gruugo.
+
+## Neue Grünerator KI-Suche
+
+Politik wird immer komplexer. Neue Rahmenbedingungen, neue Gesetze, neue Fachbegriffe und dann noch diese komplexen Verwaltungsvorlagen. Wenn man politisch etwas verändern will, braucht man viel Hintergrundwissen. Manche von uns wünschen sich eine\*n Assistent\*in, der\*die uns dabei etwas Arbeit abnimmt.
+
+Ich habe eine neue KI-Suche programmiert, die ich Gruugo taufe, eine Kombination aus Google und „Baby Yoda" aus The Mandalorian. Gruugo funktioniert von der Funktion her wie Google. Mit dem Unterschied, dass man nicht nur Suchergebnisse bekommt, sondern eine von der KI kuratierte Zusammenfassung des Inhalts.
+
+## So funktioniert's
+
+Hinter Gruugo steckt eine speziell für KI-Sprachmodelle entwickelte Suchmaschine. Diese kuratiert die Suchergebnisse anhand eines Scoring-Systems und gibt uns die zugehörigen Seiten in Volltext aus.
+
+Unser KI-Sprachmodell liest diese durch und fasst sie zusammen. Zusätzlich kuratiert die KI die zugesendeten Quellen und erstellt für sechs von ihnen Zusammenfassungen, die unter dem Text erscheinen.
+
+Gruugo ersetzt die menschliche Recherche nicht, sondern ergänzt sie. Gruugo liefert eine Ersteinschätzung und kuratierte Quellen dazu, die zum Weiterlesen anregen. Denn: KI kann Fehler machen, so auch Gruugo. Nach der KI-Recherche müssen wir sie also immer überprüfen.
+
+## Qualität der Ergebnisse meistens gut
+
+Ich habe die Suche selbst häufig getestet und bekam häufig gute Ergebnisse mit sehr seriösen Quellen wie der Böll-Stiftung. Was noch nicht so gut klappte, sind sehr lokale und/oder sehr aktuelle Informationen. Wenn du also nach Entscheidungen suchst, die du vor wenigen Wochen im Rat getroffen hast und die maximal in der Lokalpresse gelaufen sind, ist es eher unwahrscheinlich, dass du mit Gruugo fündig wirst.
+
+## Test: Antragsgenerator mit KI-Suche
+
+Ich habe außerdem als Test den Antragsgenerator mit einer Websuch-Funktion ausgestattet. Schaltet man sie ein, versucht der Antragsgenerator zu den eingegebenen Inhalten im Netz zu recherchieren und den Antrag damit zu präzisieren. Das klappt bisher unterschiedlich gut.
+
+## Noch in der Beta, bald live
+
+Ich passe die Beta-Seite derzeit so an, dass wir sie zeitnah auf den „großen" Grünerator bringen können. Daher habe ich die Sharepic-Features ausgeblendet, da wir diese hinter das Grüne Netz ziehen wollen. Dafür befinden wir uns in Gesprächen mit dem Bundesverband.
+
+Ich wäre dir sehr dankbar, wenn du die neuen Funktionen testest und mir Feedback an meine E-Mail sendest: info@moritz-waechter.de. Oder antworte einfach auf diese Mail.
+
+Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband weiterleiten. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_

--- a/documentation/docs/newsletter/2025-05-testlabor.md
+++ b/documentation/docs/newsletter/2025-05-testlabor.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 4
+title: 'Mai 2025: Komm ins Testlabor!'
+---
+
+# Komm ins Testlabor!
+
+_Newsletter Mai 2025_
+
+---
+
+Alles neu macht der Mai? Für den Grünerator gilt das zumindest ein bisschen. Eine Reihe von neuen Features ist unterwegs, die den Grünerator grundsätzlich ändern. Um diese zu testen, möchte ich in Zukunft anders arbeiten: Im Labor!
+
+## Neues Labor
+
+Der Start des Reel-Grünerators verlief nicht ganz wie erhofft. Die Arbeit mit verschiedenen Video-Codecs und Formaten ist komplexer als erwartet. Inzwischen funktioniert er jedoch relativ stabil und kann Videos bis zu 500 MB verarbeiten.
+
+Die gute Nachricht: Noch in diesem Jahr wird sich der Grünerator grundlegend verändern und an dich anpassen. Künftig kann man Profile für sich und seine Gremien anlegen und den Grünerator damit personalisieren. Und noch viel mehr. Zum Testen dieser Funktionen brauche ich eine Testgruppe, die diese zuerst im Labor ausprobiert. Dafür habe ich eine Signal-Gruppe eingerichtet:
+
+**Du ...**
+
+- bist technisch einigermaßen versiert und scheust dich nicht, die Entwicklerkonsole zu öffnen?
+- hast gelegentlich ein paar Minuten Zeit, um neue Features zu testen?
+- bist ein bisschen KI-affin?
+
+**Dann komm in die Gruppe!**
+
+Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband weiterleiten. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_

--- a/documentation/docs/newsletter/2025-10-reimagined.md
+++ b/documentation/docs/newsletter/2025-10-reimagined.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 3
+title: 'Oktober 2025: Grünerator Reimagined'
+---
+
+# Grünerator Reimagined
+
+_Newsletter Oktober 2025_
+
+---
+
+Tausende Seiten an Anträgen, Pressemitteilungen & Co werden jeden Monat mit dem Grünerator grüneriert. Und er kann jetzt noch mehr: Er sieht besser aus, kann Sharepics kreieren, deine Bilder verändern und für mehr Barrierefreiheit sorgen.
+
+## Neue, überarbeitete Grüneratoren
+
+Die Grüneratoren selbst haben ein massives Upgrade erhalten, unter anderem eine komplett überarbeitete Benutzeroberfläche. Im Grünerator für Anträge können nun auch kleine und große Anfragen erstellt werden. Für Abgeordnetenbüros und Fraktionen gibt es nun den Grünerator für Bürger\*innenanfragen im Universal-Grünerator.
+
+Mit den neuen drei Icons in jedem Grünerator kannst du Webergebnisse oder Dateien in deine Texte einfügen. Außerdem kannst du mit dem „Privacy Mode" erstmalig deutsche, von der Netzbegrünung gehostete KI-Server nutzen. Die sichere Alternative zu ChatGPT!
+
+Du kannst dich nun mit deinem Grünen Login einloggen. Klicke dazu oben rechts auf das Mensch-Icon. Das kann ich dir dringend empfehlen! Tust du dies, merkt sich der Grünerator deine letzten Gliederungen und Namen und kann diese jederzeit wieder einfügen. Außerdem kannst du dann den neuen, wunderschönen Editor verwenden und deinen Text per Chat korrigieren. Kein Markieren mehr notwendig.
+
+Auch der Export wurde verbessert. Grünerierte Texte kannst du unter anderem in die Textbegrünung teilen oder direkt als Word-Datei (docx) herunterladen.
+
+## Erstelle Sharepics mit KI
+
+Mit dem neuen Update erstellst du professionelle Sharepics für Social Media in wenigen Sekunden. Gib einfach dein Thema ein, und die KI liefert dir einen fertig gestalteten Vorschlag. Der Grünerator kann derzeit 3 Typen von Sharepics grünerieren: Normale Sharepics (drei Balken), Zitat-Sharepics (mit und ohne Bild) sowie Info-Posts. Gerade für diejenigen, die nicht fit mit Bildbearbeitung sind oder mal keine Idee haben, eine gute Alternative. Besonders gut gefallen mir die Zitat-Sharepics mit und ohne Bild. Achte bei Bildern darauf, dass diese passend zugeschnitten sind.
+
+Du kannst dir auch eine Auswahl an Sharepics automatisiert über den Presse-/Social Grünerator erstellen. Dafür musst du dich vorher einloggen. Dann erscheint im Formate-Dropdown die Option Sharepic. Wähle „Automatisch" oder eine gewünschte Variante und bekomme automatisiert Sharepics erstellt, die du mit Klick auf den Edit-Button bearbeiten kannst.
+
+## Verändere Bilder. Und die Welt.
+
+Mit Grünerator Imagine kannst du die Welt so grünerieren, wie sie sein sollte: Mit mehr Radwegen, mehr Grün, mehr Lebensfreude. Nimm ein Bild aus deiner Straße oder einem grauen Platz in deiner Kommune, wähle die gewünschte Veränderung aus und zeig der Welt, wie deine Heimat auch aussehen könnte. Imagine macht es möglich!
+
+Du hast eine andere Idee? Wähle in Imagine den Universal-Modus aus und verändere, was immer du willst. Aber Vorsicht! KI-Bilder müssen gekennzeichnet werden. Hast du ein Bild mit Imagine verändert, klicke einfach auf den KI-Label Button und erstelle einen KI-Hinweis direkt auf dem Bild. Klingt kompliziert? Probier es einfach aus!
+
+## Stark verbesserter Reel-Grünerator
+
+Der Reel-Grünerator erstellt Untertitel jetzt endlich so, wie du sie haben willst: Kurz, mit verschiedenen Designs und ohne Qualitätsverlust. Außerdem werden deine Daten jetzt ausschließlich in Europa verarbeitet. Wenn du bisher keine so wirklich gute und schnelle Alternative zum Untertiteln von Reels und TikToks gefunden hast, probiere den neuen Reel-Grünerator aus.
+
+## Für mehr Barrierefreiheit
+
+Barrierefreiheit im Netz wird immer wichtiger, bleibt aber gleichzeitig für viele Ehrenamtliche schwer umzusetzen. Der Grünerator hilft dabei auf zwei Wegen: Alt-Texte und Leichte Sprache.
+
+**Alt-Texte** sind Textbeschreibungen für Bilder. Sie dienen dazu, dass Menschen mit Sehbehinderungen, die Screenreader nutzen, verstehen können, was auf einem Bild zu sehen ist.
+
+**Leichte Sprache** ist eine vereinfachte Form der deutschen Sprache. Sie verwendet kurze Sätze, einfache Wörter, verzichtet auf Fremdwörter und Fachbegriffe und nutzt eine klare Struktur. Leichte Sprache hilft zum Beispiel Menschen mit Behinderungen, Lernschwierigkeiten, kognitiven Einschränkungen oder Deutsch als Fremdsprache. Tipp: Nimm zunächst kurze Texte wie Präambeln oder Vorstellungen von Personen und gehe schrittweise vor.
+
+Beides kannst du im neuen Grünerator für Barrierefreiheit erstellen. Bei Grünerator Imagine und dem Sharepic-Grünerator gibt es außerdem direkt Buttons, die automatisiert Alt-Texte grünerieren. Die Texte sind nicht immer perfekt, aber schon nah an den Vorgaben.
+
+## Profil & Custom Grüneratoren
+
+Klicke auf das Mensch-Icon oben rechts, logge dich mit deinem Partei-Account („Grünes Netz Login") ein und erstelle ein individuelles Profil mit einem eigenen Roboter. Du kannst dann Anweisungen für Grüneratoren hinterlegen, die du häufig verwendest, etwa den Namen der Bürgermeisterin oder bestimmte Anpassungen für Pressemitteilungen. Experimentell: Verbinde die Wolke und lese Dateien aus oder exportiere grünerierte Texte direkt in einen Wolke-Ordner.
+
+Neu im Labor: Erstelle aus jedem beliebigen Prompt einen Grünerator. Mit Custom Grüneratoren kannst du jede Textart als „Grünerator" erstellen, der genau so aussieht wie die bekannten Grüneratoren — nur mit deinen Anweisungen. Du kannst dir dein eigenes Eingabeformular für deine Arbeit bauen oder eine Kampagne erstellen, und diese mit allen Parteimitgliedern teilen. Links der Custom Grüneratoren sind öffentlich. Zukünftig können wir damit KI-assistierte Kampagnen in die gesamte Partei ausrollen — ohne teure Agenturen. Gehe zum Testen in dein Profil und wähle das Labor aus.
+
+## Sicher, Europäisch, Grün
+
+Alle deine Daten werden auf deutschen Servern der Netzbegrünung gespeichert und niemals an Dritte weitergegeben. Alle KI-Anfragen gehen auf europäische Server, Hauptanbieter ist Mistral aus Frankreich. Der Grünerator setzt auf führende Anbieter mit EU-Sitz, teilweise aus Deutschland, um die europäische Unabhängigkeit zu stärken. Grünerierungen werden niemals zum KI-Training verwendet und nach DSGVO-Standards verarbeitet. Also: Mit dem Grünerator bist du auf der richtigen Seite.
+
+Aber Achtung, der Grünerator wurde ehrenamtlich erstellt. In den kommenden Wochen können vermehrt Fehler bis hin zu Abstürzen auftreten. Nutze bitte so gut es geht den Support-Chat. Alternativ kannst du auf diese E-Mail antworten. Ich freue mich über jede noch so kleine Fehlermeldung, die hilft, den Grünerator zu verbessern.
+
+Zugegeben, das war viel Theorie. Probiere den Grünerator am besten einfach aus! Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband weiterleiten. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_

--- a/documentation/docs/newsletter/2025-12-weihnachtszeit.md
+++ b/documentation/docs/newsletter/2025-12-weihnachtszeit.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 2
+title: 'Dezember 2025: Grünerator zur Weihnachtszeit'
+---
+
+# Grünerator zur Weihnachtszeit
+
+_Newsletter Dezember 2025_
+
+---
+
+Hast du schon alle Weihnachtsgeschenke besorgt? Im privaten Stress kann es schnell mal untergehen, Weihnachtsgrüße für deinen Orts- oder Kreisverband zu erstellen. Aber keine Sorge: Dafür gibt's den Grünerator.
+
+## Weihnachts-Grünerator
+
+Mit dem neuen Weihnachts-Grünerator gibt es eine einfache Möglichkeit, sich ein schönes Weihnachts-Sharepic zu erstellen.
+
+Der Grünerator erstellt ein 5-zeiliges Weihnachtsgedicht passend zu deinem Heimatort. Du kannst zwischen 6 Hintergründen wählen, bei Bedarf einen Instagram-Beitragstext erstellen und entweder das Bild herunterladen oder eine Canva-Vorlage aufrufen. Die Erstellung dauert nur wenige Sekunden. Die Grünerierung der Bilder nutzt einen speziellen Grünerator-Algorithmus, der klimaschonend auf unseren Servern arbeitet. Der Gruß-Text ist religionsneutral und kann bei Bedarf angepasst werden.
+
+:::tip Kampagnen-Grünerator
+Der Kampagnen-Grünerator kann jede beliebige Kampagne dieser Art umsetzen, auch für Landtags-, Kommunalwahlen & Co. Interesse, dies in deinem Landesverband zu verwenden? Schreib einfach eine E-Mail!
+:::
+
+## Neues Reel-Studio
+
+Das Interface zur Erstellung der Reels wurde überarbeitet und ist nun deutlich einfacher. Beim Abspielen von Videos wird automatisch das entsprechende Untertitel-Segment markiert, so dass du deine Untertitel innerhalb weniger Sekunden grünerieren kannst. Außerdem werden die letzten 20 Reels nun automatisch im neuen Grünerator Reel-Studio gespeichert. So kannst du Fehler jederzeit beheben.
+
+Mit der neuen Teilen-Funktion (experimentell) im Reel-Studio kannst du dein Reel als Datei mit anderen teilen. Sinnvoll zum Beispiel, wenn du Reels für deine\*n Abgeordnete\*n untertitelst oder jemand anderes die Social-Media-Kanäle betreut. Kein Qualitätsverlust über Signal, kein WeTransfer mehr notwendig.
+
+Bei Fragen oder Problemen wende dich gerne jederzeit an den Support-Chat. Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband weiterleiten. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_

--- a/documentation/docs/newsletter/2026-01-jahr-der-daten.md
+++ b/documentation/docs/newsletter/2026-01-jahr-der-daten.md
@@ -1,0 +1,40 @@
+---
+sidebar_position: 1
+title: 'Januar 2026: Jahr der Daten'
+---
+
+# Jahr der Daten
+
+_Newsletter Januar 2026_
+
+---
+
+Was hast du dir dieses Jahr vorgenommen? Mehr Sport, mehr Zeit für die Familie oder einfach weniger Stress? Für den Grünerator soll das kommende Jahr entscheidend werden. Und beginnt direkt besonders: Der Grünerator ist jetzt auch in Österreich verfügbar! Nun können knapp 200.000 Mitglieder aus zwei Ländern grüne, europäische KI verwenden. Außerdem arbeitet der Grünerator nun ausschließlich mit Anbieter\*innen aus Europa. Mit jeder Grünerierung stärkst du damit die europäische Unabhängigkeit!
+
+Doch das war es noch lange nicht. Denn 2026 wollen wir eine der größten politischen Datenbanken Europas aufbauen.
+
+## Was heißt das?
+
+KI ist nur so gut wie die Daten, mit denen sie gefüttert wird. Je besseren Kontext wir einem Sprachmodell geben, desto besser die Ergebnisse. Und das Gute ist: An den Inhalten mangelt es uns nicht. Auf den Webseiten des Bundesverbandes, der Landesverbände und der Fraktionen finden sich allerhand Informationen, die öffentlich verfügbar sind. Um diese für eine KI wie den Grünerator oder ChatGPT verfügbar zu machen, muss man die in ein bestimmtes Format bringen. Dann kann sich die KI zielgenau die Informationen raussuchen, die sie braucht. Und das wollen wir machen – in einem Jahr. Das Jahr der Daten.
+
+## Wie machen wir das?
+
+Ich will für verschiedene Organisationen sogenannte „Notebooks" erstellen. Notebooks speisen sich aus öffentlichen Daten: Ganze Webseiten von Fraktionen und Landesverbänden, Grünen Wikis, Beschlüssen etc. Jedes Notebook kann individuell durch den Grünerator abgerufen werden. Dafür habe ich ein neues Interface geschaffen, das aus den Dokumenten zitiert. Du kannst also ganz genau nachprüfen, ob das auch wirklich stimmt, was die KI erzählt. Zukünftig können wir alles Wissen unserer Partei per Klick verfügbar machen. Was haben wir auf der BDK beschlossen? Was steht im Wahlprogramm der Grünen in Schleswig-Holstein? Wie mache ich meine Heimatstadt zur Schwammstadt? Frag einfach den Grünerator.
+
+Wir schaffen dafür eine einheitliche Datenbank von maschinenlesbaren Daten aus öffentlichen Quellen unserer Partei. Diese liegen sicher bei der Netzbegrünung ab. Man kann sie dann über verschiedene Wege abrufen: Der Grünerator selbst soll im Laufe dieses Jahres Apps für alle Plattformen erhalten. Außerdem sollt ihr die Datenbank des Grünerators auch mit ChatGPT, Claude und Co verbinden können – über einen sogenannten „MCP-Server". Die Datenbank ist über die Netzbegrünung zudem öffentlich, es können also weitere Projekte auf dieser Datenbank aufbauen.
+
+## Warum so schnell?
+
+Die Demokratie wird weltweit angegriffen – von innen und außen. Will sie wehrhafter werden, muss sie schneller werden. Ich erinnere mich noch, wie wir bei den Grünen über TikTok gesprochen haben. Zurecht bemängelten wir Datenschutz, den Einfluss Chinas, Teile des Gesellschaftsbildes. Und dann? Fand TikTok ohne uns statt. Bei KI darf uns das nicht nochmal passieren. Das heißt nicht, dass wir KI blind verwenden – die Gefahr von KI-Bloat, der massive CO2-Ausstoß sind real. Aber während wir über das Wie diskutieren, brauchen wir die technischen Rahmenbedingungen, dann auch ins Machen zu kommen. Ich glaube, dass wir das schaffen können.
+
+## Jetzt brauche ich dich
+
+Im Laufe des Jahres wird es eine Reihe von Beta-Tests geben, um die neuen Grünerator-Anwendungen sowie weitere Features zu prüfen. Wir wollen diese Tests strukturiert angehen und brauchen Feedback aus der Praxis – von dir.
+
+Außerdem wende ich mich in den kommenden Monaten nach und nach an die einzelnen Landesverbände, um den Plan für den Grünerator vorzustellen. Denn: Der Grünerator ist nach wie vor ein Freizeit-Projekt, wächst aber weiter. Und das wollen wir auf Dauer besser machen. Wenn du als Mitarbeiter\*in einer Landesgeschäftsstelle, einer Landtagsfraktion oder eines Bundestagsbüros Interesse an einem gemeinsamen Gespräch hast, antworte gerne auf diese E-Mail.
+
+Bei Fragen oder Problemen wende dich gerne jederzeit an den Support-Chat. Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband weiterleiten. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_

--- a/documentation/docs/newsletter/2026-03-ki-chat-launch.md
+++ b/documentation/docs/newsletter/2026-03-ki-chat-launch.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 0
+title: 'März 2026: Wessen KI nutzt du?'
+---
+
+# Wessen KI nutzt du?
+
+_Newsletter März 2026_
+
+---
+
+Während du das hier liest, bombardieren die USA und Israel den Iran. KI-Systeme von Anthropic und OpenAI halfen dabei, die Ziele zu identifizieren. Die gleichen Unternehmen, deren Chatbots wir täglich nutzen.
+
+Das ist kein dystopischer Roman. Das ist diese Woche.
+
+## Was gerade passiert
+
+Das Pentagon — von der Trump-Regierung in „Department of War" umbenannt — hat Rahmenverträge über bis zu 200 Millionen Dollar pro Anbieter mit Anthropic, OpenAI, Google und xAI geschlossen. Ziel: KI in Waffenentwicklung, Geheimdienstarbeit und Gefechtsführung einzusetzen. Als Anthropic sich weigerte, seine roten Linien gegen autonome Waffen und Massenüberwachung aufzugeben, drohte das Pentagon, das Unternehmen als „Lieferkettenrisiko" einzustufen — eine Kategorie, die sonst feindlichen Staaten vorbehalten ist.
+
+OpenAI sprang ein. Sam Altman unterschrieb einen Deal, der dem Militär Zugang zu OpenAIs Modellen auf geheimen Netzen gewährt. Die roten Linien? Stehen im Vertrag. Ob sie durchgesetzt werden? Offen.
+
+Und dann nutzte die CIA amerikanische KI-Systeme, um Irans obersten Führer zu lokalisieren. Israel schlug zu.
+
+## Warum uns das betrifft
+
+Jedes Mal, wenn wir ChatGPT oder Claude nutzen, fließt Geld an Unternehmen, die gleichzeitig Militärtechnologie liefern. Das heißt nicht, dass diese Tools schlecht sind. Aber es heißt, dass wir eine Wahl haben.
+
+Hunderte Mitarbeitende bei Google DeepMind und OpenAI haben in offenen Briefen dieselben roten Linien wie Anthropic gefordert: Nein zu Massenüberwachung, Nein zu autonomen Waffen ohne menschliche Kontrolle. Sie schrieben: „We will not be divided." Das verdient Respekt. Aber es ändert nichts daran, wohin das Geld fließt.
+
+Als Grüne stehen wir für Frieden, europäische Souveränität und verantwortungsvolle Technologie. Wenn wir das ernst meinen, müssen wir auch bei KI konsequent sein.
+
+## Grünerator Chat ist da
+
+Deshalb veröffentlichen wir heute den Grünerator Chat. Ein vollständiger KI-Chat — vergleichbar mit ChatGPT oder Claude — aber ausschließlich auf europäischen Servern, ohne militärische Verträge, ohne Überwachung, ohne dass deine Daten zum Training verwendet werden.
+
+Was kann der Chat?
+
+- **12 spezialisierte Assistenten** für Anträge, Pressemitteilungen, Social Media, Reden und mehr — tippe `/` im Eingabefeld
+- **Grüne Quellen durchsuchen** mit `@`: Grundsatzprogramm, Bundestagsfraktion, Landesverbände, KommunalWiki, Böll-Stiftung und mehr
+- **Websuche** für aktuelle Nachrichten und Fakten
+- **Bildgenerierung** direkt im Chat
+- **Dateien hochladen** — PDFs und Bilder als Kontext nutzen
+- **Quellenangaben** mit Zitaten, die du nachprüfen kannst
+
+Der Chat erkennt automatisch, ob du in Parteiprogrammen recherchieren, im Web suchen oder einen Text erstellen willst. Alles in einer Oberfläche, die du von ChatGPT kennst — nur grüner.
+
+Eine ausführliche Anleitung mit allen Assistenten, Quellen und Werkzeugen findest du in der [Chat-Dokumentation](../gruenerieren/ki-chat).
+
+## Europäisch. Ohne Kompromisse.
+
+Der Grünerator nutzt Mistral AI aus Frankreich als Hauptanbieter. Alle Daten werden auf Servern der Netzbegrünung in Deutschland gespeichert. Keine US-Server, kein Patriot Act, keine militärische Doppelnutzung. Mit jeder Grünerierung stärkst du die europäische Unabhängigkeit — gerade jetzt wichtiger denn je.
+
+## Was du tun kannst
+
+**Nutze den Chat.** Gehe auf [gruenerator.eu/chat](https://gruenerator.eu/chat) und probiere es aus. Tippe `/antrag @grundsatz` und dein Thema — und erlebe, was grüne KI kann.
+
+**Teile diesen Newsletter.** Leite ihn an deinen Orts- oder Kreisverband weiter. Je mehr Grüne europäische KI nutzen, desto stärker wird unsere digitale Unabhängigkeit.
+
+**Bleib informiert.** Die Lage entwickelt sich schnell. Wir werden in den kommenden Wochen weitere Updates zum Chat und neuen Quellen veröffentlichen.
+
+Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) für diesen Newsletter anmelden.
+
+Viel Spaß beim Grünerieren — jetzt erst recht.
+
+_Moritz_

--- a/documentation/docs/newsletter/_category_.json
+++ b/documentation/docs/newsletter/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Newsletter-Archiv",
+  "position": 7,
+  "link": {
+    "type": "generated-index",
+    "description": "Alle bisherigen Grünerator-Newsletter zum Nachlesen."
+  }
+}

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -158,6 +158,11 @@ const config: Config = {
           label: 'LLM Basics',
           position: 'left',
         },
+        {
+          to: '/docs/category/newsletter-archiv',
+          label: 'Newsletter',
+          position: 'left',
+        },
       ],
     },
     footer: {
@@ -224,6 +229,19 @@ const config: Config = {
             {
               label: 'Was kann ich fragen?',
               to: '/docs/integrationen/mcp-was-kann-ich-fragen',
+            },
+          ],
+        },
+        {
+          title: 'Newsletter',
+          items: [
+            {
+              label: 'Newsletter-Archiv',
+              to: '/docs/category/newsletter-archiv',
+            },
+            {
+              label: 'Newsletter abonnieren',
+              href: 'https://fax.gruenerator.de',
             },
           ],
         },

--- a/packages/docs/src/components/document/DocumentList.tsx
+++ b/packages/docs/src/components/document/DocumentList.tsx
@@ -73,12 +73,25 @@ export const DocumentList = ({ searchQuery }: DocumentListProps) => {
   const handleRenameDocument = async (doc: { id: string; title: string }, e: React.MouseEvent) => {
     e.stopPropagation();
     const newTitle = window.prompt('Neuer Titel:', doc.title);
+    console.log(
+      '[docs-rename] DocumentList prompt result: docId=%s, oldTitle="%s", newTitle=%o',
+      doc.id,
+      doc.title,
+      newTitle
+    );
     if (newTitle && newTitle.trim() && newTitle.trim() !== doc.title) {
       try {
         await updateDocument(apiClient, doc.id, { title: newTitle.trim() });
+        console.log('[docs-rename] DocumentList rename success: docId=%s', doc.id);
       } catch (error) {
-        console.error('Failed to rename document:', error);
+        console.error(
+          '[docs-rename] DocumentList rename failed: docId=%s, error=%o',
+          doc.id,
+          error
+        );
       }
+    } else {
+      console.log('[docs-rename] DocumentList rename skipped: cancelled or unchanged');
     }
   };
 

--- a/packages/docs/src/context/DocsContext.tsx
+++ b/packages/docs/src/context/DocsContext.tsx
@@ -45,6 +45,16 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
   async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const url = endpoint.startsWith('http') ? endpoint : `${adapter.getApiBaseUrl()}${endpoint}`;
 
+    const isRename = options.method === 'PUT' && endpoint.startsWith('/docs/');
+    if (isRename) {
+      console.log(
+        '[docs-rename] apiClient request: %s %s, body=%s',
+        options.method,
+        url,
+        options.body
+      );
+    }
+
     const response = await adapter.fetch(url, {
       ...options,
       headers: {
@@ -54,6 +64,7 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
     });
 
     if (response.status === 401) {
+      if (isRename) console.error('[docs-rename] apiClient: 401 Unauthorized for %s', url);
       adapter.onUnauthorized();
       throw new Error('Unauthorized');
     }
@@ -65,6 +76,14 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
       } catch {
         errorData = { message: response.statusText };
       }
+      if (isRename) {
+        console.error(
+          '[docs-rename] apiClient: HTTP %d for %s, error=%o',
+          response.status,
+          url,
+          errorData
+        );
+      }
       throw new Error(errorData.message || errorData.error || 'Request failed');
     }
 
@@ -73,6 +92,13 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
       return await response.json();
     }
 
+    if (isRename) {
+      console.warn(
+        '[docs-rename] apiClient: non-JSON response for %s, content-type=%s',
+        url,
+        contentType
+      );
+    }
     return response as unknown as T;
   }
 

--- a/packages/docs/src/stores/documentStore.ts
+++ b/packages/docs/src/stores/documentStore.ts
@@ -89,15 +89,21 @@ export const useDocumentStore = create<DocumentStore>((set) => ({
   },
 
   updateDocument: async (apiClient, id, updates) => {
+    console.log('[docs-rename] store.updateDocument: docId=%s, updates=%o', id, updates);
     set({ error: null });
     try {
       const updatedDocument = await apiClient.put<Document>(`/docs/${id}`, updates);
+      console.log(
+        '[docs-rename] store.updateDocument: success, docId=%s, returnedTitle="%s"',
+        id,
+        updatedDocument?.title
+      );
 
       set((state) => ({
         documents: state.documents.map((doc) => (doc.id === id ? updatedDocument : doc)),
       }));
     } catch (error) {
-      console.error('Failed to update document:', error);
+      console.error('[docs-rename] store.updateDocument: failed, docId=%s, error=%o', id, error);
       set({ error: 'Fehler beim Aktualisieren des Dokuments' });
       throw error;
     }

--- a/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
+++ b/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
@@ -38,8 +38,12 @@ export const EditorTopBar = ({
     setIsEditing(false);
     const trimmed = editValue.trim();
     const newTitle = trimmed || 'Unbenannt';
-    if (newTitle !== (title || 'Unbenannt')) {
+    const currentTitle = title || 'Unbenannt';
+    if (newTitle !== currentTitle) {
+      console.log('[docs-rename] EditorTopBar commitEdit: "%s" → "%s"', currentTitle, newTitle);
       onTitleChange?.(newTitle);
+    } else {
+      console.log('[docs-rename] EditorTopBar commitEdit: no change (both "%s")', currentTitle);
     }
   }, [editValue, title, onTitleChange]);
 

--- a/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
+++ b/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
@@ -22,6 +22,7 @@ export const EditorTopBar = ({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(title || '');
   const inputRef = useRef<HTMLInputElement>(null);
+  const committedRef = useRef(false);
 
   useEffect(() => {
     setEditValue(title || '');
@@ -35,6 +36,8 @@ export const EditorTopBar = ({
   }, [isEditing]);
 
   const commitEdit = useCallback(() => {
+    if (committedRef.current) return;
+    committedRef.current = true;
     setIsEditing(false);
     const trimmed = editValue.trim();
     const newTitle = trimmed || 'Unbenannt';
@@ -103,7 +106,14 @@ export const EditorTopBar = ({
             ) : (
               <h1
                 className={`editor-topbar__title${canEditTitle ? ' editor-topbar__title--editable' : ''}`}
-                onClick={canEditTitle ? () => setIsEditing(true) : undefined}
+                onClick={
+                  canEditTitle
+                    ? () => {
+                        committedRef.current = false;
+                        setIsEditing(true);
+                      }
+                    : undefined
+                }
                 title={canEditTitle ? 'Klicken zum Umbenennen' : undefined}
               >
                 {title || 'Unbenannt'}


### PR DESCRIPTION
## Summary
- Add Landesverband collections to MCP documentation
- Add KI-Chat documentation page and newsletter archive (6 issues)
- Add debug logging across the full document rename flow (`[docs-rename]` prefix)
- Fix double-fire bug in EditorTopBar title rename (Enter + blur race condition)

## Test plan
- [ ] Verify document rename works in editor (click title, type, press Enter)
- [ ] Verify document rename works from document list (three-dot menu → Umbenennen)
- [ ] Check browser console for `[docs-rename]` logs on rename attempts
- [ ] Verify documentation pages render correctly in Docusaurus