### PR TITLE
fix(chat): prevent false clarification on follow-ups + docs improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ pnpm --filter @gruenerator/api test:integration  # Run integration tests
 pnpm --filter @gruenerator/desktop dev           # Tauri desktop dev
 ```
 
+> **WSL RAM constraint**: `pnpm typecheck` is expensive. Only run typechecks on **newly created files** (`npx tsc --noEmit <file>`) or **before pushing**. Do not run full-project typechecks during routine edits.
+
 ## Architecture
 
 ### Monorepo Layout

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -44,6 +44,7 @@ Wenn ein GESPRÄCHSVERLAUF mitgeliefert wird, nutze ihn um die aktuelle Nachrich
   → optimizedSearchQuery: "Newsletter best practices Kreisverband Grüne"
 - Wenn die aktuelle Nachricht bereits spezifisch genug ist, ignoriere den Kontext
 - Verändere NICHT den intent basierend auf dem Kontext — nur die Suchquery
+- Wenn ein GESPRÄCHSVERLAUF vorhanden ist, setze needsClarification IMMER auf false — der nachfolgende Schritt hat Zugriff auf den vollständigen Verlauf (siehe Schritt 8)
 
 SCHRITT 2 - INHALTSTYP ANALYSIEREN:
 Manche Inhalte brauchen AUTOMATISCH Recherche:
@@ -115,17 +116,25 @@ Wenn die Anfrage SPEZIFISCHE Filterkriterien enthält, extrahiere sie:
 Setze NUR Felder die KLAR aus der Anfrage hervorgehen. Bei Unsicherheit: null.
 
 SCHRITT 8 - KLÄRUNGSBEDARF ERKENNEN:
-Wenn die Anfrage MEHRDEUTIG ist und du dir nicht sicher bist welches Thema gemeint ist:
-- Setze "needsClarification": true
-- Formuliere eine kurze Klärungsfrage in "clarificationQuestion"
-- Biete 2-4 konkrete Antwortoptionen in "clarificationOptions" an
+Standardmäßig: needsClarification: false, clarificationQuestion: null, clarificationOptions: null
 
-Beispiele:
+Setze needsClarification: false wenn:
+- Die Anfrage ein klares Thema enthält ("Grüne Position zum Klimaschutz")
+- Ein GESPRÄCHSVERLAUF vorhanden ist — auch wenn die aktuelle Nachricht allein mehrdeutig wäre ("erstelle einen Post", "mach daraus einen tweet", "kürze das"). Der nachfolgende Verarbeitungsschritt hat Zugriff auf den VOLLSTÄNDIGEN Gesprächsverlauf und kann das Thema daraus ableiten, auch wenn du es im gekürzten Verlauf hier nicht siehst.
+
+AUSNAHME — needsClarification: true NUR wenn ALLE diese Bedingungen zutreffen:
+1. KEIN Gesprächsverlauf vorhanden (erste Nachricht)
+2. Die Anfrage enthält KEIN erkennbares Thema
+3. Ohne Thema kann keine sinnvolle Antwort erstellt werden
+
+Beispiel für die Ausnahme (erste Nachricht, kein Kontext):
 - "Was ist die Position?" → needsClarification: true, clarificationQuestion: "Zu welchem Thema möchtest du die Position der Grünen erfahren?", clarificationOptions: ["Klimapolitik", "Verkehrspolitik", "Sozialpolitik", "Energiepolitik"]
 - "Erstelle einen Post" → needsClarification: true, clarificationQuestion: "Über welches Thema soll der Post sein?", clarificationOptions: ["Klimaschutz", "Soziale Gerechtigkeit", "Verkehrswende"]
-- "Grüne Position zum Klimaschutz" → needsClarification: false (eindeutig)
 
-Bei EINDEUTIGEN Anfragen: needsClarification: false, clarificationQuestion: null, clarificationOptions: null
+KEIN Klärungsbedarf (Gesprächsverlauf vorhanden):
+- Verlauf über Klimapolitik + "jetzt darauf basierend einen tweet" → needsClarification: false
+- Verlauf über Pressemitteilung + "mach das kürzer als post" → needsClarification: false
+- Verlauf über Energiewende + "erstelle einen Post dazu" → needsClarification: false
 
 Antworte NUR mit JSON:
 {

--- a/apps/api/routes/docs/exportController.ts
+++ b/apps/api/routes/docs/exportController.ts
@@ -1,5 +1,6 @@
 import { gunzipSync } from 'zlib';
 
+import { blockNoteXmlToHtml } from '@gruenerator/hocuspocus';
 import { Router, type Request, type Response } from 'express';
 import * as Y from 'yjs';
 
@@ -175,9 +176,7 @@ router.get('/:id/export/html', async (req: Request, res: Response) => {
       // Get the prosemirror XML fragment
       const xmlFragment = ydoc.getXmlFragment('document-store');
 
-      // For now, return a simple HTML structure
-      // In production, you'd convert the Y.js XML to proper HTML
-      content = xmlFragment.toString();
+      content = blockNoteXmlToHtml(xmlFragment.toString());
     }
 
     const html = `<!DOCTYPE html>
