### PR TITLE
Canvas frames, chat thread fix, docs improvements

### DIFF
--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -1,17 +1,21 @@
-import { DocsProvider, ErrorBoundary } from '@gruenerator/docs';
+import { DocsProvider, ErrorBoundary, lazyWithRetry } from '@gruenerator/docs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
 import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import { webDocsAdapter } from './lib/docsAdapter';
 
-const EditorPage = lazy(() =>
+const EditorPage = lazyWithRetry(() =>
   import('./pages/EditorPage').then((m) => ({ default: m.EditorPage }))
 );
-const HomePage = lazy(() => import('./pages/HomePage').then((m) => ({ default: m.HomePage })));
-const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })));
-const SettingsPage = lazy(() =>
+const HomePage = lazyWithRetry(() =>
+  import('./pages/HomePage').then((m) => ({ default: m.HomePage }))
+);
+const LoginPage = lazyWithRetry(() =>
+  import('./pages/LoginPage').then((m) => ({ default: m.LoginPage }))
+);
+const SettingsPage = lazyWithRetry(() =>
   import('./pages/SettingsPage').then((m) => ({ default: m.SettingsPage }))
 );
 

--- a/apps/docs/src/hooks/useAuth.ts
+++ b/apps/docs/src/hooks/useAuth.ts
@@ -20,7 +20,7 @@ interface AuthStatusResponse {
  * Automatically updates auth store when status changes
  */
 export const useAuth = () => {
-  const { user, isAuthenticated, setAuthState, clearAuth } = useAuthStore();
+  const { setAuthState, clearAuth } = useAuthStore();
 
   const {
     data: authData,
@@ -38,7 +38,7 @@ export const useAuth = () => {
     refetchOnWindowFocus: false,
   });
 
-  // Update auth store when data changes
+  // Sync auth store for consumers that read from the store directly
   useEffect(() => {
     if (authData?.isAuthenticated && authData.user) {
       setAuthState({
@@ -49,6 +49,11 @@ export const useAuth = () => {
       clearAuth();
     }
   }, [authData, setAuthState, clearAuth]);
+
+  // Derive auth state directly from query data to avoid the render gap
+  // where isLoading=false but the useEffect hasn't synced the store yet
+  const isAuthenticated = authData?.isAuthenticated ?? false;
+  const user = authData?.user ?? null;
 
   return {
     user,

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -4,12 +4,13 @@ import {
   BlockNoteEditor as BlockNoteEditorComponent,
   useDocsAdapter,
   createDocsApiClient,
+  lazyWithRetry,
   type Document,
 } from '@gruenerator/docs';
 import { EditorTopBar } from '@gruenerator/shared/components/EditorTopBar';
 import { MantineProvider, SegmentedControl, ScrollArea } from '@mantine/core';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FiCloud, FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
@@ -24,8 +25,10 @@ import type { BlockNoteEditor } from '@blocknote/core';
 import '@mantine/core/styles.css';
 import './EditorPage.css';
 
-const ShareModal = lazy(() => import('@gruenerator/docs').then((m) => ({ default: m.ShareModal })));
-const ChatSidebar = lazy(() =>
+const ShareModal = lazyWithRetry(() =>
+  import('@gruenerator/docs').then((m) => ({ default: m.ShareModal }))
+);
+const ChatSidebar = lazyWithRetry(() =>
   import('@gruenerator/docs').then((m) => ({ default: m.ChatSidebar }))
 );
 

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -125,13 +125,17 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
 
   const handleChatClick = useCallback(() => {
     useAgentStore.getState().setPendingNewThread(true);
+    if (location.pathname.startsWith('/chat')) {
+      // Already on chat — just trigger new thread, keep sidebar open
+      return;
+    }
     if (onNavigate) {
       onNavigate('/chat', 'Chat');
     } else {
       navigate('/chat');
     }
     close();
-  }, [navigate, close, onNavigate]);
+  }, [navigate, close, onNavigate, location.pathname]);
 
   const toggleDarkMode = useCallback(() => {
     const newTheme = darkMode ? 'light' : 'dark';

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -442,7 +442,7 @@ const standardRoutes: RouteConfig[] = [
   // Image Studio Routes - KI routes redirect to /imagine
   { path: '/imagine', component: ImaginePage, withForm: true },
   { path: '/imagine/:type', component: ImaginePage, withForm: true },
-  { path: '/image-studio', component: ImageStudioKiRedirect },
+  { path: '/image-studio', component: GrueneratorenBundle.ImageStudio, withForm: true },
   { path: '/image-studio/ki', component: ImageStudioKiRedirect },
   { path: '/image-studio/ki/:type', component: ImageStudioKiTypeRedirect },
   { path: '/image-studio/gallery', component: GrueneratorenBundle.ImageGallery },

--- a/apps/web/src/features/image-studio/canvas-editor/components/CanvasRenderLayer.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/components/CanvasRenderLayer.tsx
@@ -4,6 +4,7 @@ import { CanvasText } from '../primitives';
 import { AssetPrimitive } from '../primitives/AssetPrimitive';
 import { BalkenGroup } from '../primitives/BalkenGroup';
 import { CircleBadge } from '../primitives/CircleBadge';
+import { FramePrimitive } from '../primitives/FramePrimitive';
 import { IconPrimitive } from '../primitives/IconPrimitive';
 import { IllustrationPrimitive } from '../primitives/IllustrationPrimitive';
 import { PillBadge } from '../primitives/PillBadge';
@@ -16,6 +17,7 @@ import type { CanvasElementConfig, FullCanvasConfig, LayoutResult } from '../con
 import type { BalkenInstance, CircleBadgeInstance } from '../primitives';
 import type { AssetInstance } from '../utils/canvasAssets';
 import type { CanvasItem } from '../utils/canvasLayerManager';
+import type { FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { PillBadgeInstance } from '../utils/pillBadgeUtils';
 import type { ShapeInstance } from '../utils/shapes';
@@ -143,6 +145,8 @@ interface CanvasRenderLayerProps<
       scale: number,
       rotation: number
     ) => void;
+    handleFrameChange: (id: string, newAttrs: Partial<FrameInstance>) => void;
+    handleFrameImageUpload: (id: string, file: File, objectUrl: string) => void;
   };
   getSnapTargets: (id: string) => SnapTarget[];
   handleSnapChange: (h: boolean, v: boolean) => void;
@@ -293,6 +297,22 @@ function CanvasRenderLayerInner<
               isSelected={selectedElement === shape.id}
               onSelect={handlers.handleElementSelect}
               onChange={(attrs) => handlers.handleShapeChange(shape.id, attrs)}
+              draggable={true}
+            />
+          );
+        }
+
+        // Render Frame
+        if (item.type === 'frame') {
+          const frame = item.data as unknown as FrameInstance;
+          return (
+            <FramePrimitive
+              key={frame.id}
+              frame={frame}
+              isSelected={selectedElement === frame.id}
+              onSelect={handlers.handleElementSelect}
+              onChange={(attrs) => handlers.handleFrameChange(frame.id, attrs)}
+              onImageUpload={handlers.handleFrameImageUpload}
               draggable={true}
             />
           );

--- a/apps/web/src/features/image-studio/canvas-editor/configs/dreizeilen.types.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/dreizeilen.types.ts
@@ -11,6 +11,7 @@ import type { StockImageAttribution } from '../sidebar/types';
 import type { BalkenMode } from '../utils/balkenUtils';
 import type { AssetInstance } from '../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { PillBadgeInstance } from '../utils/pillBadgeUtils';
 import type { ShapeInstance } from '../utils/shapes';
@@ -89,6 +90,9 @@ export interface DreizeilenFullState {
 
   // === Circle Badge Instances ===
   circleBadgeInstances: CircleBadgeInstance[];
+
+  // === Frame Instances ===
+  frameInstances: FrameInstance[];
 
   // === Layer Ordering ===
   layerOrder: string[];
@@ -188,6 +192,12 @@ export interface DreizeilenFullActions {
   addText: () => void;
   updateAdditionalText: (textId: string, partial: Partial<AdditionalText>) => void;
   removeAdditionalText: (textId: string) => void;
+
+  // === Frame Actions ===
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
 
   // === Layer Actions ===
   moveLayerUp: (itemId: string) => void;

--- a/apps/web/src/features/image-studio/canvas-editor/configs/dreizeilen_full.config.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/dreizeilen_full.config.tsx
@@ -32,6 +32,7 @@ import {
   createPillBadgeActions,
   createCircleBadgeActions,
   createBalkenActions,
+  createFrameActions,
 } from './factory/commonActions';
 import { injectFeatureProps } from './featureInjector';
 import { PLACEHOLDER_TEXT } from './placeholders';
@@ -423,6 +424,7 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
     // Pill Badge & Circle Badge Instances
     pillBadgeInstances: (props.pillBadgeInstances as PillBadgeInstance[] | undefined) ?? [],
     circleBadgeInstances: (props.circleBadgeInstances as CircleBadgeInstance[] | undefined) ?? [],
+    frameInstances: [],
 
     // Layer Ordering
     layerOrder: (props.layerOrder as string[] | undefined) ?? [],
@@ -504,6 +506,14 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
       debouncedSaveToHistory
     );
 
+    const frameActions = createFrameActions(
+      getState,
+      setState,
+      saveToHistory,
+      DREIZEILEN_CONFIG.canvas.width,
+      DREIZEILEN_CONFIG.canvas.height
+    );
+
     return {
       // === Spread common actions ===
       ...assetActions,
@@ -513,6 +523,7 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
       ...pillBadgeActions,
       ...circleBadgeActions,
       ...genericBalkenActions,
+      ...frameActions,
 
       // === Text Actions ===
       setLine1: (text: string) => {

--- a/apps/web/src/features/image-studio/canvas-editor/configs/factory/baseTypes.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/factory/baseTypes.ts
@@ -9,6 +9,7 @@ import type { StockImageAttribution } from '../../../services/imageSourceService
 import type { BalkenInstance, BalkenMode } from '../../utils/balkenUtils';
 import type { AssetInstance } from '../../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../../utils/frameUtils';
 import type { IllustrationInstance } from '../../utils/illustrations/types';
 import type { PillBadgeInstance } from '../../utils/pillBadgeUtils';
 import type { ShapeInstance, ShapeType } from '../../utils/shapes';
@@ -37,6 +38,7 @@ export interface BaseCanvasState {
   pillBadgeInstances: PillBadgeInstance[];
   circleBadgeInstances: CircleBadgeInstance[];
   balkenInstances: BalkenInstance[];
+  frameInstances: FrameInstance[];
   [key: string]: unknown;
 }
 
@@ -127,6 +129,12 @@ export interface BaseCanvasActions {
   updateBalken: (id: string, partial: Partial<BalkenInstance>) => void;
   removeBalken: (id: string) => void;
 
+  // Frame management
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
+
   // Alternatives
   handleSelectAlternative: (alt: AlternativeItem) => void;
 }
@@ -164,6 +172,7 @@ export interface CanvasFeatures {
   balken?: boolean;
   pillBadge?: boolean;
   circleBadge?: boolean;
+  frames?: boolean;
 }
 
 /** Canvas dimension configuration */

--- a/apps/web/src/features/image-studio/canvas-editor/configs/factory/commonActions.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/factory/commonActions.ts
@@ -10,6 +10,7 @@ import { v4 as uuid } from 'uuid';
 import { createBalkenInstanceFromPreset } from '../../utils/balkenUtils';
 import { createAssetInstance } from '../../utils/canvasAssets';
 import { createCircleBadgeInstance } from '../../utils/circleBadgeUtils';
+import { createFrameInstance } from '../../utils/frameUtils';
 import { createIllustration } from '../../utils/illustrations/registry';
 import { createPillBadgeInstance } from '../../utils/pillBadgeUtils';
 import { BRAND_COLORS, createShape } from '../../utils/shapes';
@@ -18,6 +19,7 @@ import type { IconState, BaseCanvasState } from './baseTypes';
 import type { BalkenInstance, BalkenMode } from '../../utils/balkenUtils';
 import type { AssetInstance } from '../../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../../utils/frameUtils';
 import type { IllustrationInstance } from '../../utils/illustrations/types';
 import type { PillBadgeInstance } from '../../utils/pillBadgeUtils';
 import type { ShapeInstance, ShapeType } from '../../utils/shapes';
@@ -468,6 +470,61 @@ export function createBalkenActions<TState extends { balkenInstances: BalkenInst
 }
 
 // ============================================================================
+// FRAME ACTIONS
+// ============================================================================
+
+export function createFrameActions<TState extends { frameInstances: FrameInstance[] }>(
+  getState: () => TState,
+  setState: StateSetter<TState>,
+  saveToHistory: HistorySaver<TState>,
+  canvasWidth: number,
+  canvasHeight: number
+) {
+  return {
+    addFrame: (clipType: FrameClipType) => {
+      const newFrame = createFrameInstance(clipType, canvasWidth / 2, canvasHeight / 2);
+      setState((prev) => ({
+        ...prev,
+        frameInstances: [...prev.frameInstances, newFrame],
+      }));
+      saveToHistory(getState());
+    },
+    updateFrame: (id: string, partial: Partial<FrameInstance>) => {
+      setState((prev) => ({
+        ...prev,
+        frameInstances: prev.frameInstances.map((f) => (f.id === id ? { ...f, ...partial } : f)),
+      }));
+    },
+    removeFrame: (id: string) => {
+      const frame = getState().frameInstances.find((f) => f.id === id);
+      if (frame?.imageSrc) {
+        URL.revokeObjectURL(frame.imageSrc);
+      }
+      setState((prev) => ({
+        ...prev,
+        frameInstances: prev.frameInstances.filter((f) => f.id !== id),
+      }));
+      saveToHistory(getState());
+    },
+    setFrameImage: (id: string, _file: File, objectUrl: string) => {
+      const oldFrame = getState().frameInstances.find((f) => f.id === id);
+      if (oldFrame?.imageSrc) {
+        URL.revokeObjectURL(oldFrame.imageSrc);
+      }
+      setState((prev) => ({
+        ...prev,
+        frameInstances: prev.frameInstances.map((f) =>
+          f.id === id
+            ? { ...f, imageSrc: objectUrl, imageOffsetX: 0, imageOffsetY: 0, imageScale: 1 }
+            : f
+        ),
+      }));
+      saveToHistory(getState());
+    },
+  };
+}
+
+// ============================================================================
 // COMBINED BASE ACTIONS
 // ============================================================================
 
@@ -510,5 +567,6 @@ export function createBaseActions<TState extends BaseCanvasState>(
     ...createPillBadgeActions(getState, setState, saveToHistory, debouncedSaveToHistory),
     ...createCircleBadgeActions(getState, setState, saveToHistory, debouncedSaveToHistory),
     ...createBalkenActions(getState, setState, saveToHistory, debouncedSaveToHistory),
+    ...createFrameActions(getState, setState, saveToHistory, canvasWidth, canvasHeight),
   };
 }

--- a/apps/web/src/features/image-studio/canvas-editor/configs/factory/createColorTwoTextCanvas.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/factory/createColorTwoTextCanvas.ts
@@ -30,6 +30,7 @@ import type { BackgroundColorOption } from '../../sidebar/types';
 import type { BalkenInstance, BalkenMode } from '../../utils/balkenUtils';
 import type { AssetInstance } from '../../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../../utils/frameUtils';
 import type { IllustrationInstance } from '../../utils/illustrations/types';
 import type { PillBadgeInstance } from '../../utils/pillBadgeUtils';
 import type { ShapeInstance, ShapeType } from '../../utils/shapes';
@@ -66,6 +67,7 @@ export interface ColorTwoTextState {
   pillBadgeInstances: PillBadgeInstance[];
   circleBadgeInstances: CircleBadgeInstance[];
   balkenInstances: BalkenInstance[];
+  frameInstances: FrameInstance[];
 }
 
 // ============================================================================
@@ -107,6 +109,10 @@ export interface ColorTwoTextActions {
   addBalken: (mode: BalkenMode) => void;
   updateBalken: (id: string, partial: Partial<BalkenInstance>) => void;
   removeBalken: (id: string) => void;
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
   handleSelectAlternative: (alt: string) => void;
 }
 
@@ -323,6 +329,7 @@ export function createColorTwoTextCanvas(
       pillBadgeInstances: [],
       circleBadgeInstances: [],
       balkenInstances: [],
+      frameInstances: [],
     }),
 
     createActions: (getState, setState, saveToHistory, debouncedSaveToHistory, callbacks) => {

--- a/apps/web/src/features/image-studio/canvas-editor/configs/factory/createImageTwoTextCanvas.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/factory/createImageTwoTextCanvas.ts
@@ -29,6 +29,7 @@ import type { StockImageAttribution } from '../../../services/imageSourceService
 import type { BalkenInstance, BalkenMode } from '../../utils/balkenUtils';
 import type { AssetInstance } from '../../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../../utils/frameUtils';
 import type { IllustrationInstance } from '../../utils/illustrations/types';
 import type { PillBadgeInstance } from '../../utils/pillBadgeUtils';
 import type { ShapeInstance, ShapeType } from '../../utils/shapes';
@@ -71,6 +72,7 @@ export interface ImageTwoTextState {
   pillBadgeInstances: PillBadgeInstance[];
   circleBadgeInstances: CircleBadgeInstance[];
   balkenInstances: BalkenInstance[];
+  frameInstances: FrameInstance[];
 }
 
 // ============================================================================
@@ -115,6 +117,10 @@ export interface ImageTwoTextActions {
   addBalken: (mode: BalkenMode) => void;
   updateBalken: (id: string, partial: Partial<BalkenInstance>) => void;
   removeBalken: (id: string) => void;
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
   handleSelectAlternative: (alt: AlternativeItem) => void;
 }
 
@@ -349,6 +355,7 @@ export function createImageTwoTextCanvas(
       pillBadgeInstances: [],
       circleBadgeInstances: [],
       balkenInstances: [],
+      frameInstances: [],
     }),
 
     createActions: (getState, setState, saveToHistory, debouncedSaveToHistory, callbacks) => {

--- a/apps/web/src/features/image-studio/canvas-editor/configs/featureInjector.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/featureInjector.ts
@@ -17,6 +17,7 @@ import type { SectionContext } from './types';
 import type { BalkenInstance } from '../primitives/BalkenGroup';
 import type { CircleBadgeInstance } from '../primitives/CircleBadge';
 import type { ExtendedAssetsSectionProps } from '../sidebar/sections/AssetsSection';
+import type { FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { PillBadgeInstance } from '../utils/pillBadgeUtils';
 import type { ShapeInstance } from '../utils/shapes';
@@ -44,6 +45,10 @@ interface FeatureStateWithPillBadge {
 
 interface FeatureStateWithCircleBadge {
   circleBadgeInstances?: CircleBadgeInstance[];
+}
+
+interface FeatureStateWithFrames {
+  frameInstances?: FrameInstance[];
 }
 
 interface FeatureActionsBase {
@@ -190,6 +195,22 @@ export function injectFeatureProps<S extends object, A extends object>(
 
     if ('removeCircleBadge' in actions) {
       injected.onRemoveCircleBadge = actions.removeCircleBadge as (id: string) => void;
+    }
+  }
+
+  // === FRAME FEATURE ===
+  // Convention: state.frameInstances + actions.addFrame/updateFrame/removeFrame
+  if ('frameInstances' in state && 'addFrame' in actions) {
+    const stateWithFrames = state as FeatureStateWithFrames;
+    injected.frameInstances = stateWithFrames.frameInstances;
+    injected.onAddFrame = actions.addFrame as (clipType: string) => void;
+
+    if ('updateFrame' in actions) {
+      injected.onUpdateFrame = actions.updateFrame as (id: string, partial: unknown) => void;
+    }
+
+    if ('removeFrame' in actions) {
+      injected.onRemoveFrame = actions.removeFrame as (id: string) => void;
     }
   }
 

--- a/apps/web/src/features/image-studio/canvas-editor/configs/slider_full.config.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/slider_full.config.tsx
@@ -34,6 +34,7 @@ import type { BackgroundColorOption } from '../sidebar/types';
 import type { BalkenInstance, BalkenMode } from '../utils/balkenUtils';
 import type { AssetInstance } from '../utils/canvasAssets';
 import type { CircleBadgeInstance } from '../utils/circleBadgeUtils';
+import type { FrameClipType, FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { ShapeInstance } from '../utils/shapes';
 import type { BaseCanvasState, IconState } from './factory/baseTypes';
@@ -80,9 +81,10 @@ export interface SliderState extends BaseCanvasState {
   // Pill badge instances (dynamic, editable)
   pillBadgeInstances: PillBadgeInstance[];
 
-  // Circle badge and balken instances
+  // Circle badge, balken, and frame instances
   circleBadgeInstances: CircleBadgeInstance[];
   balkenInstances: BalkenInstance[];
+  frameInstances: FrameInstance[];
 
   // Base state (from BaseCanvasState)
   assetInstances: AssetInstance[];
@@ -130,6 +132,12 @@ export interface SliderActions {
   addBalken: (mode: BalkenMode) => void;
   updateBalken: (id: string, partial: Partial<BalkenInstance>) => void;
   removeBalken: (id: string) => void;
+
+  // Frame actions
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
 
   // Base actions
   addAsset: (assetId: string) => void;
@@ -475,9 +483,10 @@ export const sliderFullConfig: FullCanvasConfig<SliderState, SliderActions> = {
       // Pill badge instances
       pillBadgeInstances: initialPillBadge,
 
-      // Circle badge and balken instances
+      // Circle badge, balken, and frame instances
       circleBadgeInstances: [],
       balkenInstances: [],
+      frameInstances: [],
 
       // Base state
       assetInstances: [],

--- a/apps/web/src/features/image-studio/canvas-editor/configs/veranstaltung_full.config.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/configs/veranstaltung_full.config.tsx
@@ -23,6 +23,7 @@ import {
   createPillBadgeActions,
   createBalkenActions,
   createCircleBadgeActions,
+  createFrameActions,
 } from './factory/commonActions';
 import { injectFeatureProps } from './featureInjector';
 import { PLACEHOLDER_TEXT } from './placeholders';
@@ -32,6 +33,7 @@ import type { StockImageAttribution } from '../../services/imageSourceService';
 import type { CircleBadgeInstance, CircleBadgeTextLine } from '../primitives';
 import type { FullCanvasConfig, LayoutResult, AdditionalText } from './types';
 import type { BalkenInstance, BalkenMode } from '../utils/balkenUtils';
+import type { FrameClipType, FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { PillBadgeInstance } from '../utils/pillBadgeUtils';
 import type { ShapeInstance, ShapeType } from '../utils/shapes';
@@ -78,6 +80,8 @@ export interface VeranstaltungFullState {
   pillBadgeInstances: PillBadgeInstance[];
   // Balken instances
   balkenInstances: BalkenInstance[];
+  // Frame instances
+  frameInstances: FrameInstance[];
   // Attribution
   imageAttribution?: StockImageAttribution | null;
 
@@ -139,6 +143,11 @@ export interface VeranstaltungFullActions {
   addBalken: (mode: BalkenMode) => void;
   updateBalken: (id: string, partial: Partial<BalkenInstance>) => void;
   removeBalken: (id: string) => void;
+  // Frame actions
+  addFrame: (clipType: FrameClipType) => void;
+  updateFrame: (id: string, partial: Partial<FrameInstance>) => void;
+  removeFrame: (id: string) => void;
+  setFrameImage: (id: string, file: File, objectUrl: string) => void;
 }
 
 // ============================================================================
@@ -470,6 +479,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       circleBadgeInstances: [createInitialDateCircleBadge(weekday, date, time)],
       pillBadgeInstances: [],
       balkenInstances: [],
+      frameInstances: [],
       imageAttribution: null,
     };
   },
@@ -535,6 +545,14 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       debouncedSaveToHistory
     );
 
+    const frameActions = createFrameActions(
+      getState,
+      setState,
+      saveToHistory,
+      CANVAS_WIDTH,
+      CANVAS_HEIGHT
+    );
+
     return {
       // === Spread common actions ===
       ...assetActions,
@@ -544,6 +562,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       ...circleBadgeActions,
       ...pillBadgeActions,
       ...balkenActions,
+      ...frameActions,
 
       // === Text Actions ===
       setEventTitle: (val: string) => {

--- a/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasElementHandlers.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasElementHandlers.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { resolveValue } from '../utils/canvasValueResolver';
 
 import type { FullCanvasConfig, LayoutResult, AdditionalText } from '../configs/types';
+import type { FrameInstance } from '../utils/frameUtils';
 import type { ShapeInstance } from '../utils/shapes';
 
 /**
@@ -74,6 +75,8 @@ export interface OptionalCanvasActions {
     id: string,
     attrs: Partial<{ x: number; y: number; scale?: number; rotation?: number; text?: string }>
   ) => void;
+  updateFrame?: (id: string, attrs: Partial<FrameInstance>) => void;
+  setFrameImage?: (id: string, file: File, objectUrl: string) => void;
 }
 
 export interface UseCanvasElementHandlersOptions<
@@ -154,6 +157,8 @@ export interface UseCanvasElementHandlersResult {
     scale: number,
     rotation: number
   ) => void;
+  handleFrameChange: (id: string, newAttrs: Partial<FrameInstance>) => void;
+  handleFrameImageUpload: (id: string, file: File, objectUrl: string) => void;
 }
 
 /**
@@ -480,6 +485,24 @@ export function useCanvasElementHandlers<
     [actions]
   );
 
+  const handleFrameChange = useCallback(
+    (id: string, newAttrs: Partial<FrameInstance>) => {
+      if (actions.updateFrame) {
+        actions.updateFrame(id, newAttrs);
+      }
+    },
+    [actions]
+  );
+
+  const handleFrameImageUpload = useCallback(
+    (id: string, file: File, objectUrl: string) => {
+      if (actions.setFrameImage) {
+        actions.setFrameImage(id, file, objectUrl);
+      }
+    },
+    [actions]
+  );
+
   return {
     handleElementSelect,
     handleTextChange,
@@ -506,5 +529,7 @@ export function useCanvasElementHandlers<
     handleAssetTransformEnd,
     handleIllustrationDragEnd,
     handleIllustrationTransformEnd,
+    handleFrameChange,
+    handleFrameImageUpload,
   };
 }

--- a/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasKeyboardHandlers.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasKeyboardHandlers.ts
@@ -24,6 +24,7 @@ export interface CanvasActions {
   removeIllustration?: (id: string) => void;
   removeAsset?: (id: string) => void;
   removePillBadge?: (id: string) => void;
+  removeFrame?: (id: string) => void;
 }
 
 export interface UseCanvasKeyboardHandlersOptions<TState> {
@@ -125,6 +126,17 @@ export function useCanvasKeyboardHandlers<TState>(
             };
             const existing = getStateArray<unknown>(prevState, 'pillBadgeInstances');
             (newState as Record<string, unknown>).pillBadgeInstances = [...existing, newPill];
+          } else if (type === 'frame' && typeof data === 'object' && data !== null) {
+            const frameData = data as { x: number; y: number; imageSrc?: string | null };
+            const newFrame = {
+              ...frameData,
+              id: newId,
+              x: frameData.x + offset,
+              y: frameData.y + offset,
+              imageSrc: null, // Don't share object URL references
+            };
+            const existing = getStateArray<unknown>(prevState, 'frameInstances');
+            (newState as Record<string, unknown>).frameInstances = [...existing, newFrame];
           }
 
           return newState as TState;
@@ -186,6 +198,16 @@ export function useCanvasKeyboardHandlers<TState>(
         });
         if (pillBadge) {
           CanvasClipboard.copy('pill-badge', pillBadge);
+          return;
+        }
+
+        const frames = getStateArray<unknown>(state, 'frameInstances');
+        const frame = frames.find((f: unknown) => {
+          const frameObj = f as { id?: string };
+          return frameObj.id === selectedElement;
+        });
+        if (frame) {
+          CanvasClipboard.copy('frame', frame);
           return;
         }
 
@@ -277,6 +299,21 @@ export function useCanvasKeyboardHandlers<TState>(
         ) {
           if (actions.removePillBadge) {
             actions.removePillBadge(selectedElement);
+            setSelectedElement(null);
+            return;
+          }
+        }
+
+        // Remove Frame
+        const frameInstances = getStateArray<unknown>(state, 'frameInstances');
+        if (
+          frameInstances.find((f: unknown) => {
+            const frameObj = f as { id?: string };
+            return frameObj.id === selectedElement;
+          })
+        ) {
+          if (actions.removeFrame) {
+            actions.removeFrame(selectedElement);
             setSelectedElement(null);
             return;
           }

--- a/apps/web/src/features/image-studio/canvas-editor/hooks/useFloatingModuleState.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/hooks/useFloatingModuleState.ts
@@ -5,6 +5,7 @@ import { resolveValue } from '../utils/canvasValueResolver';
 import type { FullCanvasConfig, LayoutResult } from '../configs/types';
 import type { BalkenInstance } from '../primitives';
 import type { AssetInstance } from '../utils/canvasAssets';
+import type { FrameInstance } from '../utils/frameUtils';
 import type { IllustrationInstance } from '../utils/illustrations/types';
 import type { ShapeInstance } from '../utils/shapes';
 
@@ -16,7 +17,16 @@ import type { ShapeInstance } from '../utils/shapes';
  */
 
 export interface FloatingModuleState {
-  type: 'text' | 'image' | 'shape' | 'icon' | 'illustration' | 'asset' | 'background' | 'balken';
+  type:
+    | 'text'
+    | 'image'
+    | 'shape'
+    | 'icon'
+    | 'illustration'
+    | 'asset'
+    | 'background'
+    | 'balken'
+    | 'frame';
   data: {
     id: string;
     fontSize?: number;
@@ -265,6 +275,16 @@ export function useFloatingModuleState<
       return {
         type: 'illustration' as const,
         data: { ...illustration, id: selectedElement },
+      };
+    }
+
+    // Check if Frame
+    const frameInstances = getStateArray<FrameInstance>(state, 'frameInstances');
+    const frame = frameInstances.find((f) => f.id === selectedElement);
+    if (frame) {
+      return {
+        type: 'frame' as const,
+        data: { ...frame, id: selectedElement },
       };
     }
 

--- a/apps/web/src/features/image-studio/canvas-editor/primitives/FramePrimitive.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/primitives/FramePrimitive.tsx
@@ -1,0 +1,299 @@
+import React, { useRef, useEffect, useState, useCallback, memo } from 'react';
+import { Group, Image as KonvaImage, Shape, Transformer, Text, Rect } from 'react-konva';
+
+import type { FrameInstance } from '../utils/frameUtils';
+import type Konva from 'konva';
+import type { SceneContext } from 'konva/lib/Context';
+
+export interface FramePrimitiveProps {
+  frame: FrameInstance;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  onChange: (newAttrs: Partial<FrameInstance>) => void;
+  onImageUpload: (id: string, file: File, objectUrl: string) => void;
+  draggable?: boolean;
+}
+
+function FramePrimitiveInner({
+  frame,
+  isSelected,
+  onSelect,
+  onChange,
+  onImageUpload,
+  draggable = true,
+}: FramePrimitiveProps) {
+  const groupRef = useRef<Konva.Group>(null);
+  const trRef = useRef<Konva.Transformer>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+  const [imageNaturalSize, setImageNaturalSize] = useState({ width: 0, height: 0 });
+
+  // Load image when imageSrc changes
+  useEffect(() => {
+    if (!frame.imageSrc) {
+      setImage(null);
+      return;
+    }
+
+    const img = new window.Image();
+    img.crossOrigin = 'anonymous';
+    img.src = frame.imageSrc;
+    img.onload = () => {
+      setImage(img);
+      setImageNaturalSize({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+  }, [frame.imageSrc]);
+
+  // Attach transformer when selected
+  useEffect(() => {
+    if (isSelected && trRef.current && groupRef.current) {
+      trRef.current.nodes([groupRef.current]);
+      trRef.current.getLayer()?.batchDraw();
+    }
+  }, [isSelected]);
+
+  // Create hidden file input on first render
+  useEffect(() => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.style.display = 'none';
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      if (file) {
+        const objectUrl = URL.createObjectURL(file);
+        onImageUpload(frame.id, file, objectUrl);
+      }
+      input.value = '';
+    });
+    document.body.appendChild(input);
+    fileInputRef.current = input;
+
+    return () => {
+      document.body.removeChild(input);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frame.id]);
+
+  const handleDblClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (e: Konva.KonvaEventObject<DragEvent>) => {
+      onChange({ x: e.target.x(), y: e.target.y() });
+    },
+    [onChange]
+  );
+
+  const handleTransformEnd = useCallback(() => {
+    const node = groupRef.current;
+    if (!node) return;
+
+    onChange({
+      x: node.x(),
+      y: node.y(),
+      rotation: node.rotation(),
+      scaleX: node.scaleX(),
+      scaleY: node.scaleY(),
+    });
+  }, [onChange]);
+
+  const handleSelect = useCallback(
+    (e: Konva.KonvaEventObject<MouseEvent | TouchEvent>) => {
+      e.cancelBubble = true;
+      onSelect(frame.id);
+    },
+    [onSelect, frame.id]
+  );
+
+  const { width: w, height: h } = frame;
+
+  // Clip function based on frame type
+  const clipFunc = useCallback(
+    (ctx: SceneContext) => {
+      if (frame.clipType === 'circle') {
+        const radius = Math.min(w, h) / 2;
+        ctx.arc(w / 2, h / 2, radius, 0, Math.PI * 2);
+      } else {
+        const r = frame.cornerRadius;
+        ctx.moveTo(r, 0);
+        ctx.arcTo(w, 0, w, h, r);
+        ctx.arcTo(w, h, 0, h, r);
+        ctx.arcTo(0, h, 0, 0, r);
+        ctx.arcTo(0, 0, w, 0, r);
+        ctx.closePath();
+      }
+    },
+    [frame.clipType, frame.cornerRadius, w, h]
+  );
+
+  // Cover-fit math for image inside frame
+  let imgX = 0;
+  let imgY = 0;
+  let scaledW = w;
+  let scaledH = h;
+
+  if (image && imageNaturalSize.width > 0 && imageNaturalSize.height > 0) {
+    const coverScale =
+      Math.max(w / imageNaturalSize.width, h / imageNaturalSize.height) * frame.imageScale;
+    scaledW = imageNaturalSize.width * coverScale;
+    scaledH = imageNaturalSize.height * coverScale;
+    imgX = (w - scaledW) / 2 + frame.imageOffsetX;
+    imgY = (h - scaledH) / 2 + frame.imageOffsetY;
+  }
+
+  return (
+    <>
+      <Group
+        ref={groupRef}
+        x={frame.x}
+        y={frame.y}
+        width={w}
+        height={h}
+        rotation={frame.rotation}
+        scaleX={frame.scaleX}
+        scaleY={frame.scaleY}
+        opacity={frame.opacity}
+        offsetX={w / 2}
+        offsetY={h / 2}
+        draggable={draggable}
+        onClick={handleSelect}
+        onTap={handleSelect}
+        onDblClick={handleDblClick}
+        onDblTap={handleDblClick}
+        onDragEnd={handleDragEnd}
+        onTransformEnd={handleTransformEnd}
+        name={`frame-${frame.id}`}
+      >
+        {/* Clipped image area */}
+        <Group clipFunc={clipFunc} clipX={0} clipY={0} clipWidth={w} clipHeight={h}>
+          {image ? (
+            <KonvaImage
+              image={image}
+              x={imgX}
+              y={imgY}
+              width={scaledW}
+              height={scaledH}
+              listening={false}
+            />
+          ) : (
+            <>
+              {/* Empty placeholder background */}
+              <Rect x={0} y={0} width={w} height={h} fill="#f0f0f0" listening={false} />
+              <Text
+                text="Doppelklick\num Bild\nhinzuzufuegen"
+                x={0}
+                y={h / 2 - 30}
+                width={w}
+                align="center"
+                fontSize={16}
+                fill="#999999"
+                listening={false}
+              />
+            </>
+          )}
+        </Group>
+
+        {/* Border stroke (outside clip) */}
+        {frame.borderWidth > 0 && (
+          <Shape
+            sceneFunc={(ctx, shape) => {
+              ctx.beginPath();
+              if (frame.clipType === 'circle') {
+                const radius = Math.min(w, h) / 2;
+                ctx.arc(w / 2, h / 2, radius, 0, Math.PI * 2);
+              } else {
+                const r = frame.cornerRadius;
+                ctx.moveTo(r, 0);
+                ctx.arcTo(w, 0, w, h, r);
+                ctx.arcTo(w, h, 0, h, r);
+                ctx.arcTo(0, h, 0, 0, r);
+                ctx.arcTo(0, 0, w, 0, r);
+                ctx.closePath();
+              }
+              ctx.fillStrokeShape(shape);
+            }}
+            stroke={frame.borderColor}
+            strokeWidth={frame.borderWidth}
+            listening={false}
+          />
+        )}
+
+        {/* Dashed border for empty frames */}
+        {!frame.imageSrc && (
+          <Shape
+            sceneFunc={(ctx, shape) => {
+              ctx.beginPath();
+              if (frame.clipType === 'circle') {
+                const radius = Math.min(w, h) / 2;
+                ctx.arc(w / 2, h / 2, radius, 0, Math.PI * 2);
+              } else {
+                const r = frame.cornerRadius;
+                ctx.moveTo(r, 0);
+                ctx.arcTo(w, 0, w, h, r);
+                ctx.arcTo(w, h, 0, h, r);
+                ctx.arcTo(0, h, 0, 0, r);
+                ctx.arcTo(0, 0, w, 0, r);
+                ctx.closePath();
+              }
+              ctx.fillStrokeShape(shape);
+            }}
+            stroke="#999999"
+            strokeWidth={2}
+            dash={[8, 6]}
+            listening={false}
+          />
+        )}
+      </Group>
+
+      {isSelected && (
+        <Transformer
+          ref={trRef}
+          boundBoxFunc={(oldBox, newBox) => {
+            if (newBox.width < 20 || newBox.height < 20) {
+              return oldBox;
+            }
+            return newBox;
+          }}
+          anchorSize={10}
+          anchorCornerRadius={5}
+          rotateEnabled={true}
+          borderStroke="#005437"
+          anchorStroke="#005437"
+          anchorFill="#ffffff"
+        />
+      )}
+    </>
+  );
+}
+
+export const FramePrimitive = memo(FramePrimitiveInner, (prevProps, nextProps) => {
+  const prev = prevProps.frame;
+  const next = nextProps.frame;
+
+  if (prev.id !== next.id) return false;
+  if (prev.clipType !== next.clipType) return false;
+  if (prev.x !== next.x) return false;
+  if (prev.y !== next.y) return false;
+  if (prev.width !== next.width) return false;
+  if (prev.height !== next.height) return false;
+  if (prev.rotation !== next.rotation) return false;
+  if (prev.scaleX !== next.scaleX) return false;
+  if (prev.scaleY !== next.scaleY) return false;
+  if (prev.opacity !== next.opacity) return false;
+  if (prev.imageSrc !== next.imageSrc) return false;
+  if (prev.imageOffsetX !== next.imageOffsetX) return false;
+  if (prev.imageOffsetY !== next.imageOffsetY) return false;
+  if (prev.imageScale !== next.imageScale) return false;
+  if (prev.borderColor !== next.borderColor) return false;
+  if (prev.borderWidth !== next.borderWidth) return false;
+  if (prev.cornerRadius !== next.cornerRadius) return false;
+
+  if (prevProps.isSelected !== nextProps.isSelected) return false;
+  if (prevProps.draggable !== nextProps.draggable) return false;
+
+  return true;
+});
+
+FramePrimitive.displayName = 'FramePrimitive';

--- a/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/AssetsSection.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/AssetsSection.tsx
@@ -33,6 +33,7 @@ import { IconsSection } from './IconsSection';
 import { IllustrationenSection } from './IllustrationenSection';
 
 import type { BalkenInstance, BalkenMode } from '../../primitives';
+import type { FrameClipType, FrameInstance } from '../../utils/frameUtils';
 import type {
   IllustrationInstance,
   IllustrationDef,
@@ -332,6 +333,12 @@ export interface ExtendedAssetsSectionProps {
   onUpdateIllustration?: (id: string, partial: Partial<IllustrationInstance>) => void;
   onRemoveIllustration?: (id: string) => void;
   onDuplicateIllustration?: (id: string) => void;
+
+  // Frame props
+  frameInstances?: FrameInstance[];
+  onAddFrame?: (clipType: FrameClipType) => void;
+  onUpdateFrame?: (id: string, partial: Partial<FrameInstance>) => void;
+  onRemoveFrame?: (id: string) => void;
 }
 
 export function AssetsSection({
@@ -371,6 +378,7 @@ export function AssetsSection({
   onUpdateIllustration,
   onRemoveIllustration,
   onDuplicateIllustration,
+  onAddFrame,
 }: ExtendedAssetsSectionProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedQuery = useDebounce(searchQuery, 300);
@@ -650,6 +658,7 @@ export function AssetsSection({
             onAddPillBadge={onAddPillBadge}
             onAddCircleBadge={onAddCircleBadge}
             onAddBalken={onAddBalken}
+            onAddFrame={onAddFrame}
           />
         </>
       ),

--- a/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/FormenSection.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/FormenSection.tsx
@@ -6,6 +6,7 @@ import {
   PiArrowRightBold,
   PiTagFill,
   PiCircleFill,
+  PiFrameCornersFill,
 } from 'react-icons/pi';
 
 import { BalkenIcon } from '../../icons';
@@ -13,6 +14,7 @@ import { type ShapeType } from '../../utils/shapes';
 import './FormenSection.css';
 
 import type { BalkenMode } from '../../primitives/BalkenGroup';
+import type { FrameClipType } from '../../utils/frameUtils';
 
 export interface FormenSectionProps {
   onAddShape: (type: ShapeType) => void;
@@ -20,6 +22,7 @@ export interface FormenSectionProps {
   onAddPillBadge?: (preset?: string) => void;
   onAddCircleBadge?: (preset?: string) => void;
   onAddBalken?: (mode: BalkenMode) => void;
+  onAddFrame?: (clipType: FrameClipType) => void;
 }
 
 interface ShapeDefinition {
@@ -56,6 +59,7 @@ export function FormenSection({
   onAddPillBadge,
   onAddCircleBadge,
   onAddBalken,
+  onAddFrame,
 }: FormenSectionProps) {
   const visibleShapes = isExpanded ? SHAPES : SHAPES.slice(0, 4);
 
@@ -72,6 +76,38 @@ export function FormenSection({
             <div className="sidebar-selectable-card__preview">{shape.renderPreview()}</div>
           </button>
         ))}
+
+        {onAddFrame && (
+          <>
+            <button
+              key="frame-circle"
+              className="sidebar-selectable-card"
+              onClick={() => onAddFrame('circle')}
+              title="Kreisrahmen hinzufuegen"
+            >
+              <div className="sidebar-selectable-card__preview">
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: '50%',
+                    border: '2px dashed #005538',
+                  }}
+                />
+              </div>
+            </button>
+            <button
+              key="frame-rounded-rect"
+              className="sidebar-selectable-card"
+              onClick={() => onAddFrame('rounded-rect')}
+              title="Rechteckrahmen hinzufuegen"
+            >
+              <div className="sidebar-selectable-card__preview">
+                <PiFrameCornersFill size={24} />
+              </div>
+            </button>
+          </>
+        )}
 
         {onAddPillBadge && (
           <button

--- a/apps/web/src/features/image-studio/canvas-editor/utils/canvasClipboard.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/utils/canvasClipboard.ts
@@ -11,7 +11,8 @@ export type ClipboardItemType =
   | 'illustration'
   | 'additional-text'
   | 'asset'
-  | 'pill-badge';
+  | 'pill-badge'
+  | 'frame';
 
 export interface ClipboardItem {
   type: ClipboardItemType;

--- a/apps/web/src/features/image-studio/canvas-editor/utils/canvasLayerManager.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/utils/canvasLayerManager.ts
@@ -14,6 +14,7 @@ export interface CanvasItem {
     | 'balken'
     | 'icon'
     | 'shape'
+    | 'frame'
     | 'additional-text'
     | 'illustration'
     | 'asset'
@@ -29,6 +30,7 @@ interface StateWithFeatures {
   additionalTexts?: Array<Record<string, unknown>>;
   illustrationInstances?: Array<Record<string, unknown>>;
   assetInstances?: Array<Record<string, unknown>>;
+  frameInstances?: Array<Record<string, unknown>>;
   circleBadgeInstances?: Array<Record<string, unknown>>;
   pillBadgeInstances?: Array<Record<string, unknown>>;
 }
@@ -70,6 +72,11 @@ export function buildCanvasItems<
   // 4. Shapes
   if (state.shapeInstances) {
     state.shapeInstances.forEach((s) => items.push({ id: String(s.id), type: 'shape', data: s }));
+  }
+
+  // 4.5. Frames
+  if (state.frameInstances) {
+    state.frameInstances.forEach((f) => items.push({ id: String(f.id), type: 'frame', data: f }));
   }
 
   // 5. Additional Texts

--- a/apps/web/src/features/image-studio/canvas-editor/utils/frameUtils.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/utils/frameUtils.ts
@@ -1,0 +1,67 @@
+export type FrameClipType = 'circle' | 'rounded-rect';
+
+export interface FrameInstance {
+  id: string;
+  clipType: FrameClipType;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  rotation: number;
+  scaleX: number;
+  scaleY: number;
+  opacity: number;
+  imageSrc: string | null;
+  imageOffsetX: number;
+  imageOffsetY: number;
+  imageScale: number;
+  borderColor: string;
+  borderWidth: number;
+  cornerRadius: number;
+}
+
+export interface FramePreset {
+  id: FrameClipType;
+  name: string;
+  tags: string[];
+}
+
+export const FRAME_PRESETS: FramePreset[] = [
+  {
+    id: 'circle',
+    name: 'Kreisrahmen',
+    tags: ['kreis', 'circle', 'rund', 'round', 'rahmen', 'frame', 'bild', 'foto'],
+  },
+  {
+    id: 'rounded-rect',
+    name: 'Rechteckrahmen',
+    tags: ['rechteck', 'rectangle', 'rahmen', 'frame', 'bild', 'foto', 'abgerundet', 'rounded'],
+  },
+];
+
+export const DEFAULT_FRAME_SIZE = 300;
+
+let instanceCounter = 0;
+
+export function createFrameInstance(clipType: FrameClipType, x: number, y: number): FrameInstance {
+  instanceCounter += 1;
+  return {
+    id: `frame-${Date.now()}-${instanceCounter}`,
+    clipType,
+    x,
+    y,
+    width: DEFAULT_FRAME_SIZE,
+    height: DEFAULT_FRAME_SIZE,
+    rotation: 0,
+    scaleX: 1,
+    scaleY: 1,
+    opacity: 1,
+    imageSrc: null,
+    imageOffsetX: 0,
+    imageOffsetY: 0,
+    imageScale: 1,
+    borderColor: '#005538',
+    borderWidth: 3,
+    cornerRadius: clipType === 'rounded-rect' ? 24 : 0,
+  };
+}

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import { useEffect, useMemo } from 'react';
-import {
-  ThreadPrimitive,
-  SelectionToolbarPrimitive,
-  useThread,
-  useAssistantRuntime,
-} from '@assistant-ui/react';
+import { ThreadPrimitive, SelectionToolbarPrimitive, useThread, useAui } from '@assistant-ui/react';
 import { QuoteIcon } from 'lucide-react';
 import { useAgentStore } from '../../stores/chatStore';
 import { ModelSelector } from '../ModelSelector';
@@ -17,15 +12,15 @@ import { GrueneratorComposer } from './GrueneratorComposer';
 import { AutoMessageSender } from './AutoMessageSender';
 
 function NewThreadWatcher() {
-  const assistantRuntime = useAssistantRuntime();
+  const aui = useAui();
   const pendingNewThread = useAgentStore((s) => s.pendingNewThread);
 
   useEffect(() => {
     if (pendingNewThread) {
       useAgentStore.getState().setPendingNewThread(false);
-      assistantRuntime.switchToNewThread();
+      aui.threads().switchToNewThread();
     }
-  }, [pendingNewThread, assistantRuntime]);
+  }, [pendingNewThread, aui]);
 
   return null;
 }

--- a/packages/docs/src/components/common/ErrorBoundary.tsx
+++ b/packages/docs/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 
+import { isChunkLoadError } from '../../utils/chunkErrors';
+
 interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
@@ -11,24 +13,43 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
+  isChunkError: boolean;
   componentStack: string | null;
 }
 
+const CHUNK_RELOAD_KEY = 'docs-chunk-reload-attempted';
+
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  override state: ErrorBoundaryState = { hasError: false, error: null, componentStack: null };
+  override state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    isChunkError: false,
+    componentStack: null,
+  };
 
   static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
-    return { hasError: true, error };
+    return { hasError: true, error, isChunkError: isChunkLoadError(error) };
   }
 
   override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('[ErrorBoundary] Uncaught error:', error.message);
     this.setState({ componentStack: errorInfo.componentStack || null });
+
+    if (isChunkLoadError(error)) {
+      const hasReloaded = sessionStorage.getItem(CHUNK_RELOAD_KEY);
+      if (!hasReloaded) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+        window.location.reload();
+        return;
+      }
+      sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+    }
+
     this.props.onError?.(error, errorInfo);
   }
 
   private handleReset = () => {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, isChunkError: false });
   };
 
   override render() {
@@ -53,7 +74,17 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           gap: '1rem',
         }}
       >
-        <p style={{ fontSize: '1.1rem', margin: 0 }}>Ein unerwarteter Fehler ist aufgetreten.</p>
+        {this.state.isChunkError ? (
+          <>
+            <p style={{ fontSize: '1.1rem', margin: 0, fontWeight: 600 }}>Neue Version verfügbar</p>
+            <p style={{ fontSize: '0.9rem', margin: 0, color: '#6b7280' }}>
+              Die Anwendung wurde aktualisiert. Bitte lade die Seite neu, um die neueste Version zu
+              verwenden.
+            </p>
+          </>
+        ) : (
+          <p style={{ fontSize: '1.1rem', margin: 0 }}>Ein unerwarteter Fehler ist aufgetreten.</p>
+        )}
         {process.env.NODE_ENV === 'development' && this.state.error && (
           <pre
             style={{

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -63,5 +63,9 @@ export {
 } from './lib/blockNoteUtils';
 export { defaultDocumentContent } from './lib/defaultContent';
 
+// Utils
+export { lazyWithRetry } from './utils/lazyWithRetry';
+export { isChunkLoadError } from './utils/chunkErrors';
+
 // Icons
 export { DocsIcon } from './components/icons/DocsIcon';

--- a/packages/docs/src/utils/chunkErrors.ts
+++ b/packages/docs/src/utils/chunkErrors.ts
@@ -1,0 +1,11 @@
+export function isChunkLoadError(error: Error | null): boolean {
+  if (!error) return false;
+  return (
+    error.message?.includes('Failed to fetch dynamically imported module') ||
+    error.message?.includes('Importing a module script failed') ||
+    error.message?.includes('Unable to preload CSS') ||
+    error.message?.includes('Loading chunk') ||
+    error.message?.includes('Loading CSS chunk') ||
+    error.name === 'ChunkLoadError'
+  );
+}

--- a/packages/docs/src/utils/lazyWithRetry.ts
+++ b/packages/docs/src/utils/lazyWithRetry.ts
@@ -1,0 +1,21 @@
+import { lazy } from 'react';
+
+import { isChunkLoadError } from './chunkErrors';
+
+import type { ComponentType } from 'react';
+
+export function lazyWithRetry<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>
+) {
+  return lazy(async () => {
+    try {
+      return await factory();
+    } catch (error) {
+      if (isChunkLoadError(error instanceof Error ? error : null)) {
+        await new Promise((r) => setTimeout(r, 500));
+        return factory();
+      }
+      throw error;
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- **feat(image-studio):** Add FramePrimitive with circle and rounded-rect clip types, integrated across all canvas configs, hooks, rendering layer, and sidebar UI
- **fix(chat):** Fix "Neuer Chat" not opening a new thread when already on `/chat` — switch from `useAssistantRuntime` to `useAui().threads()` thread list runtime API, and skip redundant navigate/close when already on chat route
- **fix(docs):** Eliminate login page flash for authenticated users
- **fix(image-studio):** Render ImageStudio page at `/image-studio` instead of redirecting to `/imagine`
- **feat(docs):** Add silent chunk error recovery after deploys

## Test plan

- [ ] Navigate to `/chat`, start a conversation, click "Neuer Chat" → should clear messages and show welcome screen with sidebar staying open
- [ ] Click "Neuer Chat" from a non-chat page → should navigate to `/chat` with empty thread
- [ ] Open Image Studio, add circle and rounded-rect frames from Formen section
- [ ] Test frame drag, resize, image upload, copy/paste, and delete
- [ ] Verify frame support in dreizeilen, slider, and veranstaltung canvas types
- [ ] Verify `/image-studio` route loads directly
- [ ] Verify docs app doesn't flash login page when authenticated