### PR TITLE
fix(docker): add voice package to gruen-o-mat Dockerfile

### DIFF
--- a/apps/gruen-o-mat/Dockerfile
+++ b/apps/gruen-o-mat/Dockerfile
@@ -19,6 +19,7 @@ COPY tsconfig.base.json tsconfig.strict-migration.json ./
 
 # Copy package.json files for workspace resolution
 COPY packages/chat/package.json ./packages/chat/
+COPY packages/voice/package.json ./packages/voice/
 COPY apps/gruen-o-mat/package.json ./apps/gruen-o-mat/
 
 # Install only gruen-o-mat + transitive workspace deps
@@ -27,6 +28,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source (changes here don't bust the install cache)
 COPY packages/chat ./packages/chat
+COPY packages/voice ./packages/voice
 COPY apps/gruen-o-mat ./apps/gruen-o-mat
 
 # Build the frontend


### PR DESCRIPTION
## Summary
- `packages/chat` now depends on `@gruenerator/voice`, but the gruen-o-mat Dockerfile was missing COPY instructions for this workspace package
- Adds `packages/voice/package.json` (install layer) and `packages/voice` (source layer) to fix TS2307 build failure

## Test plan
- [x] CI build-gruen-o-mat job passes