@@ -293,7 +292,7 @@ router.get('/:id/export/markdown', async (req: Request, res: Response) => {
 
       // Get the prosemirror XML fragment
       const xmlFragment = ydoc.getXmlFragment('document-store');
-      const htmlContent = xmlFragment.toString();
+      const htmlContent = blockNoteXmlToHtml(xmlFragment.toString());
 
       // Convert to Markdown
       content = htmlToMarkdown(htmlContent);
@@ -362,7 +361,7 @@ router.get('/:id/export/text', async (req: Request, res: Response) => {
 
       // Get the prosemirror XML fragment
       const xmlFragment = ydoc.getXmlFragment('document-store');
-      const htmlContent = xmlFragment.toString();
+      const htmlContent = blockNoteXmlToHtml(xmlFragment.toString());
 
       // Strip all HTML tags (loop to handle nested/malformed tags)
       content = htmlContent;

--- a/apps/api/routes/nextcloud/nextcloudApi.ts
+++ b/apps/api/routes/nextcloud/nextcloudApi.ts
@@ -24,6 +24,7 @@ interface UploadBody {
   shareLinkId: string;
   content: string;
   filename: string;
+  folderPath?: string;
 }
 
 interface UpdateShareLinkBody {
@@ -269,6 +270,56 @@ router.post('/test-connection', async (req: Request, res: Response): Promise<voi
 });
 
 /**
+ * Browse folders in a Nextcloud share
+ * GET /api/nextcloud/share-links/:id/browse?path=
+ */
+router.get(
+  '/share-links/:id/browse',
+  async (req: Request<{ id: string }>, res: Response): Promise<void> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const shareLinkId = req.params.id;
+      const folderPath = (req.query.path as string) || '';
+
+      log.debug('[NextcloudApi] Browsing folder', { userId, shareLinkId, folderPath });
+
+      if (!shareLinkId) {
+        res.status(400).json({ error: 'Share link ID is required' });
+        return;
+      }
+
+      const shareLink = await NextcloudShareManager.getShareLinkById(userId, shareLinkId);
+
+      if (!shareLink || !shareLink.is_active) {
+        res.status(404).json({ error: 'Share link not found or inactive' });
+        return;
+      }
+
+      const client = new NextcloudApiClient(shareLink.share_link);
+      const items = await client.listFolder(folderPath || undefined);
+
+      res.json({
+        success: true,
+        path: folderPath,
+        items,
+      });
+    } catch (error) {
+      const err = error as Error;
+      log.error('[NextcloudApi] Error browsing folder', { error: err.message });
+      res.status(500).json({
+        error: 'Failed to browse folder',
+        message: err.message,
+      });
+    }
+  }
+);
+
+/**
  * Upload file to a Nextcloud share
  * POST /api/nextcloud/upload
  */
@@ -280,9 +331,14 @@ router.post('/upload', async (req: Request, res: Response): Promise<void> => {
       return;
     }
 
-    const { shareLinkId, content, filename } = req.body as UploadBody;
+    const { shareLinkId, content, filename, folderPath } = req.body as UploadBody;
 
-    log.debug('[NextcloudApi] Uploading file to Nextcloud', { userId, filename, shareLinkId });
+    log.debug('[NextcloudApi] Uploading file to Nextcloud', {
+      userId,
+      filename,
+      shareLinkId,
+      folderPath,
+    });
 
     if (!shareLinkId) {
       res.status(400).json({ error: 'Share link ID is required' });
@@ -307,7 +363,7 @@ router.post('/upload', async (req: Request, res: Response): Promise<void> => {
     }
 
     const client = new NextcloudApiClient(shareLink.share_link);
-    const uploadResult = await client.uploadFile(content, filename);
+    const uploadResult = await client.uploadFile(content, filename, folderPath);
 
     res.json(uploadResult);
   } catch (error) {

--- a/apps/api/services/api-clients/nextcloudApiClient.ts
+++ b/apps/api/services/api-clients/nextcloudApiClient.ts
@@ -28,6 +28,7 @@ export interface NextcloudFile {
   size: number | null;
   lastModified: Date | null;
   etag: string | null;
+  isDirectory?: boolean;
 }
 
 export interface ShareInfo {
@@ -197,16 +198,32 @@ class NextcloudApiClient {
   /**
    * Upload a file to the Nextcloud share
    */
-  async uploadFile(content: string | Buffer, filename: string): Promise<UploadFileResult> {
+  async uploadFile(
+    content: string | Buffer,
+    filename: string,
+    folderPath?: string
+  ): Promise<UploadFileResult> {
     try {
       console.log('[NextcloudApiClient] Uploading file to Nextcloud', {
         filename,
+        folderPath,
         contentLength: content.length,
       });
 
       // Ensure filename is safe
       const safeFilename = this.sanitizeFilename(filename);
-      const uploadUrl = `${this.webdavUrl}/${encodeURIComponent(safeFilename)}`;
+
+      // Build upload URL with optional folder path
+      let uploadUrl = this.webdavUrl;
+      if (folderPath) {
+        const encodedPath = folderPath
+          .split('/')
+          .filter(Boolean)
+          .map((segment) => encodeURIComponent(segment))
+          .join('/');
+        uploadUrl = `${this.webdavUrl}/${encodedPath}`;
+      }
+      uploadUrl = `${uploadUrl}/${encodeURIComponent(safeFilename)}`;
 
       // Detect and handle base64-encoded content
       let uploadContent: string | Buffer = content;
@@ -300,6 +317,57 @@ class NextcloudApiClient {
   }
 
   /**
+   * List files and folders at a given path within the share
+   */
+  async listFolder(folderPath?: string): Promise<NextcloudFile[]> {
+    try {
+      let propfindUrl = this.webdavUrl;
+      if (folderPath) {
+        const encodedPath = folderPath
+          .split('/')
+          .filter(Boolean)
+          .map((segment) => encodeURIComponent(segment))
+          .join('/');
+        propfindUrl = `${this.webdavUrl}/${encodedPath}`;
+      }
+
+      console.log('[NextcloudApiClient] Listing folder', { folderPath, propfindUrl });
+
+      const response = await this.axiosInstance.request<string>({
+        method: 'PROPFIND',
+        url: propfindUrl,
+        headers: {
+          Depth: '1',
+          'Content-Type': 'application/xml',
+        },
+        data: `<?xml version="1.0" encoding="utf-8" ?>
+               <propfind xmlns="DAV:">
+                   <prop>
+                       <resourcetype/>
+                       <getcontentlength/>
+                       <getlastmodified/>
+                       <displayname/>
+                       <getetag/>
+                   </prop>
+               </propfind>`,
+      });
+
+      if (response.status === 207) {
+        return this.parseWebDAVResponse(response.data);
+      }
+
+      return [];
+    } catch (error) {
+      const err = error as Error;
+      console.error('[NextcloudApiClient] Failed to list folder', {
+        folderPath,
+        error: err.message,
+      });
+      throw new Error(err.message || 'Failed to list folder');
+    }
+  }
+
+  /**
    * Get information about the share
    */
   async getShareInfo(): Promise<ShareInfo> {
@@ -385,6 +453,7 @@ class NextcloudApiClient {
             /<d:getlastmodified[^>]*>(.*?)<\/d:getlastmodified>/
           );
           const etagMatch = responseXml.match(/<d:getetag[^>]*>(.*?)<\/d:getetag>/);
+          const isDirectory = /<d:collection\s*\/?>/.test(responseXml);
 
           if (hrefMatch && hrefMatch[1]) {
             const href = hrefMatch[1].trim();
@@ -400,12 +469,20 @@ class NextcloudApiClient {
               etag = etagMatch[1].trim().replace(/^["']|["']$/g, '');
             }
 
+            // For directories, extract name from href (trailing slash)
+            let name = displayNameMatch ? displayNameMatch[1].trim() : '';
+            if (!name) {
+              const segments = href.replace(/\/$/, '').split('/');
+              name = decodeURIComponent(segments.pop() || '');
+            }
+
             files.push({
               href: href,
-              name: displayNameMatch ? displayNameMatch[1].trim() : href.split('/').pop() || '',
+              name,
               size: contentLengthMatch ? parseInt(contentLengthMatch[1]) : null,
               lastModified: lastModifiedMatch ? new Date(lastModifiedMatch[1]) : null,
               etag: etag,
+              isDirectory,
             });
           }
         });

--- a/apps/docs/src/components/WolkeSaveModal.tsx
+++ b/apps/docs/src/components/WolkeSaveModal.tsx
@@ -1,0 +1,332 @@
+import {
+  Alert,
+  Breadcrumbs,
+  Anchor,
+  Button,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+  UnstyledButton,
+} from '@mantine/core';
+import { useCallback, useEffect, useState } from 'react';
+import { FiAlertCircle, FiCheck, FiChevronRight, FiFolder, FiFile } from 'react-icons/fi';
+
+import {
+  fetchShareLinks,
+  browseFolder,
+  type ShareLink,
+  type WolkeFolderItem,
+} from '../lib/wolkeApi';
+
+interface WolkeSaveModalProps {
+  opened: boolean;
+  onClose: () => void;
+  onSave: (shareLinkId: string, folderPath?: string) => Promise<void>;
+}
+
+export const WolkeSaveModal = ({ opened, onClose, onSave }: WolkeSaveModalProps) => {
+  const [shareLinks, setShareLinks] = useState<ShareLink[]>([]);
+  const [isLoadingLinks, setIsLoadingLinks] = useState(false);
+  const [selectedShareLink, setSelectedShareLink] = useState<ShareLink | null>(null);
+
+  const [currentPath, setCurrentPath] = useState<string[]>([]);
+  const [folderContents, setFolderContents] = useState<WolkeFolderItem[]>([]);
+  const [isBrowsing, setIsBrowsing] = useState(false);
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(
+    null
+  );
+
+  // Load share links when modal opens
+  useEffect(() => {
+    if (!opened) return;
+    setIsLoadingLinks(true);
+    setFeedback(null);
+    setSelectedShareLink(null);
+    setCurrentPath([]);
+    setFolderContents([]);
+    fetchShareLinks()
+      .then(setShareLinks)
+      .catch(() => setShareLinks([]))
+      .finally(() => setIsLoadingLinks(false));
+  }, [opened]);
+
+  const loadFolder = useCallback(async (shareLinkId: string, pathSegments: string[]) => {
+    setIsBrowsing(true);
+    setFeedback(null);
+    try {
+      const path = pathSegments.join('/');
+      const items = await browseFolder(shareLinkId, path || undefined);
+      setFolderContents(items);
+      setCurrentPath(pathSegments);
+    } catch {
+      setFeedback({ type: 'error', message: 'Ordner konnte nicht geladen werden.' });
+    } finally {
+      setIsBrowsing(false);
+    }
+  }, []);
+
+  const handleSelectShareLink = useCallback(
+    (link: ShareLink) => {
+      setSelectedShareLink(link);
+      loadFolder(link.id, []);
+    },
+    [loadFolder]
+  );
+
+  const handleNavigateInto = useCallback(
+    (folderName: string) => {
+      if (!selectedShareLink) return;
+      const newPath = [...currentPath, folderName];
+      loadFolder(selectedShareLink.id, newPath);
+    },
+    [selectedShareLink, currentPath, loadFolder]
+  );
+
+  const handleBreadcrumbClick = useCallback(
+    (index: number) => {
+      if (!selectedShareLink) return;
+      // index -1 = root
+      const newPath = index < 0 ? [] : currentPath.slice(0, index + 1);
+      loadFolder(selectedShareLink.id, newPath);
+    },
+    [selectedShareLink, currentPath, loadFolder]
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!selectedShareLink) return;
+    setIsUploading(true);
+    setFeedback(null);
+    try {
+      const folderPath = currentPath.length > 0 ? currentPath.join('/') : undefined;
+      await onSave(selectedShareLink.id, folderPath);
+      setFeedback({ type: 'success', message: 'Dokument wurde in der Wolke gespeichert.' });
+    } catch {
+      setFeedback({ type: 'error', message: 'Speichern fehlgeschlagen. Bitte erneut versuchen.' });
+    } finally {
+      setIsUploading(false);
+    }
+  }, [selectedShareLink, currentPath, onSave]);
+
+  const folders = folderContents.filter((item) => item.isDirectory);
+  const files = folderContents.filter((item) => !item.isDirectory);
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="In Wolke speichern" size="lg" centered>
+      <Stack gap="md">
+        {feedback && (
+          <Alert
+            color={feedback.type === 'success' ? 'green' : 'red'}
+            icon={feedback.type === 'success' ? <FiCheck /> : <FiAlertCircle />}
+            withCloseButton
+            onClose={() => setFeedback(null)}
+          >
+            {feedback.message}
+          </Alert>
+        )}
+
+        {/* Step 1: Select a share link */}
+        {!selectedShareLink && (
+          <>
+            {isLoadingLinks ? (
+              <Group justify="center" py="xl">
+                <Loader size="sm" color="var(--primary-600)" />
+                <Text size="sm" c="dimmed">
+                  Wolke-Verbindungen werden geladen...
+                </Text>
+              </Group>
+            ) : shareLinks.length === 0 ? (
+              <Stack align="center" gap="sm" py="xl">
+                <Text size="sm" c="dimmed">
+                  Keine Wolke-Verbindungen vorhanden.
+                </Text>
+                <Button
+                  component="a"
+                  href="/settings"
+                  variant="light"
+                  color="var(--primary-600)"
+                  size="sm"
+                >
+                  Verbindung in den Einstellungen einrichten
+                </Button>
+              </Stack>
+            ) : (
+              <>
+                <Text size="sm" c="dimmed">
+                  Wolke-Verbindung auswählen:
+                </Text>
+                {shareLinks
+                  .filter((link) => link.is_active)
+                  .map((link) => (
+                    <UnstyledButton
+                      key={link.id}
+                      onClick={() => handleSelectShareLink(link)}
+                      style={{
+                        padding: '0.75rem 1rem',
+                        borderRadius: '0.5rem',
+                        border: '1px solid var(--grey-200, #e5e7eb)',
+                        cursor: 'pointer',
+                        transition: 'background 0.15s',
+                      }}
+                      styles={{
+                        root: {
+                          '&:hover': {
+                            background: 'var(--grey-100, #f3f4f6)',
+                          },
+                        },
+                      }}
+                    >
+                      <Group gap="sm">
+                        <FiFolder style={{ color: 'var(--primary-600)', flexShrink: 0 }} />
+                        <div>
+                          <Text size="sm" fw={500}>
+                            {link.label || 'Wolke-Verbindung'}
+                          </Text>
+                          {link.base_url && (
+                            <Text size="xs" c="dimmed">
+                              {link.base_url}
+                            </Text>
+                          )}
+                        </div>
+                      </Group>
+                    </UnstyledButton>
+                  ))}
+              </>
+            )}
+          </>
+        )}
+
+        {/* Step 2: Folder browser */}
+        {selectedShareLink && (
+          <>
+            <div>
+              <Group gap="xs" mb="xs">
+                <Button
+                  variant="subtle"
+                  size="xs"
+                  color="var(--primary-600)"
+                  onClick={() => {
+                    setSelectedShareLink(null);
+                    setCurrentPath([]);
+                    setFolderContents([]);
+                  }}
+                >
+                  Andere Verbindung
+                </Button>
+              </Group>
+
+              <Breadcrumbs separator={<FiChevronRight size={12} />} separatorMargin={4}>
+                <Anchor
+                  size="sm"
+                  onClick={() => handleBreadcrumbClick(-1)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {selectedShareLink.label || 'Wolke'}
+                </Anchor>
+                {currentPath.map((segment, i) => (
+                  <Anchor
+                    key={i}
+                    size="sm"
+                    onClick={() => handleBreadcrumbClick(i)}
+                    style={{ cursor: 'pointer' }}
+                    fw={i === currentPath.length - 1 ? 600 : 400}
+                  >
+                    {segment}
+                  </Anchor>
+                ))}
+              </Breadcrumbs>
+            </div>
+
+            {isBrowsing ? (
+              <Group justify="center" py="md">
+                <Loader size="sm" color="var(--primary-600)" />
+              </Group>
+            ) : (
+              <Stack
+                gap={0}
+                style={{
+                  border: '1px solid var(--grey-200, #e5e7eb)',
+                  borderRadius: '0.5rem',
+                  maxHeight: '300px',
+                  overflowY: 'auto',
+                }}
+              >
+                {folders.length === 0 && files.length === 0 && (
+                  <Text size="sm" c="dimmed" ta="center" py="md">
+                    Dieser Ordner ist leer.
+                  </Text>
+                )}
+
+                {folders.map((folder) => (
+                  <UnstyledButton
+                    key={folder.href}
+                    onClick={() => handleNavigateInto(folder.name)}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                      padding: '0.5rem 0.75rem',
+                      borderBottom: '1px solid var(--grey-100, #f3f4f6)',
+                      cursor: 'pointer',
+                      transition: 'background 0.15s',
+                    }}
+                    styles={{
+                      root: {
+                        '&:hover': {
+                          background: 'var(--grey-50, #f9fafb)',
+                        },
+                      },
+                    }}
+                  >
+                    <FiFolder style={{ color: 'var(--primary-600)', flexShrink: 0 }} />
+                    <Text size="sm">{folder.name}</Text>
+                    <FiChevronRight
+                      size={14}
+                      style={{ marginLeft: 'auto', color: 'var(--grey-400)' }}
+                    />
+                  </UnstyledButton>
+                ))}
+
+                {files.map((file) => (
+                  <div
+                    key={file.href}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '0.5rem',
+                      padding: '0.5rem 0.75rem',
+                      borderBottom: '1px solid var(--grey-100, #f3f4f6)',
+                      opacity: 0.5,
+                    }}
+                  >
+                    <FiFile style={{ color: 'var(--grey-400)', flexShrink: 0 }} />
+                    <Text size="sm" c="dimmed">
+                      {file.name}
+                    </Text>
+                  </div>
+                ))}
+              </Stack>
+            )}
+
+            <Group justify="space-between" mt="sm">
+              <Text size="xs" c="dimmed">
+                /{currentPath.join('/')}
+              </Text>
+              <Button
+                color="var(--primary-600)"
+                onClick={handleSave}
+                loading={isUploading}
+                disabled={isUploading}
+              >
+                Hier speichern
+              </Button>
+            </Group>
+          </>
+        )}
+      </Stack>
+    </Modal>
+  );
+};

--- a/apps/docs/src/lib/wolkeApi.ts
+++ b/apps/docs/src/lib/wolkeApi.ts
@@ -69,3 +69,41 @@ export async function testConnection(shareLink: string): Promise<ConnectionTestR
   });
   return data;
 }
+
+export interface WolkeFolderItem {
+  name: string;
+  href: string;
+  isDirectory: boolean;
+  size: number | null;
+  lastModified: string | null;
+}
+
+export async function browseFolder(shareLinkId: string, path?: string): Promise<WolkeFolderItem[]> {
+  const params = path ? `?path=${encodeURIComponent(path)}` : '';
+  const { data } = await apiClient.get<{ success: boolean; items: WolkeFolderItem[] }>(
+    `/nextcloud/share-links/${shareLinkId}/browse${params}`
+  );
+  return data.items;
+}
+
+export interface UploadResult {
+  success: boolean;
+  message: string;
+  filename?: string;
+  url?: string;
+}
+
+export async function uploadToWolke(
+  shareLinkId: string,
+  content: string,
+  filename: string,
+  folderPath?: string
+): Promise<UploadResult> {
+  const { data } = await apiClient.post<UploadResult>('/nextcloud/upload', {
+    shareLinkId,
+    content,
+    filename,
+    ...(folderPath ? { folderPath } : {}),
+  });
+  return data;
+}

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -87,6 +87,7 @@ export const EditorPage = () => {
   const adapter = useDocsAdapter();
   const apiClient = useMemo(() => createDocsApiClient(adapter), [adapter]);
   const user = useAuthStore((state) => state.user);
+  const isAuthLoading = useAuthStore((state) => state.isLoading);
   const isGuest = !user;
 
   const guestIdentity = useMemo(() => (isGuest ? getOrCreateGuestIdentity() : null), [isGuest]);
@@ -101,7 +102,7 @@ export const EditorPage = () => {
       }
       return apiClient.get<Document>(`/docs/${id}`);
     },
-    enabled: !!id,
+    enabled: !!id && !isAuthLoading,
   });
 
   const canEdit = useMemo(() => {

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -10,11 +10,13 @@ import { EditorTopBar } from '@gruenerator/shared/components/EditorTopBar';
 import { MantineProvider, SegmentedControl, ScrollArea } from '@mantine/core';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
+import { FiCloud, FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { EditorFAB } from '../components/EditorFAB';
+import { WolkeSaveModal } from '../components/WolkeSaveModal';
 import { useColorScheme } from '../hooks/useColorScheme';
+import { uploadToWolke } from '../lib/wolkeApi';
 import { useAuthStore } from '../stores/authStore';
 
 import type { BlockNoteEditor } from '@blocknote/core';
@@ -149,6 +151,7 @@ export const EditorPage = () => {
   );
 
   const [showShareModal, setShowShareModal] = useState(false);
+  const [showWolkeModal, setShowWolkeModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarTab, setSidebarTab] = useState<'chat' | 'comments'>('chat');
@@ -246,6 +249,29 @@ export const EditorPage = () => {
     }
   }, [docData, editor]);
 
+  const handleSaveToWolke = useCallback(
+    async (shareLinkId: string, folderPath?: string) => {
+      if (!docData || !editor) throw new Error('Editor not ready');
+
+      const { DOCXExporter, docxDefaultSchemaMappings } =
+        await import('@blocknote/xl-docx-exporter');
+      const exporter = new DOCXExporter(editor.schema, docxDefaultSchemaMappings);
+      const blob = await exporter.toBlob(editor.document);
+
+      const arrayBuffer = await blob.arrayBuffer();
+      const bytes = new Uint8Array(arrayBuffer);
+      let binary = '';
+      for (let i = 0; i < bytes.length; i++) {
+        binary += String.fromCharCode(bytes[i]);
+      }
+      const base64Content = btoa(binary);
+
+      const filename = `${docData.title || 'Dokument'}.docx`;
+      await uploadToWolke(shareLinkId, base64Content, filename, folderPath);
+    },
+    [docData, editor]
+  );
+
   const toggleSidebar = useCallback(() => {
     setSidebarOpen((prev) => !prev);
   }, []);
@@ -337,6 +363,15 @@ export const EditorPage = () => {
                       )}
                     </div>
 
