### PR TITLE
fix(gruen-o-mat): fix 502 Bad Gateway on Coolify deployment

### DIFF
--- a/apps/gruen-o-mat/docker-entrypoint.sh
+++ b/apps/gruen-o-mat/docker-entrypoint.sh
@@ -5,9 +5,13 @@ set -e
 : "${EMBED_ALLOWED_ORIGINS:=}"
 export EMBED_ALLOWED_ORIGINS
 
+# Extract hostname from API_BASE_URL for proxy Host header and SNI
+API_HOST=$(echo "$API_BASE_URL" | sed -E 's|^https?://||; s|[:/].*||')
+export API_HOST
+
 # Substitute environment variables in nginx config.
 # Restricted to known variables so nginx variables ($host, $uri, etc.) are untouched.
-envsubst '${API_BASE_URL} ${EMBED_ALLOWED_ORIGINS}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+envsubst '${API_BASE_URL} ${EMBED_ALLOWED_ORIGINS} ${API_HOST}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
 
 # Optional basic auth (set AUTH_USERNAME + AUTH_PASSWORD to enable)
 if [ -n "$AUTH_USERNAME" ] && [ -n "$AUTH_PASSWORD" ]; then

--- a/apps/gruen-o-mat/nginx.conf.template
+++ b/apps/gruen-o-mat/nginx.conf.template
@@ -46,9 +46,11 @@ server {
     # SSE streaming requires buffering off + long timeouts
     location /api/ {
         # __AUTH_PLACEHOLDER__
+        resolver 127.0.0.11 valid=30s ipv6=off;
         proxy_pass ${API_BASE_URL}/api/;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${API_HOST};
+        proxy_ssl_server_name on;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;

--- a/apps/web/src/components/common/FeatureIcons.tsx
+++ b/apps/web/src/components/common/FeatureIcons.tsx
@@ -613,9 +613,8 @@ const FeatureIcons = ({
                   variant="ghost"
                   size="icon"
                   className={cn(
-                    'size-9 sm:size-10',
-                    useAgentMode &&
-                      'bg-primary-500 text-white hover:bg-primary-600 hover:text-white'
+                    'size-9 sm:size-10 hover:bg-transparent',
+                    useAgentMode && 'text-primary-500'
                   )}
                   onClick={toggleAgentMode}
                   aria-label="Agent-Modus"


### PR DESCRIPTION
## Summary

- **Fix 502 Bad Gateway** when gruen-o-mat nginx proxies `/api/` requests to `https://gruenerator.eu`
- Root cause: Traefik (upstream reverse proxy) requires the correct `Host` header and SNI for TLS routing
- Extract `API_HOST` from `API_BASE_URL` in entrypoint script and use it for proxy `Host` header
- Add `proxy_ssl_server_name on` for SNI and `resolver 127.0.0.11` for Docker DNS resolution
- Simplify agent mode button styling in FeatureIcons (hover state cleanup)

## Changes

| File | Change |
|------|--------|
| `apps/gruen-o-mat/docker-entrypoint.sh` | Extract `API_HOST` hostname, pass to `envsubst` |
| `apps/gruen-o-mat/nginx.conf.template` | Add resolver, correct Host header, enable SNI |
| `apps/web/src/components/common/FeatureIcons.tsx` | Simplify agent mode button active/hover styling |

## Test plan

- [ ] Rebuild gruen-o-mat Docker image and deploy to Coolify
- [ ] Verify `curl https://<domain>/api/gruen-o-mat/status` returns JSON (not 502)
- [ ] Verify SSE streaming works in browser (send a message, check response streams)
- [ ] Check nginx logs show correct API proxy target
- [ ] Verify full-stack docker-compose (`http://api:3001`) still works