### PR TITLE
test-branch → master: vision endpoint, playground simplification, collection sync

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -1,17 +1,17 @@
 /**
  * Rerank Node
  *
- * Uses Mistral-small to rerank search results by semantic relevance.
- * Sits between the search and respond nodes in the graph pipeline.
+ * Uses Regolo's dedicated Rerank API (Qwen3-Reranker-4B cross-encoder)
+ * to rerank search results by semantic relevance. Sits between the search
+ * and respond nodes in the graph pipeline.
  *
- * Takes the top results from search, asks the LLM to score relevance,
- * and returns only the best matches. This improves precision significantly
- * when combined with cross-collection search (which increases candidate volume).
+ * After cross-encoder scoring, applies MMR diversity filtering to reduce
+ * redundancy in the final result set.
  */
 
 import { applyMMR } from '../../../../services/search/DiversityReranker.js';
+import { regoloRerankService } from '../../../../services/search/RegoloRerankService.js';
 import { createLogger } from '../../../../utils/logger.js';
-import { INTERMEDIATE_MODEL } from '../llmConfig.js';
 
 import type { ChatGraphState, SearchResult } from '../types.js';
 
@@ -20,52 +20,19 @@ const log = createLogger('ChatGraph:Rerank');
 const RERANK_INPUT_LIMIT = 12;
 const RERANK_OUTPUT_LIMIT = 8;
 
