### PR TITLE
fix(ui): prevent chat page crash for unauthenticated users

### DIFF
--- a/apps/web/public/sw-illustration-cache.js
+++ b/apps/web/public/sw-illustration-cache.js
@@ -75,17 +75,19 @@ self.addEventListener('install', (event) => {
 
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => {
-      console.log('[SW] Precaching top 50 illustrations...');
-      // Use addAll with { mode: 'no-cors' } to handle potential CORS issues
-      return cache
-        .addAll(TOP_ILLUSTRATIONS.map((url) => new Request(url, { mode: 'no-cors' })))
-        .then(() => {
-          console.log('[SW] Precaching complete!');
-        })
-        .catch((err) => {
-          console.warn('[SW] Some illustrations failed to precache:', err);
-          // Continue anyway - missing illustrations will be fetched on demand
-        });
+      console.log('[SW] Precaching top illustrations...');
+      return Promise.allSettled(
+        TOP_ILLUSTRATIONS.map((url) =>
+          fetch(url)
+            .then((response) => {
+              if (response.ok) return cache.put(url, response);
+            })
+            .catch(() => {})
+        )
+      ).then((results) => {
+        const cached = results.filter((r) => r.status === 'fulfilled').length;
+        console.log(`[SW] Precached ${cached}/${TOP_ILLUSTRATIONS.length} illustrations`);
+      });
     })
   );
 

--- a/apps/web/src/components/common/LoginRequired/withAuthRequired.tsx
+++ b/apps/web/src/components/common/LoginRequired/withAuthRequired.tsx
@@ -7,6 +7,7 @@ import LoginRequired from './LoginRequired';
 interface AuthRequiredOptions {
   title?: string;
   message?: string;
+  fallback?: React.ReactNode;
 }
 
 /**
@@ -22,6 +23,7 @@ const withAuthRequired = <P extends Record<string, unknown>>(
   const {
     title, // Optional: will auto-generate from route if not provided
     message, // Optional: will use standard message if not provided
+    fallback,
   } = options;
 
   return function AuthRequiredComponent(props: P) {
@@ -32,7 +34,7 @@ const withAuthRequired = <P extends Record<string, unknown>>(
       return (
         <>
           <div className="protected-content-blur">
-            <Component {...props} user={null} />
+            {fallback ?? <Component {...props} user={null} />}
           </div>
           <LoginRequired title={title} message={message} variant="fullpage" />
         </>

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -59,4 +59,7 @@ function ChatPage() {
   );
 }
 
-export default withAuthRequired(ChatPage, { title: 'Chat' });
+export default withAuthRequired(ChatPage, {
+  title: 'Chat',
+  fallback: <div className="flex min-h-0 flex-1 bg-background" />,
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "@hocuspocus/provider": "^3.4.3",
       "@isaacs/brace-expansion": ">=5.0.1",
       "diff": ">=5.2.2",
-      "hono": ">=4.11.9",
+      "hono": ">=4.12.7",
       "langsmith": ">=0.4.6",
       "markdown-it": ">=14.1.0",
       "tar": ">=7.5.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   '@hocuspocus/provider': ^3.4.3
   '@isaacs/brace-expansion': '>=5.0.1'
   diff: '>=5.2.2'
-  hono: '>=4.11.9'
+  hono: '>=4.12.7'
   langsmith: '>=0.4.6'
   markdown-it: '>=14.1.0'
   tar: '>=7.5.11'
@@ -1242,7 +1242,7 @@ importers:
     dependencies:
       '@wordpress/block-editor':
         specifier: ^15.14.0
-        version: 15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))
+        version: 15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))
       '@wordpress/blocks':
         specifier: ^15.14.0
         version: 15.14.0(react@19.2.4)
@@ -4590,7 +4590,7 @@ packages:
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.11.9'
+      hono: '>=4.12.7'
 
   '@huggingface/hub@2.10.5':
     resolution: {integrity: sha512-g1gmvztiUw4t9rx8hPECBXOXw0y1Iprlb1JVGH3NvzBeZEHvMEMFpaRj1Vb1Q+YyY9g8VEf6jfmYJxAydQdFjA==}
@@ -13295,8 +13295,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.5:
-    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
+  hono@4.12.7:
+    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
@@ -25679,9 +25679,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@hono/node-server@1.19.11(hono@4.12.5)':
+  '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
-      hono: 4.12.5
+      hono: 4.12.7
 
   '@huggingface/hub@2.10.5':
     dependencies:
@@ -26683,7 +26683,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.5)
+      '@hono/node-server': 1.19.11(hono@4.12.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -26693,7 +26693,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.5
+      hono: 4.12.7
       jose: 6.2.0
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -31235,7 +31235,7 @@ snapshots:
 
   '@wordpress/blob@4.41.0': {}
 
-  '@wordpress/block-editor@15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))':
+  '@wordpress/block-editor@15.14.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(stylelint@16.26.1(typescript@5.9.3))':
     dependencies:
       '@react-spring/web': 9.7.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/a11y': 4.41.0
@@ -31244,7 +31244,7 @@ snapshots:
       '@wordpress/blob': 4.41.0
       '@wordpress/block-serialization-default-parser': 5.41.0
       '@wordpress/blocks': 15.14.0(react@19.2.4)
-      '@wordpress/commands': 1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@wordpress/commands': 1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/components': 32.3.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@wordpress/compose': 7.41.0(react@19.2.4)
       '@wordpress/data': 10.41.0(react@19.2.4)
@@ -31332,7 +31332,7 @@ snapshots:
 
   '@wordpress/browserslist-config@6.41.0': {}
 
-  '@wordpress/commands@1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@wordpress/commands@1.41.0(@emotion/is-prop-valid@1.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@wordpress/base-styles': 6.17.0
       '@wordpress/components': 32.3.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -36654,7 +36654,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.5: {}
+  hono@4.12.7: {}
 
   hook-std@4.0.0: {}
 


### PR DESCRIPTION
## Summary
- Fix crash on `/chat` without login — `AuiProvider required` error replaced by proper login overlay
- Add `fallback` option to `withAuthRequired` HOC for pages with provider dependencies
- Fix service worker precache failure by using individual fetches instead of atomic `addAll()`

## Test plan
- [ ] Visit `/chat` without login → login overlay shows, no console errors
- [ ] Visit `/chat` with login → chat works normally
- [ ] Check browser console for clean SW precache log instead of error