+                    <button
+                      className="glass-btn"
+                      onClick={() => setShowWolkeModal(true)}
+                      aria-label="In Wolke speichern"
+                      title="In Wolke speichern"
+                    >
+                      <FiCloud />
+                    </button>
+
                     {canEdit && (
                       <button
                         className="glass-btn"
@@ -419,6 +454,14 @@ export const EditorPage = () => {
           <Suspense fallback={null}>
             <ShareModal documentId={id!} onClose={() => setShowShareModal(false)} />
           </Suspense>
+        )}
+
+        {!isGuest && (
+          <WolkeSaveModal
+            opened={showWolkeModal}
+            onClose={() => setShowWolkeModal(false)}
+            onSave={handleSaveToWolke}
+          />
         )}
       </div>
     </MantineProvider>

--- a/apps/mobile/app/(tabs)/(media)/vorlagen.tsx
+++ b/apps/mobile/app/(tabs)/(media)/vorlagen.tsx
@@ -90,8 +90,14 @@ export default function VorlagenScreen() {
   );
 
   useEffect(() => {
-    setIsLoading(true);
-    loadData(selectedCategory).finally(() => setIsLoading(false));
+    let cancelled = false;
+    setIsLoading(true); // eslint-disable-line react-hooks/set-state-in-effect -- loading state must be set synchronously before async call
+    loadData(selectedCategory).finally(() => {
+      if (!cancelled) setIsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [loadData, selectedCategory]);
 
   const handleRefresh = useCallback(async () => {

--- a/apps/mobile/components/chat/AssistantComposer.tsx
+++ b/apps/mobile/components/chat/AssistantComposer.tsx
@@ -90,6 +90,7 @@ export function AssistantComposer({
     []
   );
 
+  /* eslint-disable react-hooks/preserve-manual-memoization -- inputRef is stable (ref identity) */
   const handleMentionSelect = useCallback(
     (mentionable: Mentionable) => {
       if (!mention) return;
@@ -109,6 +110,7 @@ export function AssistantComposer({
     },
     [aui, mention]
   );
+  /* eslint-enable react-hooks/preserve-manual-memoization */
 
   const handlePickFile = useCallback(async () => {
     console.log('[Attachment] Step 1: picking document...');

--- a/apps/mobile/components/common/editor-toolbar/ToolPill.tsx
+++ b/apps/mobile/components/common/editor-toolbar/ToolPill.tsx
@@ -62,11 +62,13 @@ export function ToolPill({
 
   const handlePressIn = () => {
     if (!disabled) {
+      // eslint-disable-next-line react-hooks/immutability -- Reanimated shared value API
       scale.value = withSpring(0.96, { damping: 15 });
     }
   };
 
   const handlePressOut = () => {
+    // eslint-disable-next-line react-hooks/immutability -- Reanimated shared value API
     scale.value = withSpring(1, { damping: 15 });
   };
 

--- a/apps/mobile/components/generators/UniversalForm.tsx
+++ b/apps/mobile/components/generators/UniversalForm.tsx
@@ -64,6 +64,7 @@ export function UniversalForm({ onResult, onError }: UniversalFormProps) {
   };
 
   // Reset type-specific fields when switching
+  /* eslint-disable react-hooks/set-state-in-effect -- batch reset on type change is intentional */
   useEffect(() => {
     setInhalt('');
     setTextForm('');
@@ -76,6 +77,7 @@ export function UniversalForm({ onResult, onError }: UniversalFormProps) {
     setAntwort('');
     setOriginalText('');
   }, [textType]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const currentType = UNIVERSAL_TEXT_TYPES.find((t) => t.id === textType)!;
   const title = GENERATOR_TITLES.UNIVERSAL[textType] || 'Was möchtest du heute grünerieren?';

--- a/apps/mobile/components/share/ShareModal.tsx
+++ b/apps/mobile/components/share/ShareModal.tsx
@@ -60,6 +60,7 @@ export function ShareModal({
     clearError,
   } = useShareStore();
 
+  /* eslint-disable react-hooks/set-state-in-effect -- batch state sync is intentional */
   // Reset state when modal opens
   useEffect(() => {
     if (visible) {
@@ -83,6 +84,7 @@ export function ShareModal({
       setLocalError(storeError);
     }
   }, [isCreating, currentShare, storeError]);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const handleCreateShare = async () => {
     if (!uploadId) {

--- a/apps/mobile/hooks/useMobileChatRuntime.ts
+++ b/apps/mobile/hooks/useMobileChatRuntime.ts
@@ -11,7 +11,7 @@ import {
   type GrueneratorAdapterConfig,
   type StreamMetadata,
 } from '@gruenerator/chat';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 
 interface MobileChatRuntimeOptions {
@@ -58,9 +58,11 @@ export function useMobileChatRuntime(opts?: MobileChatRuntimeOptions) {
   );
 
   const needsCompactionRef = useRef(needsCompaction);
-  needsCompactionRef.current = needsCompaction;
   const compactionSummaryRef = useRef(compactionState.summary);
-  compactionSummaryRef.current = compactionState.summary;
+  useEffect(() => {
+    needsCompactionRef.current = needsCompaction;
+    compactionSummaryRef.current = compactionState.summary;
+  }, [needsCompaction, compactionState.summary]);
 
   const onComplete = useCallback(
     (_metadata: StreamMetadata) => {
@@ -77,10 +79,13 @@ export function useMobileChatRuntime(opts?: MobileChatRuntimeOptions) {
     [incrementMessageCount, triggerCompaction, runtimeApiClient]
   );
 
+  const callbacks = useMemo(() => ({ onThreadCreated, onComplete }), [onThreadCreated, onComplete]);
+  /* eslint-disable react-hooks/refs -- callbacks are only invoked asynchronously, not during render */
   const modelAdapter = useMemo(
-    () => createGrueneratorModelAdapter(getConfig, { onThreadCreated, onComplete }),
-    [getConfig, onThreadCreated, onComplete]
+    () => createGrueneratorModelAdapter(getConfig, callbacks),
+    [getConfig, callbacks]
   );
+  /* eslint-enable react-hooks/refs */
 
   const runtimeOptions: LocalRuntimeOptions = useMemo(
     () => ({

--- a/apps/mobile/hooks/useReelProcessing.ts
+++ b/apps/mobile/hooks/useReelProcessing.ts
@@ -213,7 +213,7 @@ export function useReelProcessing() {
         handleError('upload_failed', getErrorMessage(error));
       }
     },
-    [handleError, reset, startPolling, updateState, user?.id]
+    [handleError, reset, startPolling, updateState, user]
   );
 
   const cancelProcessing = useCallback(() => {

--- a/apps/mobile/hooks/useSubtitleEditor.ts
+++ b/apps/mobile/hooks/useSubtitleEditor.ts
@@ -156,6 +156,7 @@ export function useSubtitleEditor({ player, timelineRef }: UseSubtitleEditorOpti
     (time: number) => {
       if (player) {
         lastSeekRef.current = time;
+        // eslint-disable-next-line react-hooks/immutability -- expo-video player API is mutation-based
         player.currentTime = time;
         setCurrentTime(time);
       }

--- a/apps/mobile/providers/MobileChatProvider.tsx
+++ b/apps/mobile/providers/MobileChatProvider.tsx
@@ -140,10 +140,10 @@ function ThreadSetup({ threadId }: { threadId?: string | null }) {
 export function MobileChatProvider({
   children,
   threadId,
-  initialMessages,
+  initialMessages: _initialMessages,
 }: MobileChatProviderProps) {
-  const configuredRef = useRef(false);
-  if (!configuredRef.current) {
+  const configuredRef = useRef<boolean>(null);
+  if (configuredRef.current == null) {
     configureMobileChat();
     configuredRef.current = true;
   }

--- a/packages/docs/src/lib/templates.ts
+++ b/packages/docs/src/lib/templates.ts
@@ -4,7 +4,9 @@ export type TemplateType =
   | 'pressemitteilung'
   | 'protokoll'
   | 'notizen'
-  | 'redaktionsplan';
+  | 'redaktionsplan'
+  | 'checkliste'
+  | 'einladung';
 
 export interface DocumentTemplate {
   id: TemplateType;
@@ -185,6 +187,96 @@ export const templates: DocumentTemplate[] = [
   <li>Erklärvideo: Wie funktioniert ein Bürgerbegehren?</li>
   <li>Mitmach-Aktion: Lieblingsorte in der Natur rund um Musterstadt</li>
 </ul>
+`,
+  },
+  {
+    id: 'checkliste',
+    name: 'Checkliste',
+    description: 'Aufgaben mit Häkchen abhaken',
+    icon: '☑️',
+    defaultTitle: 'Neue Checkliste',
+    content: `
+<h1>Checkliste — Vorbereitung Aktionstag</h1>
+
+<h2>Organisation</h2>
+<ul>
+  <li><input type="checkbox">Standort und Genehmigung klären</li>
+  <li><input type="checkbox">Helfer*innen einteilen und Schichtplan erstellen</li>
+  <li><input type="checkbox">Auf- und Abbauzeiten mit der Gemeinde abstimmen</li>
+</ul>
+
+<h2>Material</h2>
+<ul>
+  <li><input type="checkbox">Pavillon / Zelt reservieren</li>
+  <li><input type="checkbox">Flyer und Infomaterial drucken lassen</li>
+  <li><input type="checkbox">Banner und Roll-Ups einpacken</li>
+  <li><input type="checkbox">Tische, Stühle und Klemmbrett organisieren</li>
+</ul>
+
+<h2>Kommunikation</h2>
+<ul>
+  <li><input type="checkbox">Social-Media-Posts vorbereiten und einplanen</li>
+  <li><input type="checkbox">Pressemitteilung verschicken</li>
+  <li><input type="checkbox">Einladung an Mitglieder per E-Mail senden</li>
+</ul>
+
+<h2>Am Tag selbst</h2>
+<ul>
+  <li><input type="checkbox">Aufbau vor Ort</li>
+  <li><input type="checkbox">Fotos und Videos für Social Media machen</li>
+  <li><input type="checkbox">Unterschriftenlisten und Kontaktformulare bereitlegen</li>
+  <li><input type="checkbox">Abbau und Material zurückbringen</li>
+</ul>
+
+<h2>Nachbereitung</h2>
+<ul>
+  <li><input type="checkbox">Fotos sichten und Social-Media-Rückblick posten</li>
+  <li><input type="checkbox">Gesammelte Kontakte in Verteiler übernehmen</li>
+  <li><input type="checkbox">Kurzes Feedback-Gespräch im Team</li>
+</ul>
+`,
+  },
+  {
+    id: 'einladung',
+    name: 'Einladung',
+    description: 'Einladung zu Sitzungen und Versammlungen',
+    icon: '✉️',
+    defaultTitle: 'Neue Einladung',
+    content: `
+<h1>Einladung zur Sitzung des Ortsvorstandes Bad Musterdorf</h1>
+
+<p>Liebe Vorstandsmitglieder,</p>
+
+<p>hiermit lade ich euch herzlich zur nächsten Sitzung des Ortsvorstandes ein:</p>
+
+<p><strong>Datum:</strong> Donnerstag, 19. Juni 2026, 19:00 Uhr<br>
+<strong>Ort:</strong> Grünes Büro, Hauptstr. 12, 12345 Bad Musterdorf<br>
+<strong>Videokonferenz:</strong> Link folgt per E-Mail</p>
+
+<hr>
+
+<h2>Tagesordnung</h2>
+<ol>
+  <li>Begrüßung und Feststellung der Beschlussfähigkeit</li>
+  <li>Genehmigung der Tagesordnung</li>
+  <li>Genehmigung des Protokolls der letzten Sitzung</li>
+  <li>Bericht der Sprecher*innen</li>
+  <li>Bericht aus der Fraktion</li>
+  <li>Vorbereitung der Mitgliederversammlung am 10. Juli</li>
+  <li>Planung Infostand Wochenmarkt</li>
+  <li>Finanzbericht und Haushaltslage</li>
+  <li>Verschiedenes</li>
+</ol>
+
+<hr>
+
+<p>Anträge zur Tagesordnung bitte bis spätestens <strong>17. Juni 2026</strong> an vorstand@gruene-bad-musterdorf.example senden.</p>
+
+<p>Bitte gebt kurz Bescheid, ob ihr teilnehmen könnt.</p>
+
+<p>Grüne Grüße<br>
+Maxi Mustermensch<br>
+<em>Sprecher*in OV Bad Musterdorf</em></p>
 `,
   },
 ];

--- a/services/hocuspocus/src/blockNoteXmlToHtml.ts
+++ b/services/hocuspocus/src/blockNoteXmlToHtml.ts
@@ -13,38 +13,38 @@ const log = createLogger('XmlToHtml');
  *
  * Note: Y.js XmlElement.toString() outputs attributes in alphabetical order,
  * so `level` may not be the first attribute on <heading> elements. The regex
- * uses [^>]* before `level` to handle any preceding attributes.
+ * uses [^<>]* before `level` to handle any preceding attributes.
  */
 export function blockNoteXmlToHtml(xml: string): string {
   let html = xml;
 
   // Strip wrapper elements (may have attributes like id, blockColor)
-  // Split open/close to avoid ReDoS from `\/?` + `[^>]*` ambiguity (CodeQL)
-  html = html.replace(/<blockGroup[^>]*>/g, '');
+  // Split open/close to avoid ReDoS from `\/?` + `[^<>]*` ambiguity (CodeQL)
+  html = html.replace(/<blockGroup[^<>]*>/g, '');
   html = html.replace(/<\/blockGroup>/g, '');
-  html = html.replace(/<blockContainer[^>]*>/g, '');
+  html = html.replace(/<blockContainer[^<>]*>/g, '');
   html = html.replace(/<\/blockContainer>/g, '');
 
   // Convert block elements
   html = html.replace(
-    /<heading\s[^>]*level="(\d)"[^>]*>([\s\S]*?)<\/heading>/g,
+    /<heading\s[^<>]*level="(\d)"[^<>]*>([\s\S]*?)<\/heading>/g,
     (_, level, content) => `<h${level}>${content}</h${level}>`
   );
-  html = html.replace(/<paragraph[^>]*>([\s\S]*?)<\/paragraph>/g, '<p>$1</p>');
+  html = html.replace(/<paragraph[^<>]*>([\s\S]*?)<\/paragraph>/g, '<p>$1</p>');
   html = html.replace(
-    /<bulletListItem[^>]*>([\s\S]*?)<\/bulletListItem>/g,
+    /<bulletListItem[^<>]*>([\s\S]*?)<\/bulletListItem>/g,
     '<li data-list="ul">$1</li>'
   );
   html = html.replace(
-    /<numberedListItem[^>]*>([\s\S]*?)<\/numberedListItem>/g,
+    /<numberedListItem[^<>]*>([\s\S]*?)<\/numberedListItem>/g,
     '<li data-list="ol">$1</li>'
   );
 
   // Convert inline marks
-  html = html.replace(/<bold[^>]*>([\s\S]*?)<\/bold>/g, '<strong>$1</strong>');
-  html = html.replace(/<italic[^>]*>([\s\S]*?)<\/italic>/g, '<em>$1</em>');
-  html = html.replace(/<underline[^>]*>([\s\S]*?)<\/underline>/g, '<u>$1</u>');
-  html = html.replace(/<strike[^>]*>([\s\S]*?)<\/strike>/g, '<s>$1</s>');
+  html = html.replace(/<bold[^<>]*>([\s\S]*?)<\/bold>/g, '<strong>$1</strong>');
+  html = html.replace(/<italic[^<>]*>([\s\S]*?)<\/italic>/g, '<em>$1</em>');
+  html = html.replace(/<underline[^<>]*>([\s\S]*?)<\/underline>/g, '<u>$1</u>');
+  html = html.replace(/<strike[^<>]*>([\s\S]*?)<\/strike>/g, '<s>$1</s>');
 
   // Group consecutive bullet list items into <ul>
   html = html.replace(
@@ -61,7 +61,7 @@ export function blockNoteXmlToHtml(xml: string): string {
   html = html.replace(/\s+/g, ' ').trim();
 
   // Diagnostic logging
-  const headingCount = (html.match(/<h[123][^>]*>/g) || []).length;
+  const headingCount = (html.match(/<h[123][^<>]*>/g) || []).length;
   const unconverted = (html.match(/<heading[\s>]/g) || []).length;
   if (headingCount > 0) {
     log.debug(`[XmlToHtml] Converted ${headingCount} heading(s)`);

--- a/services/hocuspocus/src/blockNoteXmlToHtml.ts
+++ b/services/hocuspocus/src/blockNoteXmlToHtml.ts
@@ -1,0 +1,71 @@
+import { createLogger } from './logger.js';
+
+const log = createLogger('XmlToHtml');
+
+/**
+ * Convert BlockNote's Y.js XML fragment to simple HTML.
+ *
+ * BlockNote uses ProseMirror custom element names:
+ *   <blockGroup><blockContainer><heading level="1">text</heading></blockContainer>
+ *   <blockContainer><paragraph>text</paragraph></blockContainer></blockGroup>
+ *
+ * This converts them to standard HTML tags that browsers can style natively.
+ *
+ * Note: Y.js XmlElement.toString() outputs attributes in alphabetical order,
+ * so `level` may not be the first attribute on <heading> elements. The regex
+ * uses [^>]* before `level` to handle any preceding attributes.
+ */
+export function blockNoteXmlToHtml(xml: string): string {
+  let html = xml;
+
+  // Strip wrapper elements (may have attributes like id, blockColor)
+  html = html.replace(/<\/?blockGroup[^>]*>/g, '');
+  html = html.replace(/<\/?blockContainer[^>]*>/g, '');
+
+  // Convert block elements
+  html = html.replace(
+    /<heading\s[^>]*level="(\d)"[^>]*>([\s\S]*?)<\/heading>/g,
+    (_, level, content) => `<h${level}>${content}</h${level}>`
+  );
+  html = html.replace(/<paragraph[^>]*>([\s\S]*?)<\/paragraph>/g, '<p>$1</p>');
+  html = html.replace(
+    /<bulletListItem[^>]*>([\s\S]*?)<\/bulletListItem>/g,
+    '<li data-list="ul">$1</li>'
+  );
+  html = html.replace(
+    /<numberedListItem[^>]*>([\s\S]*?)<\/numberedListItem>/g,
+    '<li data-list="ol">$1</li>'
+  );
+
+  // Convert inline marks
+  html = html.replace(/<bold[^>]*>([\s\S]*?)<\/bold>/g, '<strong>$1</strong>');
+  html = html.replace(/<italic[^>]*>([\s\S]*?)<\/italic>/g, '<em>$1</em>');
+  html = html.replace(/<underline[^>]*>([\s\S]*?)<\/underline>/g, '<u>$1</u>');
+  html = html.replace(/<strike[^>]*>([\s\S]*?)<\/strike>/g, '<s>$1</s>');
+
+  // Group consecutive bullet list items into <ul>
+  html = html.replace(
+    /(<li data-list="ul">[\s\S]*?<\/li>\s*)+/g,
+    (match) => `<ul>${match.replace(/ data-list="ul"/g, '')}</ul>`
+  );
+  // Group consecutive numbered list items into <ol>
+  html = html.replace(
+    /(<li data-list="ol">[\s\S]*?<\/li>\s*)+/g,
+    (match) => `<ol>${match.replace(/ data-list="ol"/g, '')}</ol>`
+  );
+
+  // Clean up whitespace
+  html = html.replace(/\s+/g, ' ').trim();
+
+  // Diagnostic logging
+  const headingCount = (html.match(/<h[123][^>]*>/g) || []).length;
+  const unconverted = (html.match(/<heading[\s>]/g) || []).length;
+  if (headingCount > 0) {
+    log.debug(`[XmlToHtml] Converted ${headingCount} heading(s)`);
+  }
+  if (unconverted > 0) {
+    log.warn(`[XmlToHtml] ${unconverted} unconverted <heading> tag(s) remain`);
+  }
+
+  return html;
+}

--- a/services/hocuspocus/src/blockNoteXmlToHtml.ts
+++ b/services/hocuspocus/src/blockNoteXmlToHtml.ts
@@ -19,8 +19,11 @@ export function blockNoteXmlToHtml(xml: string): string {
   let html = xml;
 
   // Strip wrapper elements (may have attributes like id, blockColor)
-  html = html.replace(/<\/?blockGroup[^>]*>/g, '');
-  html = html.replace(/<\/?blockContainer[^>]*>/g, '');
+  // Split open/close to avoid ReDoS from `\/?` + `[^>]*` ambiguity (CodeQL)
+  html = html.replace(/<blockGroup[^>]*>/g, '');
+  html = html.replace(/<\/blockGroup>/g, '');
+  html = html.replace(/<blockContainer[^>]*>/g, '');
+  html = html.replace(/<\/blockContainer>/g, '');
 
   // Convert block elements
   html = html.replace(

--- a/services/hocuspocus/src/index.ts
+++ b/services/hocuspocus/src/index.ts
@@ -1,4 +1,5 @@
 // Public API for consumption by @gruenerator/api
+export { blockNoteXmlToHtml } from './blockNoteXmlToHtml.js';
 export { PostgresPersistence } from './persistence.js';
 export { AuthService } from './auth.js';
 export type {

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -3,6 +3,7 @@ import { gzip, gunzip } from 'zlib';
 
 import * as Y from 'yjs';
 
+import { blockNoteXmlToHtml } from './blockNoteXmlToHtml.js';
 import { createLogger } from './logger.js';
 
 import type { DbQueryFn } from './types.js';
@@ -10,60 +11,6 @@ import type { DbQueryFn } from './types.js';
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
 const log = createLogger('PostgresPersistence');
-
-/**
- * Convert BlockNote's Y.js XML fragment to simple HTML for card previews.
- *
- * BlockNote uses ProseMirror custom element names:
- *   <blockGroup><blockContainer><heading level="1">text</heading></blockContainer>
- *   <blockContainer><paragraph>text</paragraph></blockContainer></blockGroup>
- *
- * This converts them to standard HTML tags that the preview CSS already styles.
- */
-function blockNoteXmlToHtml(xml: string): string {
-  let html = xml;
-
-  // Strip wrapper elements (may have attributes like id, blockColor)
-  html = html.replace(/<\/?blockGroup[^>]*>/g, '');
-  html = html.replace(/<\/?blockContainer[^>]*>/g, '');
-
-  // Convert block elements
-  html = html.replace(
-    /<heading\s+level="(\d)"[^>]*>([\s\S]*?)<\/heading>/g,
-    (_, level, content) => `<h${level}>${content}</h${level}>`
-  );
-  html = html.replace(/<paragraph[^>]*>([\s\S]*?)<\/paragraph>/g, '<p>$1</p>');
-  html = html.replace(
-    /<bulletListItem[^>]*>([\s\S]*?)<\/bulletListItem>/g,
-    '<li data-list="ul">$1</li>'
-  );
-  html = html.replace(
-    /<numberedListItem[^>]*>([\s\S]*?)<\/numberedListItem>/g,
-    '<li data-list="ol">$1</li>'
-  );
-
-  // Convert inline marks
-  html = html.replace(/<bold[^>]*>([\s\S]*?)<\/bold>/g, '<strong>$1</strong>');
-  html = html.replace(/<italic[^>]*>([\s\S]*?)<\/italic>/g, '<em>$1</em>');
-  html = html.replace(/<underline[^>]*>([\s\S]*?)<\/underline>/g, '<u>$1</u>');
-  html = html.replace(/<strike[^>]*>([\s\S]*?)<\/strike>/g, '<s>$1</s>');
-
-  // Group consecutive bullet list items into <ul>
-  html = html.replace(
-    /(<li data-list="ul">[\s\S]*?<\/li>\s*)+/g,
-    (match) => `<ul>${match.replace(/ data-list="ul"/g, '')}</ul>`
-  );
-  // Group consecutive numbered list items into <ol>
-  html = html.replace(
-    /(<li data-list="ol">[\s\S]*?<\/li>\s*)+/g,
-    (match) => `<ol>${match.replace(/ data-list="ol"/g, '')}</ol>`
-  );
-
-  // Clean up whitespace
-  html = html.replace(/\s+/g, ' ').trim();
-
-  return html;
-}
 
 const DEFAULT_TITLES = new Set([
   'Neues Dokument',
@@ -274,6 +221,7 @@ export class PostgresPersistence {
     try {
       const fragment = ydoc.getXmlFragment('document-store');
       const xml = fragment.toString();
+      log.debug(`[Preview] Raw XML (first 200): ${xml.slice(0, 200)}`);
 
       // Try HTML conversion first, fall back to plain text
       let preview = blockNoteXmlToHtml(xml).slice(0, 2000);
@@ -344,6 +292,23 @@ export class PostgresPersistence {
     } catch (error) {
       log.debug(`[Backfill] Failed to extract preview for ${documentId}: ${error}`);
       return null;
+    }
+  }
+
+  async backfillAllPreviews(): Promise<void> {
+    try {
+      const docs = await this.db(`SELECT id FROM collaborative_documents WHERE is_deleted = false`);
+      log.info(`[Backfill] Starting preview backfill for ${docs.length} documents`);
+
+      let updated = 0;
+      for (const doc of docs) {
+        const result = await this.extractContentPreview(doc.id as string);
+        if (result) updated++;
+      }
+
+      log.info(`[Backfill] Completed: ${updated}/${docs.length} previews regenerated`);
+    } catch (error) {
+      log.error(`[Backfill] Failed to backfill previews: ${error}`);
     }
   }
 

--- a/services/hocuspocus/src/server.ts
+++ b/services/hocuspocus/src/server.ts
@@ -130,6 +130,11 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
     async onListen() {
       log.info(`Hocuspocus server listening on ${host}:${port}`);
       log.info('WebSocket endpoint: ws://' + host + ':' + port);
+
+      // One-time backfill: regenerate previews with fixed heading conversion
+      persistence.backfillAllPreviews().catch((err) => {
+        log.error(`[Backfill] Error during startup backfill: ${err}`);
+      });
     },
 
     async onStateless(_data) {},


### PR DESCRIPTION
## Summary

- **fix(chat)**: Restructure classifier prompt Step 8 so `needsClarification: false` is the default. Clarification is now the explicit exception (AUSNAHME), only triggered when ALL conditions are met: no conversation history, no topic, can't answer without one. Fixes follow-up messages like "jetzt darauf basierend einen tweet" falsely triggering clarification buttons.
- **feat(docs)**: Add Wolke save button with folder browser and fix document export
- **feat(docs)**: Add Checkliste and Einladung document templates
- **fix(docs)**: Gate document query on auth loading state
- **fix**: Resolve CodeQL ReDoS vulnerability in `blockNoteXmlToHtml.ts` by splitting regex
- **fix(mobile)**: Resolve all 13 React Compiler lint errors (refs during render, Reanimated/expo-video immutability, useCallback dep mismatches, setState-in-effect)
- **docs**: Add WSL RAM constraint note for typechecks in CLAUDE.md

## Test plan

- [ ] Generate a press release, then say "jetzt darauf basierend einen tweet" → should produce tweet directly (no clarification)
- [ ] Fresh conversation, say "Erstelle einen Post" → should still trigger clarification (no history, no topic)
- [ ] Fresh conversation, say "Erstelle einen Post über Klimaschutz" → should NOT trigger clarification (topic is explicit)
- [ ] Verify docs templates (Checkliste, Einladung) render correctly
- [ ] Verify Wolke save button and folder browser work
- [ ] CI passes (lint + CodeQL)