### PR TITLE
chore(docs): add ownership mismatch logging to sharing endpoints

### DIFF
--- a/apps/api/routes/docs/groupShareController.ts
+++ b/apps/api/routes/docs/groupShareController.ts
@@ -73,6 +73,12 @@ router.get('/:id/groups', async (req: Request, res: Response) => {
     }
 
     if (doc[0].created_by !== userId) {
+      console.error(
+        '[Docs] Group share 403: created_by=%s, userId=%s, docId=%s',
+        doc[0].created_by,
+        userId,
+        id
+      );
       return res.status(403).json({ error: 'Only document owner can manage group sharing' });
     }
 

--- a/apps/api/routes/docs/permissionsController.ts
+++ b/apps/api/routes/docs/permissionsController.ts
@@ -75,6 +75,13 @@ router.get('/:id/permissions', async (req: Request<{ id: string }>, res: Respons
       document.created_by === userId || (document.permissions && document.permissions[userId]);
 
     if (!hasAccess) {
+      console.error(
+        '[Docs] Permissions 403: created_by=%s, userId=%s, docId=%s, permKeys=%o',
+        document.created_by,
+        userId,
+        id,
+        Object.keys(document.permissions || {})
+      );
       return res.status(403).json({ error: 'Access denied' });
     }
 

--- a/apps/api/routes/docs/shareController.ts
+++ b/apps/api/routes/docs/shareController.ts
@@ -39,6 +39,13 @@ async function getOwnedDocument(
   }
 
   if (!isOwner(result[0], userId)) {
+    console.error(
+      '[Docs] Share 403: created_by=%s, userId=%s, docId=%s, permKeys=%o',
+      result[0].created_by,
+      userId,
+      id,
+      Object.keys(result[0].permissions || {})
+    );
     res.status(403).json({ error: 'Only owners can manage sharing settings' });
     return null;
   }


### PR DESCRIPTION
## Summary
- Adds `console.error` debug logging to the three docs sharing endpoints (`/groups`, `/permissions`, `/share`) when a 403 is returned
- Logs `created_by`, `userId`, and `permKeys` to diagnose why document owners get access denied when trying to share

## Context
Document owners are getting 403 errors on all three sharing endpoints when clicking "Teilen" in the docs editor. The root cause is unknown — these logs will reveal the exact ID mismatch.

## Test plan
- [ ] Reproduce the 403 on sharing endpoints
- [ ] Check server logs for `[Docs] ... 403:` lines showing the ID comparison