### PR TITLE
fix(web): research filter overflow + advanced settings collapse

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -47,6 +47,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run content sync
+        id: sync
+        continue-on-error: true
         run: |
           ARGS=""
           if [ -n "${{ inputs.source }}" ]; then ARGS="$ARGS --source ${{ inputs.source }}"; fi
@@ -58,3 +60,100 @@ jobs:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
+          BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
+          BREVO_SMTP_USER: ${{ secrets.BREVO_SMTP_USER }}
+          BREVO_SMTP_PASS: ${{ secrets.BREVO_SMTP_PASS }}
+          EMAIL_FROM: ${{ vars.EMAIL_FROM || 'Grünerator <info@gruenerator.eu>' }}
+          CONTENT_SYNC_EMAIL: ${{ vars.CONTENT_SYNC_EMAIL }}
+          SYNC_SUMMARY_PATH: ${{ github.workspace }}/sync-summary.json
+
+      - name: Generate job summary
+        if: always()
+        run: |
+          SUMMARY_FILE="${{ github.workspace }}/sync-summary.json"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ ! -f "$SUMMARY_FILE" ]; then
+            echo "## ❌ Content Sync — No Summary" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The sync script did not produce a summary file. Check the [workflow logs]($RUN_URL)." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+
+          # Parse JSON summary
+          TIMESTAMP=$(jq -r '.timestamp' "$SUMMARY_FILE")
+          DRY_RUN=$(jq -r '.dryRun' "$SUMMARY_FILE")
+          FORCE=$(jq -r '.force' "$SUMMARY_FILE")
+          TOTAL_SOURCES=$(jq -r '.totals.sources' "$SUMMARY_FILE")
+          SUCCEEDED=$(jq -r '.totals.succeeded' "$SUMMARY_FILE")
+          FAILED=$(jq -r '.totals.failed' "$SUMMARY_FILE")
+          STORED=$(jq -r '.totals.stored' "$SUMMARY_FILE")
+          UPDATED=$(jq -r '.totals.updated' "$SUMMARY_FILE")
+          SKIPPED=$(jq -r '.totals.skipped' "$SUMMARY_FILE")
+          ERRORS=$(jq -r '.totals.errors' "$SUMMARY_FILE")
+          DURATION=$(jq -r '.totalDuration' "$SUMMARY_FILE")
+
+          # Determine status
+          if [ "$FAILED" -gt 0 ] || [ "$ERRORS" -gt 0 ]; then
+            STATUS_ICON="⚠️"
+          else
+            STATUS_ICON="✅"
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            TITLE="$STATUS_ICON Content Sync — Dry Run"
+          else
+            TITLE="$STATUS_ICON Content Sync Report"
+          fi
+
+          # Build summary
+          {
+            echo "## $TITLE"
+            echo ""
+            echo "**Date:** $(date -d "$TIMESTAMP" '+%d.%m.%Y %H:%M UTC' 2>/dev/null || echo "$TIMESTAMP")"
+            echo "**Duration:** ${DURATION}s"
+            echo "**Run:** [${{ github.run_id }}]($RUN_URL)"
+            if [ "$FORCE" = "true" ]; then echo "**Mode:** Force re-index"; fi
+            echo ""
+            echo "### Totals"
+            echo ""
+            echo "| Metric | Count |"
+            echo "|--------|------:|"
+            echo "| Sources | $TOTAL_SOURCES ($SUCCEEDED ok, $FAILED failed) |"
+            echo "| New documents | $STORED |"
+            echo "| Updated | $UPDATED |"
+            echo "| Skipped (unchanged) | $SKIPPED |"
+            echo "| Errors | $ERRORS |"
+            echo ""
+            echo "### Per Source"
+            echo ""
+            echo "| Source | Status | New | Updated | Skipped | Errors | Duration |"
+            echo "|--------|--------|----:|--------:|--------:|-------:|---------:|"
+
+            jq -r '.sources[] | "| \(.name) | \(if .status == "success" then "✅" else "❌" end) | \(.stored) | \(.updated) | \(.skipped) | \(.errors) | \(.duration)s |"' "$SUMMARY_FILE"
+
+            echo ""
+
+            # Show failed sources with error messages
+            FAILED_SOURCES=$(jq -r '.sources[] | select(.status == "failed") | "- **\(.name):** \(.error)"' "$SUMMARY_FILE")
+            if [ -n "$FAILED_SOURCES" ]; then
+              echo "### ❌ Failed Sources"
+              echo ""
+              echo "$FAILED_SOURCES"
+              echo ""
+            fi
+
+            # Show sources with new content
+            NEW_CONTENT=$(jq -r '.sources[] | select(.stored > 0) | "- **\(.name):** +\(.stored) new documents"' "$SUMMARY_FILE")
+            if [ -n "$NEW_CONTENT" ]; then
+              echo "### 📥 New Content"
+              echo ""
+              echo "$NEW_CONTENT"
+              echo ""
+            fi
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if sync had errors
+        if: steps.sync.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/desktop-weekly.yml
+++ b/.github/workflows/desktop-weekly.yml
@@ -1,0 +1,96 @@
+name: Weekly Desktop Release
+
+on:
+  schedule:
+    # Every Sunday at 22:00 UTC
+    - cron: '0 22 * * 0'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force build even without changes'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  check-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find latest desktop tag
+        id: latest_tag
+        run: |
+          TAG=$(git tag -l 'desktop-v*' --sort=-v:refname | head -n1)
+          echo "tag=${TAG:-none}" >> $GITHUB_OUTPUT
+          echo "Latest desktop tag: ${TAG:-none}"
+
+      - name: Check for relevant changes
+        id: changes
+        run: |
+          TAG="${{ steps.latest_tag.outputs.tag }}"
+          FORCE="${{ github.event.inputs.force }}"
+
+          if [[ "$FORCE" == "true" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Forced build requested"
+            exit 0
+          fi
+
+          if [[ "$TAG" == "none" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "No previous tag found, building"
+            exit 0
+          fi
+
+          # Check if web, packages, or desktop source changed
+          CHANGED=$(git diff --name-only "$TAG"..HEAD -- \
+            apps/web/ \
+            apps/desktop/ \
+            packages/shared/ \
+            packages/chat/ \
+            packages/docs/ \
+          )
+
+          if [[ -n "$CHANGED" ]]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Changes found since $TAG:"
+            echo "$CHANGED" | head -20
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No relevant changes since $TAG"
+          fi
+
+      - name: Bump version and create tag
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          TAG="${{ steps.latest_tag.outputs.tag }}"
+
+          if [[ "$TAG" == "none" ]]; then
+            NEW_VERSION="1.1.1"
+          else
+            # Extract version, bump patch
+            VERSION="${TAG#desktop-v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            PATCH=$((PATCH + 1))
+            NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          fi
+
+          NEW_TAG="desktop-v${NEW_VERSION}"
+          echo "Creating tag: $NEW_TAG"
+
+          # Update version in tauri.conf.json and package.json
+          sed -i "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" apps/desktop/src-tauri/tauri.conf.json
+          sed -i "0,/\"version\": \".*\"/s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" apps/desktop/package.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/desktop/src-tauri/tauri.conf.json apps/desktop/package.json
+          git commit -m "chore(desktop): bump version to ${NEW_VERSION}"
+          git tag "$NEW_TAG"
+          git push origin master "$NEW_TAG"

--- a/apps/api/services/email/emailService.ts
+++ b/apps/api/services/email/emailService.ts
@@ -5,8 +5,10 @@ import { createLogger } from '../../utils/logger.js';
 
 import {
   renderContentDeliveryTemplate,
+  renderContentSyncTemplate,
   renderDocumentShareTemplate,
   type ContentDeliveryTemplateParams,
+  type ContentSyncTemplateParams,
   type DocumentShareTemplateParams,
 } from './templates.js';
 
@@ -146,6 +148,22 @@ export async function sendContentDeliveryEmail(
     text,
     attachments: params.attachment ? [params.attachment] : undefined,
   });
+}
+
+export async function sendContentSyncEmail(
+  to: string,
+  params: ContentSyncTemplateParams
+): Promise<boolean> {
+  if (!isConfigured()) return false;
+
+  const { html, text } = renderContentSyncTemplate(params);
+  const hasFailures = params.totals.failed > 0 || params.totals.errors > 0;
+  const icon = hasFailures ? '⚠️' : '✅';
+  const subject = hasFailures
+    ? `${icon} Content Sync: ${params.totals.failed}/${params.totals.sources} Quellen fehlgeschlagen`
+    : `${icon} Content Sync: +${params.totals.stored} neu, ${params.totals.updated} aktualisiert`;
+
+  return sendEmail({ to, subject, html, text });
 }
 
 export async function verifyEmailConnection(): Promise<boolean> {

--- a/apps/api/services/email/templates.ts
+++ b/apps/api/services/email/templates.ts
@@ -114,6 +114,158 @@ ${PRIMARY_URL}`;
   return { html: baseLayout(content), text };
 }
 
+export interface ContentSyncSourceResult {
+  name: string;
+  status: 'success' | 'failed';
+  stored: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+  duration: number;
+  error?: string;
+}
+
+export interface ContentSyncTemplateParams {
+  timestamp: string;
+  totalDuration: number;
+  sources: ContentSyncSourceResult[];
+  totals: {
+    sources: number;
+    succeeded: number;
+    failed: number;
+    stored: number;
+    updated: number;
+    skipped: number;
+    errors: number;
+  };
+  runUrl?: string;
+  dryRun: boolean;
+}
+
+export function renderContentSyncTemplate(params: ContentSyncTemplateParams): {
+  html: string;
+  text: string;
+} {
+  const { sources, totals, totalDuration, runUrl, dryRun } = params;
+
+  const hasFailures = totals.failed > 0 || totals.errors > 0;
+  const statusIcon = hasFailures ? '⚠️' : '✅';
+  const title = dryRun ? 'Content Sync — Dry Run' : 'Content Sync Report';
+
+  const dateStr = new Date(params.timestamp).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Europe/Berlin',
+  });
+
+  const sourceRows = sources
+    .map((s) => {
+      const icon = s.status === 'success' ? '✅' : '❌';
+      const bgColor = s.status === 'failed' ? '#fff5f5' : 'transparent';
+      return `<tr style="background-color:${bgColor};">
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;">${icon} ${escapeHtml(s.name)}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;font-weight:${s.stored > 0 ? '700' : '400'};">${s.stored}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${s.updated}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${s.skipped}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;${s.errors > 0 ? 'color:#c00;font-weight:700;' : ''}">${s.errors}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${s.duration}s</td>
+      </tr>${s.error ? `<tr style="background-color:#fff5f5;"><td colspan="6" style="padding:4px 12px;border:1px solid #e5e5e5;color:#c00;font-size:13px;">Fehler: ${escapeHtml(s.error)}</td></tr>` : ''}`;
+    })
+    .join('\n');
+
+  const content = `
+    <h1 style="margin:0 0 8px 0;font-size:20px;color:#333333;">${statusIcon} ${title}</h1>
+    <p style="margin:0 0 24px 0;font-size:14px;color:#888888;">${dateStr} &middot; Dauer: ${totalDuration}s</p>
+
+    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;margin-bottom:24px;font-size:14px;">
+      <tr>
+        <td style="padding:6px 0;color:#555555;">Quellen</td>
+        <td style="padding:6px 0;color:#333333;font-weight:600;text-align:right;">${totals.sources} (${totals.succeeded} ok, ${totals.failed} fehlgeschlagen)</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#555555;">Neue Dokumente</td>
+        <td style="padding:6px 0;color:${PRIMARY_COLOR};font-weight:700;text-align:right;font-size:16px;">+${totals.stored}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#555555;">Aktualisiert</td>
+        <td style="padding:6px 0;color:#333333;text-align:right;">${totals.updated}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#555555;">&Uuml;bersprungen</td>
+        <td style="padding:6px 0;color:#333333;text-align:right;">${totals.skipped}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#555555;">Fehler</td>
+        <td style="padding:6px 0;color:${totals.errors > 0 ? '#c00' : '#333333'};font-weight:${totals.errors > 0 ? '700' : '400'};text-align:right;">${totals.errors}</td>
+      </tr>
+    </table>
+
+    <h2 style="margin:0 0 12px 0;font-size:16px;color:#333333;">Details pro Quelle</h2>
+    <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;border-collapse:collapse;font-size:13px;margin-bottom:24px;">
+      <tr style="background-color:#f8f8f8;">
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:left;">Quelle</th>
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">Neu</th>
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">Update</th>
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">&Uuml;berspr.</th>
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">Fehler</th>
+        <th style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">Dauer</th>
+      </tr>
+      ${sourceRows}
+      <tr style="background-color:#f0f0f0;font-weight:600;">
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;">Gesamt</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${totals.stored}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${totals.updated}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${totals.skipped}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${totals.errors}</td>
+        <td style="padding:8px 12px;border:1px solid #e5e5e5;text-align:right;">${totalDuration}s</td>
+      </tr>
+    </table>
+
+    ${
+      runUrl
+        ? `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 auto;">
+      <tr>
+        <td style="background-color:${PRIMARY_COLOR};border-radius:6px;">
+          <a href="${escapeHtml(runUrl)}" style="display:inline-block;padding:10px 24px;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;">
+            Workflow-Log ansehen
+          </a>
+        </td>
+      </tr>
+    </table>`
+        : ''
+    }`;
+
+  // Plain text version
+  const sourceLines = sources
+    .map((s) => {
+      const icon = s.status === 'success' ? '✓' : '✗';
+      const line = `  ${icon} ${s.name}: +${s.stored} neu, ${s.updated} aktualisiert, ${s.skipped} übersprungen, ${s.errors} Fehler (${s.duration}s)`;
+      return s.error ? `${line}\n    Fehler: ${s.error}` : line;
+    })
+    .join('\n');
+
+  const text = `${statusIcon} ${title}
+${dateStr} · Dauer: ${totalDuration}s
+
+Quellen: ${totals.sources} (${totals.succeeded} ok, ${totals.failed} fehlgeschlagen)
+Neue Dokumente: +${totals.stored}
+Aktualisiert: ${totals.updated}
+Übersprungen: ${totals.skipped}
+Fehler: ${totals.errors}
+
+Details:
+${sourceLines}
+${runUrl ? `\nWorkflow-Log: ${runUrl}` : ''}
+--
+${BRAND.name} — KI-Werkzeuge für Grüne
+${PRIMARY_URL}`;
+
+  return { html: baseLayout(content), text };
+}
+
 export interface ContentDeliveryTemplateParams {
   recipientName?: string;
   contentTitle: string;

--- a/apps/api/update-all-content.ts
+++ b/apps/api/update-all-content.ts
@@ -20,6 +20,7 @@
  * Run: npx tsx apps/api/update-all-content.ts
  */
 
+import { sendContentSyncEmail } from './services/email/emailService.js';
 import { boellStiftungScraperService } from './services/scrapers/implementations/BoellStiftungScraper.js';
 import { gruenblogScraperService } from './services/scrapers/implementations/GruenblogScraper.js';
 import { grueneAtScraperService } from './services/scrapers/implementations/GrueneAtScraper.js';
@@ -239,8 +240,29 @@ async function runSourceGroup(group: SourceGroup, args: CliArgs): Promise<Source
   }
 }
 
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+interface SyncSummary {
+  timestamp: string;
+  dryRun: boolean;
+  force: boolean;
+  sources: SourceGroupResult[];
+  totals: {
+    sources: number;
+    succeeded: number;
+    failed: number;
+    stored: number;
+    updated: number;
+    skipped: number;
+    errors: number;
+  };
+  totalDuration: number;
+}
+
 async function main() {
   const args = parseArgs();
+  const syncStart = Date.now();
 
   // Resolve which groups to run
   let groups = SOURCE_GROUPS;
@@ -316,6 +338,57 @@ async function main() {
       console.log(`  ${r.id}: ${r.error}`);
     }
     console.log('');
+  }
+
+  // Write structured summary JSON for CI consumption
+  const summary: SyncSummary = {
+    timestamp: new Date().toISOString(),
+    dryRun: args.dryRun,
+    force: args.force,
+    sources: results,
+    totals: {
+      sources: results.length,
+      succeeded: succeeded.length,
+      failed: failed.length,
+      stored: totals.stored,
+      updated: totals.updated,
+      skipped: totals.skipped,
+      errors: totals.errors,
+    },
+    totalDuration: Math.round((Date.now() - syncStart) / 1000),
+  };
+
+  const summaryPath =
+    process.env.SYNC_SUMMARY_PATH || path.join(process.cwd(), 'sync-summary.json');
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+  console.log(`Summary written to ${summaryPath}`);
+
+  // Send email notification via existing Brevo SMTP (never crash on email failure)
+  const emailTo = process.env.CONTENT_SYNC_EMAIL;
+  if (emailTo) {
+    try {
+      const runId = process.env.GITHUB_RUN_ID;
+      const repo = process.env.GITHUB_REPOSITORY;
+      const server = process.env.GITHUB_SERVER_URL || 'https://github.com';
+      const runUrl = runId && repo ? `${server}/${repo}/actions/runs/${runId}` : undefined;
+
+      const sent = await sendContentSyncEmail(emailTo, {
+        timestamp: summary.timestamp,
+        totalDuration: summary.totalDuration,
+        sources: summary.sources,
+        totals: summary.totals,
+        runUrl,
+        dryRun: args.dryRun,
+      });
+      console.log(
+        sent ? `Email sent to ${emailTo}` : 'Email sending skipped (SMTP not configured)'
+      );
+    } catch (err) {
+      console.error(
+        'Email notification failed (non-fatal):',
+        err instanceof Error ? err.message : err
+      );
+    }
   }
 
   process.exit(totals.errors > 0 || failed.length > 0 ? 1 : 0);

--- a/apps/web/src/features/apps/AppsPage.tsx
+++ b/apps/web/src/features/apps/AppsPage.tsx
@@ -224,8 +224,8 @@ const ConnectSection = () => {
     <section className="flex w-full max-w-[40rem] flex-col items-center gap-6">
       <h2 className="text-xl font-bold text-foreground-heading">Mit KI-Chat verbinden</h2>
       <p className="text-center text-sm text-grey-600 dark:text-grey-400">
-        Du kannst den Gr\u00fcnerator direkt in ChatGPT, Claude, Mistral Le Chat oder OpenWebUI
-        verwenden. Dein KI-Assistent kann dann gr\u00fcne Parteiprogramme durchsuchen und dir beim
+        Du kannst den Grünerator direkt in ChatGPT, Claude, Mistral Le Chat oder OpenWebUI
+        verwenden. Dein KI-Assistent kann dann grüne Parteiprogramme durchsuchen und dir beim
         Erstellen politischer Texte helfen.
       </p>
 
@@ -280,7 +280,7 @@ const ConnectSection = () => {
         rel="noopener noreferrer"
         className="inline-flex items-center gap-1.5 text-sm text-link underline underline-offset-2 hover:opacity-80"
       >
-        Ausf\u00fchrliche Einrichtungsanleitung
+        Ausführliche Einrichtungsanleitung
         <HiExternalLink className="text-sm" />
       </a>
     </section>
@@ -361,7 +361,7 @@ const AppsPage = () => {
     }
 
     if (!release) {
-      return <p className="py-4 text-sm text-grey-500">Keine Releases verf\u00fcgbar.</p>;
+      return <p className="py-4 text-sm text-grey-500">Keine Releases verfügbar.</p>;
     }
 
     return (
@@ -400,7 +400,7 @@ const AppsPage = () => {
             {/* Secondary downloads */}
             {secondaryAssets.length > 0 && (
               <p className="text-xs text-grey-500">
-                Auch verf\u00fcgbar als{' '}
+                Auch verfügbar als{' '}
                 {secondaryAssets.map((asset, i) => (
                   <span key={asset.id || asset.name}>
                     {i > 0 && ', '}
@@ -418,9 +418,7 @@ const AppsPage = () => {
             )}
           </div>
         ) : (
-          <p className="text-sm text-grey-500">
-            Keine Downloads f\u00fcr diese Plattform verf\u00fcgbar.
-          </p>
+          <p className="text-sm text-grey-500">Keine Downloads für diese Plattform verfügbar.</p>
         )}
       </>
     );
@@ -433,7 +431,7 @@ const AppsPage = () => {
         Apps & Connect
       </h1>
       <p className="mb-10 text-center text-sm text-grey-500">
-        Desktop-App herunterladen oder den Gr\u00fcnerator mit deinem KI-Chat verbinden.
+        Desktop-App herunterladen oder den Grünerator mit deinem KI-Chat verbinden.
       </p>
 
       {/* Desktop App Section */}

--- a/apps/web/src/features/research/components/ResearchFilterPanel.tsx
+++ b/apps/web/src/features/research/components/ResearchFilterPanel.tsx
@@ -178,7 +178,7 @@ export default function ResearchFilterPanel({
       </PopoverTrigger>
       <PopoverContent
         align="start"
-        className="w-[22rem] sm:w-[30rem] max-h-[28rem] sm:max-h-[32rem] overflow-y-auto p-3"
+        className="w-[22rem] sm:w-[30rem] max-h-[var(--radix-popover-content-available-height,28rem)] overflow-y-auto p-3"
       >
         <div className="space-y-3">
           <div className="flex items-center justify-between">

--- a/apps/web/src/features/research/components/ResearchSettingsPanel.tsx
+++ b/apps/web/src/features/research/components/ResearchSettingsPanel.tsx
@@ -1,4 +1,5 @@
-import { HiCheck, HiCog6Tooth } from 'react-icons/hi2';
+import { useState } from 'react';
+import { HiCheck, HiChevronDown, HiCog6Tooth } from 'react-icons/hi2';
 
 import {
   type ActiveFilters,
@@ -114,6 +115,12 @@ export default function ResearchSettingsPanel({
 
   const filterEntries = Object.entries(filterFields);
 
+  const advancedCount =
+    (selectedCollectionIds.length > 0 ? selectedCollectionIds.length : 0) +
+    (searchMode !== 'hybrid' ? 1 : 0) +
+    (sortBy !== 'relevance' ? 1 : 0);
+  const [advancedOpen, setAdvancedOpen] = useState(advancedCount > 0);
+
   return (
     <Popover
       onOpenChange={(open) => {
@@ -143,7 +150,7 @@ export default function ResearchSettingsPanel({
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="w-[22rem] sm:w-[30rem] max-h-[32rem] sm:max-h-[36rem] overflow-y-auto p-3"
+        className="w-[22rem] sm:w-[30rem] max-h-[var(--radix-popover-content-available-height,32rem)] overflow-y-auto p-3"
       >
         <div className="space-y-3">
           <div className="flex items-center justify-between">
@@ -159,68 +166,9 @@ export default function ResearchSettingsPanel({
             )}
           </div>
 
-          {/* Collections */}
-          <div className="space-y-1.5">
-            <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
-              Kollektionen
-            </span>
-            {collectionsLoading ? (
-              <p className="text-xs text-grey-400">Werden geladen…</p>
-            ) : (
-              <div className="flex flex-wrap gap-1.5">
-                {collections.map((col) => (
-                  <PillButton
-                    key={col.id}
-                    active={selectedCollectionIds.includes(col.id)}
-                    onClick={() => toggleCollection(col.id)}
-                  >
-                    {col.name}
-                  </PillButton>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Search Mode */}
-          <div className="space-y-1.5">
-            <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
-              Suchmodus
-            </span>
-            <div className="flex flex-wrap gap-1.5">
-              {MODE_OPTIONS.map((opt) => (
-                <PillButton
-                  key={opt.value}
-                  active={searchMode === opt.value}
-                  onClick={() => onSearchModeChange(opt.value)}
-                >
-                  {opt.label}
-                </PillButton>
-              ))}
-            </div>
-          </div>
-
-          {/* Sort */}
-          <div className="space-y-1.5">
-            <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
-              Sortierung
-            </span>
-            <div className="flex flex-wrap gap-1.5">
-              {SORT_OPTIONS.map((opt) => (
-                <PillButton
-                  key={opt.value}
-                  active={sortBy === opt.value}
-                  onClick={() => onSortByChange(opt.value)}
-                >
-                  {opt.label}
-                </PillButton>
-              ))}
-            </div>
-          </div>
-
           {/* Filters */}
           {(filterEntries.length > 0 || filtersLoading) && (
             <>
-              <div className="border-t border-grey-200 dark:border-grey-700" />
               <div className="space-y-1.5">
                 <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
                   Filter{activeFilterCount > 0 && ` (${activeFilterCount} aktiv)`}
@@ -267,6 +215,93 @@ export default function ResearchSettingsPanel({
               })}
             </>
           )}
+
+          {/* Advanced Settings (Collections, Search Mode, Sort) */}
+          <div className="border-t border-grey-200 dark:border-grey-700" />
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={() => setAdvancedOpen((o) => !o)}
+              className="flex w-full items-center justify-between"
+            >
+              <span className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                Erweiterte Einstellungen
+                {advancedCount > 0 && (
+                  <Badge className="h-4 min-w-4 justify-center rounded-full px-1 text-[10px]">
+                    {advancedCount}
+                  </Badge>
+                )}
+              </span>
+              <HiChevronDown
+                className={cn(
+                  'size-3.5 text-grey-400 transition-transform',
+                  advancedOpen && 'rotate-180'
+                )}
+              />
+            </button>
+
+            {advancedOpen && (
+              <div className="space-y-3">
+                {/* Collections */}
+                <div className="space-y-1.5">
+                  <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                    Kollektionen
+                  </span>
+                  {collectionsLoading ? (
+                    <p className="text-xs text-grey-400">Werden geladen…</p>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                      {collections.map((col) => (
+                        <PillButton
+                          key={col.id}
+                          active={selectedCollectionIds.includes(col.id)}
+                          onClick={() => toggleCollection(col.id)}
+                        >
+                          {col.name}
+                        </PillButton>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Search Mode */}
+                <div className="space-y-1.5">
+                  <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                    Suchmodus
+                  </span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {MODE_OPTIONS.map((opt) => (
+                      <PillButton
+                        key={opt.value}
+                        active={searchMode === opt.value}
+                        onClick={() => onSearchModeChange(opt.value)}
+                      >
+                        {opt.label}
+                      </PillButton>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Sort */}
+                <div className="space-y-1.5">
+                  <span className="text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                    Sortierung
+                  </span>
+                  <div className="flex flex-wrap gap-1.5">
+                    {SORT_OPTIONS.map((opt) => (
+                      <PillButton
+                        key={opt.value}
+                        active={sortBy === opt.value}
+                        onClick={() => onSortByChange(opt.value)}
+                      >
+                        {opt.label}
+                      </PillButton>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## Summary
- **Fix dropdown overflow**: Replace hardcoded `max-h` with Radix's `--radix-popover-content-available-height` CSS variable so filter popovers dynamically fit the viewport
- **Collapse advanced settings**: Move Collections, Search Mode, and Sort behind a collapsible "Erweiterte Einstellungen" section (collapsed by default, auto-opens when non-default settings are active)
- Content sync CI reporting with email notifications
- Desktop weekly auto-release workflow
- Fix Unicode escape sequences in AppsPage

## Test plan
- [ ] Open Research page, open settings gear — filters visible, advanced collapsed
- [ ] Click "Erweiterte Einstellungen" — collections/mode/sort appear
- [ ] Resize browser to short viewport — popover fits and scrolls
- [ ] Select a collection — badge shows count on advanced toggle