### PR TITLE
fix(ui): rename sidebar chat label to Chat

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -86,7 +86,7 @@ export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuI
   items.chat = {
     id: 'chat',
     path: '/chat',
-    title: 'Neuer Chat',
+    title: 'Chat',
     description: 'KI-Chat',
     icon: getIcon('navigation', 'messenger'),
     badge: 'beta',


### PR DESCRIPTION
## Summary
- Renames sidebar menu item from "Neuer Chat" to "Chat" since it now links to the chat overview page

## Test plan
- [ ] Verify sidebar shows "Chat" label on desktop and mobile