### PR TITLE
fix: clear dead threadId on 404 and reduce FeatureIcons re-renders

### DIFF
--- a/apps/api/routes/chat/chatGraphController.ts
+++ b/apps/api/routes/chat/chatGraphController.ts
@@ -57,6 +57,7 @@ import {
   createThread,
   createMessage,
   touchThread,
+  threadExists,
 } from './services/threadPersistenceService.js';
 
 import type { ProcessedAttachmentMeta } from './services/attachmentProcessingService.js';
@@ -186,6 +187,12 @@ router.post('/stream', async (req, res) => {
     }
 
     if (actualThreadId && lastUserMessage) {
+      // Validate thread exists before inserting (prevents FK violation on deleted threads)
+      if (!isNewThread && !(await threadExists(actualThreadId))) {
+        sse.send('error', { error: 'Thread not found' });
+        res.end();
+        return;
+      }
       const userText = extractTextContent(lastUserMessage.content);
       await createMessage(actualThreadId, 'user', userText);
     }

--- a/apps/api/routes/chat/services/threadPersistenceService.ts
+++ b/apps/api/routes/chat/services/threadPersistenceService.ts
@@ -52,6 +52,17 @@ export async function createMessage(
 }
 
 /**
+ * Check if a thread exists.
+ */
+export async function threadExists(threadId: string): Promise<boolean> {
+  const postgres = getPostgresInstance();
+  const result = (await postgres.query(`SELECT 1 FROM chat_threads WHERE id = $1`, [
+    threadId,
+  ])) as unknown[];
+  return result.length > 0;
+}
+
+/**
  * Update thread timestamp.
  */
 export async function touchThread(threadId: string): Promise<void> {

--- a/apps/web/src/components/common/FeatureIcons.tsx
+++ b/apps/web/src/components/common/FeatureIcons.tsx
@@ -371,8 +371,6 @@ const FeatureIcons = ({
   hideLoginPrompt = false,
   showAgentMode = false,
 }: FeatureIconsProps): JSX.Element | null => {
-  console.debug('[FeatureIcons] render');
-
   // Single batched selector — prevents N re-renders when store hydrates
   const {
     useWebSearch,
@@ -780,4 +778,4 @@ const FeatureIcons = ({
   );
 };
 
-export default FeatureIcons;
+export default React.memo(FeatureIcons);

--- a/apps/web/src/components/common/Form/BaseForm/FormExtrasSection.tsx
+++ b/apps/web/src/components/common/Form/BaseForm/FormExtrasSection.tsx
@@ -84,6 +84,14 @@ const FormExtrasSection: React.FC<ExtendedFormExtrasSectionProps> = ({
     }
   }, [interactiveModeToggle]);
 
+  const handleBalancedModeClick = useCallback(() => {
+    balancedModeToggle?.onToggle?.(!balancedModeToggle.isActive);
+  }, [balancedModeToggle]);
+
+  const handleRemoveFile = useCallback(() => {
+    onRemoveFile?.(0);
+  }, [onRemoveFile]);
+
   if (hide) {
     return null;
   }
@@ -99,10 +107,6 @@ const FormExtrasSection: React.FC<ExtendedFormExtrasSectionProps> = ({
   if (!hasExtras) {
     return null;
   }
-
-  const handleBalancedModeClick = balancedModeToggle
-    ? () => balancedModeToggle.onToggle?.(!balancedModeToggle.isActive)
-    : undefined;
 
   const handleInteractiveMode =
     interactiveModeToggle && useInteractiveModeToggle ? handleInteractiveModeClick : undefined;
@@ -122,9 +126,9 @@ const FormExtrasSection: React.FC<ExtendedFormExtrasSectionProps> = ({
             <div className="flex items-center gap-sm flex-1 min-w-0">
               {useFeatureIcons && (
                 <FeatureIcons
-                  onBalancedModeClick={handleBalancedModeClick}
+                  onBalancedModeClick={balancedModeToggle ? handleBalancedModeClick : undefined}
                   onAttachmentClick={onAttachmentClick}
-                  onRemoveFile={() => onRemoveFile?.(0)}
+                  onRemoveFile={handleRemoveFile}
                   onInteractiveModeClick={handleInteractiveMode}
                   interactiveModeActive={
                     interactiveModeToggle ? interactiveModeToggle.isActive : false
@@ -186,9 +190,9 @@ const FormExtrasSection: React.FC<ExtendedFormExtrasSectionProps> = ({
             {useFeatureIcons && (
               <div>
                 <FeatureIcons
-                  onBalancedModeClick={handleBalancedModeClick}
+                  onBalancedModeClick={balancedModeToggle ? handleBalancedModeClick : undefined}
                   onAttachmentClick={onAttachmentClick}
-                  onRemoveFile={() => onRemoveFile?.(0)}
+                  onRemoveFile={handleRemoveFile}
                   onInteractiveModeClick={handleInteractiveMode}
                   interactiveModeActive={
                     interactiveModeToggle ? interactiveModeToggle.isActive : false

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -198,6 +198,8 @@ function GrueneratorHistoryProvider({ children }: PropsWithChildren) {
             return ExportedMessageRepository.fromArray(converted);
           } catch (error) {
             console.error('Error loading messages:', error);
+            // Thread likely deleted — clear stale threadId to prevent FK violations on send
+            useAgentStore.getState().setCurrentThread(null);
           }
         }
 


### PR DESCRIPTION
## Summary

- **Dead thread fix**: When loading messages for a deleted thread returns 404, the frontend now clears the stale `currentThreadId` from the store. Additionally, the backend validates thread existence before `INSERT INTO chat_messages`, returning a graceful SSE error instead of an FK constraint violation (GRUENERATOR-5K).
- **Render storm fix**: Wrapped `FeatureIcons` in `React.memo`, stabilized inline callbacks in `FormExtrasSection` with `useCallback`, and removed a `console.debug` left in production code.

## Test plan

- [ ] Delete a chat thread from DB, navigate to `/chat` with that threadId in state → should show empty chat, not "Internal server error"
- [ ] Send a message after thread recovery → new thread should be created normally
- [ ] Open any generator page (e.g. `/texte/presse-social`) → verify FeatureIcons does not log excessively in console
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes