### PR TITLE
chore(desktop): bump version to 1.1.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gruenerator/desktop",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gruenerator-desktop"
-version = "1.0.1"
+version = "1.1.0"
 description = "Grünerator Desktop App"
 authors = ["Grünerator Team"]
 edition = "2021"

--- a/apps/desktop/src-tauri/splashscreen.html
+++ b/apps/desktop/src-tauri/splashscreen.html
@@ -198,6 +198,6 @@
     </div>
   </div>
 
-  <span class="version">Version 1.0.0</span>
+  <span class="version">Version 1.1.0</span>
 </body>
 </html>

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Grünerator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "identifier": "de.gruenerator.desktop",
   "build": {
     "beforeBuildCommand": "cd ../.. && pnpm exec cross-env TAURI_ENV_PLATFORM=desktop VITE_API_BASE_URL=https://gruenerator.eu/api pnpm --filter @gruenerator/web build",


### PR DESCRIPTION
## Summary
- Bump desktop app version from 1.0.1 → 1.1.0 across all config files
- Updates `package.json`, `tauri.conf.json`, `Cargo.toml`, and `splashscreen.html`
- Rebuilds desktop with latest web frontend

## Files changed
- `apps/desktop/package.json`
- `apps/desktop/src-tauri/tauri.conf.json`
- `apps/desktop/src-tauri/Cargo.toml`
- `apps/desktop/src-tauri/splashscreen.html`

## After merge
Trigger desktop release workflow manually with `platforms: windows`