-const INTENT_RERANK_GUIDANCE: Record<string, string> = {
-  research: '\nHinweis: Bevorzuge Quellen mit Analyse, Synthese und Vergleichen.',
-  search: '\nHinweis: Offizielle Parteibeschlüsse und Programme höher als Kommentare bewerten.',
-  web: '\nHinweis: Seriöse Nachrichtenquellen höher als Social Media oder Foren bewerten.',
-  examples: '\nHinweis: Aktuelle und visuell ansprechende Beispiele bevorzugen.',
-};
-
-const RERANK_PROMPT = `Du bewertest die Relevanz von Suchergebnissen für eine Benutzeranfrage.
-
-Für jedes Ergebnis vergib einen Relevanz-Score von 1-5:
-5 = Direkt relevant, beantwortet die Frage
-4 = Sehr relevant, enthält wichtige Informationen
-3 = Teilweise relevant, enthält Hintergrundinformationen
-2 = Wenig relevant, nur am Rande verwandt
-1 = Nicht relevant
-
-Antworte NUR mit JSON:
-{ "scores": [{"index": 0, "score": 5}, {"index": 1, "score": 3}, ...] }`;
-
-const RERANK_PROMPT_TEMPORAL = `Du bewertest die Relevanz von Suchergebnissen für eine Benutzeranfrage.
-Bevorzuge aktuelle Ergebnisse — neuere Quellen mit aktuellen Informationen sollten höher bewertet werden.
-
-Für jedes Ergebnis vergib einen Relevanz-Score von 1-5:
-5 = Direkt relevant, beantwortet die Frage, aktuell
-4 = Sehr relevant, enthält wichtige aktuelle Informationen
-3 = Teilweise relevant, enthält Hintergrundinformationen
-2 = Wenig relevant, nur am Rande verwandt oder veraltet
-1 = Nicht relevant oder stark veraltet
-
-Antworte NUR mit JSON:
-{ "scores": [{"index": 0, "score": 5}, {"index": 1, "score": 3}, ...] }`;
-
 /**
- * Rerank search results using Mistral-small.
- * Batches all passages into a single LLM call for efficiency.
+ * Rerank search results using Regolo's cross-encoder reranker.
+ * Applies MMR diversity filtering as a second pass.
  */
 export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGraphState>> {
   const startTime = Date.now();
-  const { searchResults, searchQuery, aiWorkerPool, hasTemporal, intent, researchBrief } = state;
+  const { searchResults, searchQuery, hasTemporal, researchBrief } = state;
 
   // Notebook-scoped searches get higher limits for deeper recall
   const isNotebookScoped = (state.notebookCollectionIds?.length ?? 0) > 0;
   const inputLimit = isNotebookScoped ? 20 : RERANK_INPUT_LIMIT;
   const outputLimit = isNotebookScoped ? 12 : RERANK_OUTPUT_LIMIT;
 
-  // Skip reranking if only one result
   if (searchResults.length <= 2) {
     log.info(`[Rerank] Skipping — only ${searchResults.length} results`);
     return { rerankTimeMs: Date.now() - startTime };
@@ -78,55 +45,40 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
   );
 
   try {
-    // Build the passage list for the LLM
-    const passageList = candidates
-      .map((r, i) => `[${i}] ${r.title}\n${r.content.slice(0, 300)}`)
-      .join('\n\n');
+    const documents = candidates.map((r) => `${r.title}\n${r.content.slice(0, 300)}`);
 
-    const userMessage = `Suchanfrage: "${searchQuery}"${researchBrief ? `\nRecherche-Kontext: ${researchBrief}` : ''}${INTENT_RERANK_GUIDANCE[intent] || ''}
+    const instruct = hasTemporal
+      ? 'Given a search query, retrieve relevant and current passages that answer the query. Prefer recent sources.'
+      : undefined;
 
-Ergebnisse:
-${passageList}`;
+    const queryStr = researchBrief ? `${searchQuery}\n${researchBrief}` : searchQuery || '';
 
-    const response = await aiWorkerPool.processRequest(
-      {
-        type: 'chat_rerank',
-        provider: INTERMEDIATE_MODEL.provider,
-        systemPrompt: hasTemporal ? RERANK_PROMPT_TEMPORAL : RERANK_PROMPT,
-        messages: [{ role: 'user', content: userMessage }],
-        options: {
-          model: INTERMEDIATE_MODEL.model,
-          max_tokens: 200,
-          temperature: 0.0,
-          top_p: 1.0,
-          response_format: { type: 'json_object' },
-        },
-      },
-      null
-    );
+    const rerankResults = await regoloRerankService.rerank({
+      query: queryStr,
+      documents,
+      topN: inputLimit,
+      instruct,
+    });
 
-    // Parse scores
-    const parsed = parseRerankResponse(response.content || '', candidates.length);
     const rerankTimeMs = Date.now() - startTime;
 
-    if (!parsed) {
-      log.warn('[Rerank] Failed to parse response, keeping original order');
-      return { rerankTimeMs };
+    // Map scores back onto SearchResult objects
+    const scoreMap = new Map<number, number>();
+    for (const r of rerankResults) {
+      scoreMap.set(r.originalIndex, r.relevanceScore);
     }
 
-    // Apply scores and re-sort
     const scoredResults: SearchResult[] = candidates.map((r, i) => ({
       ...r,
-      relevance: parsed[i] !== undefined ? parsed[i] / 5 : r.relevance || 0.5,
+      relevance: scoreMap.get(i) ?? r.relevance ?? 0.5,
     }));
 
     scoredResults.sort((a, b) => (b.relevance || 0) - (a.relevance || 0));
 
-    // Filter out low-relevance results (score 1 = not relevant)
+    // Filter out low-relevance results
     const filtered = scoredResults.filter((r) => (r.relevance || 0) > 0.2);
 
-    // B3: Apply MMR diversity reranking as second pass
-    // Keep top 2 results unchanged, apply diversity for positions 3+
+    // Apply MMR diversity reranking as second pass
     const diverse = filtered.length > 3 ? applyMMR(filtered, 0.7, 2) : filtered;
     const reranked = diverse.slice(0, outputLimit);
 
@@ -141,43 +93,5 @@ ${passageList}`;
   } catch (error: any) {
     log.error('[Rerank] Error:', error.message);
     return { rerankTimeMs: Date.now() - startTime };
-  }
-}
-
-/**
- * Parse the rerank LLM response into a score map.
- * Returns index→score mapping, or null if parsing fails.
- */
-function parseRerankResponse(
-  content: string,
-  candidateCount: number
-): Record<number, number> | null {
-  try {
-    const parsed = JSON.parse(content);
-    const scores: Record<number, number> = {};
-
-    if (parsed.scores && Array.isArray(parsed.scores)) {
-      for (const entry of parsed.scores) {
-        const idx = Number(entry.index);
-        const score = Number(entry.score);
-        if (idx >= 0 && idx < candidateCount && score >= 1 && score <= 5) {
-          scores[idx] = score;
-        }
-      }
-    }
-
-    if (Object.keys(scores).length === 0) return null;
-    return scores;
-  } catch {
-    // Try extracting JSON from text
-    const jsonMatch = content.match(/\{[\s\S]*\}/);
-    if (jsonMatch) {
-      try {
-        return parseRerankResponse(jsonMatch[0], candidateCount);
-      } catch {
-        return null;
-      }
-    }
-    return null;
   }
 }

--- a/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.ts
@@ -12,8 +12,8 @@ import { z } from 'zod';
 import { executeDirectSearch } from '../../../../routes/chat/agents/directSearch.js';
 import { getQdrantDocumentService } from '../../../../services/document-services/DocumentSearchService/index.js';
 import { applyMMR } from '../../../../services/search/DiversityReranker.js';
+import { regoloRerankService } from '../../../../services/search/RegoloRerankService.js';
 import { createLogger } from '../../../../utils/logger.js';
-import { INTERMEDIATE_MODEL } from '../llmConfig.js';
 import {
   getDefaultCollectionsForLocale,
   getSupplementaryCollectionsForLocale,
@@ -23,18 +23,6 @@ import type { ToolDependencies } from './registry.js';
 
 const log = createLogger('Tool:SearchDocuments');
 
-const RERANK_PROMPT = `Du bewertest die Relevanz von Suchergebnissen für eine Benutzeranfrage.
-
-Für jedes Ergebnis vergib einen Relevanz-Score von 1-5:
-5 = Direkt relevant, beantwortet die Frage
-4 = Sehr relevant, enthält wichtige Informationen
-3 = Teilweise relevant, enthält Hintergrundinformationen
-2 = Wenig relevant, nur am Rande verwandt
-1 = Nicht relevant
-
-Antworte NUR mit JSON:
-{ "scores": [{"index": 0, "score": 5}, {"index": 1, "score": 3}, ...] }`;
-
 interface ScoredResult {
   source: string;
   title: string;
@@ -43,52 +31,26 @@ interface ScoredResult {
   relevance: number;
 }
 
-async function rerankResults(
-  results: ScoredResult[],
-  query: string,
-  aiWorkerPool: any
-): Promise<ScoredResult[]> {
+async function rerankResults(results: ScoredResult[], query: string): Promise<ScoredResult[]> {
   if (results.length <= 3) return results;
 
   const candidates = results.slice(0, 12);
-  const passageList = candidates
-    .map((r, i) => `[${i}] ${r.title}\n${r.content.slice(0, 300)}`)
-    .join('\n\n');
 
   try {
-    const response = await aiWorkerPool.processRequest(
-      {
-        type: 'chat_rerank',
-        provider: INTERMEDIATE_MODEL.provider,
-        systemPrompt: RERANK_PROMPT,
-        messages: [
-          { role: 'user', content: `Suchanfrage: "${query}"\n\nErgebnisse:\n${passageList}` },
-        ],
-        options: {
-          model: INTERMEDIATE_MODEL.model,
-          max_tokens: 200,
-          temperature: 0.0,
-          top_p: 1.0,
-          response_format: { type: 'json_object' },
-        },
-      },
-      null
-    );
+    const documents = candidates.map((r) => `${r.title}\n${r.content.slice(0, 300)}`);
+    const rerankResults = await regoloRerankService.rerank({
+      query,
+      documents,
+      topN: 12,
+    });
 
-    const rawContent = (response.content || '{}').trim();
-    const cleanedContent = rawContent
-      .replace(/^```(?:json)?\s*/i, '')
-      .replace(/\s*```\s*$/i, '')
-      .trim();
-    const parsed = JSON.parse(cleanedContent);
-    if (parsed.scores && Array.isArray(parsed.scores)) {
-      for (const entry of parsed.scores) {
-        const idx = Number(entry.index);
-        const score = Number(entry.score);
-        if (idx >= 0 && idx < candidates.length && score >= 1 && score <= 5) {
-          candidates[idx].relevance = score / 5;
-        }
-      }
+    const scoreMap = new Map<number, number>();
+    for (const r of rerankResults) {
+      scoreMap.set(r.originalIndex, r.relevanceScore);
+    }
+
+    for (let i = 0; i < candidates.length; i++) {
+      candidates[i].relevance = scoreMap.get(i) ?? candidates[i].relevance;
     }
   } catch (err: any) {
     log.warn(`[SearchDocuments] Rerank failed, keeping original order: ${err.message}`);
@@ -155,7 +117,7 @@ export function createSearchDocumentsTool(deps: ToolDependencies): DynamicStruct
             relevance: r.score ?? 0.5,
           }));
 
-          const reranked = await rerankResults(results, query, deps.aiWorkerPool);
+          const reranked = await rerankResults(results, query);
 
           if (reranked.length === 0) {
             return 'Keine relevanten Inhalte in den referenzierten Dokumenten gefunden.';
@@ -225,7 +187,7 @@ export function createSearchDocumentsTool(deps: ToolDependencies): DynamicStruct
       allResults.sort((a, b) => b.relevance - a.relevance);
 
       // Integrated reranking
-      const reranked = await rerankResults(allResults, query, deps.aiWorkerPool);
+      const reranked = await rerankResults(allResults, query);
 
       if (reranked.length === 0) {
         return 'Keine relevanten Dokumente gefunden.';

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -219,6 +219,7 @@ export async function setupRoutes(app: Application): Promise<void> {
   const { default: emailRouter } = await import('./routes/email/emailController.js');
   const { default: videoRouter } = await import('./routes/video/index.js');
   const { default: transferRouter } = await import('./routes/transfer/transferController.js');
+  const { default: visionRouter } = await import('./routes/vision/visionController.js');
 
   // Auth routes — authLimiter applied inside authCore.ts to login/callback only
   app.use('/api/auth', standardMutationLimiter, authRouter);
@@ -234,6 +235,7 @@ export async function setupRoutes(app: Application): Promise<void> {
 
   app.use('/api/claude_social', aiGenerationLimiter, claudeSocialRoute);
   app.use('/api/claude_alttext', aiGenerationLimiter, claudeAlttextRoute);
+  app.use('/api/vision', requireAuth, aiGenerationLimiter, visionRouter);
   app.use('/api/claude_website', aiGenerationLimiter, claudeWebsiteRoute);
   app.use('/api/leichte_sprache', aiGenerationLimiter, leichteSpracheRoute);
   app.use('/api/claude_rede', aiGenerationLimiter, redeRouter);

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -235,7 +235,7 @@ export async function setupRoutes(app: Application): Promise<void> {
 
   app.use('/api/claude_social', aiGenerationLimiter, claudeSocialRoute);
   app.use('/api/claude_alttext', aiGenerationLimiter, claudeAlttextRoute);
-  app.use('/api/vision', requireAuth, aiGenerationLimiter, visionRouter);
+  app.use('/api/vision', aiGenerationLimiter, requireAuth, visionRouter);
   app.use('/api/claude_website', aiGenerationLimiter, claudeWebsiteRoute);
   app.use('/api/leichte_sprache', aiGenerationLimiter, leichteSpracheRoute);
   app.use('/api/claude_rede', aiGenerationLimiter, redeRouter);

--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -6,6 +6,8 @@
 import { createMistral } from '@ai-sdk/mistral';
 import { createOpenAI } from '@ai-sdk/openai';
 
+import { isVisionCapable } from '../../../services/ai/modelDiscovery.js';
+
 import type { AgentConfig } from './types.js';
 import type { LanguageModel } from 'ai';
 
@@ -13,12 +15,12 @@ const LITELLM_DEFAULT_MODEL = 'gpt-oss:120b';
 
 export const VISION_MODEL = {
   provider: 'regolo' as const,
-  model: 'mistral-small-2503',
+  model: process.env.VISION_DEFAULT_MODEL || 'qwen3-vl-32b',
 };
 
 export { INTERMEDIATE_MODEL, getIntermediateModel } from '../../../services/ai/providers.js';
 
-export const VISION_CAPABLE_MODELS = new Set(['pixtral-large-latest', 'mistral-small-2503']);
+export { isVisionCapable };
 
 /**
  * Available models that can be selected by the user.

--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -35,8 +35,8 @@ import type express from 'express';
 const log = createLogger('NotebookStreamCore');
 const notebookHelper = new NotebookQdrantHelper();
 
-const DEFAULT_PROVIDER = 'mistral';
-const DEFAULT_MODEL = 'mistral-large-latest';
+const DEFAULT_PROVIDER = 'litellm';
+const DEFAULT_MODEL = 'gpt-oss:120b';
 
 export interface NotebookStreamOptions {
   req: express.Request;
@@ -175,7 +175,6 @@ export async function handleNotebookStream(
         results: searchContext.sortedResults,
         referencesMap: searchContext.referencesMap,
         question,
-        aiWorkerPool: req.app.locals.aiWorkerPool,
         limit: 10,
       });
       searchContext.sortedResults = reranked.results;

--- a/apps/api/routes/chat/services/responseStreamingService.ts
+++ b/apps/api/routes/chat/services/responseStreamingService.ts
@@ -10,12 +10,7 @@
 import { streamText } from 'ai';
 
 import { createLogger } from '../../../utils/logger.js';
-import {
-  getModel,
-  getModelConfig,
-  VISION_MODEL,
-  VISION_CAPABLE_MODELS,
-} from '../agents/providers.js';
+import { getModel, getModelConfig, VISION_MODEL, isVisionCapable } from '../agents/providers.js';
 
 import { sanitizeContentPartsForModel, stripEmptyAssistantMessages } from './messageHelpers.js';
 import { PROGRESS_MESSAGES } from './sseHelpers.js';
@@ -53,7 +48,7 @@ export function resolveModel(
     }
   }
 
-  if (options?.hasImages && !VISION_CAPABLE_MODELS.has(modelName)) {
+  if (options?.hasImages && !isVisionCapable(modelName)) {
     log.info(
       `[ChatGraph] Images present but "${modelName}" lacks vision — switching to ${VISION_MODEL.provider}/${VISION_MODEL.model}`
     );

--- a/apps/api/routes/texte/alttext.ts
+++ b/apps/api/routes/texte/alttext.ts
@@ -1,34 +1,19 @@
 import { type Router, type Request, type Response } from 'express';
 
+import { visionService } from '../../services/vision/index.js';
 import { createAuthenticatedRouter } from '../../utils/keycloak/index.js';
 import { createLogger } from '../../utils/logger.js';
+
 const log = createLogger('claude_alttext');
 const router: Router = createAuthenticatedRouter();
 
 interface AlttextRequestBody {
   imageBase64: string;
   imageDescription?: string;
-  usePrivacyMode?: boolean;
 }
-
-interface ImageContentBlock {
-  type: 'image';
-  source: {
-    type: 'base64';
-    media_type: string;
-    data: string;
-  };
-}
-
-interface TextContentBlock {
-  type: 'text';
-  text: string;
-}
-
-type ContentBlock = ImageContentBlock | TextContentBlock;
 
 router.post('/', async (req: Request, res: Response): Promise<void> => {
-  const { imageBase64, imageDescription, usePrivacyMode } = req.body as AlttextRequestBody;
+  const { imageBase64, imageDescription } = req.body as AlttextRequestBody;
 
   log.debug('[claude_alttext] Request received:', {
     hasImageBase64: !!imageBase64,
@@ -45,109 +30,9 @@ router.post('/', async (req: Request, res: Response): Promise<void> => {
   }
 
   try {
-    log.debug('[claude_alttext] Starting AI Worker request');
+    const altText = await visionService.generateAltText(imageBase64, imageDescription);
 
-    const systemPrompt = `Du erstellst Alternativtexte (Alt-Text) für Bilder basierend auf den Richtlinien des Deutschen Blinden- und Sehbehindertenverbands (DBSV). Alt-Text ist entscheidend, um Bilder für blinde und sehbehinderte Menschen zugänglich zu machen.
-
-Befolge diese Richtlinien für effektiven Alt-Text:
-
-1. Beginne mit den wichtigsten Informationen, die das Wesentliche des Bildes vermitteln (wie würdest du es jemandem am Telefon unter Zeitdruck beschreiben?)
-2. Sei prägnant aber beschreibend, strebe 1-2 Sätze an
-3. Verwende einfache, klare Sprache und vermeide Fachbegriffe oder Jargon
-4. Beschreibe den Inhalt und die Funktion des Bildes, ohne zu interpretieren oder Meinungen zu äußern
-5. Füge relevante Details hinzu, die für das Verständnis des Bildkontexts wesentlich sind
-6. Vermeide Phrasen wie "Bild von" oder "Foto von", da Screenreader bereits anzeigen, dass es sich um ein Bild handelt
-7. WICHTIG: Wenn Text im Bild sichtbar ist und für den Kontext relevant ist, gib den Text wörtlich wieder, ohne Anführungszeichen. Beispiel: "Plakat mit der Aufschrift Klimaschutz jetzt" statt "Plakat mit Text über Klimaschutz"
-
-Struktur deinen Alt-Text in zwei Teilen:
-- Pflicht: Kurz und knapp die nötigsten Infos im ersten Satz
-- Kür: Genauere Beschreibung mit weniger wichtigen Details (falls nötig)
-
-Gib deinen Alt-Text in <alt_text> Tags aus.`;
-
-    let userContent =
-      'Analysiere dieses Bild und erstelle einen Alt-Text, der den DBSV-Richtlinien für Barrierefreiheit entspricht.';
-
-    if (imageDescription) {
-      userContent += `\n\nZusätzliche Bildbeschreibung vom Nutzer: ${imageDescription}`;
-    }
-
-    const payload = {
-      systemPrompt,
-      provider: 'mistral',
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'image',
-              source: {
-                type: 'base64',
-                media_type: 'image/png',
-                data: imageBase64.replace(/^data:image\/[^;]+;base64,/, ''),
-              },
-            } as ImageContentBlock,
-            {
-              type: 'text',
-              text: userContent,
-            } as TextContentBlock,
-          ] as ContentBlock[],
-        },
-      ],
-      options: {
-        max_tokens: 2000,
-        temperature: 0.3,
-        model: 'mistral-large-2512',
-      },
-    };
-
-    log.debug('[claude_alttext] Payload overview:', {
-      systemPromptLength: systemPrompt.length,
-      userContentLength: userContent.length,
-      messageCount: payload.messages.length,
-      userId: req.user?.id,
-    });
-
-    const result = await req.app.locals.aiWorkerPool.processRequest(
-      {
-        type: 'alttext',
-        usePrivacyMode: usePrivacyMode || false,
-        ...payload,
-      },
-      req
-    );
-
-    log.debug('[claude_alttext] AI Worker response received:', {
-      success: result.success,
-      contentLength: result.content?.length,
-      error: result.error,
-      userId: req.user?.id,
-    });
-
-    if (!result.success) {
-      log.error('[claude_alttext] AI Worker error:', result.error);
-      throw new Error(result.error);
-    }
-
-    let altText = result.content;
-
-    const altTextMatch = altText.match(/<alt_text>(.*?)<\/alt_text>/s);
-    if (altTextMatch) {
-      altText = altTextMatch[1].trim();
-    }
-
-    const response = {
-      altText: altText,
-      metadata: result.metadata,
-    };
-
-    log.debug('[claude_alttext] Sending successful response:', {
-      altTextLength: response.altText?.length,
-      hasMetadata: !!response.metadata,
-      userId: req.user?.id,
-    });
-
-    res.json(response);
+    res.json({ altText });
   } catch (error) {
     log.error('[claude_alttext] Error creating alt text:', error);
     res.status(500).json({

--- a/apps/api/routes/texte/playground.ts
+++ b/apps/api/routes/texte/playground.ts
@@ -6,6 +6,7 @@
 import express, { type Router, type Request, type Response } from 'express';
 
 import { processGraphRequestStreaming } from '../../agents/langgraph/streamingProcessor.js';
+import { getAvailableModels } from '../../services/ai/modelDiscovery.js';
 import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('playground');
@@ -66,81 +67,15 @@ router.get('/prompts', async (_req: Request, res: Response): Promise<void> => {
   }
 });
 
-router.get('/models', async (_req: Request, res: Response): Promise<void> => {
-  const models = [
-    {
-      id: 'mistral-large-2512',
-      provider: 'mistral',
-      name: 'Mistral Large',
-      category: 'Mistral',
-      reasoning: false,
-    },
-    {
-      id: 'magistral-medium-latest',
-      provider: 'mistral',
-      name: 'Magistral Medium',
-      category: 'Mistral',
-      reasoning: true,
-    },
-    {
-      id: 'mistral-small-latest',
-      provider: 'mistral',
-      name: 'Mistral Small',
-      category: 'Mistral',
-      reasoning: false,
-    },
-    {
-      id: 'qwen3.5-122b',
-      provider: 'regolo',
-      name: 'Qwen 3.5 122B',
-      category: 'Regolo',
-      reasoning: true,
-    },
-    {
-      id: 'mistral-small-4-119b',
-      provider: 'regolo',
-      name: 'Mistral Small 4 119B',
-      category: 'Regolo',
-      reasoning: true,
-    },
-    {
-      id: 'Llama-3.3-70B-Instruct',
-      provider: 'regolo',
-      name: 'Llama 3.3 70B',
-      category: 'Regolo',
-      reasoning: false,
-    },
-    {
-      id: 'gpt-oss-120b',
-      provider: 'regolo',
-      name: 'GPT-OSS 120B',
-      category: 'Regolo',
-      reasoning: true,
-    },
-    {
-      id: 'mistral-small3.2',
-      provider: 'regolo',
-      name: 'Mistral Small 3.2',
-      category: 'Regolo',
-      reasoning: false,
-    },
-    {
-      id: 'gpt-oss:120b',
-      provider: 'litellm',
-      name: 'GPT-OSS 120B',
-      category: 'LiteLLM',
-      reasoning: true,
-    },
-    {
-      id: 'openai/gpt-oss-120b',
-      provider: 'ionos',
-      name: 'GPT-OSS 120B',
-      category: 'IONOS',
-      reasoning: true,
-    },
-  ];
-
-  res.json({ models });
+router.get('/models', async (req: Request, res: Response): Promise<void> => {
+  try {
+    const forceRefresh = req.query.refresh === 'true';
+    const models = await getAvailableModels(forceRefresh);
+    res.json({ models });
+  } catch (error) {
+    log.error('[playground] Failed to fetch models:', error);
+    res.status(500).json({ error: 'Failed to fetch models' });
+  }
 });
 
 export default router;

--- a/apps/api/routes/texte/playground.ts
+++ b/apps/api/routes/texte/playground.ts
@@ -13,58 +13,55 @@ const log = createLogger('playground');
 
 const router: Router = express.Router();
 
+const PLAYGROUND_PROMPTS = [
+  {
+    id: 'free',
+    name: 'Freie Eingabe',
+    description: 'Eigenen System-Prompt und Nachricht eingeben',
+    fields: ['systemPrompt', 'userMessage'],
+  },
+  {
+    id: 'universal',
+    name: 'Text Generator',
+    description: 'Texte in verschiedenen Formaten generieren',
+    fields: ['textForm', 'inhalt'],
+  },
+  {
+    id: 'leichte_sprache',
+    name: 'Leichte Sprache',
+    description: 'Texte in Leichte Sprache übersetzen',
+    fields: ['originalText'],
+  },
+];
+
 router.post('/generate', async (req: Request, res: Response): Promise<void> => {
   const { type, provider, model, ...rest } = req.body;
 
-  if (!type) {
+  const resolvedType = type === 'free' ? 'custom_prompt' : type;
+
+  if (!resolvedType) {
     res.status(400).json({ error: 'type is required' });
     return;
   }
 
-  log.debug(`[playground] Generate: type=${type}, provider=${provider}, model=${model}`);
+  log.debug(`[playground] Generate: type=${resolvedType}, provider=${provider}, model=${model}`);
 
-  req.body = { ...rest, provider, model };
+  if (type === 'free') {
+    req.body = {
+      provider,
+      model,
+      prompt: rest.systemPrompt || '',
+      userInput: rest.userMessage || '',
+    };
+  } else {
+    req.body = { ...rest, provider, model };
+  }
 
-  return processGraphRequestStreaming(type, req, res);
+  return processGraphRequestStreaming(resolvedType, req, res);
 });
 
-router.get('/prompts', async (_req: Request, res: Response): Promise<void> => {
-  const fs = await import('fs/promises');
-  const path = await import('path');
-  const { fileURLToPath } = await import('url');
-
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const promptsDir = path.join(__dirname, '../../prompts');
-
-  try {
-    const files = await fs.readdir(promptsDir);
-    const prompts = [];
-
-    for (const file of files) {
-      if (!file.endsWith('.json')) continue;
-      try {
-        const content = await fs.readFile(path.join(promptsDir, file), 'utf-8');
-        const config = JSON.parse(content);
-        if (config.id && config.name && config.requestFields) {
-          prompts.push({
-            id: config.id,
-            name: config.name,
-            requestFields: config.requestFields,
-            platforms: config.platforms ? Object.keys(config.platforms) : [],
-            features: config.features || {},
-            options: config.options || {},
-          });
-        }
-      } catch {
-        // skip invalid files
-      }
-    }
-
-    res.json({ prompts });
-  } catch (error) {
-    log.error('[playground] Failed to list prompts:', error);
-    res.status(500).json({ error: 'Failed to list prompts' });
-  }
+router.get('/prompts', (_req: Request, res: Response): void => {
+  res.json({ prompts: PLAYGROUND_PROMPTS });
 });
 
 router.get('/models', async (req: Request, res: Response): Promise<void> => {

--- a/apps/api/routes/vision/visionController.ts
+++ b/apps/api/routes/vision/visionController.ts
@@ -1,0 +1,173 @@
+import express, { type Router, type Request, type Response } from 'express';
+
+import { getAvailableModels } from '../../services/ai/modelDiscovery.js';
+import { ocrService } from '../../services/OcrService/index.js';
+import { visionService } from '../../services/vision/index.js';
+import { createLogger } from '../../utils/logger.js';
+
+import type { ProviderName } from '../../services/ai/providers.js';
+
+const log = createLogger('vision');
+
+const router: Router = express.Router();
+
+const MAX_IMAGE_LENGTH = 15_000_000; // ~10MB base64
+const MAX_INSTRUCTION_LENGTH = 10_000;
+
+function validateImageInput(image: unknown): string | null {
+  if (typeof image !== 'string' || image.length === 0) {
+    return 'image is required and must be a non-empty string (base64, data URL, or HTTP URL)';
+  }
+  if (image.length > MAX_IMAGE_LENGTH) {
+    return `image exceeds maximum size (~10MB base64)`;
+  }
+  return null;
+}
+
+router.post('/analyze', async (req: Request, res: Response): Promise<void> => {
+  const { image, instruction, provider, model, maxTokens } = req.body;
+
+  const imageError = validateImageInput(image);
+  if (imageError) {
+    res.status(400).json({ error: imageError });
+    return;
+  }
+
+  if (
+    instruction &&
+    typeof instruction === 'string' &&
+    instruction.length > MAX_INSTRUCTION_LENGTH
+  ) {
+    res.status(400).json({ error: `instruction exceeds ${MAX_INSTRUCTION_LENGTH} characters` });
+    return;
+  }
+
+  try {
+    const options = {
+      provider: provider as ProviderName | undefined,
+      model: model as string | undefined,
+      maxTokens: maxTokens as number | undefined,
+    };
+
+    const result = await visionService.analyzeWithOcr(image, instruction, options);
+
+    res.json({
+      description: result.description,
+      textDetection: result.textDetection,
+      extractedText: result.extractedText,
+      ocrMethod: result.ocrMethod ?? null,
+      model: options.model ?? process.env.VISION_DEFAULT_MODEL ?? 'qwen3-vl-32b',
+      provider: options.provider ?? 'regolo',
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error('[vision/analyze] Error:', message);
+    res.status(500).json({ error: 'Bildanalyse fehlgeschlagen', details: message });
+  }
+});
+
+router.post('/detect-text', async (req: Request, res: Response): Promise<void> => {
+  const { image } = req.body;
+
+  const imageError = validateImageInput(image);
+  if (imageError) {
+    res.status(400).json({ error: imageError });
+    return;
+  }
+
+  try {
+    const result = await visionService.detectTextContent(image);
+    res.json(result);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error('[vision/detect-text] Error:', message);
+    res.status(500).json({ error: 'Texterkennung fehlgeschlagen', details: message });
+  }
+});
+
+router.post('/ocr', async (req: Request, res: Response): Promise<void> => {
+  const { image, mimeType } = req.body;
+
+  const imageError = validateImageInput(image);
+  if (imageError) {
+    res.status(400).json({ error: imageError });
+    return;
+  }
+
+  try {
+    let base64Data = image as string;
+    let resolvedMimeType = (mimeType as string) || 'image/jpeg';
+
+    if (base64Data.startsWith('data:')) {
+      const match = base64Data.match(/^data:(image\/[^;]+);base64,(.+)$/s);
+      if (match) {
+        resolvedMimeType = match[1];
+        base64Data = match[2];
+      }
+    }
+
+    const result = await ocrService.extractTextFromBase64(
+      base64Data,
+      'image.jpg',
+      resolvedMimeType
+    );
+
+    res.json({
+      text: result.text,
+      method: result.method,
+      confidence: result.confidence ?? null,
+      pageCount: result.pageCount,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error('[vision/ocr] Error:', message);
+    res.status(500).json({ error: 'OCR-Extraktion fehlgeschlagen', details: message });
+  }
+});
+
+router.post('/alt-text', async (req: Request, res: Response): Promise<void> => {
+  const { image, context, provider, model } = req.body;
+
+  const imageError = validateImageInput(image);
+  if (imageError) {
+    res.status(400).json({ error: imageError });
+    return;
+  }
+
+  try {
+    const options = {
+      provider: provider as ProviderName | undefined,
+      model: model as string | undefined,
+    };
+
+    const altText = await visionService.generateAltText(
+      image,
+      context as string | undefined,
+      options
+    );
+
+    res.json({
+      altText,
+      model: options.model ?? process.env.VISION_DEFAULT_MODEL ?? 'qwen3-vl-32b',
+      provider: options.provider ?? 'regolo',
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error('[vision/alt-text] Error:', message);
+    res.status(500).json({ error: 'Alt-Text-Generierung fehlgeschlagen', details: message });
+  }
+});
+
+router.get('/models', async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const allModels = await getAvailableModels();
+    const visionModels = allModels.filter((m) => m.vision);
+    res.json({ models: visionModels });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error('[vision/models] Error:', message);
+    res.status(500).json({ error: 'Modelle konnten nicht geladen werden', details: message });
+  }
+});
+
+export default router;

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -35,6 +35,7 @@ const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision:
   'magistral-small-latest': { name: 'Magistral Small', reasoning: true, vision: false },
   'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
   'mistral-small-2503': { name: 'Mistral Small (Vision)', reasoning: false, vision: true },
+  'qwen3-vl-32b': { name: 'Qwen3 VL 32B', reasoning: false, vision: true },
   'mistral-medium-latest': { name: 'Mistral Medium', reasoning: false, vision: false },
   'pixtral-large-latest': { name: 'Pixtral Large', reasoning: false, vision: true },
   'gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
@@ -232,4 +233,22 @@ export async function getAvailableModels(forceRefresh = false): Promise<Playgrou
     });
 
   return fetchInProgress;
+}
+
+/**
+ * Check if a model ID is known to support vision.
+ * Uses MODEL_METADATA (synchronous, no API call needed).
+ */
+export function isVisionCapable(modelId: string): boolean {
+  const meta = MODEL_METADATA[modelId];
+  return meta?.vision ?? false;
+}
+
+/**
+ * Get all vision-capable models from the cached discovery results.
+ * Falls back to MODEL_METADATA if cache is empty.
+ */
+export async function getVisionCapableModels(): Promise<PlaygroundModel[]> {
+  const allModels = await getAvailableModels();
+  return allModels.filter((m) => m.vision);
 }

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -1,0 +1,235 @@
+import { createLogger } from '../../utils/logger.js';
+
+import {
+  type ProviderName,
+  IONOS_INCOMPATIBLE_PATTERNS,
+  IONOS_BASE_URL,
+  LITELLM_DEFAULT_BASE_URL,
+  MISTRAL_API_URL,
+  REGOLO_BASE_URL,
+  isProviderConfigured,
+} from './providers.js';
+
+const log = createLogger('modelDiscovery');
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface PlaygroundModel {
+  id: string;
+  provider: ProviderName;
+  name: string;
+  category: string;
+  reasoning: boolean;
+  vision: boolean;
+}
+
+interface OpenAIModelsResponse {
+  data: Array<{ id: string; object?: string; owned_by?: string }>;
+}
+
+const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision: boolean }> = {
+  'mistral-large-2512': { name: 'Mistral Large', reasoning: false, vision: false },
+  'mistral-large-latest': { name: 'Mistral Large', reasoning: false, vision: false },
+  'magistral-medium-latest': { name: 'Magistral Medium', reasoning: true, vision: false },
+  'magistral-small-latest': { name: 'Magistral Small', reasoning: true, vision: false },
+  'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
+  'mistral-small-2503': { name: 'Mistral Small (Vision)', reasoning: false, vision: true },
+  'mistral-medium-latest': { name: 'Mistral Medium', reasoning: false, vision: false },
+  'pixtral-large-latest': { name: 'Pixtral Large', reasoning: false, vision: true },
+  'gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
+  'gpt-oss:120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
+  'openai/gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
+  'qwen3.5-122b': { name: 'Qwen 3.5 122B', reasoning: true, vision: false },
+  'mistral-small-4-119b': { name: 'Mistral Small 4 119B', reasoning: true, vision: false },
+  'Llama-3.3-70B-Instruct': { name: 'Llama 3.3 70B', reasoning: false, vision: false },
+  'mistral-small3.2': { name: 'Mistral Small 3.2', reasoning: false, vision: false },
+};
+
+const EXCLUDE_PATTERNS = [
+  /embed/i,
+  /whisper/i,
+  /rerank/i,
+  /tts/i,
+  /dall-e/i,
+  /moderation/i,
+  /flux/i,
+  /diffusion/i,
+  /codestral-mamba/i,
+];
+
+const CATEGORY_NAMES: Record<ProviderName, string> = {
+  mistral: 'Mistral',
+  litellm: 'LiteLLM',
+  ionos: 'IONOS',
+  regolo: 'Regolo',
+};
+
+const CAT_ORDER: Record<string, number> = { Mistral: 0, Regolo: 1, LiteLLM: 2, IONOS: 3 };
+
+let cachedModels: PlaygroundModel[] | null = null;
+let cacheTimestamp = 0;
+let fetchInProgress: Promise<PlaygroundModel[]> | null = null;
+
+function isExcludedModel(modelId: string): boolean {
+  return EXCLUDE_PATTERNS.some((p) => p.test(modelId));
+}
+
+function deriveDisplayName(modelId: string): string {
+  return modelId
+    .replace(/^openai\//, '')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function enrichModel(modelId: string, provider: ProviderName): PlaygroundModel {
+  const meta = MODEL_METADATA[modelId];
+  return {
+    id: modelId,
+    provider,
+    name: meta?.name || deriveDisplayName(modelId),
+    category: CATEGORY_NAMES[provider],
+    reasoning: meta?.reasoning ?? false,
+    vision: meta?.vision ?? false,
+  };
+}
+
+async function fetchWithTimeout(url: string, headers: Record<string, string>): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function fetchProviderModels(
+  provider: ProviderName,
+  url: string,
+  apiKey: string | null
+): Promise<PlaygroundModel[]> {
+  if (!apiKey) {
+    return [];
+  }
+
+  try {
+    const response = await fetchWithTimeout(url, {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+    });
+
+    if (!response.ok) {
+      log.warn(`[${provider}] API returned ${response.status}`);
+      return [];
+    }
+
+    const data = (await response.json()) as OpenAIModelsResponse;
+    if (!data.data || !Array.isArray(data.data)) {
+      log.warn(`[${provider}] Unexpected response format`);
+      return [];
+    }
+
+    const models = data.data
+      .map((m) => m.id)
+      .filter((id) => !isExcludedModel(id))
+      .filter((id) => provider !== 'ionos' || !IONOS_INCOMPATIBLE_PATTERNS.some((p) => p.test(id)))
+      .map((id) => enrichModel(id, provider));
+
+    log.info(`[${provider}] Discovered ${models.length} models`);
+    return models;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    log.warn(`[${provider}] Failed to fetch models: ${msg}`);
+    return [];
+  }
+}
+
+const PROVIDER_ENDPOINTS: Record<ProviderName, { url: () => string; envKey: string }> = {
+  mistral: { url: () => `${MISTRAL_API_URL}/models`, envKey: 'MISTRAL_API_KEY' },
+  litellm: {
+    url: () => {
+      const base = process.env.LITELLM_BASE_URL || LITELLM_DEFAULT_BASE_URL;
+      return base.endsWith('/v1') ? `${base}/models` : `${base}/v1/models`;
+    },
+    envKey: 'LITELLM_API_KEY',
+  },
+  ionos: { url: () => `${IONOS_BASE_URL}/models`, envKey: 'IONOS_API_TOKEN' },
+  regolo: { url: () => `${REGOLO_BASE_URL}/models`, envKey: 'REGOLO_API_KEY' },
+};
+
+function fetchModelsForProvider(provider: ProviderName): Promise<PlaygroundModel[]> {
+  const endpoint = PROVIDER_ENDPOINTS[provider];
+  return fetchProviderModels(provider, endpoint.url(), process.env[endpoint.envKey] || null);
+}
+
+const FALLBACK_MODELS: PlaygroundModel[] = [
+  'mistral-large-2512',
+  'magistral-medium-latest',
+  'mistral-small-latest',
+]
+  .map((id) => enrichModel(id, 'mistral'))
+  .concat(
+    [
+      'qwen3.5-122b',
+      'mistral-small-4-119b',
+      'Llama-3.3-70B-Instruct',
+      'gpt-oss-120b',
+      'mistral-small3.2',
+    ].map((id) => enrichModel(id, 'regolo')),
+    [enrichModel('gpt-oss:120b', 'litellm')],
+    [enrichModel('openai/gpt-oss-120b', 'ionos')]
+  );
+
+async function discoverModels(): Promise<PlaygroundModel[]> {
+  const providers: ProviderName[] = ['mistral', 'litellm', 'ionos', 'regolo'];
+  const results = await Promise.allSettled(
+    providers.filter((p) => isProviderConfigured(p)).map((p) => fetchModelsForProvider(p))
+  );
+
+  const allModels: PlaygroundModel[] = [];
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      allModels.push(...result.value);
+    }
+  }
+
+  if (allModels.length === 0) {
+    log.warn('All provider APIs failed, using fallback models');
+    return FALLBACK_MODELS;
+  }
+
+  allModels.sort((a, b) => {
+    const catDiff = (CAT_ORDER[a.category] ?? 99) - (CAT_ORDER[b.category] ?? 99);
+    return catDiff !== 0 ? catDiff : a.name.localeCompare(b.name);
+  });
+
+  return allModels;
+}
+
+export async function getAvailableModels(forceRefresh = false): Promise<PlaygroundModel[]> {
+  if (!forceRefresh && cachedModels && Date.now() - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedModels;
+  }
+
+  if (fetchInProgress) {
+    return fetchInProgress;
+  }
+
+  fetchInProgress = discoverModels()
+    .then((models) => {
+      cachedModels = models;
+      cacheTimestamp = Date.now();
+      log.info(`Model cache refreshed: ${models.length} models`);
+      return models;
+    })
+    .catch((error) => {
+      log.error('Model discovery failed:', error);
+      return cachedModels ?? FALLBACK_MODELS;
+    })
+    .finally(() => {
+      fetchInProgress = null;
+    });
+
+  return fetchInProgress;
+}

--- a/apps/api/services/ai/providers.ts
+++ b/apps/api/services/ai/providers.ts
@@ -37,10 +37,13 @@ export function getIntermediateModel(): LanguageModel {
   return getModel(INTERMEDIATE_MODEL.provider, INTERMEDIATE_MODEL.model);
 }
 
-const LITELLM_DEFAULT_BASE_URL = 'https://litellm.netzbegruenung.verdigado.net';
+export const LITELLM_DEFAULT_BASE_URL = 'https://litellm.netzbegruenung.verdigado.net';
+export const IONOS_BASE_URL = 'https://openai.inference.de-txl.ionos.com/v1';
+export const REGOLO_BASE_URL = 'https://api.regolo.ai/v1';
+export const MISTRAL_API_URL = 'https://api.mistral.ai/v1';
 
 // Models incompatible with IONOS OpenAI-compatible endpoint
-const IONOS_INCOMPATIBLE_PATTERNS = [
+export const IONOS_INCOMPATIBLE_PATTERNS = [
   /^mistral/i,
   /^mixtral/i,
   /^claude/i,
@@ -100,7 +103,7 @@ function getIONOSProvider(): ReturnType<typeof createOpenAI> {
       throw new Error('IONOS_API_TOKEN environment variable is required');
     }
     ionosInstance = createOpenAI({
-      baseURL: 'https://openai.inference.de-txl.ionos.com/v1',
+      baseURL: IONOS_BASE_URL,
       apiKey,
       name: 'ionos',
     });
@@ -119,7 +122,7 @@ function getRegoloProvider(): ReturnType<typeof createOpenAI> {
       throw new Error('REGOLO_API_KEY environment variable is required');
     }
     regoloInstance = createOpenAI({
-      baseURL: 'https://api.regolo.ai/v1',
+      baseURL: REGOLO_BASE_URL,
       apiKey,
       name: 'regolo',
     });
@@ -172,7 +175,7 @@ export function getModel(provider: ProviderName | string, modelId?: string): Lan
     }
     case 'litellm': {
       const litellm = getLiteLLMProvider();
-      return litellm.chat(PROVIDER_DEFAULTS.litellm);
+      return litellm.chat(modelId || PROVIDER_DEFAULTS.litellm);
     }
     case 'ionos': {
       const ionos = getIONOSProvider();

--- a/apps/api/services/notebook/rerankNotebookResults.ts
+++ b/apps/api/services/notebook/rerankNotebookResults.ts
@@ -1,35 +1,21 @@
 /**
  * Rerank utility for notebook search results.
  *
- * Uses mistral-small to score search results by relevance, then filters
- * and returns the top N. Adapted from ChatGraph's rerankNode but operates
- * on ExpandedChunkResult[] + referencesMap (notebook types).
+ * Uses Regolo's dedicated Rerank API (Qwen3-Reranker-4B cross-encoder)
+ * to score search results by relevance, then filters and returns the top N.
  */
 
-import { INTERMEDIATE_MODEL } from '../../routes/chat/agents/providers.js';
 import { createLogger } from '../../utils/logger.js';
+import { regoloRerankService } from '../search/RegoloRerankService.js';
 
 import type { ExpandedChunkResult } from '../search/types.js';
 
 const log = createLogger('NotebookRerank');
 
-const RERANK_PROMPT = `Du bewertest die Relevanz von Suchergebnissen für eine Benutzeranfrage.
-
-Für jedes Ergebnis vergib einen Relevanz-Score von 1-5:
-5 = Direkt relevant, beantwortet die Frage
-4 = Sehr relevant, enthält wichtige Informationen
-3 = Teilweise relevant, enthält Hintergrundinformationen
-2 = Wenig relevant, nur am Rande verwandt
-1 = Nicht relevant
-
-Antworte NUR mit JSON:
-{ "scores": [{"index": 0, "score": 5}, {"index": 1, "score": 3}, ...] }`;
-
 export interface RerankOptions {
   results: ExpandedChunkResult[];
   referencesMap: Record<string, any>;
   question: string;
-  aiWorkerPool: any;
   limit?: number;
   inputLimit?: number;
 }
@@ -41,44 +27,10 @@ export interface RerankResult {
   rerankTimeMs: number;
 }
 
-function parseRerankResponse(
-  content: string,
-  candidateCount: number
-): Record<number, number> | null {
-  try {
-    const parsed = JSON.parse(content);
-    const scores: Record<number, number> = {};
-
-    if (parsed.scores && Array.isArray(parsed.scores)) {
-      for (const entry of parsed.scores) {
-        const idx = Number(entry.index);
-        const score = Number(entry.score);
-        if (idx >= 0 && idx < candidateCount && score >= 1 && score <= 5) {
-          scores[idx] = score;
-        }
-      }
-    }
-
-    if (Object.keys(scores).length === 0) return null;
-    return scores;
-  } catch {
-    const jsonMatch = content.match(/\{[\s\S]*\}/);
-    if (jsonMatch) {
-      try {
-        return parseRerankResponse(jsonMatch[0], candidateCount);
-      } catch {
-        return null;
-      }
-    }
-    return null;
-  }
-}
-
 export async function rerankNotebookResults({
   results,
   referencesMap,
   question,
-  aiWorkerPool,
   limit = 10,
   inputLimit = 20,
 }: RerankOptions): Promise<RerankResult> {
@@ -97,53 +49,25 @@ export async function rerankNotebookResults({
   const candidates = results.slice(0, inputLimit);
 
   try {
-    const passageList = candidates
-      .map((r, i) => `[${i}] ${r.title}\n${r.snippet.slice(0, 300)}`)
-      .join('\n\n');
+    const documents = candidates.map((r) => `${r.title}\n${r.snippet.slice(0, 300)}`);
 
-    const userMessage = `Suchanfrage: "${question}"\n\nErgebnisse:\n${passageList}`;
+    const rerankResults = await regoloRerankService.rerank({
+      query: question,
+      documents,
+      topN: limit,
+    });
 
-    const response = await aiWorkerPool.processRequest(
-      {
-        type: 'notebook_rerank',
-        provider: INTERMEDIATE_MODEL.provider,
-        systemPrompt: RERANK_PROMPT,
-        messages: [{ role: 'user', content: userMessage }],
-        options: {
-          model: INTERMEDIATE_MODEL.model,
-          max_tokens: 200,
-          temperature: 0.0,
-          top_p: 1.0,
-          response_format: { type: 'json_object' },
-        },
-      },
-      null
-    );
-
-    const parsed = parseRerankResponse(response.content || '', candidates.length);
     const rerankTimeMs = Date.now() - startTime;
 
-    if (!parsed) {
-      log.warn('[Rerank] Failed to parse response, keeping original order');
-      return {
-        results,
-        referencesMap,
-        contextSummary: buildContextSummary(referencesMap),
-        rerankTimeMs,
-      };
-    }
+    // Map back to candidates and filter low-relevance results
+    const scored = rerankResults
+      .filter((r) => r.relevanceScore > 0.2)
+      .map((r) => ({
+        result: candidates[r.originalIndex],
+        relevanceScore: r.relevanceScore,
+      }));
 
-    // Score and sort candidates
-    const scored = candidates.map((r, i) => ({
-      result: r,
-      originalIndex: i,
-      score: parsed[i] ?? 2.5,
-    }));
-    scored.sort((a, b) => b.score - a.score);
-
-    // Filter out low-relevance (score 1) and take top N
-    const filtered = scored.filter((s) => s.score > 1).slice(0, limit);
-    const rerankedResults = filtered.map((s) => s.result);
+    const rerankedResults = scored.map((s) => s.result);
 
     // Build a set of kept document_ids to filter the referencesMap
     const keptDocIds = new Set(rerankedResults.map((r) => r.document_id));

--- a/apps/api/services/search/RegoloRerankService.ts
+++ b/apps/api/services/search/RegoloRerankService.ts
@@ -1,0 +1,102 @@
+/**
+ * Regolo Rerank Service
+ *
+ * Uses Regolo's dedicated /rerank endpoint with Qwen3-Reranker-4B
+ * (a cross-encoder model) for fast, accurate relevance scoring.
+ *
+ * Replaces the previous LLM-based reranking that sent documents to
+ * mistral-small-4 and parsed JSON score responses.
+ */
+
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('RegoloRerank');
+
+const REGOLO_RERANK_URL = 'https://api.regolo.ai/rerank';
+const RERANK_MODEL = 'Qwen3-Reranker-4B';
+const DEFAULT_INSTRUCT = 'Given a search query, retrieve relevant passages that answer the query';
+
+export interface RerankRequest {
+  query: string;
+  documents: string[];
+  topN?: number;
+  instruct?: string;
+}
+
+export interface RerankResultItem {
+  originalIndex: number;
+  relevanceScore: number;
+  text: string;
+}
+
+interface RegoloRerankResponse {
+  id: string;
+  results: Array<{
+    index: number;
+    relevance_score: number;
+    document: { text: string };
+  }>;
+  meta: unknown;
+}
+
+class RegoloRerankService {
+  private apiKey: string;
+
+  constructor() {
+    this.apiKey = process.env.REGOLO_API_KEY || '';
+    if (!this.apiKey) {
+      log.warn('Missing REGOLO_API_KEY — reranking will fall back to original order');
+    }
+  }
+
+  async rerank(request: RerankRequest): Promise<RerankResultItem[]> {
+    if (!this.apiKey) {
+      throw new Error('REGOLO_API_KEY is not configured');
+    }
+
+    const { query, documents, topN, instruct } = request;
+    const instructText = instruct || DEFAULT_INSTRUCT;
+
+    const formattedQuery = `<Instruct>: ${instructText}\n<Query>: ${query}`;
+    const formattedDocuments = documents.map((doc) => `<Document>: ${doc}`);
+
+    log.info(`Reranking ${documents.length} documents${topN ? ` (top_n=${topN})` : ''}`);
+
+    const startTime = Date.now();
+
+    const response = await fetch(REGOLO_RERANK_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: RERANK_MODEL,
+        query: formattedQuery,
+        documents: formattedDocuments,
+        ...(topN && { top_n: topN }),
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(`Regolo rerank API error ${response.status}: ${errorText.slice(0, 200)}`);
+    }
+
+    const data = (await response.json()) as RegoloRerankResponse;
+
+    const results: RerankResultItem[] = data.results.map((r) => ({
+      originalIndex: r.index,
+      relevanceScore: r.relevance_score,
+      text: r.document.text,
+    }));
+
+    log.info(
+      `Reranked in ${Date.now() - startTime}ms — top score: ${results[0]?.relevanceScore.toFixed(3) ?? 'N/A'}`
+    );
+
+    return results;
+  }
+}
+
+export const regoloRerankService = new RegoloRerankService();

--- a/apps/api/services/search/__tests__/regoloRerank.test.ts
+++ b/apps/api/services/search/__tests__/regoloRerank.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration test for RegoloRerankService.
+ *
+ * Requires REGOLO_API_KEY to be set.
+ * Run with: npx tsx apps/api/services/search/__tests__/regoloRerank.test.ts
+ */
+
+import { regoloRerankService } from '../RegoloRerankService.js';
+
+const HAS_KEY = !!process.env.REGOLO_API_KEY;
+
+async function testBasicRerank() {
+  console.log('--- Test: Basic rerank ---');
+
+  const results = await regoloRerankService.rerank({
+    query: 'Klimapolitik der Grünen',
+    documents: [
+      'Die Grünen setzen sich für ambitionierte Klimaziele ein und fordern den Ausstieg aus fossilen Energien bis 2035.',
+      'Der FC Bayern München hat gestern ein Freundschaftsspiel gegen Real Madrid gewonnen.',
+      'Das Grundsatzprogramm der Grünen beschreibt die Parteiposition zum Klimaschutz und zur Energiewende.',
+      'Die Schwerkraft ist eine fundamentale Naturkraft, die alle Massen zueinander zieht.',
+    ],
+    topN: 4,
+  });
+
+  console.log('Results:');
+  for (const r of results) {
+    console.log(
+      `  [${r.originalIndex}] score=${r.relevanceScore.toFixed(4)} — ${r.text.slice(0, 80)}...`
+    );
+  }
+
+  // Sanity checks
+  const topResult = results[0];
+  if (topResult.originalIndex !== 0 && topResult.originalIndex !== 2) {
+    console.error('FAIL: Expected index 0 or 2 (climate-related) to be top result');
+    process.exit(1);
+  }
+  if (topResult.relevanceScore < 0.5) {
+    console.error('FAIL: Expected top result to have relevance > 0.5');
+    process.exit(1);
+  }
+
+  // The football and gravity docs should be at the bottom
+  const bottomTwo = results.slice(-2).map((r) => r.originalIndex);
+  if (!bottomTwo.includes(1) || !bottomTwo.includes(3)) {
+    console.error('FAIL: Expected football (1) and gravity (3) to be lowest scored');
+    process.exit(1);
+  }
+
+  console.log('PASS\n');
+}
+
+async function testTopN() {
+  console.log('--- Test: top_n limits results ---');
+
+  const results = await regoloRerankService.rerank({
+    query: 'Energiewende',
+    documents: [
+      'Erneuerbare Energien sind die Zukunft der deutschen Energieversorgung.',
+      'Kochen mit Gas wird in vielen Haushalten bevorzugt.',
+      'Windkraftanlagen liefern einen großen Teil des grünen Stroms.',
+      'Die Ölpreise schwanken stark auf dem Weltmarkt.',
+    ],
+    topN: 2,
+  });
+
+  if (results.length !== 2) {
+    console.error(`FAIL: Expected 2 results, got ${results.length}`);
+    process.exit(1);
+  }
+
+  console.log(`Got ${results.length} results (expected 2)`);
+  console.log('PASS\n');
+}
+
+async function testCustomInstruct() {
+  console.log('--- Test: Custom instruct for temporal queries ---');
+
+  const results = await regoloRerankService.rerank({
+    query: 'Aktuelle Klimapolitik 2026',
+    documents: [
+      'Die Klimapolitik der Grünen wurde 2020 grundlegend überarbeitet.',
+      'Im März 2026 verabschiedeten die Grünen neue Klimaziele auf ihrem Parteitag.',
+    ],
+    instruct:
+      'Given a search query, retrieve relevant and current passages that answer the query. Prefer recent sources.',
+  });
+
+  console.log('Results:');
+  for (const r of results) {
+    console.log(`  [${r.originalIndex}] score=${r.relevanceScore.toFixed(4)}`);
+  }
+  console.log('PASS\n');
+}
+
+async function main() {
+  if (!HAS_KEY) {
+    console.log('SKIPPED: REGOLO_API_KEY not set');
+    return;
+  }
+
+  await testBasicRerank();
+  await testTopN();
+  await testCustomInstruct();
+
+  console.log('All tests passed!');
+}
+
+main().catch((err) => {
+  console.error('Test failed:', err);
+  process.exit(1);
+});

--- a/apps/api/services/vision/VisionService.ts
+++ b/apps/api/services/vision/VisionService.ts
@@ -1,35 +1,102 @@
 import { generateText } from 'ai';
 
-import { getModel } from '../../routes/chat/agents/providers.js';
 import { createLogger } from '../../utils/logger.js';
+import { getModel, type ProviderName } from '../ai/providers.js';
+
+import type { ExtractionResult } from '../OcrService/types.js';
 
 const log = createLogger('VisionService');
 
-const VISION_PROVIDER = 'regolo' as const;
-const VISION_MODEL_ID = 'mistral-small-2503';
+const DEFAULT_VISION_PROVIDER: ProviderName = 'regolo';
+const DEFAULT_VISION_MODEL = process.env.VISION_DEFAULT_MODEL || 'qwen3-vl-32b';
 
-export interface VisionAnalysisOptions {
+export interface VisionOptions {
+  provider?: ProviderName;
+  model?: string;
   maxTokens?: number;
   temperature?: number;
 }
 
+export interface TextDetectionResult {
+  hasText: boolean;
+  textType: 'screenshot' | 'document' | 'sign' | 'handwriting' | 'none';
+  confidence: number;
+  briefDescription: string;
+}
+
+export interface VisionAnalysisResult {
+  description: string;
+  textDetection: TextDetectionResult;
+  extractedText: string | null;
+  ocrMethod?: string;
+}
+
+const DBSV_ALT_TEXT_PROMPT = `Du erstellst Alternativtexte (Alt-Text) für Bilder basierend auf den Richtlinien des Deutschen Blinden- und Sehbehindertenverbands (DBSV). Alt-Text ist entscheidend, um Bilder für blinde und sehbehinderte Menschen zugänglich zu machen.
+
+Befolge diese Richtlinien für effektiven Alt-Text:
+
+1. Beginne mit den wichtigsten Informationen, die das Wesentliche des Bildes vermitteln (wie würdest du es jemandem am Telefon unter Zeitdruck beschreiben?)
+2. Sei prägnant aber beschreibend, strebe 1-2 Sätze an
+3. Verwende einfache, klare Sprache und vermeide Fachbegriffe oder Jargon
+4. Beschreibe den Inhalt und die Funktion des Bildes, ohne zu interpretieren oder Meinungen zu äußern
+5. Füge relevante Details hinzu, die für das Verständnis des Bildkontexts wesentlich sind
+6. Vermeide Phrasen wie "Bild von" oder "Foto von", da Screenreader bereits anzeigen, dass es sich um ein Bild handelt
+7. WICHTIG: Wenn Text im Bild sichtbar ist und für den Kontext relevant ist, gib den Text wörtlich wieder, ohne Anführungszeichen. Beispiel: "Plakat mit der Aufschrift Klimaschutz jetzt" statt "Plakat mit Text über Klimaschutz"
+
+Struktur deinen Alt-Text in zwei Teilen:
+- Pflicht: Kurz und knapp die nötigsten Infos im ersten Satz
+- Kür: Genauere Beschreibung mit weniger wichtigen Details (falls nötig)
+
+Gib deinen Alt-Text in <alt_text> Tags aus.`;
+
+const TEXT_DETECTION_PROMPT = `Analyze this image and determine if it contains readable text. Respond ONLY with valid JSON, no other text:
+{"hasText": boolean, "textType": "screenshot"|"document"|"sign"|"handwriting"|"none", "confidence": number between 0 and 1, "briefDescription": "one sentence describing the image"}`;
+
+function resolveImageContent(
+  imageSource: string
+): { type: 'image'; image: URL } | { type: 'image'; image: string } {
+  if (imageSource.startsWith('http://') || imageSource.startsWith('https://')) {
+    return { type: 'image', image: new URL(imageSource) };
+  }
+  if (imageSource.startsWith('data:')) {
+    return { type: 'image', image: imageSource };
+  }
+  return { type: 'image', image: `data:image/jpeg;base64,${imageSource}` };
+}
+
+function resolveVisionModel(options?: VisionOptions) {
+  const provider = options?.provider ?? DEFAULT_VISION_PROVIDER;
+  const modelId = options?.model ?? DEFAULT_VISION_MODEL;
+  return { model: getModel(provider, modelId), provider, modelId };
+}
+
+function stripBase64Prefix(imageSource: string): string {
+  if (imageSource.startsWith('data:')) {
+    return imageSource.replace(/^data:image\/[^;]+;base64,/, '');
+  }
+  return imageSource;
+}
+
+function guessMimeType(imageSource: string): string {
+  if (imageSource.startsWith('data:')) {
+    const match = imageSource.match(/^data:(image\/[^;]+);base64,/);
+    if (match) return match[1];
+  }
+  return 'image/jpeg';
+}
+
 export class VisionService {
   async analyzeImage(
-    imageBase64: string,
+    imageSource: string,
     instruction: string,
-    options?: VisionAnalysisOptions
+    options?: VisionOptions
   ): Promise<string> {
-    const model = getModel(VISION_PROVIDER, VISION_MODEL_ID);
+    const { model, provider, modelId } = resolveVisionModel(options);
+    const imageContent = resolveImageContent(imageSource);
 
-    let dataUrl: string;
-    if (imageBase64.startsWith('data:')) {
-      dataUrl = imageBase64;
-    } else {
-      const mimeType = 'image/jpeg';
-      dataUrl = `data:${mimeType};base64,${imageBase64}`;
-    }
-
-    log.info(`[Vision] Analyzing image (instruction: "${instruction.slice(0, 60)}...")`);
+    log.info(
+      `[Vision] Analyzing image (${provider}/${modelId}, instruction: "${instruction.slice(0, 60)}...")`
+    );
     const startTime = Date.now();
 
     const result = await generateText({
@@ -37,27 +104,151 @@ export class VisionService {
       messages: [
         {
           role: 'user',
-          content: [
-            { type: 'text', text: instruction },
-            { type: 'image', image: dataUrl },
-          ],
+          content: [{ type: 'text', text: instruction }, imageContent],
         },
       ],
       maxOutputTokens: options?.maxTokens ?? 2000,
       temperature: options?.temperature ?? 0.3,
     });
 
-    const elapsed = Date.now() - startTime;
-    log.info(`[Vision] Analysis complete (${elapsed}ms, ${result.text.length} chars)`);
-
+    log.info(
+      `[Vision] Analysis complete (${Date.now() - startTime}ms, ${result.text.length} chars)`
+    );
     return result.text;
   }
 
-  async describeImage(imageBase64: string): Promise<string> {
+  async describeImage(imageSource: string, options?: VisionOptions): Promise<string> {
     return this.analyzeImage(
-      imageBase64,
-      'Beschreibe dieses Bild detailliert. Was ist darauf zu sehen? Nenne Objekte, Personen, Text, Farben und den allgemeinen Kontext.'
+      imageSource,
+      'Beschreibe dieses Bild detailliert. Was ist darauf zu sehen? Nenne Objekte, Personen, Text, Farben und den allgemeinen Kontext.',
+      options
     );
+  }
+
+  async detectTextContent(
+    imageSource: string,
+    options?: VisionOptions
+  ): Promise<TextDetectionResult> {
+    const { model, provider, modelId } = resolveVisionModel(options);
+    const imageContent = resolveImageContent(imageSource);
+
+    log.info(`[Vision] Detecting text content (${provider}/${modelId})`);
+    const startTime = Date.now();
+
+    const result = await generateText({
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: TEXT_DETECTION_PROMPT }, imageContent],
+        },
+      ],
+      maxOutputTokens: 200,
+      temperature: 0.1,
+    });
+
+    log.info(`[Vision] Text detection complete (${Date.now() - startTime}ms)`);
+
+    try {
+      const jsonMatch = result.text.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        const parsed = JSON.parse(jsonMatch[0]) as TextDetectionResult;
+        return {
+          hasText: Boolean(parsed.hasText),
+          textType: parsed.textType || 'none',
+          confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
+          briefDescription: parsed.briefDescription || '',
+        };
+      }
+    } catch {
+      log.warn('[Vision] Failed to parse text detection response, falling back to no-text');
+    }
+
+    return { hasText: false, textType: 'none', confidence: 0, briefDescription: '' };
+  }
+
+  async analyzeWithOcr(
+    imageSource: string,
+    instruction?: string,
+    options?: VisionOptions
+  ): Promise<VisionAnalysisResult> {
+    const textDetection = await this.detectTextContent(imageSource, options);
+
+    const defaultInstruction =
+      instruction || 'Beschreibe dieses Bild detailliert. Was ist darauf zu sehen?';
+
+    if (textDetection.hasText) {
+      log.info(
+        `[Vision] Text detected (type=${textDetection.textType}, confidence=${textDetection.confidence}), running vision + OCR in parallel`
+      );
+
+      const { ocrService } = await import('../OcrService/index.js');
+      const base64Data = stripBase64Prefix(imageSource);
+      const mimeType = guessMimeType(imageSource);
+
+      const [description, ocrResult] = await Promise.all([
+        this.analyzeImage(imageSource, defaultInstruction, options),
+        ocrService
+          .extractTextFromBase64(base64Data, 'image.jpg', mimeType)
+          .catch((error: unknown) => {
+            const msg = error instanceof Error ? error.message : String(error);
+            log.warn(`[Vision] OCR failed, continuing with vision only: ${msg}`);
+            return null;
+          }) as Promise<ExtractionResult | null>,
+      ]);
+
+      return {
+        description,
+        textDetection,
+        extractedText: ocrResult?.text || null,
+        ocrMethod: ocrResult?.method,
+      };
+    }
+
+    const description = await this.analyzeImage(imageSource, defaultInstruction, options);
+
+    return {
+      description,
+      textDetection,
+      extractedText: null,
+    };
+  }
+
+  async generateAltText(
+    imageSource: string,
+    context?: string,
+    options?: VisionOptions
+  ): Promise<string> {
+    const { model, provider, modelId } = resolveVisionModel(options);
+    const imageContent = resolveImageContent(imageSource);
+
+    let userPrompt =
+      'Analysiere dieses Bild und erstelle einen Alt-Text, der den DBSV-Richtlinien für Barrierefreiheit entspricht.';
+
+    if (context) {
+      userPrompt += `\n\nZusätzliche Bildbeschreibung vom Nutzer: ${context}`;
+    }
+
+    log.info(`[Vision] Generating alt text (${provider}/${modelId})`);
+    const startTime = Date.now();
+
+    const result = await generateText({
+      model,
+      messages: [
+        { role: 'system', content: DBSV_ALT_TEXT_PROMPT },
+        {
+          role: 'user',
+          content: [imageContent, { type: 'text', text: userPrompt }],
+        },
+      ],
+      maxOutputTokens: options?.maxTokens ?? 2000,
+      temperature: options?.temperature ?? 0.3,
+    });
+
+    log.info(`[Vision] Alt text generated (${Date.now() - startTime}ms)`);
+
+    const match = result.text.match(/<alt_text>(.*?)<\/alt_text>/s);
+    return match ? match[1].trim() : result.text;
   }
 }
 

--- a/apps/api/services/vision/__tests__/vision.vitest.ts
+++ b/apps/api/services/vision/__tests__/vision.vitest.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 
-import { isProviderConfigured, getModel } from '../../ai/providers.js';
+import { isProviderConfigured } from '../../ai/providers.js';
 import { isVisionCapable, getAvailableModels } from '../../ai/modelDiscovery.js';
 import { executeProvider } from '../../../workers/providers/index.js';
 

--- a/apps/api/services/vision/__tests__/vision.vitest.ts
+++ b/apps/api/services/vision/__tests__/vision.vitest.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { isProviderConfigured, getModel } from '../../ai/providers.js';
+import { isVisionCapable, getAvailableModels } from '../../ai/modelDiscovery.js';
+import { executeProvider } from '../../../workers/providers/index.js';
+
+const HAS_REGOLO = !!process.env.REGOLO_API_KEY;
+
+// A tiny 1x1 red PNG pixel as base64
+const TINY_RED_PNG =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+// ─── Unit tests (no API key required) ────────────────────────────────────
+
+describe('Vision — unit tests', () => {
+  describe('isVisionCapable', () => {
+    it('returns true for known vision models', () => {
+      expect(isVisionCapable('qwen3-vl-32b')).toBe(true);
+      expect(isVisionCapable('pixtral-large-latest')).toBe(true);
+    });
+
+    it('returns false for non-vision models', () => {
+      expect(isVisionCapable('qwen3.5-122b')).toBe(false);
+      expect(isVisionCapable('mistral-large-2512')).toBe(false);
+      expect(isVisionCapable('gpt-oss-120b')).toBe(false);
+    });
+
+    it('returns false for unknown model IDs', () => {
+      expect(isVisionCapable('nonexistent-model-999')).toBe(false);
+    });
+  });
+
+  describe('VisionService import and structure', () => {
+    it('exports visionService singleton', async () => {
+      const { visionService } = await import('../index.js');
+      expect(visionService).toBeDefined();
+      expect(typeof visionService.analyzeImage).toBe('function');
+      expect(typeof visionService.describeImage).toBe('function');
+      expect(typeof visionService.detectTextContent).toBe('function');
+      expect(typeof visionService.analyzeWithOcr).toBe('function');
+      expect(typeof visionService.generateAltText).toBe('function');
+    });
+  });
+});
+
+// ─── Regolo adapter multimodal tests (no API call, tests message conversion) ─
+
+describe('Regolo adapter — multimodal message handling', () => {
+  it('preserves image content in Anthropic format via executeProvider', async () => {
+    if (!HAS_REGOLO) {
+      expect(true).toBe(true);
+      return;
+    }
+
+    const result = await executeProvider('regolo', 'test-vision-anthropic-format', {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What color is this pixel? Answer in one word.' },
+            {
+              type: 'image',
+              source: {
+                type: 'base64',
+                data: TINY_RED_PNG,
+                media_type: 'image/png',
+              },
+            },
+          ] as any,
+        },
+      ],
+      type: 'vision-test',
+      options: { max_tokens: 50, model: 'qwen3-vl-32b', temperature: 0.1 },
+      metadata: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBeTruthy();
+    expect(result.metadata?.provider).toBe('regolo');
+  }, 30000);
+
+  it('preserves image_url content format via executeProvider', async () => {
+    if (!HAS_REGOLO) {
+      expect(true).toBe(true);
+      return;
+    }
+
+    const dataUrl = `data:image/png;base64,${TINY_RED_PNG}`;
+
+    const result = await executeProvider('regolo', 'test-vision-imageurl-format', {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What color is this pixel? Answer in one word.' },
+            { type: 'image_url', image_url: { url: dataUrl } },
+          ] as any,
+        },
+      ],
+      type: 'vision-test',
+      options: { max_tokens: 50, model: 'qwen3-vl-32b', temperature: 0.1 },
+      metadata: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBeTruthy();
+    expect(result.metadata?.provider).toBe('regolo');
+  }, 30000);
+
+  it('falls back to text-only for non-image content arrays', async () => {
+    if (!HAS_REGOLO) {
+      expect(true).toBe(true);
+      return;
+    }
+
+    const result = await executeProvider('regolo', 'test-text-array', {
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: 'Say just "OK"' }] as any,
+        },
+      ],
+      type: 'text-test',
+      options: { max_tokens: 50, model: 'qwen3-vl-32b', temperature: 0.1 },
+      metadata: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.content).toBeTruthy();
+  }, 30000);
+});
+
+// ─── VisionService integration tests (requires REGOLO_API_KEY) ───────────
+
+describe.skipIf(!HAS_REGOLO)('VisionService — integration tests (requires REGOLO_API_KEY)', () => {
+  beforeAll(() => {
+    expect(isProviderConfigured('regolo')).toBe(true);
+  });
+
+  it('analyzeImage returns a description', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.analyzeImage(
+      TINY_RED_PNG,
+      'What is this image? Answer briefly.'
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('analyzeImage accepts data URL format', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.analyzeImage(
+      `data:image/png;base64,${TINY_RED_PNG}`,
+      'What is this image? Answer briefly.'
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it('detectTextContent returns structured result', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.detectTextContent(TINY_RED_PNG);
+
+    expect(result).toHaveProperty('hasText');
+    expect(result).toHaveProperty('textType');
+    expect(result).toHaveProperty('confidence');
+    expect(result).toHaveProperty('briefDescription');
+    expect(typeof result.hasText).toBe('boolean');
+    expect(['screenshot', 'document', 'sign', 'handwriting', 'none']).toContain(result.textType);
+    expect(typeof result.confidence).toBe('number');
+  }, 30000);
+
+  it('detectTextContent returns hasText=false for a plain pixel', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.detectTextContent(TINY_RED_PNG);
+
+    expect(result.hasText).toBe(false);
+    expect(result.textType).toBe('none');
+  }, 30000);
+
+  it('analyzeWithOcr returns full analysis result', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.analyzeWithOcr(TINY_RED_PNG);
+
+    expect(result).toHaveProperty('description');
+    expect(result).toHaveProperty('textDetection');
+    expect(result).toHaveProperty('extractedText');
+    expect(typeof result.description).toBe('string');
+    expect(result.description.length).toBeGreaterThan(0);
+    expect(result.textDetection.hasText).toBe(false);
+    expect(result.extractedText).toBeNull();
+  }, 60000);
+
+  it('generateAltText returns alt text string', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.generateAltText(TINY_RED_PNG);
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+    // Should not contain the XML tags (they should be stripped)
+    expect(result).not.toContain('<alt_text>');
+    expect(result).not.toContain('</alt_text>');
+  }, 30000);
+
+  it('generateAltText accepts context parameter', async () => {
+    const { visionService } = await import('../index.js');
+
+    const result = await visionService.generateAltText(
+      TINY_RED_PNG,
+      'Dieses Bild zeigt ein Testbild für Barrierefreiheit'
+    );
+
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  }, 30000);
+});
+
+// ─── Model discovery vision utilities ────────────────────────────────────
+
+describe('Model discovery — vision utilities', () => {
+  it('getAvailableModels includes vision flag', async () => {
+    const models = await getAvailableModels();
+    expect(Array.isArray(models)).toBe(true);
+
+    if (models.length > 0) {
+      const firstModel = models[0];
+      expect(firstModel).toHaveProperty('vision');
+      expect(typeof firstModel.vision).toBe('boolean');
+    }
+  }, 15000);
+
+  it('getVisionCapableModels returns only vision models', async () => {
+    const { getVisionCapableModels } = await import('../../ai/modelDiscovery.js');
+    const visionModels = await getVisionCapableModels();
+
+    expect(Array.isArray(visionModels)).toBe(true);
+    for (const model of visionModels) {
+      expect(model.vision).toBe(true);
+    }
+  }, 15000);
+});

--- a/apps/api/services/vision/index.ts
+++ b/apps/api/services/vision/index.ts
@@ -1,2 +1,2 @@
 export { VisionService, visionService } from './VisionService.js';
-export type { VisionAnalysisOptions } from './VisionService.js';
+export type { VisionOptions, VisionAnalysisResult, TextDetectionResult } from './VisionService.js';

--- a/apps/api/workers/providers/regoloAdapter.ts
+++ b/apps/api/workers/providers/regoloAdapter.ts
@@ -29,23 +29,77 @@ function convertMessages(
       continue;
     }
 
-    let content: string;
     if (typeof msg.content === 'string') {
-      content = msg.content;
-    } else if (Array.isArray(msg.content)) {
-      content = msg.content
-        .map((c) => {
-          const block = c as { text?: string; content?: string };
-          return block.text || block.content || '';
-        })
-        .join('\n');
-    } else {
-      content = String(msg.content);
+      modelMessages.push({
+        role: msg.role as 'user' | 'assistant' | 'system',
+        content: msg.content,
+      });
+      continue;
+    }
+
+    if (Array.isArray(msg.content)) {
+      const contentParts = msg.content as Array<{
+        type: string;
+        text?: string;
+        content?: string;
+        source?: { data?: string; media_type?: string };
+        image_url?: { url: string };
+      }>;
+
+      const hasImages = contentParts.some(
+        (c) =>
+          (c.type === 'image' && c.source?.data) || (c.type === 'image_url' && c.image_url?.url)
+      );
+
+      if (hasImages) {
+        const parts: Array<
+          { type: 'text'; text: string } | { type: 'image'; image: Buffer | URL; mimeType?: string }
+        > = [];
+
+        for (const c of contentParts) {
+          if (c.type === 'text') {
+            parts.push({ type: 'text', text: c.text || '' });
+          } else if (c.type === 'image' && c.source?.data) {
+            const mediaType = c.source.media_type || 'image/png';
+            const base64Data = c.source.data.replace(/^data:image\/[^;]+;base64,/, '');
+            parts.push({
+              type: 'image',
+              image: Buffer.from(base64Data, 'base64'),
+              mimeType: mediaType,
+            });
+          } else if (c.type === 'image_url' && c.image_url?.url) {
+            const url = c.image_url.url;
+            if (url.startsWith('data:')) {
+              const match = url.match(/^data:(image\/[^;]+);base64,(.+)$/);
+              if (match) {
+                parts.push({
+                  type: 'image',
+                  image: Buffer.from(match[2], 'base64'),
+                  mimeType: match[1],
+                });
+              }
+            } else {
+              parts.push({ type: 'image', image: new URL(url) });
+            }
+          }
+        }
+
+        modelMessages.push({ role: 'user', content: parts });
+        continue;
+      }
+
+      const textContent = contentParts.map((c) => c.text || c.content || '').join('\n');
+
+      modelMessages.push({
+        role: msg.role as 'user' | 'assistant' | 'system',
+        content: textContent,
+      });
+      continue;
     }
 
     modelMessages.push({
       role: msg.role as 'user' | 'assistant' | 'system',
-      content,
+      content: String(msg.content),
     });
   }
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -765,7 +765,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2555,7 +2555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3305,7 +3305,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3361,7 +3361,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4467,7 +4467,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5216,7 +5216,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
+++ b/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  useIsMobile,
 } from '@gruenerator/ui';
 import { type MutableRefObject, memo, useState, useCallback } from 'react';
 import { HiOutlineDocumentText } from 'react-icons/hi';
@@ -25,6 +26,7 @@ const NewItemDropdown = memo(function NewItemDropdown({
   onLinkClick,
   onClose,
 }: NewItemDropdownProps) {
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
 
   const handleOpenChange = useCallback(
@@ -44,7 +46,7 @@ const NewItemDropdown = memo(function NewItemDropdown({
             <span className={titleClass}>Neu</span>
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent side="right" align="start" sideOffset={8}>
+        <DropdownMenuContent side={isMobile ? 'bottom' : 'right'} align="start" sideOffset={8}>
           <DropdownMenuItem
             onClick={() => {
               onChatClick();

--- a/apps/web/src/features/docs/DocsPage.tsx
+++ b/apps/web/src/features/docs/DocsPage.tsx
@@ -448,7 +448,7 @@ function DocumentsContent() {
 
 const DocsPage = () => (
   <ErrorBoundary>
-    <PageContainer maxWidth="lg" noPadTop>
+    <PageContainer maxWidth="lg" noPadTop className="max-md:pt-lg">
       <DocsProvider adapter={webAppDocsAdapter}>
         <DocumentsContent />
       </DocsProvider>

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -13,7 +13,6 @@ import {
   type ChatMessageMetadata,
   type ExtraAction,
   type NotebookMessageMetadata,
-  MODEL_OPTIONS,
 } from '@gruenerator/chat';
 import { PanelLeft } from 'lucide-react';
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
@@ -130,15 +129,6 @@ const NotebookPageContent = ({
   const filterValuesCache = useNotebookStore((s) => s.filterValuesCache);
   const activeFiltersStore = useNotebookStore((s) => s.activeFilters);
   const [mode, setMode] = useState<'fast' | 'deep'>('fast');
-  const [selectedModelId, setSelectedModelId] = useState('mistral');
-  const selectedModelOption =
-    MODEL_OPTIONS.find((m) => m.id === selectedModelId) || MODEL_OPTIONS[0];
-  const handleModelChange = useCallback((modelId: string) => {
-    setSelectedModelId(modelId);
-    if (modelId === 'litellm') {
-      setMode('fast');
-    }
-  }, []);
   const [searchParams, setSearchParams] = useSearchParams();
   const [threadId, setThreadId] = useState<string | null>(
     threadIdProp || searchParams.get('thread')
@@ -300,8 +290,6 @@ const NotebookPageContent = ({
       onThreadCreated={handleThreadCreated}
       threadId={threadId}
       mode={mode}
-      provider={selectedModelOption.provider}
-      model={selectedModelOption.id}
       documentIds={documentIds}
     >
       <CitationPanelProvider>
@@ -331,8 +319,6 @@ const NotebookPageContent = ({
                 categoryFilters={categoryFilters}
                 mode={mode}
                 onModeChange={setMode}
-                selectedModel={selectedModelId}
-                onModelChange={handleModelChange}
               />
             </ThreadPrimitive.Root>
           </div>

--- a/apps/web/src/features/playground/PlaygroundPage.tsx
+++ b/apps/web/src/features/playground/PlaygroundPage.tsx
@@ -23,7 +23,7 @@ import {
   SelectValue,
   Textarea,
 } from '@gruenerator/ui';
-import { Beaker, BrainCircuit, Cpu, Play, Square, Type } from 'lucide-react';
+import { Beaker, BrainCircuit, Cpu, ImagePlus, Play, Square, Trash2, Type } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { cn } from '../../utils/cn';
@@ -42,8 +42,8 @@ interface ModelConfig {
 interface PromptConfig {
   id: string;
   name: string;
-  requestFields: string[];
-  platforms: string[];
+  description: string;
+  fields: string[];
 }
 
 interface PanelState {
@@ -55,28 +55,23 @@ interface PanelState {
   streaming: boolean;
   elapsed: number;
   error: string | null;
+  ocrText: string | null;
 }
 
 const FIELD_LABELS: Record<string, string> = {
+  systemPrompt: 'System-Prompt',
+  userMessage: 'Nachricht',
   inhalt: 'Inhalt / Thema',
   textForm: 'Textform',
-  requestType: 'Antragstyp',
-  gliederung: 'Gliederung / Absender*in',
-  platform: 'Plattform',
-  text: 'Text',
-  zielgruppe: 'Zielgruppe',
-  laenge: 'Gewünschte Länge',
-  stil: 'Stil',
-  kontext: 'Kontext',
+  originalText: 'Ausgangstext',
 };
 
 const FIELD_PLACEHOLDERS: Record<string, string> = {
+  systemPrompt: 'Du bist ein hilfreicher Assistent...',
+  userMessage: 'Schreibe eine Nachricht an das Modell...',
   inhalt: 'Worum soll es gehen? Beschreibe das Thema, die politische Forderung oder den Anlass...',
   textForm: 'z.B. Pressemitteilung, Blogpost, Newsletter, Rede...',
-  requestType: 'z.B. antrag, kleine_anfrage, grosse_anfrage',
-  gliederung: 'z.B. Kreisverband Musterstadt',
-  platform: 'z.B. facebook, twitter, instagram, linkedin',
-  text: 'Ausgangstext eingeben...',
+  originalText: 'Den zu übersetzenden Text hier eingeben...',
 };
 
 const REASONING_OPTIONS: { value: ReasoningEffort; label: string }[] = [
@@ -109,7 +104,11 @@ const FieldInput = memo(function FieldInput({
     [field, onChange]
   );
 
-  const isTextarea = field === 'inhalt' || field === 'text';
+  const isTextarea =
+    field === 'systemPrompt' ||
+    field === 'userMessage' ||
+    field === 'inhalt' ||
+    field === 'originalText';
 
   return (
     <div className={cn('flex flex-col gap-1.5', isTextarea && 'lg:col-span-2')}>
@@ -224,6 +223,17 @@ const OutputPanel = memo(function OutputPanel({
                 {panel.output}
               </div>
             )}
+            {panel.ocrText && (
+              <details className="group">
+                <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium text-muted-foreground select-none">
+                  <Type className="size-3" />
+                  Extrahierter Text (OCR)
+                </summary>
+                <div className="mt-2 whitespace-pre-wrap rounded-lg bg-grey-50 p-3 text-xs leading-relaxed text-muted-foreground dark:bg-grey-800/50">
+                  {panel.ocrText}
+                </div>
+              </details>
+            )}
           </div>
         ) : panel.streaming ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -322,6 +332,7 @@ function createEmptyPanel(): PanelState {
     streaming: false,
     elapsed: 0,
     error: null,
+    ocrText: null,
   };
 }
 
@@ -334,6 +345,8 @@ function PlaygroundPage() {
     createEmptyPanel(),
     createEmptyPanel(),
   ]);
+  const [imageData, setImageData] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const abortRefs = useRef<[AbortController | null, AbortController | null]>([null, null]);
   const fieldsRef = useRef(fields);
@@ -356,10 +369,10 @@ function PlaygroundPage() {
       .then((d) => {
         const list = (d.prompts || []) as PromptConfig[];
         setPrompts(list);
-        const universal = list.find((p) => p.id === 'universal');
-        if (universal) {
-          setSelectedPrompt(universal);
-          setFields(Object.fromEntries(universal.requestFields.map((f) => [f, ''])));
+        const initial = list.find((p) => p.id === 'free') || list[0];
+        if (initial) {
+          setSelectedPrompt(initial);
+          setFields(Object.fromEntries(initial.fields.map((f) => [f, ''])));
         }
       })
       .catch(() => {});
@@ -370,7 +383,7 @@ function PlaygroundPage() {
       const prompt = prompts.find((p) => p.id === id);
       if (prompt) {
         setSelectedPrompt(prompt);
-        setFields(Object.fromEntries(prompt.requestFields.map((f) => [f, ''])));
+        setFields(Object.fromEntries(prompt.fields.map((f) => [f, ''])));
       }
     },
     [prompts]
@@ -380,197 +393,232 @@ function PlaygroundPage() {
     setFields((prev) => ({ ...prev, [field]: value }));
   }, []);
 
+  const updatePanel = useCallback((idx: 0 | 1, patch: Partial<PanelState>) => {
+    setPanels((prev) => {
+      const next = [...prev] as [PanelState, PanelState];
+      next[idx] = { ...next[idx], ...patch };
+      return next;
+    });
+  }, []);
+
   const handleModelChangeA = useCallback(
     (modelId: string) => {
       const model = models.find((m) => `${m.provider}/${m.id}` === modelId) || null;
-      setPanels((prev) => {
-        const next = [...prev] as [PanelState, PanelState];
-        next[0] = { ...next[0], model };
-        return next;
-      });
+      updatePanel(0, { model });
     },
-    [models]
+    [models, updatePanel]
   );
 
   const handleModelChangeB = useCallback(
     (modelId: string) => {
       const model = models.find((m) => `${m.provider}/${m.id}` === modelId) || null;
-      setPanels((prev) => {
-        const next = [...prev] as [PanelState, PanelState];
-        next[1] = { ...next[1], model };
-        return next;
-      });
+      updatePanel(1, { model });
     },
-    [models]
+    [models, updatePanel]
   );
 
-  const handleReasoningChangeA = useCallback((value: ReasoningEffort) => {
-    setPanels((prev) => {
-      const next = [...prev] as [PanelState, PanelState];
-      next[0] = { ...next[0], reasoningEffort: value };
-      return next;
-    });
+  const handleReasoningChangeA = useCallback(
+    (value: ReasoningEffort) => updatePanel(0, { reasoningEffort: value }),
+    [updatePanel]
+  );
+
+  const handleReasoningChangeB = useCallback(
+    (value: ReasoningEffort) => updatePanel(1, { reasoningEffort: value }),
+    [updatePanel]
+  );
+
+  const handleImageUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setImageData(reader.result as string);
+    reader.readAsDataURL(file);
+    e.target.value = '';
   }, []);
 
-  const handleReasoningChangeB = useCallback((value: ReasoningEffort) => {
-    setPanels((prev) => {
-      const next = [...prev] as [PanelState, PanelState];
-      next[1] = { ...next[1], reasoningEffort: value };
-      return next;
-    });
-  }, []);
+  const handleRemoveImage = useCallback(() => setImageData(null), []);
 
-  const streamGenerate = useCallback(async (panelIdx: 0 | 1) => {
-    const panel = panelsRef.current[panelIdx];
-    const prompt = selectedPromptRef.current;
-    if (!panel.model || !prompt) return;
+  const imageDataRef = useRef(imageData);
+  imageDataRef.current = imageData;
 
-    abortRefs.current[panelIdx]?.abort();
-    const controller = new AbortController();
-    abortRefs.current[panelIdx] = controller;
+  const visionAnalyze = useCallback(
+    async (panelIdx: 0 | 1) => {
+      const panel = panelsRef.current[panelIdx];
+      if (!panel.model || !imageDataRef.current) return;
 
-    setPanels((prev) => {
-      const next = [...prev] as [PanelState, PanelState];
-      next[panelIdx] = {
-        ...next[panelIdx],
+      abortRefs.current[panelIdx]?.abort();
+      const controller = new AbortController();
+      abortRefs.current[panelIdx] = controller;
+
+      updatePanel(panelIdx, {
         output: '',
         reasoning: '',
         isReasoning: false,
         streaming: true,
         elapsed: 0,
         error: null,
-      };
-      return next;
-    });
-
-    const startTime = performance.now();
-    const timerInterval = setInterval(() => {
-      setPanels((prev) => {
-        const next = [...prev] as [PanelState, PanelState];
-        next[panelIdx] = { ...next[panelIdx], elapsed: Math.round(performance.now() - startTime) };
-        return next;
-      });
-    }, 100);
-
-    try {
-      const response = await fetch('/api/texte/playground/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
-        credentials: 'include',
-        signal: controller.signal,
-        body: JSON.stringify({
-          type: prompt.id,
-          provider: panel.model.provider,
-          model: panel.model.id,
-          ...(panel.model.reasoning && panel.reasoningEffort !== 'medium'
-            ? { reasoningEffort: panel.reasoningEffort }
-            : {}),
-          ...fieldsRef.current,
-        }),
+        ocrText: null,
       });
 
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const startTime = performance.now();
 
-      const reader = response.body?.getReader();
-      if (!reader) throw new Error('No response body');
+      try {
+        const instruction =
+          Object.values(fieldsRef.current).filter(Boolean).join('\n') ||
+          'Beschreibe dieses Bild detailliert. Was ist darauf zu sehen?';
 
-      const decoder = new TextDecoder();
-      let buffer = '';
-      let fullText = '';
-      let fullReasoning = '';
-      let currentEvent = '';
+        const response = await fetch('/api/vision/analyze', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          signal: controller.signal,
+          body: JSON.stringify({
+            image: imageDataRef.current,
+            instruction,
+            provider: panel.model.provider,
+            model: panel.model.id,
+          }),
+        });
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const data = await response.json();
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          if (line.startsWith('event: ')) {
-            currentEvent = line.slice(7).trim();
-            continue;
-          }
-          if (line.startsWith(': ')) continue;
-          if (!line.startsWith('data: ')) continue;
-
-          try {
-            const data = JSON.parse(line.slice(6));
-
-            if (currentEvent === 'reasoning_start') {
-              setPanels((prev) => {
-                const next = [...prev] as [PanelState, PanelState];
-                next[panelIdx] = { ...next[panelIdx], isReasoning: true };
-                return next;
-              });
-            } else if (currentEvent === 'reasoning_delta' && data.text) {
-              fullReasoning += data.text;
-              const currentReasoning = fullReasoning;
-              setPanels((prev) => {
-                const next = [...prev] as [PanelState, PanelState];
-                next[panelIdx] = { ...next[panelIdx], reasoning: currentReasoning };
-                return next;
-              });
-            } else if (currentEvent === 'reasoning_end') {
-              setPanels((prev) => {
-                const next = [...prev] as [PanelState, PanelState];
-                next[panelIdx] = { ...next[panelIdx], isReasoning: false };
-                return next;
-              });
-            } else if (currentEvent === 'text_delta' && data.text) {
-              fullText += data.text;
-              const currentText = fullText;
-              setPanels((prev) => {
-                const next = [...prev] as [PanelState, PanelState];
-                next[panelIdx] = { ...next[panelIdx], output: currentText };
-                return next;
-              });
-            } else if (data.text && !currentEvent) {
-              fullText += data.text;
-              const currentText = fullText;
-              setPanels((prev) => {
-                const next = [...prev] as [PanelState, PanelState];
-                next[panelIdx] = { ...next[panelIdx], output: currentText };
-                return next;
-              });
-            }
-
-            if (data.error) throw new Error(data.error);
-          } catch (e) {
-            if (e instanceof SyntaxError) continue;
-            throw e;
-          }
-
-          currentEvent = '';
-        }
-      }
-    } catch (e: unknown) {
-      if ((e as Error).name === 'AbortError') return;
-      setPanels((prev) => {
-        const next = [...prev] as [PanelState, PanelState];
-        next[panelIdx] = { ...next[panelIdx], error: (e as Error).message };
-        return next;
-      });
-    } finally {
-      clearInterval(timerInterval);
-      setPanels((prev) => {
-        const next = [...prev] as [PanelState, PanelState];
-        next[panelIdx] = {
-          ...next[panelIdx],
+        updatePanel(panelIdx, {
+          output: data.description || '',
+          ocrText: data.extractedText || null,
+        });
+      } catch (e: unknown) {
+        if ((e as Error).name === 'AbortError') return;
+        updatePanel(panelIdx, { error: (e as Error).message });
+      } finally {
+        updatePanel(panelIdx, {
           streaming: false,
           elapsed: Math.round(performance.now() - startTime),
-        };
-        return next;
+        });
+      }
+    },
+    [updatePanel]
+  );
+
+  const streamGenerate = useCallback(
+    async (panelIdx: 0 | 1) => {
+      const panel = panelsRef.current[panelIdx];
+      const prompt = selectedPromptRef.current;
+      if (!panel.model || !prompt) return;
+
+      abortRefs.current[panelIdx]?.abort();
+      const controller = new AbortController();
+      abortRefs.current[panelIdx] = controller;
+
+      updatePanel(panelIdx, {
+        output: '',
+        reasoning: '',
+        isReasoning: false,
+        streaming: true,
+        elapsed: 0,
+        error: null,
+        ocrText: null,
       });
-    }
-  }, []);
+
+      const startTime = performance.now();
+      const timerInterval = setInterval(() => {
+        updatePanel(panelIdx, { elapsed: Math.round(performance.now() - startTime) });
+      }, 500);
+
+      try {
+        const response = await fetch('/api/texte/playground/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
+          credentials: 'include',
+          signal: controller.signal,
+          body: JSON.stringify({
+            type: prompt.id,
+            provider: panel.model.provider,
+            model: panel.model.id,
+            ...(panel.model.reasoning && panel.reasoningEffort !== 'medium'
+              ? { reasoningEffort: panel.reasoningEffort }
+              : {}),
+            ...fieldsRef.current,
+          }),
+        });
+
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        const reader = response.body?.getReader();
+        if (!reader) throw new Error('No response body');
+
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let fullText = '';
+        let fullReasoning = '';
+        let currentEvent = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
+
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              currentEvent = line.slice(7).trim();
+              continue;
+            }
+            if (line.startsWith(': ')) continue;
+            if (!line.startsWith('data: ')) continue;
+
+            try {
+              const data = JSON.parse(line.slice(6));
+
+              if (currentEvent === 'reasoning_start') {
+                updatePanel(panelIdx, { isReasoning: true });
+              } else if (currentEvent === 'reasoning_delta' && data.text) {
+                fullReasoning += data.text;
+                updatePanel(panelIdx, { reasoning: fullReasoning });
+              } else if (currentEvent === 'reasoning_end') {
+                updatePanel(panelIdx, { isReasoning: false });
+              } else if ((currentEvent === 'text_delta' || !currentEvent) && data.text) {
+                fullText += data.text;
+                updatePanel(panelIdx, { output: fullText });
+              }
+
+              if (data.error) throw new Error(data.error);
+            } catch (e) {
+              if (e instanceof SyntaxError) continue;
+              throw e;
+            }
+
+            currentEvent = '';
+          }
+        }
+      } catch (e: unknown) {
+        if ((e as Error).name === 'AbortError') return;
+        updatePanel(panelIdx, { error: (e as Error).message });
+      } finally {
+        clearInterval(timerInterval);
+        updatePanel(panelIdx, {
+          streaming: false,
+          elapsed: Math.round(performance.now() - startTime),
+        });
+      }
+    },
+    [updatePanel]
+  );
 
   const handleGenerate = useCallback(() => {
-    if (panelsRef.current[0].model) streamGenerate(0);
-    if (panelsRef.current[1].model) streamGenerate(1);
-  }, [streamGenerate]);
+    const hasImage = !!imageDataRef.current;
+    for (const idx of [0, 1] as const) {
+      const panel = panelsRef.current[idx];
+      if (!panel.model) continue;
+      if (hasImage && panel.model.vision) {
+        visionAnalyze(idx);
+      } else {
+        streamGenerate(idx);
+      }
+    }
+  }, [streamGenerate, visionAnalyze]);
 
   const handleStop = useCallback(() => {
     abortRefs.current[0]?.abort();
@@ -578,10 +626,10 @@ function PlaygroundPage() {
   }, []);
 
   const isAnyStreaming = panels[0].streaming || panels[1].streaming;
+  const hasVisionModel = panels.some((p) => p.model?.vision);
   const canGenerate =
-    selectedPrompt &&
     (panels[0].model || panels[1].model) &&
-    Object.values(fields).some((v) => v.trim());
+    (Object.values(fields).some((v) => v.trim()) || imageData);
 
   const groupedModels = useMemo(
     () =>
@@ -633,11 +681,11 @@ function PlaygroundPage() {
         <CardContent>
           <div className="grid grid-cols-1 gap-md lg:grid-cols-3">
             <div className="flex flex-col gap-1.5">
-              <Label className="text-xs text-muted-foreground">Generator</Label>
+              <Label className="text-xs text-muted-foreground">Modus</Label>
               <Select value={selectedPrompt?.id || ''} onValueChange={handlePromptChange}>
                 <SelectTrigger className="w-full">
                   <Type className="size-3.5 text-muted-foreground" />
-                  <SelectValue placeholder="Generator wählen..." />
+                  <SelectValue placeholder="Modus wählen..." />
                 </SelectTrigger>
                 <SelectContent>
                   {prompts.map((p) => (
@@ -674,7 +722,7 @@ function PlaygroundPage() {
           <CardContent className="pt-0">
             <CollapsibleSection title="Eingabefelder" defaultOpen bordered>
               <div className="grid grid-cols-1 gap-sm lg:grid-cols-2">
-                {selectedPrompt.requestFields.map((field) => (
+                {selectedPrompt.fields.map((field) => (
                   <FieldInput
                     key={field}
                     field={field}
@@ -687,6 +735,57 @@ function PlaygroundPage() {
           </CardContent>
         )}
       </Card>
+
+      {/* Image upload — shown when at least one vision model is selected */}
+      {hasVisionModel && (
+        <Card>
+          <CardContent>
+            <div className="flex items-center gap-md">
+              {imageData ? (
+                <div className="flex items-center gap-sm">
+                  <img
+                    src={imageData}
+                    alt="Vorschau"
+                    className="size-16 rounded-md border border-grey-200 object-cover dark:border-grey-700"
+                  />
+                  <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">Bild angehängt</span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleRemoveImage}
+                      className="h-7 gap-1 px-2 text-xs"
+                    >
+                      <Trash2 className="size-3" />
+                      Entfernen
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="gap-1.5"
+                >
+                  <ImagePlus className="size-3.5" />
+                  Bild hinzufügen
+                </Button>
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleImageUpload}
+                className="hidden"
+              />
+              <span className="text-xs text-muted-foreground">
+                Vision-Modelle analysieren das Bild und extrahieren Text via OCR
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Output panels */}
       <div className="grid min-h-[400px] grid-cols-1 gap-md lg:grid-cols-2">

--- a/apps/web/src/features/playground/PlaygroundPage.tsx
+++ b/apps/web/src/features/playground/PlaygroundPage.tsx
@@ -36,6 +36,7 @@ interface ModelConfig {
   name: string;
   category: string;
   reasoning: boolean;
+  vision: boolean;
 }
 
 interface PromptConfig {

--- a/packages/chat/src/components/notebook/NotebookComposer.tsx
+++ b/packages/chat/src/components/notebook/NotebookComposer.tsx
@@ -19,8 +19,6 @@ import {
 import { type CategoryFilterField } from './CategoryFilterDropdown';
 import { type SourceFilterCollection } from './SourceFilterDropdown';
 import { composerToolbarButtonClass } from '../../lib/utils';
-import { MODEL_ICONS } from '../../lib/modelIcons';
-import { MODEL_OPTIONS } from '../../stores/chatStore';
 import { GrueneratorComposer } from '../thread/GrueneratorComposer';
 
 export interface SourceFilterConfig {
@@ -44,8 +42,6 @@ interface NotebookComposerProps {
   categoryFilters?: CategoryFilterConfig;
   mode?: 'fast' | 'deep';
   onModeChange?: (mode: 'fast' | 'deep') => void;
-  selectedModel?: string;
-  onModelChange?: (modelId: string) => void;
 }
 
 function CategoryFilterItems({
@@ -89,19 +85,12 @@ function NotebookSettingsDropdown({
   onModeChange,
   sourceFilters,
   categoryFilters,
-  selectedModel = 'mistral',
-  onModelChange,
 }: {
   mode?: 'fast' | 'deep';
   onModeChange?: (mode: 'fast' | 'deep') => void;
   sourceFilters?: SourceFilterConfig;
   categoryFilters?: CategoryFilterConfig;
-  selectedModel?: string;
-  onModelChange?: (modelId: string) => void;
 }) {
-  const currentModel = MODEL_OPTIONS.find((m) => m.id === selectedModel) || MODEL_OPTIONS[0];
-  const CurrentModelIcon = MODEL_ICONS[currentModel.icon];
-  const isLimitedContext = selectedModel === 'litellm';
   const categoryActiveCount = categoryFilters
     ? Object.values(categoryFilters.activeFilters).reduce((sum, arr) => sum + arr.length, 0)
     : 0;
@@ -135,39 +124,11 @@ function NotebookSettingsDropdown({
                 <Zap className="h-3.5 w-3.5" />
                 Schnell
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="deep" disabled={isLimitedContext}>
+              <DropdownMenuRadioItem value="deep">
                 <BookOpen className="h-3.5 w-3.5" />
                 Tiefenrecherche
               </DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>
-          </>
-        )}
-
-        {onModelChange && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <CurrentModelIcon className="h-3.5 w-3.5" />
-                Modell
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                <DropdownMenuRadioGroup
-                  value={selectedModel}
-                  onValueChange={(v) => onModelChange(v)}
-                >
-                  {MODEL_OPTIONS.map((m) => {
-                    const Icon = MODEL_ICONS[m.icon];
-                    return (
-                      <DropdownMenuRadioItem key={m.id} value={m.id}>
-                        <Icon className="h-3.5 w-3.5" />
-                        {m.name}
-                      </DropdownMenuRadioItem>
-                    );
-                  })}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
           </>
         )}
 
@@ -301,8 +262,6 @@ export function NotebookComposer({
   categoryFilters,
   mode,
   onModeChange,
-  selectedModel,
-  onModelChange,
 }: NotebookComposerProps) {
   const isRunning = useAuiState((s) => s.thread.isRunning);
 
@@ -320,8 +279,6 @@ export function NotebookComposer({
           onModeChange={onModeChange}
           sourceFilters={sourceFilters}
           categoryFilters={categoryFilters}
-          selectedModel={selectedModel}
-          onModelChange={onModelChange}
         />
       }
     />

--- a/packages/chat/src/runtime/NotebookChatProvider.tsx
+++ b/packages/chat/src/runtime/NotebookChatProvider.tsx
@@ -34,8 +34,6 @@ export interface NotebookChatProviderProps {
   endpoint?: string;
   documentIds?: string[];
   threadId?: string | null;
-  provider?: string;
-  model?: string;
 }
 
 /**
@@ -61,8 +59,6 @@ function NotebookChatProviderInner({
   endpoint,
   documentIds,
   threadId: initialThreadId,
-  provider,
-  model,
 }: NotebookChatProviderProps) {
   const isMulti = collections.length > 1;
   // Use a ref for threadId so adapter is not recreated when it changes mid-conversation
@@ -89,21 +85,8 @@ function NotebookChatProviderInner({
       endpoint,
       documentIds,
       threadId: threadIdRef.current,
-      provider,
-      model,
     }),
-    [
-      collections,
-      isMulti,
-      filters,
-      locale,
-      extraParams,
-      mode,
-      endpoint,
-      documentIds,
-      provider,
-      model,
-    ]
+    [collections, isMulti, filters, locale, extraParams, mode, endpoint, documentIds]
   );
 
   const onCompleteRef = useRef(onComplete);

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -38,8 +38,6 @@ export interface NotebookAdapterConfig {
   endpoint?: string;
   documentIds?: string[];
   threadId?: string | null;
-  provider?: string;
-  model?: string;
 }
 
 export interface Citation {
@@ -138,8 +136,6 @@ export function createNotebookModelAdapter(
         ...(config.mode && { mode: config.mode }),
         ...(config.documentIds?.length && { documentIds: config.documentIds }),
         ...(config.threadId && { threadId: config.threadId }),
-        ...(config.provider && { provider: config.provider }),
-        ...(config.model && { model: config.model }),
         ...config.extraParams,
       };
 

--- a/packages/shared/src/search/collections/config.ts
+++ b/packages/shared/src/search/collections/config.ts
@@ -43,6 +43,7 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       primary_category: { label: 'Bereich', type: 'keyword' },
       country: { label: 'Land', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     supportsPersonDetection: true,
@@ -57,6 +58,7 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       primary_category: { label: 'Bereich', type: 'keyword' },
       country: { label: 'Land', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     country: 'DE',
@@ -70,6 +72,7 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       primary_category: { label: 'Bereich', type: 'keyword' },
       country: { label: 'Land', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     country: 'AT',
@@ -84,6 +87,7 @@ export const COLLECTIONS: CollectionConfigMap = {
       content_type: { label: 'Artikeltyp', type: 'keyword' },
       primary_category: { label: 'Kategorie', type: 'keyword' },
       subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     includeInDefaultSearch: true,
@@ -98,6 +102,7 @@ export const COLLECTIONS: CollectionConfigMap = {
       primary_category: { label: 'Thema', type: 'keyword' },
       subcategories: { label: 'Unterkategorien', type: 'keyword' },
       region: { label: 'Region', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     includeInDefaultSearch: true,
@@ -123,6 +128,8 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       content_type: { label: 'Typ', type: 'keyword' },
       primary_category: { label: 'Kategorie', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     defaultFilter: { field: 'landesverband', value: 'HH' },
@@ -135,7 +142,10 @@ export const COLLECTIONS: CollectionConfigMap = {
     displayName: 'Grüne Schleswig-Holstein',
     description: 'Wahlprogramm der Grünen Schleswig-Holstein zur Landtagswahl',
     filterableFields: {
+      content_type: { label: 'Typ', type: 'keyword' },
       primary_category: { label: 'Programm', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     defaultFilter: { field: 'landesverband', value: 'SH' },
@@ -150,6 +160,8 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       content_type: { label: 'Typ', type: 'keyword' },
       primary_category: { label: 'Kategorie', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     defaultFilter: { field: 'landesverband', value: ['TH', 'TH-F'] },
@@ -162,7 +174,10 @@ export const COLLECTIONS: CollectionConfigMap = {
     displayName: 'Grüne Bayern',
     description: 'Regierungsprogramm der Grünen Bayern zur Landtagswahl',
     filterableFields: {
+      content_type: { label: 'Typ', type: 'keyword' },
       primary_category: { label: 'Programm', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
     defaultFilter: { field: 'landesverband', value: 'BY' },
@@ -173,15 +188,83 @@ export const COLLECTIONS: CollectionConfigMap = {
   berlin: {
     name: 'landesverbaende_documents',
     displayName: 'Grüne Berlin',
-    description: 'Pressemitteilungen und Beschlüsse der Grünen Berlin',
+    description: 'Pressemitteilungen und Beschlüsse der Grünen Berlin (Landesverband & Fraktion)',
+    filterableFields: {
+      source_id: {
+        label: 'Quelle',
+        type: 'keyword',
+        valueLabels: {
+          'berlin-lv-presse': 'LV Presse',
+          'berlin-lv-beschluesse': 'LV Beschlüsse',
+          'berlin-lv-wahlprogramm': 'LV Wahlprogramm',
+          'berlin-fraktion-presse': 'Fraktion Presse',
+          'berlin-fraktion-beschluesse': 'Fraktion Beschlüsse',
+        },
+      },
+      published_at: { label: 'Datum', type: 'date_range' },
+    },
+    defaultSearchMode: 'hybrid',
+    defaultFilter: { field: 'landesverband', value: ['BE', 'BE-F'] },
+    country: 'DE',
+    includeInDefaultSearch: false,
+  },
+
+  'mecklenburg-vorpommern': {
+    name: 'landesverbaende_documents',
+    displayName: 'Grüne Mecklenburg-Vorpommern',
+    description: 'Pressemitteilungen und Parteitagsbeschlüsse der Grünen Mecklenburg-Vorpommern',
     filterableFields: {
       content_type: { label: 'Typ', type: 'keyword' },
       primary_category: { label: 'Kategorie', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',
-    defaultFilter: { field: 'landesverband', value: 'BE' },
+    defaultFilter: { field: 'landesverband', value: 'MV' },
     country: 'DE',
     includeInDefaultSearch: false,
+  },
+
+  brandenburg: {
+    name: 'landesverbaende_documents',
+    displayName: 'Grüne Brandenburg',
+    description:
+      'Pressemitteilungen, Beschlüsse und Landtagswahlprogramm 2024 der Grünen Brandenburg',
+    filterableFields: {
+      content_type: { label: 'Typ', type: 'keyword' },
+      primary_category: { label: 'Kategorie', type: 'keyword' },
+      subcategories: { label: 'Unterkategorien', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
+    },
+    defaultSearchMode: 'hybrid',
+    defaultFilter: { field: 'landesverband', value: 'BB' },
+    country: 'DE',
+    includeInDefaultSearch: false,
+  },
+
+  satzungen: {
+    name: 'satzungen_documents',
+    displayName: 'Satzungen',
+    description: 'Satzungen der Kreisverbände und Ortsverbände',
+    filterableFields: {
+      landesverband: { label: 'Landesverband', type: 'keyword' },
+      gremium: { label: 'Gremium', type: 'keyword' },
+    },
+    defaultSearchMode: 'hybrid',
+    includeInDefaultSearch: false,
+  },
+
+  gruenblog: {
+    name: 'gruenblog_documents',
+    displayName: 'Grünblog',
+    description: 'Onlinemagazin der Grünen – Artikel zu Wissen, Meinen, Machen',
+    filterableFields: {
+      primary_category: { label: 'Kategorie', type: 'keyword' },
+      published_at: { label: 'Datum', type: 'date_range' },
+    },
+    defaultSearchMode: 'hybrid',
+    country: 'DE',
+    includeInDefaultSearch: true,
   },
 };
 

--- a/packages/shared/src/search/collections/types.ts
+++ b/packages/shared/src/search/collections/types.ts
@@ -7,7 +7,7 @@
 /**
  * Type of field filter (how the field should be queried)
  */
-export type FilterFieldType = 'keyword' | 'text' | 'numeric' | 'boolean';
+export type FilterFieldType = 'keyword' | 'text' | 'numeric' | 'boolean' | 'date_range';
 
 /**
  * Configuration for a filterable field within a collection
@@ -17,6 +17,8 @@ export interface FilterFieldConfig {
   label: string;
   /** How this field should be filtered */
   type: FilterFieldType;
+  /** Optional mapping of field values to human-readable display names */
+  valueLabels?: Record<string, string>;
   /** Optional description for documentation */
   description?: string;
 }
@@ -66,4 +68,8 @@ export type CollectionKey =
   | 'schleswig-holstein'
   | 'thueringen'
   | 'bayern'
-  | 'berlin';
+  | 'berlin'
+  | 'mecklenburg-vorpommern'
+  | 'brandenburg'
+  | 'satzungen'
+  | 'gruenblog';

--- a/packages/shared/src/search/filters/QdrantFilterBuilder.ts
+++ b/packages/shared/src/search/filters/QdrantFilterBuilder.ts
@@ -25,6 +25,9 @@ export const COMMON_FILTER_FIELDS: CommonFilterField[] = [
   'region',
   'country',
   'platform',
+  'source_id',
+  'landesverband',
+  'gremium',
 ];
 
 /**
@@ -59,6 +62,18 @@ export function buildQdrantFilter(
         key,
         match: { value },
       } as QdrantMatchCondition);
+    }
+  }
+
+  // Handle date range filtering (date_from / date_to → published_at range)
+  const dateFrom = filters['date_from'];
+  const dateTo = filters['date_to'];
+  if (dateFrom || dateTo) {
+    const range: { gte?: string; lte?: string } = {};
+    if (typeof dateFrom === 'string' && dateFrom) range.gte = dateFrom;
+    if (typeof dateTo === 'string' && dateTo) range.lte = dateTo;
+    if (Object.keys(range).length > 0) {
+      must.push({ key: 'published_at', range } as QdrantRangeCondition);
     }
   }
 
@@ -110,7 +125,7 @@ export function buildQdrantFilterFromSpecs(specs: FilterSpec[]): QdrantFilter | 
         break;
 
       case 'range':
-        if (typeof value === 'number' && rangeOp) {
+        if ((typeof value === 'number' || typeof value === 'string') && rangeOp) {
           must.push({
             key: field,
             range: { [rangeOp]: value },
@@ -218,7 +233,12 @@ export function textMatch(field: string, text: string): QdrantTextCondition {
  */
 export function rangeMatch(
   field: string,
-  range: { gt?: number; gte?: number; lt?: number; lte?: number }
+  range: {
+    gt?: number | string;
+    gte?: number | string;
+    lt?: number | string;
+    lte?: number | string;
+  }
 ): QdrantRangeCondition {
   return { key: field, range };
 }

--- a/packages/shared/src/search/filters/types.ts
+++ b/packages/shared/src/search/filters/types.ts
@@ -30,10 +30,10 @@ export interface QdrantMatchAnyCondition {
 export interface QdrantRangeCondition {
   key: string;
   range: {
-    gt?: number;
-    gte?: number;
-    lt?: number;
-    lte?: number;
+    gt?: number | string;
+    gte?: number | string;
+    lt?: number | string;
+    lte?: number | string;
   };
 }
 
@@ -88,4 +88,7 @@ export type CommonFilterField =
   | 'subcategories'
   | 'region'
   | 'country'
-  | 'platform';
+  | 'platform'
+  | 'source_id'
+  | 'landesverband'
+  | 'gremium';

--- a/services/mcp/src/tools/filters.ts
+++ b/services/mcp/src/tools/filters.ts
@@ -24,11 +24,14 @@ WICHTIG: Rufe dieses Tool IMMER auf BEVOR du gruenerator_search mit Filtern verw
 
 ## Verfügbare Filter pro Sammlung
 
-- **kommunalwiki**: content_type, primary_category, subcategories
-- **boell-stiftung**: content_type, primary_category, subcategories, region
-- **bundestagsfraktion**, **gruene-de**, **gruene-at**: primary_category, country
+- **kommunalwiki**: content_type, primary_category, subcategories, published_at (Datum)
+- **boell-stiftung**: content_type, primary_category, subcategories, region, published_at (Datum)
+- **bundestagsfraktion**, **gruene-de**, **gruene-at**: primary_category, country, published_at (Datum)
+- **gruenblog**: primary_category, published_at (Datum)
 - **examples**: platform (instagram/facebook), country (DE/AT)
-- **Landesverbände** (hamburg, schleswig-holstein, thueringen, bayern, berlin): content_type, primary_category
+- **Landesverbände** (hamburg, schleswig-holstein, thueringen, bayern, mecklenburg-vorpommern, brandenburg): content_type, primary_category, subcategories, published_at (Datum)
+- **berlin**: source_id (Quelle mit Anzeigenamen), published_at (Datum)
+- **satzungen**: landesverband, gremium
 
 ## Beispiel-Workflow
 
@@ -64,25 +67,50 @@ WICHTIG: Rufe dieses Tool IMMER auf BEVOR du gruenerator_search mit Filtern verw
     try {
       const filters: Record<
         string,
-        { label: string; type: string; values: unknown[]; totalUniqueValues: number }
+        {
+          label: string;
+          type: string;
+          values?: unknown[];
+          totalUniqueValues?: number;
+          valueLabels?: Record<string, string>;
+          usage?: { date_from: string; date_to: string };
+        }
       > = {};
       const baseFilter = buildCollectionDefaultFilter(collection) as Record<string, unknown> | null;
 
       for (const [field, fieldConfig] of Object.entries(col.filterableFields)) {
+        if (fieldConfig.type === 'date_range') {
+          filters[field] = {
+            label: fieldConfig.label,
+            type: 'date_range',
+            usage: {
+              date_from: 'ISO-Datum als Startdatum (z.B. "2024-01-01")',
+              date_to: 'ISO-Datum als Enddatum (z.B. "2025-12-31")',
+            },
+          };
+          continue;
+        }
+
         console.error(`[Filters] Fetching value counts for ${collection}.${field}`);
         const valuesWithCounts = await getFieldValueCounts(col.name, field, 50, baseFilter);
 
-        filters[field] = {
+        const filterEntry: (typeof filters)[string] = {
           label: fieldConfig.label,
           type: fieldConfig.type,
           values: valuesWithCounts,
           totalUniqueValues: valuesWithCounts.length,
         };
+
+        if (fieldConfig.valueLabels) {
+          filterEntry.valueLabels = fieldConfig.valueLabels;
+        }
+
+        filters[field] = filterEntry;
       }
 
-      const firstField = Object.keys(filters)[0];
+      const firstField = Object.keys(filters).find((f) => filters[f]?.values);
       const firstValue = firstField
-        ? (filters[firstField]?.values[0] as { value: string } | undefined)?.value
+        ? (filters[firstField]?.values?.[0] as { value: string } | undefined)?.value
         : null;
       const usageExample = firstField
         ? {

--- a/services/mcp/src/tools/search.ts
+++ b/services/mcp/src/tools/search.ts
@@ -203,7 +203,10 @@ WICHTIG: Rufe ZUERST gruenerator_get_filters auf, um gültige Filterwerte zu erf
 | boell-stiftung | region (z.B. europa, asien, nahost) |
 | bundestagsfraktion, gruene-de, gruene-at | country (DE oder AT) |
 | examples | platform (instagram, facebook), country (DE oder AT) |
-| Landesverbände | content_type (Typ), primary_category (Kategorie) |
+| Landesverbände | content_type (Typ), primary_category, subcategories |
+| berlin | source_id (Quelle: LV/Fraktion Presse/Beschlüsse) |
+| satzungen | landesverband, gremium |
+| viele Sammlungen | date_from / date_to (Datumsbereich, ISO-Format) |
 
 ## Beispiele
 
@@ -217,7 +220,13 @@ Suche in einem Landesverband:
 { "query": "Klimaschutz", "country": "DE", "collection": "hamburg" }
 
 Suche mit Filter (NACH Aufruf von gruenerator_get_filters):
-{ "query": "Klimaschutz", "country": "DE", "collection": "kommunalwiki", "filters": { "content_type": "praxishilfe" } }`;
+{ "query": "Klimaschutz", "country": "DE", "collection": "kommunalwiki", "filters": { "content_type": "praxishilfe" } }
+
+Suche mit Datumsfilter:
+{ "query": "Energiewende", "country": "DE", "collection": "gruene-de", "filters": { "date_from": "2025-01-01" } }
+
+Suche in Berlin nach Quelle:
+{ "query": "Verkehrswende", "country": "DE", "collection": "berlin", "filters": { "source_id": "berlin-lv-presse" } }`;
 }
 
 export const searchTool = {
@@ -248,13 +257,13 @@ export const searchTool = {
           .string()
           .optional()
           .describe(
-            'Inhaltstyp (für kommunalwiki, boell-stiftung) - erst gruenerator_get_filters aufrufen!'
+            'Inhaltstyp (für kommunalwiki, boell-stiftung, Landesverbände) - erst gruenerator_get_filters aufrufen!'
           ),
         subcategories: z
           .string()
           .optional()
           .describe(
-            'Unterkategorie (für kommunalwiki, boell-stiftung) - erst gruenerator_get_filters aufrufen!'
+            'Unterkategorie (für kommunalwiki, boell-stiftung, Landesverbände) - erst gruenerator_get_filters aufrufen!'
           ),
         region: z
           .string()
@@ -273,6 +282,32 @@ export const searchTool = {
           .optional()
           .describe(
             'Plattform (instagram oder facebook, nur für examples) - erst gruenerator_get_filters aufrufen!'
+          ),
+        source_id: z
+          .string()
+          .optional()
+          .describe(
+            'Quellen-ID (nur berlin: berlin-lv-presse, berlin-fraktion-presse, etc.) - erst gruenerator_get_filters aufrufen!'
+          ),
+        landesverband: z
+          .string()
+          .optional()
+          .describe('Landesverband (nur satzungen) - erst gruenerator_get_filters aufrufen!'),
+        gremium: z
+          .string()
+          .optional()
+          .describe('Gremium (nur satzungen) - erst gruenerator_get_filters aufrufen!'),
+        date_from: z
+          .string()
+          .optional()
+          .describe(
+            'Startdatum (ISO-Format, z.B. "2024-01-01") - für Sammlungen mit published_at Filter'
+          ),
+        date_to: z
+          .string()
+          .optional()
+          .describe(
+            'Enddatum (ISO-Format, z.B. "2025-12-31") - für Sammlungen mit published_at Filter'
           ),
       })
       .optional()


### PR DESCRIPTION
## Summary

- **Vision endpoint** (`/api/vision`): Standardized vision API with text detection, OCR routing, and alt-text generation via `VisionService`. Refactored `alttext.ts` to use shared service. Added `isVisionCapable()` to model discovery.
- **Playground simplification**: Replaced filesystem scan of 24 prompt JSONs with 3 curated modes (Freie Eingabe, Text Generator, Leichte Sprache). Extracted `updatePanel` helper, merged redundant state, reduced timer interval, unified SSE branches.
- **Dynamic model discovery**: Playground fetches available models from LiteLLM/Regolo at runtime with caching and categorization.
- **Collection sync** (MCP + shared): Synced collection filters between MCP server and shared package, added new collections.
- **Notebook model switch**: Switched notebook to GPT-OSS, replaced LLM reranking with Regolo cross-encoder.
- **UI fixes**: Mobile dropdown positioning, hamburger menu clearance on docs overview.
- **Cargo.lock**: Minor `windows-sys` dependency bumps.

## Test plan

- [ ] Verify playground loads with 3 modes and model selector works
- [ ] Test "Freie Eingabe" mode with custom system prompt
- [ ] Test vision image upload + analysis with a vision-capable model
- [ ] Verify `/api/vision/analyze` and `/api/vision/alt-text` endpoints
- [ ] Check MCP collection filters match shared package
- [ ] Verify notebook chat uses GPT-OSS model
- [ ] Test mobile UI: dropdown positioning, docs overview spacing