### PR TITLE
fix(docker): add voice package to web Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,6 +19,7 @@ COPY tsconfig.base.json tsconfig.strict-migration.json ./
 COPY packages/shared/package.json ./packages/shared/
 COPY packages/docs/package.json ./packages/docs/
 COPY packages/chat/package.json ./packages/chat/
+COPY packages/voice/package.json ./packages/voice/
 COPY apps/web/package.json ./apps/web/
 
 # Install only web + transitive workspace deps (not all ~6 workspaces)
@@ -29,6 +30,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 COPY packages/shared ./packages/shared
 COPY packages/docs ./packages/docs
 COPY packages/chat ./packages/chat
+COPY packages/voice ./packages/voice
 COPY apps/web ./apps/web
 COPY CHANGELOG.md ./
 


### PR DESCRIPTION
## Summary
- Adds `packages/voice/` to the web Dockerfile build context (both `package.json` and source COPY steps)
- Fixes CI Docker build failure: `Rollup failed to resolve import "@gruenerator/voice"`

## Test plan
- [ ] Docker build-web CI job passes