### PR TITLE
fix(security,web,api): harden inputs, fix types, and minor cleanups

### DIFF
--- a/apps/api/agents/langgraph/PromptProcessor.ts
+++ b/apps/api/agents/langgraph/PromptProcessor.ts
@@ -199,8 +199,16 @@ export function loadPromptConfig(type: string): PromptConfig {
     return configCache.get(type)!;
   }
 
+  if (!/^[a-z0-9_-]+$/i.test(type)) {
+    throw new Error(`Invalid prompt config type: ${type}`);
+  }
+
   try {
-    const configPath = path.join(__dirname, '../../prompts', `${type}.json`);
+    const promptsDir = path.resolve(__dirname, '../../prompts');
+    const configPath = path.resolve(promptsDir, `${type}.json`);
+    if (!configPath.startsWith(promptsDir + path.sep)) {
+      throw new Error(`Invalid prompt config type: ${type}`);
+    }
     const configData = fs.readFileSync(configPath, 'utf8');
     const config = JSON.parse(configData) as PromptConfig;
     configCache.set(type, config);

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -348,7 +348,7 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/claude_wahlprogramm', aiGenerationLimiter, wahlprogrammRouter);
   app.use('/api/claude_universal', aiGenerationLimiter, universalRouter);
   app.use('/api/texte/smart', aiGenerationLimiter, smartTexteRouter);
-  app.use('/api/texte/playground', requireAuth, playgroundRouter);
+  app.use('/api/texte/playground', requireAuth, aiGenerationLimiter, playgroundRouter);
   app.use('/api/generate-content-title', aiGenerationLimiter, contentTitleRouter);
   app.use('/api/claude_gruene_jugend', aiGenerationLimiter, claudeGrueneJugendRoute);
   app.use('/api/claude_gruenerator_ask', aiGenerationLimiter, claudeGrueneratorAskRoute);
@@ -365,14 +365,14 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/share', shareRouter);
   app.use('/api/transfer', standardMutationLimiter, transferRouter);
   app.use('/api/mem0', requireAuth, mem0Router);
-  app.use('/api/email', requireAuth, emailRouter);
-  app.use('/api/auth/init', authInitRouter);
-  app.use('/api/recent-activity', recentActivityRouter);
+  app.use('/api/email', requireAuth, standardMutationLimiter, emailRouter);
+  app.use('/api/auth/init', publicReadLimiter, authInitRouter);
+  app.use('/api/recent-activity', publicReadLimiter, recentActivityRouter);
   app.use('/api/notifications', requireAuth, notificationsRouter);
   app.use('/api/media', requireAuth, mediaRouter);
   app.use('/api/docs/public', publicDocRouter);
-  app.use('/api/docs', requireAuth, docsRouter);
-  app.use('/api/presentations', requireAuth, presentationsRouter);
+  app.use('/api/docs', requireAuth, standardMutationLimiter, docsRouter);
+  app.use('/api/presentations', requireAuth, standardMutationLimiter, presentationsRouter);
   app.use('/api/boards/public', publicBoardRouter);
   app.use('/api/boards', requireAuth, boardsRouter);
   app.use('/api/users', requireAuth, usersRouter);

--- a/apps/api/routes/auth/initController.ts
+++ b/apps/api/routes/auth/initController.ts
@@ -81,7 +81,13 @@ async function fetchSavedTexts(userId: string): Promise<any[]> {
     );
 
     return (data || []).map((item: any) => {
-      const plainText = (item.content || '').replace(/<[^>]*>/g, '').trim();
+      let plainText = item.content || '';
+      let prev: string;
+      do {
+        prev = plainText;
+        plainText = plainText.replace(/<[^>]*>/g, '');
+      } while (plainText !== prev);
+      plainText = plainText.trim();
       const wordCount = plainText.split(/\s+/).filter((w: string) => w.length > 0).length;
       return {
         id: item.document_id,

--- a/apps/api/routes/transfer/transferController.ts
+++ b/apps/api/routes/transfer/transferController.ts
@@ -120,7 +120,11 @@ router.post(
       res.status(500).json({ error: 'Upload fehlgeschlagen. Bitte versuche es erneut.' });
     } finally {
       if (tempPath) {
-        fs.unlink(tempPath, () => {});
+        const expectedDir = path.resolve(os.tmpdir(), 'gruenerator-transfer');
+        const resolvedTemp = path.resolve(tempPath);
+        if (resolvedTemp.startsWith(expectedDir + path.sep)) {
+          fs.unlink(tempPath, () => {});
+        }
       }
     }
   }

--- a/apps/api/routes/workplace/recentActivityController.ts
+++ b/apps/api/routes/workplace/recentActivityController.ts
@@ -246,7 +246,13 @@ export async function fetchRecentTexts(
 
   return rows.map((row: any) => {
     const rawContent = typeof row.content === 'string' ? row.content : '';
-    const stripped = rawContent.replace(/<[^>]*>/g, '').slice(0, 500);
+    let stripped = rawContent;
+    let prev: string;
+    do {
+      prev = stripped;
+      stripped = stripped.replace(/<[^>]*>/g, '');
+    } while (stripped !== prev);
+    stripped = stripped.slice(0, 500);
 
     return {
       id: row.id,

--- a/apps/api/services/api-clients/nextcloudApiClient.ts
+++ b/apps/api/services/api-clients/nextcloudApiClient.ts
@@ -1,6 +1,10 @@
+import * as os from 'os';
+import * as path from 'path';
+
 import axios, { type AxiosInstance, type AxiosError } from 'axios';
 
 import { sanitizeFilename } from '../../utils/validation/index.js';
+import { validateUrlSync } from '../../utils/validation/urlSecurity.js';
 
 // Type Definitions
 export interface ParsedShareLink {
@@ -72,6 +76,11 @@ class NextcloudApiClient {
     this.baseURL = this.parsedLink.baseUrl;
     this.shareToken = this.parsedLink.shareToken;
     this.webdavUrl = `${this.baseURL}/public.php/webdav`;
+
+    const urlCheck = validateUrlSync(this.baseURL, { allowedProtocols: ['https:'] });
+    if (!urlCheck.isValid) {
+      throw new Error(`Invalid Nextcloud share URL: ${urlCheck.error}`);
+    }
 
     // Create axios instance with basic authentication using share token
     this.axiosInstance = axios.create({
@@ -279,6 +288,12 @@ class NextcloudApiClient {
         uploadUrl = `${this.webdavUrl}/${encodedPath}`;
       }
       uploadUrl = `${uploadUrl}/${encodeURIComponent(safeFilename)}`;
+
+      const expectedDir = path.resolve(os.tmpdir(), 'gruenerator-transfer');
+      const resolvedPath = path.resolve(filePath);
+      if (!resolvedPath.startsWith(expectedDir + path.sep) && resolvedPath !== expectedDir) {
+        throw new Error('File path outside allowed directory');
+      }
 
       const stat = fs.statSync(filePath);
       const stream = fs.createReadStream(filePath);

--- a/apps/api/services/monitor/PolitProService.ts
+++ b/apps/api/services/monitor/PolitProService.ts
@@ -32,12 +32,12 @@ interface PolitProResponse {
 
 const PARTY_NAME_MAP: Record<string, string> = {
   'CDU/CSU': 'CDU/CSU',
-  'AfD': 'AfD',
-  'SPD': 'SPD',
-  'Grüne': 'GRÜNE',
-  'Linke': 'DIE LINKE',
-  'BSW': 'BSW',
-  'FDP': 'FDP',
+  AfD: 'AfD',
+  SPD: 'SPD',
+  Grüne: 'GRÜNE',
+  Linke: 'DIE LINKE',
+  BSW: 'BSW',
+  FDP: 'FDP',
 };
 
 async function fetchPolitPro(parliament: string, year: number): Promise<PolitProResponse | null> {
@@ -110,7 +110,7 @@ export interface PolitProPollData extends PollData {
 function toExtendedPollData(
   data: PolitProResponse,
   parliament: string,
-  institutePolls?: PollResult[],
+  institutePolls?: PollResult[]
 ): PolitProPollData {
   const base = toPollData(data, parliament);
 
@@ -121,7 +121,9 @@ function toExtendedPollData(
   }
 
   const useInstitutePolls = institutePolls && institutePolls.length > 0;
-  log.info(`[toExtendedPollData] Branch: ${useInstitutePolls ? `institutePolls (${institutePolls!.length})` : `base.polls (${base.polls.length})`}`);
+  log.info(
+    `[toExtendedPollData] Branch: ${useInstitutePolls ? `institutePolls (${institutePolls!.length})` : `base.polls (${base.polls.length})`}`
+  );
 
   return {
     ...base,
@@ -160,7 +162,9 @@ async function scrapeInstitutePolls(parliament: string): Promise<PollResult[]> {
     log.info(`[scrapeInstitutePolls] Found ${pollListItems.length} .poll-list-item elements`);
 
     if (pollListItems.length === 0) {
-      log.warn(`[scrapeInstitutePolls] No .poll-list-item elements found — HTML snippet (first 500 chars): ${html.slice(0, 500)}`);
+      log.warn(
+        `[scrapeInstitutePolls] No .poll-list-item elements found — HTML snippet (first 500 chars): ${html.slice(0, 500)}`
+      );
     }
 
     const polls: PollResult[] = [];
@@ -171,23 +175,36 @@ async function scrapeInstitutePolls(parliament: string): Promise<PollResult[]> {
       if (!institute) return;
 
       const parties: Record<string, number | null> = {};
-      $(el).find('.horizontal-parties-list-item').each((_, partyEl) => {
-        const name = $(partyEl).attr('title');
-        const val = $(partyEl).find('.list-horizontal-value').text().trim();
-        if (name && val) {
-          const partyName = PARTY_NAME_MAP[name] || name;
-          parties[partyName] = parseFloat(val) || null;
-        }
-      });
+      $(el)
+        .find('.horizontal-parties-list-item')
+        .each((_, partyEl) => {
+          const name = $(partyEl).attr('title');
+          const val = $(partyEl).find('.list-horizontal-value').text().trim();
+          if (name && val) {
+            const partyName = PARTY_NAME_MAP[name] || name;
+            parties[partyName] = parseFloat(val) || null;
+          }
+        });
 
       polls.push({ institute, date, parties });
     });
 
     log.info(`[scrapeInstitutePolls] Parsed ${polls.length} institute polls for ${parliament}`);
     if (polls.length > 0) {
-      log.info(`[scrapeInstitutePolls] First 2 polls:`, polls.slice(0, 2).map((p) => ({ institute: p.institute, date: p.date, partyCount: Object.keys(p.parties).length })));
+      log.info(
+        `[scrapeInstitutePolls] First 2 polls:`,
+        polls
+          .slice(0, 2)
+          .map((p) => ({
+            institute: p.institute,
+            date: p.date,
+            partyCount: Object.keys(p.parties).length,
+          }))
+      );
     } else {
-      log.warn(`[scrapeInstitutePolls] 0 institute polls parsed despite ${pollListItems.length} DOM elements`);
+      log.warn(
+        `[scrapeInstitutePolls] 0 institute polls parsed despite ${pollListItems.length} DOM elements`
+      );
     }
     return polls;
   } catch (error) {
@@ -197,15 +214,22 @@ async function scrapeInstitutePolls(parliament: string): Promise<PollResult[]> {
 }
 
 export async function getPolitProPolls(
-  parliament = 'deutschland',
+  parliament = 'deutschland'
 ): Promise<PolitProPollData | null> {
+  if (!VALID_PARLIAMENT_IDS.has(parliament)) {
+    log.warn(`[getPolitProPolls] Invalid parliament ID: ${parliament}`);
+    return null;
+  }
+
   const cacheKey = `monitor:politpro:${parliament}`;
 
   try {
     const cached = await redisClient.get(cacheKey);
     if (cached) {
       const parsed = JSON.parse(cached) as PolitProPollData;
-      log.info(`[getPolitProPolls] Cache hit (${parliament}): ${parsed.polls.length} polls, first poll date: ${parsed.polls[0]?.date ?? 'none'}, institute: ${parsed.polls[0]?.institute ?? 'none'}`);
+      log.info(
+        `[getPolitProPolls] Cache hit (${parliament}): ${parsed.polls.length} polls, first poll date: ${parsed.polls[0]?.date ?? 'none'}, institute: ${parsed.polls[0]?.institute ?? 'none'}`
+      );
       return parsed;
     }
   } catch {
@@ -221,13 +245,15 @@ export async function getPolitProPolls(
 
   log.info(`[getPolitProPolls] Institute polls found: ${institutePolls.length} for ${parliament}`);
   if (institutePolls.length === 0) {
-    log.warn(`[getPolitProPolls] No institute polls scraped — will fall back to API interpolated data`);
+    log.warn(
+      `[getPolitProPolls] No institute polls scraped — will fall back to API interpolated data`
+    );
   }
 
   const result = toExtendedPollData(data, parliament, institutePolls);
 
   log.info(
-    `[getPolitProPolls] Final result (${parliament}): ${result.polls.length} polls, ${Object.keys(result.average).length} parties`,
+    `[getPolitProPolls] Final result (${parliament}): ${result.polls.length} polls, ${Object.keys(result.average).length} parties`
   );
 
   try {
@@ -259,3 +285,5 @@ export const POLITPRO_PARLIAMENTS = [
   { id: 'schleswig-holstein', name: 'Schleswig-Holstein' },
   { id: 'thueringen', name: 'Thüringen' },
 ] as const;
+
+const VALID_PARLIAMENT_IDS: Set<string> = new Set(POLITPRO_PARLIAMENTS.map((p) => p.id));

--- a/apps/api/services/scrapers/implementations/UrlCrawler/validators/UrlValidator.ts
+++ b/apps/api/services/scrapers/implementations/UrlCrawler/validators/UrlValidator.ts
@@ -7,6 +7,8 @@
 import { createRequire } from 'module';
 import { URL } from 'url';
 
+import { safeFetch } from '../../../../../utils/validation/urlSecurity.js';
+
 const require = createRequire(import.meta.url);
 const robotsParser = require('robots-parser') as (
   url: string,
@@ -35,7 +37,7 @@ async function isAllowedByRobotsTxt(url: string): Promise<boolean> {
     }
 
     const robotsUrl = `${origin}/robots.txt`;
-    const resp = await fetch(robotsUrl, {
+    const resp = await safeFetch(robotsUrl, {
       signal: AbortSignal.timeout(ROBOTS_FETCH_TIMEOUT),
       headers: { 'User-Agent': BOT_USER_AGENT },
     });

--- a/apps/docs/server.ts
+++ b/apps/docs/server.ts
@@ -127,7 +127,7 @@ app.get('/document/:id', async (req, res, next) => {
   const docId = match[1];
 
   try {
-    const ogRes = await fetch(`${API_TARGET}/api/docs/public/${docId}/og`);
+    const ogRes = await fetch(`${API_TARGET}/api/docs/public/${encodeURIComponent(docId!)}/og`);
     if (!ogRes.ok) {
       res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
       return res.send(indexHtmlTemplate);

--- a/apps/web/src/components/common/TemplatePreviewModal/TemplatePreviewModal.tsx
+++ b/apps/web/src/components/common/TemplatePreviewModal/TemplatePreviewModal.tsx
@@ -40,7 +40,7 @@ interface TemplateMetadata {
 }
 
 interface Template {
-  id?: string;
+  id?: string | number;
   content_data?: TemplateContentData;
   metadata?: TemplateMetadata;
   external_url?: string;

--- a/apps/web/src/features/boards/hooks/useBoardCollaboration.ts
+++ b/apps/web/src/features/boards/hooks/useBoardCollaboration.ts
@@ -15,7 +15,7 @@ export const useBoardCollaboration = (boardId: string) => {
             id: String(user.id),
             display_name: user.display_name,
             email: user.email,
-            avatar_robot_id: user.avatar_robot_id,
+            avatar_robot_id: user.avatar_robot_id ? Number(user.avatar_robot_id) : null,
           }
         : null,
     [user?.id, user?.display_name, user?.email, user?.avatar_robot_id]

--- a/apps/web/src/features/subtitler-beta/components/SubtitleList.tsx
+++ b/apps/web/src/features/subtitler-beta/components/SubtitleList.tsx
@@ -29,7 +29,7 @@ interface SubtitleListProps {
   isPlaying?: boolean;
   onSeek?: (time: number) => void;
   onPlayPause?: () => void;
-  videoPlayerRef?: RefObject<BetaVideoPlayerRef>;
+  videoPlayerRef?: RefObject<BetaVideoPlayerRef | null>;
 }
 
 export function SubtitleList({ className, videoPlayerRef }: SubtitleListProps) {

--- a/apps/web/src/features/subtitler-beta/components/SubtitlerBetaPage.tsx
+++ b/apps/web/src/features/subtitler-beta/components/SubtitlerBetaPage.tsx
@@ -337,6 +337,4 @@ function SubtitlerBetaPageInner() {
   );
 }
 
-export default withAuthRequired(SubtitlerBetaPageInner, {
-  redirectTo: '/login',
-});
+export default withAuthRequired(SubtitlerBetaPageInner);

--- a/apps/web/src/features/transfer/TransferPage.tsx
+++ b/apps/web/src/features/transfer/TransferPage.tsx
@@ -2,7 +2,7 @@ import { Button, FileCard, RetroGrid } from '@gruenerator/ui';
 import { useShareLinks, useWolkePreferencesStore } from '@gruenerator/wolke';
 import { useCallback, useState } from 'react';
 import { PiCheck, PiCopy, PiFile, PiPlus, PiShareNetwork, PiUploadSimple } from 'react-icons/pi';
-import { QRCode } from 'react-qr-code';
+import QRCode from 'react-qr-code';
 import { Link } from 'react-router-dom';
 
 import Spinner from '../../components/common/Spinner';

--- a/apps/web/src/features/workplace/components/TextCard.tsx
+++ b/apps/web/src/features/workplace/components/TextCard.tsx
@@ -64,7 +64,15 @@ const TextCard = React.memo(
           {text.content ? (
             <div className="w-[600px] origin-top-left scale-[0.25] p-8 pointer-events-none select-none text-foreground font-sans leading-relaxed">
               <p className="text-base whitespace-pre-line">
-                {text.content.replace(/<[^>]*>/g, '').slice(0, 500)}
+                {(() => {
+                  let s = text.content;
+                  let p: string;
+                  do {
+                    p = s;
+                    s = s.replace(/<[^>]*>/g, '');
+                  } while (s !== p);
+                  return s.slice(0, 500);
+                })()}
               </p>
             </div>
           ) : (

--- a/packages/docs/src/context/DocsContext.tsx
+++ b/packages/docs/src/context/DocsContext.tsx
@@ -26,7 +26,7 @@ export interface DocsAdapter {
   /** Navigate to document list */
   navigateToHome(): void;
   /** Optional custom WebSocket constructor for environments where native WS doesn't work (e.g. Expo DOM) */
-  getWebSocketPolyfill?(): unknown;
+  getWebSocketPolyfill?(): (new (...args: unknown[]) => WebSocket) | undefined;
   /** Get the current user's display name (for personalized sharing) */
   getCurrentUserDisplayName?(): string | null;
 }

--- a/packages/slides/src/components/RemoteSvgIcon.tsx
+++ b/packages/slides/src/components/RemoteSvgIcon.tsx
@@ -133,7 +133,7 @@ export function useRemoteSvgIcon(url?: string, options: RemoteSvgOptions = {}) {
         return;
       }
       // non-svg extensions fallback
-      if (/\.(png|jpe?g|gif|webp)(\?.*)?$/i.test(url)) {
+      if (/\.(png|jpe?g|gif|webp)(?:\?|$)/i.test(url)) {
         const stroke = options.strokeColor || 'currentColor';
         const fill = options.fillColor ?? 'none';
         const cls = options.className ? ` class=\"${options.className}\"` : '';


### PR DESCRIPTION
## Summary
- Path traversal protection in PromptProcessor and transfer temp file cleanup
- URL validation for Nextcloud share links
- Input validation for PolitPro parliament IDs
- Use safeFetch in UrlValidator robots.txt fetching
- Encode docId in docs OG endpoint
- Add rate limiters to playground, email, docs, presentations routes
- Iterative HTML stripping to prevent nested tag bypass
- Type fixes across web and packages
- QRCode import fix, remove redundant redirectTo

## Test plan
- [ ] Verify transfer upload still works
- [ ] Verify docs OG previews render
- [ ] Verify PolitPro polls load
- [ ] Run `pnpm ci`