### PR TITLE
fix: canvas auto-save, docs updated_at, error logging

### DIFF
--- a/apps/api/database/postgres/migrations/add_draft_status_to_shared_media.sql
+++ b/apps/api/database/postgres/migrations/add_draft_status_to_shared_media.sql
@@ -1,0 +1,6 @@
+-- Add 'draft' to shared_media status CHECK constraint
+-- This allows auto-save to create draft entries that are promoted to 'ready' on explicit share
+
+ALTER TABLE shared_media DROP CONSTRAINT IF EXISTS shared_media_status_check;
+ALTER TABLE shared_media ADD CONSTRAINT shared_media_status_check
+  CHECK (status IN ('processing', 'ready', 'failed', 'draft'));

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -633,7 +633,7 @@ CREATE TABLE IF NOT EXISTS shared_media (
     project_id UUID REFERENCES subtitler_projects(id) ON DELETE SET NULL,
     image_type TEXT,
     image_metadata JSONB DEFAULT '{}',
-    status VARCHAR(20) DEFAULT 'ready' CHECK (status IN ('processing', 'ready', 'failed')),
+    status VARCHAR(20) DEFAULT 'ready' CHECK (status IN ('processing', 'ready', 'failed', 'draft')),
     download_count INTEGER DEFAULT 0,
     view_count INTEGER DEFAULT 0,
     created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -73,6 +73,7 @@
     "domhandler": "^5.0.3",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.0",
     "express-session": "^1.19.0",
     "fastembed": "^2.1.0",
     "form-data": "^4.0.5",

--- a/apps/api/routes/docs/documentController.ts
+++ b/apps/api/routes/docs/documentController.ts
@@ -320,17 +320,17 @@ router.put('/:id', async (req: Request, res: Response) => {
     if (content !== undefined) {
       updates.push(`content = $${paramIndex++}`);
       values.push(content);
+      updates.push(`last_edited_by = $${paramIndex++}`);
+      values.push(userId);
+      updates.push(`last_edited_at = CURRENT_TIMESTAMP`);
+      updates.push(`updated_at = CURRENT_TIMESTAMP`);
     }
-
-    updates.push(`last_edited_by = $${paramIndex++}`);
-    values.push(userId);
-    updates.push(`last_edited_at = CURRENT_TIMESTAMP`);
 
     values.push(id);
 
     const result = (await db.query(
       `UPDATE collaborative_documents
-       SET ${updates.join(', ')}, updated_at = CURRENT_TIMESTAMP
+       SET ${updates.join(', ')}
        WHERE id = $${paramIndex}
        RETURNING *`,
       values

--- a/apps/api/routes/share/shareController.ts
+++ b/apps/api/routes/share/shareController.ts
@@ -57,7 +57,11 @@ interface SharedMediaService {
     userId: string,
     params: CreatePendingVideoShareParams
   ): Promise<ShareResult>;
-  getUserShares(userId: string, type: string | null): Promise<SharedMediaRow[]>;
+  getUserShares(
+    userId: string,
+    type: string | null,
+    status?: string | null
+  ): Promise<SharedMediaRow[]>;
   getUserShareCount(userId: string): Promise<number>;
   getShareByToken(shareToken: string): Promise<SharedMediaRow | null>;
   recordView(shareToken: string): Promise<void>;
@@ -103,6 +107,7 @@ interface CreateImageShareParams {
   imageType: string | null;
   metadata: Record<string, unknown>;
   originalImage: string | null;
+  status?: 'ready' | 'draft';
 }
 
 interface CreateVideoShareParams {
@@ -134,6 +139,7 @@ interface ImageShareRequest extends AuthenticatedRequest {
     imageType?: string;
     metadata?: Record<string, unknown>;
     originalImage?: string;
+    status?: 'ready' | 'draft';
   };
 }
 
@@ -299,6 +305,9 @@ async function triggerBackgroundRender(
 
 const router: Router = express.Router();
 
+// Override global body parser limit for share routes (canvas images can exceed 10MB)
+router.use(express.json({ limit: '50mb' }));
+
 // ============================================================================
 // IMAGE SHARE ROUTES
 // ============================================================================
@@ -306,7 +315,7 @@ const router: Router = express.Router();
 router.post('/image', requireAuth, async (req: ImageShareRequest, res: Response<ShareResponse>) => {
   try {
     const userId = req.user!.id;
-    const { imageData, title, imageType, metadata, originalImage } = req.body;
+    const { imageData, title, imageType, metadata, originalImage, status } = req.body;
 
     if (!imageData) {
       return res.status(400).json({
@@ -322,6 +331,7 @@ router.post('/image', requireAuth, async (req: ImageShareRequest, res: Response<
       imageType: imageType || null,
       metadata: metadata || {},
       originalImage: originalImage || null,
+      status: status === 'draft' ? 'draft' : 'ready',
     });
 
     log.info(
@@ -346,6 +356,54 @@ router.post('/image', requireAuth, async (req: ImageShareRequest, res: Response<
     });
   }
 });
+
+// Promote a draft to ready (publish)
+router.put(
+  '/:shareToken/publish',
+  requireAuth,
+  async (req: Request<ShareTokenParams>, res: Response<ShareResponse>) => {
+    try {
+      const userId = (req as AuthenticatedRequest).user!.id;
+      const { shareToken } = req.params;
+
+      const service = await getSharedMediaService();
+      const share = await service.getShareByToken(shareToken as string);
+
+      if (!share) {
+        return res.status(404).json({ success: false, error: 'Share nicht gefunden' });
+      }
+
+      if (share.user_id !== userId) {
+        return res.status(403).json({ success: false, error: 'Nicht berechtigt' });
+      }
+
+      const pg = (await import('../../database/services/PostgresService.js')).getPostgresInstance();
+      await pg.query('UPDATE shared_media SET status = $1 WHERE share_token = $2', [
+        'ready',
+        shareToken,
+      ]);
+
+      log.info(`Share ${shareToken} published by user ${userId}`);
+
+      return res.json({
+        success: true,
+        share: {
+          shareToken: share.share_token,
+          shareUrl: `/share/${shareToken}`,
+          createdAt: share.created_at,
+          mediaType: share.media_type as 'image' | 'video',
+          status: 'ready',
+        },
+      });
+    } catch (error) {
+      log.error('Failed to publish share:', error);
+      return res.status(500).json({
+        success: false,
+        error: 'Share konnte nicht veröffentlicht werden',
+      });
+    }
+  }
+);
 
 // ============================================================================
 // VIDEO SHARE ROUTES
@@ -580,9 +638,10 @@ router.get(
     try {
       const userId = req.user!.id;
       const type = req.query.type as string | undefined;
+      const status = req.query.status as string | undefined;
 
       const service = await getSharedMediaService();
-      const shares = await service.getUserShares(userId, type || null);
+      const shares = await service.getUserShares(userId, type || null, status || null);
       const count = await service.getUserShareCount(userId);
 
       res.json({

--- a/apps/api/routes/share/shareController.ts
+++ b/apps/api/routes/share/shareController.ts
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 
 import express, { type Request, type Response, type Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import sharp from 'sharp';
 
 import { requireAuth } from '../../middleware/authMiddleware.js';
@@ -18,6 +19,14 @@ import type { SharedMediaRow, ShareResult } from '../../types/media.js';
 
 const fsPromises = fs.promises;
 const log = createLogger('share');
+
+// Rate limiters for share mutation routes
+const shareWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 50,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // ============================================================================
 // Types
@@ -312,54 +321,60 @@ router.use(express.json({ limit: '50mb' }));
 // IMAGE SHARE ROUTES
 // ============================================================================
 
-router.post('/image', requireAuth, async (req: ImageShareRequest, res: Response<ShareResponse>) => {
-  try {
-    const userId = req.user!.id;
-    const { imageData, title, imageType, metadata, originalImage, status } = req.body;
+router.post(
+  '/image',
+  shareWriteLimiter,
+  requireAuth,
+  async (req: ImageShareRequest, res: Response<ShareResponse>) => {
+    try {
+      const userId = req.user!.id;
+      const { imageData, title, imageType, metadata, originalImage, status } = req.body;
 
-    if (!imageData) {
-      return res.status(400).json({
+      if (!imageData) {
+        return res.status(400).json({
+          success: false,
+          error: 'Bilddaten werden benötigt',
+        });
+      }
+
+      const service = await getSharedMediaService();
+      const share = await service.createImageShare(userId, {
+        imageBase64: imageData,
+        title: title || 'Geteiltes Bild',
+        imageType: imageType || null,
+        metadata: metadata || {},
+        originalImage: originalImage || null,
+        status: status === 'draft' ? 'draft' : 'ready',
+      });
+
+      log.info(
+        `Image share created: ${share.shareToken} by user ${userId}${originalImage ? ' (with original)' : ''}`
+      );
+
+      return res.json({
+        success: true,
+        share: {
+          shareToken: share.shareToken,
+          shareUrl: share.shareUrl,
+          createdAt: share.createdAt,
+          mediaType: 'image',
+          hasOriginalImage: share.hasOriginalImage || false,
+        },
+      });
+    } catch (error) {
+      log.error('Failed to create image share:', error);
+      return res.status(500).json({
         success: false,
-        error: 'Bilddaten werden benötigt',
+        error: 'Bild konnte nicht geteilt werden',
       });
     }
-
-    const service = await getSharedMediaService();
-    const share = await service.createImageShare(userId, {
-      imageBase64: imageData,
-      title: title || 'Geteiltes Bild',
-      imageType: imageType || null,
-      metadata: metadata || {},
-      originalImage: originalImage || null,
-      status: status === 'draft' ? 'draft' : 'ready',
-    });
-
-    log.info(
-      `Image share created: ${share.shareToken} by user ${userId}${originalImage ? ' (with original)' : ''}`
-    );
-
-    return res.json({
-      success: true,
-      share: {
-        shareToken: share.shareToken,
-        shareUrl: share.shareUrl,
-        createdAt: share.createdAt,
-        mediaType: 'image',
-        hasOriginalImage: share.hasOriginalImage || false,
-      },
-    });
-  } catch (error) {
-    log.error('Failed to create image share:', error);
-    return res.status(500).json({
-      success: false,
-      error: 'Bild konnte nicht geteilt werden',
-    });
   }
-});
+);
 
 // Promote a draft to ready (publish)
 router.put(
   '/:shareToken/publish',
+  shareWriteLimiter,
   requireAuth,
   async (req: Request<ShareTokenParams>, res: Response<ShareResponse>) => {
     try {

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -553,6 +553,13 @@ async function startWorker(): Promise<void> {
     let errorMessage = 'Bitte versuchen Sie es später erneut';
     let statusCode = 500;
 
+    log.error(`[GlobalErrorHandler] ${err.name}: ${err.message}`, {
+      path: req.path,
+      method: req.method,
+      statusCode,
+      errorCode: (err as NodeJS.ErrnoException).code,
+    });
+
     if (
       err.name === 'AuthenticationError' ||
       (err.message && err.message.includes('authentication'))

--- a/apps/api/services/sharedMediaService.ts
+++ b/apps/api/services/sharedMediaService.ts
@@ -227,7 +227,14 @@ class SharedMediaService {
     await this.ensureInitialized();
     await this.enforceUserLimit(userId);
 
-    const { imageBase64, title, imageType, metadata = {}, originalImage = null } = params;
+    const {
+      imageBase64,
+      title,
+      imageType,
+      metadata = {},
+      originalImage = null,
+      status = 'ready',
+    } = params;
     const shareToken = this.generateShareToken();
     const shareDir = getSafeShareDir(shareToken);
 
@@ -300,7 +307,7 @@ class SharedMediaService {
                 INSERT INTO shared_media
                 (user_id, share_token, media_type, title, file_path, file_name, thumbnail_path,
                  file_size, mime_type, image_type, image_metadata, status)
-                VALUES ($1, $2, 'image', $3, $4, $5, $6, $7, $8, $9, $10, 'ready')
+                VALUES ($1, $2, 'image', $3, $4, $5, $6, $7, $8, $9, $10, $11)
                 RETURNING id, share_token, created_at
             `;
 
@@ -319,6 +326,7 @@ class SharedMediaService {
         mimeType,
         imageType || null,
         JSON.stringify(enrichedMetadata),
+        status,
       ]);
 
       console.log(
@@ -480,7 +488,8 @@ class SharedMediaService {
 
   async getUserShares(
     userId: string,
-    mediaType: 'image' | 'video' | null = null
+    mediaType: 'image' | 'video' | null = null,
+    status: string | null = null
   ): Promise<SharedMediaRow[]> {
     await this.ensureInitialized();
 
@@ -492,10 +501,18 @@ class SharedMediaService {
                 WHERE user_id = $1
             `;
       const params: unknown[] = [userId];
+      let paramIndex = 2;
 
       if (mediaType) {
-        query += ` AND media_type = $2`;
+        query += ` AND media_type = $${paramIndex}`;
         params.push(mediaType);
+        paramIndex++;
+      }
+
+      if (status) {
+        query += ` AND status = $${paramIndex}`;
+        params.push(status);
+        paramIndex++;
       }
 
       query += ` ORDER BY created_at DESC LIMIT 100`;
@@ -905,6 +922,7 @@ class SharedMediaService {
       }
 
       const shareDir = getSafeShareDir(shareToken);
+      await fs.mkdir(shareDir, { recursive: true });
 
       const base64Data = imageBase64.replace(/^data:image\/\w+;base64,/, '');
       const imageBuffer = Buffer.from(base64Data, 'base64');

--- a/apps/api/types/media.d.ts
+++ b/apps/api/types/media.d.ts
@@ -36,7 +36,7 @@ export interface SharedMediaRow {
   project_id: string | null;
   image_type: string | null;
   image_metadata: Record<string, unknown> | null;
-  status: 'processing' | 'ready' | 'failed';
+  status: 'processing' | 'ready' | 'failed' | 'draft';
   download_count: number;
   view_count: number;
   is_library_item: boolean;
@@ -90,6 +90,7 @@ export interface CreateImageShareParams {
   imageType?: string;
   metadata?: Record<string, unknown>;
   originalImage?: string | null;
+  status?: 'ready' | 'draft';
 }
 
 /**

--- a/apps/docs/server.ts
+++ b/apps/docs/server.ts
@@ -78,14 +78,23 @@ app.use(
     setHeaders(res, filePath) {
       // index.html must not be cached — it references hashed chunks that change on each deploy
       if (filePath.endsWith('.html')) {
-        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
       }
     },
   })
 );
 
+// Missing assets should 404, not fall through to SPA (prevents serving index.html as JS)
+app.use('/assets', (_req, res) => {
+  res.status(404).end();
+});
+app.use('/fonts', (_req, res) => {
+  res.status(404).end();
+});
+
 // SPA fallback - send all non-matched requests to index.html
 app.use((_req, res) => {
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
   res.sendFile(path.join(DIST_PATH, 'index.html'));
 });
 

--- a/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasAutoSave.ts
+++ b/apps/web/src/features/image-studio/canvas-editor/hooks/useCanvasAutoSave.ts
@@ -230,6 +230,7 @@ export const useCanvasAutoSave = (
           imageType: refs.canvasType,
           metadata,
           originalImage: originalImageBase64,
+          status: 'draft',
         });
       }
 

--- a/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/GenericShareSection.tsx
+++ b/apps/web/src/features/image-studio/canvas-editor/sidebar/sections/GenericShareSection.tsx
@@ -1,4 +1,4 @@
-import { useShareStore } from '@gruenerator/shared/share';
+import { useShareStore, shareApi } from '@gruenerator/shared/share';
 import { useCallback, useState, useMemo, useRef, useEffect, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import {
@@ -115,6 +115,17 @@ function DownloadShareSubsection({
   const canUseNativeShare = typeof navigator !== 'undefined' && 'share' in navigator;
   const isMultiPage = pageCount > 1 && onDownloadAllZip;
 
+  const publishDraftIfNeeded = useCallback(async () => {
+    const token = shareToken || useAutoSaveStore.getState().autoSavedShareToken;
+    if (token) {
+      try {
+        await shareApi.publishShare(token);
+      } catch (err) {
+        console.warn('[DownloadShareSubsection] Failed to publish draft:', err);
+      }
+    }
+  }, [shareToken]);
+
   const handleSingleDownload = async () => {
     dlDropdown.setOpen(false);
     setDownloadState('capturing');
@@ -122,6 +133,7 @@ function DownloadShareSubsection({
       onCaptureCanvas();
       await new Promise((resolve) => setTimeout(resolve, 150));
       onDownload();
+      void publishDraftIfNeeded();
       setDownloadState('success');
       setTimeout(() => setDownloadState('idle'), 1500);
     } catch (error) {
@@ -172,6 +184,7 @@ function DownloadShareSubsection({
           title: 'Grünerator Share',
         });
       }
+      void publishDraftIfNeeded();
       setShareSuccess(true);
       setTimeout(() => setShareSuccess(false), 2000);
     } catch (err) {
@@ -181,7 +194,7 @@ function DownloadShareSubsection({
     } finally {
       setIsSharing(false);
     }
-  }, [exportedImage, canvasText, onCaptureCanvas, shareDropdown]);
+  }, [exportedImage, canvasText, onCaptureCanvas, shareDropdown, publishDraftIfNeeded]);
 
   const handleShareAllPages = useCallback(async () => {
     shareDropdown.setOpen(false);

--- a/apps/web/src/features/image-studio/gallery/ImageGallery.tsx
+++ b/apps/web/src/features/image-studio/gallery/ImageGallery.tsx
@@ -176,6 +176,14 @@ const ImageGalleryCard: React.FC<ImageGalleryCardProps> = ({
           </div>
         )}
         {image.imageType && <span className="image-gallery-type-badge">{image.imageType}</span>}
+        {image.status === 'draft' && (
+          <span
+            className="image-gallery-type-badge"
+            style={{ background: 'var(--grey-500)', color: 'white' }}
+          >
+            Entwurf
+          </span>
+        )}
         {isTemplate && (
           <span className="image-gallery-template-badge">
             <FaSave /> Vorlage

--- a/apps/web/src/features/image-studio/hooks/useDraftAutoSave.ts
+++ b/apps/web/src/features/image-studio/hooks/useDraftAutoSave.ts
@@ -8,17 +8,15 @@ import { useAutoSaveStore } from './useAutoSaveStore';
 import { useImageHelpers } from './useImageHelpers';
 import { useStepFlow } from './useStepFlow';
 
+const MAX_RETRY_COUNT = 3;
+
 export const useDraftAutoSave = (): void => {
   const { type, generatedImageSrc, galleryEditMode } = useImageStudioStore();
 
-  const {
-    autoSaveStatus,
-    autoSavedShareToken,
-    lastAutoSavedImageSrc,
-    setAutoSaveStatus,
-    setAutoSavedShareToken,
-    setLastAutoSavedImageSrc,
-  } = useAutoSaveStore();
+  // Only subscribe to action setters (stable references) — not state values
+  const setAutoSaveStatus = useAutoSaveStore((s) => s.setAutoSaveStatus);
+  const setAutoSavedShareToken = useAutoSaveStore((s) => s.setAutoSavedShareToken);
+  const setLastAutoSavedImageSrc = useAutoSaveStore((s) => s.setLastAutoSavedImageSrc);
 
   const { createImageShare, updateImageShare } = useShareStore();
   const { getOriginalImageBase64, buildShareMetadata } = useImageHelpers();
@@ -27,15 +25,14 @@ export const useDraftAutoSave = (): void => {
   const typeConfig = getTypeConfig(type || '');
   const fieldConfig = getTemplateFieldConfig(type || '');
 
+  const retryCountRef = useRef(0);
+
   // Use refs to store latest values for the debounced function
   const latestRefs = useRef({
     type,
     typeConfig,
     fieldConfig,
     galleryEditMode,
-    autoSaveStatus,
-    autoSavedShareToken,
-    lastAutoSavedImageSrc,
     generatedImageSrc,
     getOriginalImageBase64,
     buildShareMetadata,
@@ -47,16 +44,13 @@ export const useDraftAutoSave = (): void => {
     getFieldValue,
   });
 
-  // Update refs on render
+  // Update refs via effect (React hooks lint forbids ref updates during render)
   useEffect(() => {
     latestRefs.current = {
       type,
       typeConfig,
       fieldConfig,
       galleryEditMode,
-      autoSaveStatus,
-      autoSavedShareToken,
-      lastAutoSavedImageSrc,
       generatedImageSrc,
       getOriginalImageBase64,
       buildShareMetadata,
@@ -67,35 +61,17 @@ export const useDraftAutoSave = (): void => {
       setLastAutoSavedImageSrc,
       getFieldValue,
     };
-  }, [
-    type,
-    typeConfig,
-    fieldConfig,
-    galleryEditMode,
-    autoSaveStatus,
-    autoSavedShareToken,
-    lastAutoSavedImageSrc,
-    generatedImageSrc,
-    getOriginalImageBase64,
-    buildShareMetadata,
-    createImageShare,
-    updateImageShare,
-    setAutoSaveStatus,
-    setAutoSavedShareToken,
-    setLastAutoSavedImageSrc,
-    getFieldValue,
-  ]);
+  });
 
   const performSave = useCallback(async () => {
     const refs = latestRefs.current;
+    // Read current store state directly to avoid stale closures
+    const storeState = useAutoSaveStore.getState();
 
     // Safety checks
-    if (refs.galleryEditMode) return; // Don't auto-save if editing existing gallery item (handle separately?)
-    if (refs.autoSaveStatus === 'saving') return;
-    if (!refs.generatedImageSrc && !refs.autoSavedShareToken) return; // Need an image to start
-
-    // If we have no changes and already saved?
-    // We check purely by triggering this function (debounced).
+    if (refs.galleryEditMode) return;
+    if (storeState.autoSaveStatus === 'saving') return;
+    if (!refs.generatedImageSrc && !storeState.autoSavedShareToken) return;
 
     console.log('[useDraftAutoSave] Starting save...');
     refs.setAutoSaveStatus('saving');
@@ -104,18 +80,17 @@ export const useDraftAutoSave = (): void => {
       const originalImage = await refs.getOriginalImageBase64();
       const metadata = refs.buildShareMetadata();
       const title = refs.typeConfig?.label || 'Draft';
-      const imageSrc = refs.generatedImageSrc || refs.lastAutoSavedImageSrc || '';
+      const imageSrc = refs.generatedImageSrc || storeState.lastAutoSavedImageSrc || '';
 
       if (!imageSrc) {
-        // Can't save without image?
         refs.setAutoSaveStatus('idle');
         return;
       }
 
-      if (refs.autoSavedShareToken) {
+      if (storeState.autoSavedShareToken) {
         // UPDATE existing
         await refs.updateImageShare({
-          shareToken: refs.autoSavedShareToken,
+          shareToken: storeState.autoSavedShareToken,
           title,
           metadata: metadata ?? undefined,
           imageBase64: imageSrc,
@@ -129,7 +104,7 @@ export const useDraftAutoSave = (): void => {
           imageType: refs.typeConfig?.legacyType || refs.type || '',
           metadata: metadata,
           originalImage: originalImage ?? undefined,
-          // status: 'draft' // If supported
+          status: 'draft',
         });
         if (share?.shareToken) {
           console.log('[useDraftAutoSave] Create successful:', share.shareToken);
@@ -139,20 +114,25 @@ export const useDraftAutoSave = (): void => {
 
       refs.setLastAutoSavedImageSrc(imageSrc);
       refs.setAutoSaveStatus('saved');
+      retryCountRef.current = 0;
 
-      // Revert to idle after delay?
+      // Revert to idle after delay
       setTimeout(() => refs.setAutoSaveStatus('idle'), 2000);
     } catch (error) {
       console.error('[useDraftAutoSave] Save failed:', error);
+      retryCountRef.current += 1;
       refs.setAutoSaveStatus('error');
+
+      if (retryCountRef.current >= MAX_RETRY_COUNT) {
+        console.warn('[useDraftAutoSave] Max retries reached, stopping auto-save attempts');
+      }
     }
   }, []);
 
-  // Create debounced save using timeout ref pattern (similar to useDebouncedCallback)
+  // Create debounced save using timeout ref pattern
   const debouncedSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const performSaveRef = useRef(performSave);
 
-  // Keep performSave ref up to date
   useEffect(() => {
     performSaveRef.current = performSave;
   }, [performSave]);
@@ -177,16 +157,18 @@ export const useDraftAutoSave = (): void => {
     };
   }, []);
 
-  // Trigger save when generatedImageSrc changes (immediate or debounced?)
-  // If user clicked "Save", we want immediate feedback.
+  // Trigger save when generatedImageSrc changes
   useEffect(() => {
-    if (generatedImageSrc && generatedImageSrc !== lastAutoSavedImageSrc) {
-      void performSave(); // Immediate save for image changes
+    const storeState = useAutoSaveStore.getState();
+    if (
+      generatedImageSrc &&
+      generatedImageSrc !== storeState.lastAutoSavedImageSrc &&
+      retryCountRef.current < MAX_RETRY_COUNT
+    ) {
+      void performSave();
     }
-  }, [generatedImageSrc, lastAutoSavedImageSrc, performSave]);
+  }, [generatedImageSrc, performSave]);
 
-  // Trigger debounced save when form values change
-  // For now, debouncedSave is available for future use when form state subscription is added
-  // To support "Early Draft" (metadata only), we'll need access to form state
-  void debouncedSave; // Mark as intentionally available for future use
+  // Mark debouncedSave as intentionally available for future use
+  void debouncedSave;
 };

--- a/packages/docs/src/components/common/ErrorBoundary.tsx
+++ b/packages/docs/src/components/common/ErrorBoundary.tsx
@@ -54,6 +54,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   override render() {
     if (!this.state.hasError) {
+      // Clear reload flag on successful render — ready for next deployment
+      sessionStorage.removeItem(CHUNK_RELOAD_KEY);
       return this.props.children;
     }
 

--- a/packages/shared/src/share/api/index.ts
+++ b/packages/shared/src/share/api/index.ts
@@ -11,6 +11,7 @@ export {
   getUserShares,
   getShareInfo,
   deleteShare,
+  publishShare,
   shareApi,
   getUserDevices,
   pushToPhone,

--- a/packages/shared/src/share/api/shareApi.ts
+++ b/packages/shared/src/share/api/shareApi.ts
@@ -6,7 +6,6 @@
 import { apiRequest } from '../../api/client.js';
 
 import type {
-  Share,
   ShareResponse,
   ShareListResponse,
   DeleteShareResponse,
@@ -15,6 +14,7 @@ import type {
   CreateImageShareParams,
   UpdateImageShareParams,
   ShareMediaType,
+  ShareStatus,
 } from '../types.js';
 
 /**
@@ -31,6 +31,7 @@ export const SHARE_ENDPOINTS = {
   SHARE_DOWNLOAD: (token: string) => `/share/${token}/download`,
   UPDATE_IMAGE: (token: string) => `/share/${token}/image`,
   DELETE_SHARE: (token: string) => `/share/${token}`,
+  PUBLISH: (token: string) => `/share/${token}/publish`,
   SAVE_AS_TEMPLATE: (token: string) => `/share/${token}/save-as-template`,
   PUSH_TO_PHONE: '/share/push-to-phone',
   DEVICES: '/share/devices',
@@ -74,13 +75,25 @@ export async function updateImageShare(params: UpdateImageShareParams): Promise<
 }
 
 /**
- * Get user's shares (optionally filtered by media type)
+ * Get user's shares (optionally filtered by media type and status)
  */
-export async function getUserShares(mediaType?: ShareMediaType): Promise<ShareListResponse> {
-  const url = mediaType
-    ? `${SHARE_ENDPOINTS.USER_SHARES}?type=${mediaType}`
-    : SHARE_ENDPOINTS.USER_SHARES;
+export async function getUserShares(
+  mediaType?: ShareMediaType,
+  status?: ShareStatus
+): Promise<ShareListResponse> {
+  const params = new URLSearchParams();
+  if (mediaType) params.set('type', mediaType);
+  if (status) params.set('status', status);
+  const query = params.toString();
+  const url = query ? `${SHARE_ENDPOINTS.USER_SHARES}?${query}` : SHARE_ENDPOINTS.USER_SHARES;
   return apiRequest<ShareListResponse>('get', url);
+}
+
+/**
+ * Publish a draft share (promote draft → ready)
+ */
+export async function publishShare(shareToken: string): Promise<ShareResponse> {
+  return apiRequest<ShareResponse>('put', SHARE_ENDPOINTS.PUBLISH(shareToken));
 }
 
 /**
@@ -159,6 +172,7 @@ export const shareApi = {
   getUserShares,
   getShareInfo,
   deleteShare,
+  publishShare,
   saveAsTemplate,
   getUserDevices,
   pushToPhone,

--- a/packages/shared/src/share/constants.ts
+++ b/packages/shared/src/share/constants.ts
@@ -84,4 +84,5 @@ export const SHARE_STATUS_LABELS = {
   processing: 'Wird verarbeitet...',
   ready: 'Bereit',
   failed: 'Fehlgeschlagen',
+  draft: 'Entwurf',
 } as const;

--- a/packages/shared/src/share/hooks/useShareStore.ts
+++ b/packages/shared/src/share/hooks/useShareStore.ts
@@ -15,6 +15,7 @@ import type {
   CreateImageShareParams,
   UpdateImageShareParams,
   ShareMediaType,
+  ShareStatus,
   SaveAsTemplateResponse,
 } from '../types.js';
 
@@ -156,13 +157,42 @@ export const useShareStore = create<ShareStoreState & ShareStoreActions>((set, g
   },
 
   /**
-   * Fetch user's shares (optionally filtered by media type)
+   * Publish a draft share (promote draft → ready)
    */
-  fetchUserShares: async (mediaType?: ShareMediaType): Promise<Share[]> => {
+  publishShare: async (shareToken: string): Promise<Share> => {
+    try {
+      const response = await shareApi.publishShare(shareToken);
+
+      if (response.success && response.share) {
+        const updatedShare = response.share;
+        set((state) => ({
+          shares: state.shares.map((s) =>
+            s.shareToken === shareToken ? { ...s, ...updatedShare, status: 'ready' } : s
+          ),
+          currentShare:
+            state.currentShare?.shareToken === shareToken
+              ? { ...state.currentShare, ...updatedShare, status: 'ready' }
+              : state.currentShare,
+        }));
+        return updatedShare;
+      } else {
+        throw new Error(response.error || 'Failed to publish share');
+      }
+    } catch (error) {
+      const errorMessage = extractErrorMessage(error, 'Failed to publish share');
+      set({ error: errorMessage });
+      throw new Error(errorMessage);
+    }
+  },
+
+  /**
+   * Fetch user's shares (optionally filtered by media type and status)
+   */
+  fetchUserShares: async (mediaType?: ShareMediaType, status?: ShareStatus): Promise<Share[]> => {
     set({ isLoading: true, error: null });
 
     try {
-      const response = await shareApi.getUserShares(mediaType);
+      const response = await shareApi.getUserShares(mediaType, status);
 
       if (response.success) {
         set({

--- a/packages/shared/src/share/index.ts
+++ b/packages/shared/src/share/index.ts
@@ -53,6 +53,7 @@ export {
   getUserShares,
   getShareInfo,
   deleteShare,
+  publishShare,
   shareApi,
   getUserDevices,
   pushToPhone,

--- a/packages/shared/src/share/types.ts
+++ b/packages/shared/src/share/types.ts
@@ -10,7 +10,7 @@ export type SharePlatform = 'instagram' | 'facebook' | 'twitter' | 'linkedin' | 
 export type ShareMediaType = 'video' | 'image';
 
 // Share status
-export type ShareStatus = 'processing' | 'ready' | 'failed';
+export type ShareStatus = 'processing' | 'ready' | 'failed' | 'draft';
 
 /**
  * Share record from backend
@@ -58,6 +58,7 @@ export interface CreateImageShareParams {
   imageType?: string;
   metadata?: Record<string, unknown>;
   originalImage?: string;
+  status?: ShareStatus;
 }
 
 /**
@@ -108,7 +109,8 @@ export interface ShareStoreActions {
   ) => Promise<Share>;
   createImageShare: (params: CreateImageShareParams) => Promise<Share>;
   updateImageShare: (params: UpdateImageShareParams) => Promise<Share>;
-  fetchUserShares: (mediaType?: ShareMediaType) => Promise<Share[]>;
+  publishShare: (shareToken: string) => Promise<Share>;
+  fetchUserShares: (mediaType?: ShareMediaType, status?: ShareStatus) => Promise<Share[]>;
   fetchImageShares: () => Promise<Share[]>;
   fetchVideoShares: () => Promise<Share[]>;
   deleteShare: (shareToken: string) => Promise<boolean>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.3.0
+        version: 8.3.0(express@5.2.1)
       express-session:
         specifier: ^1.19.0
         version: 1.19.0
@@ -1215,7 +1218,7 @@ importers:
     dependencies:
       '@wordpress/block-editor':
         specifier: ^15.14.0
-        version: 15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))
+        version: 15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/blocks':
         specifier: ^15.14.0
         version: 15.14.0(react@19.2.4)
@@ -1231,7 +1234,7 @@ importers:
         version: 6.17.0
       '@wordpress/scripts':
         specifier: ^31.6.0
-        version: 31.6.0(@playwright/test@1.58.2)(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/eslint@9.6.1)(@types/node@25.3.5)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(canvas@3.2.0)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(file-loader@6.2.0(webpack@5.105.4))(node-sass@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.97.3)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)))(type-fest@4.41.0)(typescript@5.9.3)
+        version: 31.6.0(@playwright/test@1.58.2)(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/eslint@9.6.1)(@types/node@25.3.5)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(canvas@3.2.0)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(file-loader@6.2.0(webpack@5.105.4))(node-sass@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.97.3)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)))(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.9.3)
       sass:
         specifier: ^1.97.3
         version: 1.97.3
@@ -1246,7 +1249,7 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.9.2
-        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.9.2
         version: 3.9.2(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)
@@ -23796,6 +23799,70 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
+  '@docusaurus/core@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+    dependencies:
+      '@docusaurus/babel': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/bundler': 3.9.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/logger': 3.9.2
+      '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils-common': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
+      boxen: 6.2.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cli-table3: 0.6.5
+      combine-promises: 1.2.0
+      commander: 5.1.0
+      core-js: 3.48.0
+      detect-port: 1.6.1
+      escape-html: 1.0.3
+      eta: 2.2.0
+      eval: 0.1.8
+      execa: 5.1.1
+      fs-extra: 11.3.4
+      html-tags: 3.3.1
+      html-webpack-plugin: 5.6.6(@rspack/core@1.7.6(@swc/helpers@0.5.19))(webpack@5.105.4)
+      leven: 3.1.0
+      lodash: 4.17.23
+      open: 8.4.2
+      p-map: 4.0.0
+      prompts: 2.4.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)'
+      react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.105.4)
+      react-router: 5.3.4(react@19.2.4)
+      react-router-config: 5.1.1(react-router@5.3.4(react@19.2.4))(react@19.2.4)
+      react-router-dom: 5.3.4(react@19.2.4)
+      semver: 7.7.4
+      serve-handler: 6.1.7
+      tinypool: 1.1.1
+      tslib: 2.8.1
+      update-notifier: 6.0.2
+      webpack: 5.105.4(webpack-cli@5.1.4)
+      webpack-bundle-analyzer: 4.10.2
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
+      webpack-merge: 6.0.1
+    transitivePeerDependencies:
+      - '@docusaurus/faster'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+
   '@docusaurus/cssnano-preset@3.9.2':
     dependencies:
       cssnano-preset-advanced: 6.1.2(postcss@8.5.8)
@@ -23863,10 +23930,10 @@ snapshots:
 
   '@docusaurus/plugin-content-blog@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -23942,9 +24009,49 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
+  '@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
+    dependencies:
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/logger': 3.9.2
+      '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/module-type-aliases': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils-common': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/react-router-config': 5.0.11
+      combine-promises: 1.2.0
+      fs-extra: 11.3.4
+      js-yaml: 4.1.1
+      lodash: 4.17.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      schema-dts: 1.1.5
+      tslib: 2.8.1
+      utility-types: 3.11.0
+      webpack: 5.105.4(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - '@docusaurus/faster'
+      - '@mdx-js/react'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@swc/css'
+      - bufferutil
+      - csso
+      - debug
+      - esbuild
+      - lightningcss
+      - supports-color
+      - typescript
+      - uglify-js
+      - utf-8-validate
+      - webpack-cli
+
   '@docusaurus/plugin-content-pages@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -23974,7 +24081,7 @@ snapshots:
 
   '@docusaurus/plugin-css-cascade-layers@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -24001,7 +24108,7 @@ snapshots:
 
   '@docusaurus/plugin-debug@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fs-extra: 11.3.4
@@ -24029,7 +24136,7 @@ snapshots:
 
   '@docusaurus/plugin-google-analytics@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -24055,7 +24162,7 @@ snapshots:
 
   '@docusaurus/plugin-google-gtag@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/gtag.js': 0.0.12
@@ -24082,7 +24189,7 @@ snapshots:
 
   '@docusaurus/plugin-google-tag-manager@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -24108,7 +24215,7 @@ snapshots:
 
   '@docusaurus/plugin-sitemap@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -24139,7 +24246,7 @@ snapshots:
 
   '@docusaurus/plugin-svgr@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/types': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-validation': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -24169,9 +24276,9 @@ snapshots:
 
   '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/plugin-content-pages': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/plugin-css-cascade-layers': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/plugin-debug': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
@@ -24214,12 +24321,12 @@ snapshots:
 
   '@docusaurus/theme-classic@3.9.2(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
       '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/module-type-aliases': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/plugin-content-pages': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/theme-translations': 3.9.2
@@ -24263,7 +24370,7 @@ snapshots:
     dependencies:
       '@docusaurus/mdx-loader': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/module-type-aliases': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/utils-common': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/history': 4.7.11
@@ -24286,9 +24393,9 @@ snapshots:
   '@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.49.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@docsearch/react': 4.6.0(@algolia/client-search@5.49.1)(@types/react@19.2.14)(algoliasearch@5.49.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(search-insights@2.17.3)
-      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(debug@4.4.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))(@rspack/core@1.7.6(@swc/helpers@0.5.19))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@docusaurus/theme-translations': 3.9.2
       '@docusaurus/utils': 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -27445,7 +27552,7 @@ snapshots:
     optionalDependencies:
       '@types/webpack': 4.41.40
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.4)
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -30802,7 +30909,7 @@ snapshots:
       webpack: 5.105.4(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.105.4)
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.4)
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
 
   '@wordpress/a11y@4.41.0':
     dependencies:
@@ -30836,7 +30943,7 @@ snapshots:
 
   '@wordpress/blob@4.41.0': {}
 
-  '@wordpress/block-editor@15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/block-editor@15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@react-spring/web': 9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/a11y': 4.41.0
@@ -30845,7 +30952,7 @@ snapshots:
       '@wordpress/blob': 4.41.0
       '@wordpress/block-serialization-default-parser': 5.41.0
       '@wordpress/blocks': 15.14.0(react@19.2.4)
-      '@wordpress/commands': 1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@wordpress/commands': 1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/components': 32.3.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/compose': 7.41.0(react@19.2.4)
       '@wordpress/data': 10.41.0(react@19.2.4)
@@ -30933,7 +31040,7 @@ snapshots:
 
   '@wordpress/browserslist-config@6.41.0': {}
 
-  '@wordpress/commands@1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@wordpress/commands@1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@wordpress/base-styles': 6.17.0
       '@wordpress/components': 32.3.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -31323,7 +31430,7 @@ snapshots:
       memize: 2.1.1
       react: 19.2.4
 
-  '@wordpress/scripts@31.6.0(@playwright/test@1.58.2)(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/eslint@9.6.1)(@types/node@25.3.5)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(canvas@3.2.0)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(file-loader@6.2.0(webpack@5.105.4))(node-sass@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.97.3)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)))(type-fest@4.41.0)(typescript@5.9.3)':
+  '@wordpress/scripts@31.6.0(@playwright/test@1.58.2)(@rspack/core@1.7.6(@swc/helpers@0.5.19))(@types/eslint@9.6.1)(@types/node@25.3.5)(@types/webpack@4.41.40)(babel-plugin-macros@3.1.0)(canvas@3.2.0)(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1))(file-loader@6.2.0(webpack@5.105.4))(node-sass@9.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.97.3)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.9.3)))(tslib@2.8.1)(type-fest@4.41.0)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.25.7
       '@playwright/test': 1.58.2
@@ -31386,7 +31493,7 @@ snapshots:
       webpack: 5.105.4(webpack-cli@5.1.4)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.3)(webpack@5.105.4)
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.4)
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -44420,7 +44527,7 @@ snapshots:
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.4)
+      webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4)
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.105.4):
     dependencies:
@@ -44474,7 +44581,7 @@ snapshots:
       - tslib
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.105.4):
+  webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@5.1.4)(webpack@5.105.4):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/services/hocuspocus/src/auth.ts
+++ b/services/hocuspocus/src/auth.ts
@@ -256,8 +256,7 @@ export class AuthService {
 
       this.db(
         `UPDATE collaborative_documents
-         SET permissions = COALESCE(permissions, '{}')::jsonb || $1::jsonb,
-             updated_at = CURRENT_TIMESTAMP
+         SET permissions = COALESCE(permissions, '{}')::jsonb || $1::jsonb
          WHERE id = $2
            AND NOT (COALESCE(permissions, '{}')::jsonb ? $3)`,
         [permissionEntry, documentName, userId]

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -234,17 +234,17 @@ export class PostgresPersistence {
       }
 
       if (preview) {
-        await this.db('UPDATE collaborative_documents SET content = $2 WHERE id = $1', [
-          documentId,
-          preview,
-        ]);
+        await this.db(
+          'UPDATE collaborative_documents SET content = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1',
+          [documentId, preview]
+        );
         log.debug(`[Preview] Updated preview for ${documentId} (${preview.length} chars)`);
 
         const autoTitle = extractAutoTitle(preview);
         if (autoTitle) {
           const result = await this.db(
             `UPDATE collaborative_documents
-             SET title = $2, updated_at = CURRENT_TIMESTAMP
+             SET title = $2
              WHERE id = $1 AND title = ANY($3::text[])
              RETURNING id`,
             [documentId, autoTitle, [...DEFAULT_TITLES]]


### PR DESCRIPTION
## Summary

- **Canvas auto-save 500 fix**: Add route-level 50MB JSON body parser for share routes (base64 canvas images exceed the global 10MB limit), add `fs.mkdir` in `updateImageShare` to prevent ENOENT, add error logging to the global Express error handler
- **Draft/share separation**: Auto-save creates `draft` entries; explicit download/share promotes to `ready` via `PUT /:shareToken/publish`. Gallery shows "Entwurf" badge on drafts
- **Re-render fix**: `useDraftAutoSave` no longer subscribes to the full `useAutoSaveStore` — uses individual selectors for action setters and reads state imperatively (matching `useCanvasAutoSave` pattern). Adds max retry counter (3) to prevent infinite loops
- **Docs `updated_at` fix**: `last_edited_by`/`updated_at` only update when content changes (not metadata-only updates). Hocuspocus persistence adds `updated_at` on content saves, removes it from permission and auto-title updates

## Test plan

- [ ] Open canvas editor → auto-save should succeed (no 500 error in network tab)
- [ ] Check gallery → draft items show "Entwurf" badge
- [ ] Download or share an image → badge disappears (draft promoted to ready)
- [ ] Check server logs → errors now logged by global error handler
- [ ] Verify no re-render loops (no repeated SubsectionTabBar mounts in console)
- [ ] Edit a document title without changing content → `updated_at` should not change
- [ ] Edit document content → `updated_at` and `last_edited_by` should update
- [ ] Run DB migration: `add_draft_status_to_shared_media.sql`