### PR TITLE
fix(sites): resolve set-state-in-effect lint errors in useLoadingProgress

### DIFF
--- a/apps/sites/src/hooks/useLoadingProgress.ts
+++ b/apps/sites/src/hooks/useLoadingProgress.ts
@@ -1,34 +1,37 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 export function useLoadingProgress(isLoading: boolean, estimatedDuration: number = 30000) {
   const [progress, setProgress] = useState(0);
+  const wasLoading = useRef(false);
 
   useEffect(() => {
-    if (!isLoading) {
-      setProgress(0);
-      return;
+    if (isLoading) {
+      wasLoading.current = true;
+      const startTime = Date.now();
+      const interval = setInterval(() => {
+        const elapsed = Date.now() - startTime;
+        const pct = (elapsed / estimatedDuration) * 100;
+        const asymptotic = 95 * (1 - Math.exp(-pct / 30));
+        setProgress(Math.min(asymptotic, 95));
+      }, 100);
+
+      return () => clearInterval(interval);
     }
 
-    const startTime = Date.now();
-    const interval = setInterval(() => {
-      const elapsed = Date.now() - startTime;
-      const rawProgress = (elapsed / estimatedDuration) * 100;
-
-      const asymptotic = 95 * (1 - Math.exp(-rawProgress / 30));
-
-      setProgress(Math.min(asymptotic, 95));
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, [isLoading, estimatedDuration]);
-
-  useEffect(() => {
-    if (!isLoading && progress > 0) {
-      setProgress(100);
+    // Loading just finished — animate to 100 then reset
+    if (wasLoading.current) {
+      wasLoading.current = false;
+      // Use rAF to avoid synchronous setState in effect body
+      const raf = requestAnimationFrame(() => {
+        setProgress(100);
+      });
       const timeout = setTimeout(() => setProgress(0), 500);
-      return () => clearTimeout(timeout);
+      return () => {
+        cancelAnimationFrame(raf);
+        clearTimeout(timeout);
+      };
     }
-  }, [isLoading, progress]);
+  }, [isLoading, estimatedDuration]);
 
   return Math.round(progress);
 }


### PR DESCRIPTION
## Summary
- Move `setProgress` calls from effect body into `requestAnimationFrame`/`setTimeout` callbacks to satisfy `react-hooks/set-state-in-effect` rule

## Test plan
- [ ] `pnpm lint` passes for `@gruenerator/sites`