### PR TITLE
fix(api): deduplicate LV scraper vectors and fix content stats

### DIFF
--- a/apps/api/generate-content-stats.ts
+++ b/apps/api/generate-content-stats.ts
@@ -33,12 +33,16 @@ const CONTENT_COLLECTIONS = [
 ];
 
 const LV_SHORT_NAMES: { code: string; label: string }[] = [
+  { code: 'BB', label: 'Brandenburg' },
+  { code: 'BE', label: 'Berlin' },
+  { code: 'BE-F', label: 'Berlin Fraktion' },
+  { code: 'BY', label: 'Bayern' },
+  { code: 'HH', label: 'Hamburg' },
   { code: 'LSA', label: 'Sachsen-Anhalt' },
   { code: 'LSA-F', label: 'Sachsen-Anhalt Fraktion' },
   { code: 'MV', label: 'Mecklenburg-Vorpommern' },
   { code: 'MV-F', label: 'Mecklenburg-Vorpommern Fraktion' },
-  { code: 'HH', label: 'Hamburg' },
-  { code: 'BE', label: 'Berlin' },
+  { code: 'SH', label: 'Schleswig-Holstein' },
   { code: 'TH', label: 'Thüringen' },
   { code: 'TH-F', label: 'Thüringen Fraktion' },
 ];

--- a/apps/api/scripts/debug-lv-counts.ts
+++ b/apps/api/scripts/debug-lv-counts.ts
@@ -1,0 +1,276 @@
+/**
+ * Debug: Landesverbände Vector Count Analysis
+ *
+ * Discovers all distinct `landesverband` values in the landesverbaende_documents
+ * collection and counts vectors per value. Helps diagnose discrepancies between
+ * the total collection count and the per-LV breakdown in generate-content-stats.ts.
+ *
+ * Usage: npx tsx apps/api/scripts/debug-lv-counts.ts
+ *
+ * Requires: QDRANT_URL, QDRANT_API_KEY, QDRANT_BASIC_AUTH_USERNAME, QDRANT_BASIC_AUTH_PASSWORD
+ */
+
+const QDRANT_URL = (process.env.QDRANT_URL || '').replace(/\/+$/, '');
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY || '';
+const BASIC_USER = process.env.QDRANT_BASIC_AUTH_USERNAME;
+const BASIC_PASS = process.env.QDRANT_BASIC_AUTH_PASSWORD;
+const COLLECTION = 'landesverbaende_documents';
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'api-key': QDRANT_API_KEY,
+  };
+  if (BASIC_USER && BASIC_PASS) {
+    headers['Authorization'] =
+      `Basic ${Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString('base64')}`;
+  }
+  return headers;
+}
+
+async function qdrantPost(path: string, body: Record<string, unknown> = {}): Promise<any> {
+  const resp = await fetch(`${QDRANT_URL}${path}`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Qdrant ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+async function qdrantGet(path: string): Promise<any> {
+  const resp = await fetch(`${QDRANT_URL}${path}`, {
+    method: 'GET',
+    headers: buildHeaders(),
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Qdrant ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+async function getTotalCount(): Promise<number> {
+  const data = await qdrantPost(`/collections/${COLLECTION}/points/count`);
+  return data.result?.count ?? 0;
+}
+
+async function getFilteredCount(filter: Record<string, unknown>): Promise<number> {
+  const data = await qdrantPost(`/collections/${COLLECTION}/points/count`, { filter });
+  return data.result?.count ?? 0;
+}
+
+async function discoverLandesverbandValues(): Promise<string[]> {
+  const values = new Set<string>();
+  let offset: string | number | null = null;
+  const batchSize = 100;
+  let scrolled = 0;
+
+  console.log('Scrolling collection to discover distinct landesverband values...');
+
+  while (true) {
+    const body: Record<string, unknown> = {
+      limit: batchSize,
+      with_payload: { include: ['landesverband'] },
+      with_vector: false,
+    };
+    if (offset !== null) {
+      body.offset = offset;
+    }
+
+    const data = await qdrantPost(`/collections/${COLLECTION}/points/scroll`, body);
+    const points = data.result?.points ?? [];
+
+    if (points.length === 0) break;
+
+    for (const point of points) {
+      const lv = point.payload?.landesverband;
+      if (lv) {
+        values.add(String(lv));
+      } else {
+        values.add('__MISSING__');
+      }
+    }
+
+    scrolled += points.length;
+    offset = data.result?.next_page_offset ?? null;
+
+    if (scrolled % 10000 === 0) {
+      console.log(`  ...scrolled ${scrolled} points, found ${values.size} distinct values so far`);
+    }
+
+    if (offset === null) break;
+  }
+
+  console.log(`Scrolled ${scrolled} points total, found ${values.size} distinct values\n`);
+  return [...values].sort();
+}
+
+async function main() {
+  if (!QDRANT_URL || !QDRANT_API_KEY) {
+    console.error('QDRANT_URL and QDRANT_API_KEY are required');
+    process.exit(1);
+  }
+
+  console.log(`\nQuerying ${COLLECTION} at ${QDRANT_URL}\n`);
+
+  // Step 1: Total count
+  const total = await getTotalCount();
+  console.log(`Total vectors in collection: ${total.toLocaleString()}\n`);
+
+  // Step 2: Discover all distinct landesverband values
+  const lvValues = await discoverLandesverbandValues();
+
+  // Step 3: Count per value
+  console.log('Counting vectors per landesverband value...\n');
+
+  const results: { code: string; count: number }[] = [];
+
+  for (const code of lvValues) {
+    let count: number;
+    if (code === '__MISSING__') {
+      count = await getFilteredCount({
+        must_not: [
+          { key: 'landesverband', match: { any: lvValues.filter((v) => v !== '__MISSING__') } },
+        ],
+      });
+    } else {
+      count = await getFilteredCount({
+        must: [{ key: 'landesverband', match: { value: code } }],
+      });
+    }
+    results.push({ code, count });
+  }
+
+  // Step 4: Print results
+  results.sort((a, b) => b.count - a.count);
+
+  const codeWidth = Math.max(20, ...results.map((r) => r.code.length + 2));
+  const header = `${'landesverband'.padEnd(codeWidth)} ${'count'.padStart(10)} ${'%'.padStart(7)}`;
+  console.log(header);
+  console.log('─'.repeat(header.length));
+
+  let accountedFor = 0;
+  for (const { code, count } of results) {
+    const pct = total > 0 ? ((count / total) * 100).toFixed(1) : '0.0';
+    console.log(
+      `${code.padEnd(codeWidth)} ${count.toLocaleString().padStart(10)} ${(pct + '%').padStart(7)}`
+    );
+    accountedFor += count;
+  }
+
+  console.log('─'.repeat(header.length));
+  console.log(
+    `${'SUM'.padEnd(codeWidth)} ${accountedFor.toLocaleString().padStart(10)} ${((accountedFor / total) * 100).toFixed(1).padStart(6)}%`
+  );
+  console.log(`${'TOTAL'.padEnd(codeWidth)} ${total.toLocaleString().padStart(10)}`);
+
+  if (accountedFor !== total) {
+    console.log(`\n⚠ Gap: ${(total - accountedFor).toLocaleString()} vectors unaccounted for`);
+  } else {
+    console.log('\n✓ All vectors accounted for');
+  }
+
+  // Step 5: Check collection info for segment count (might reveal orphaned segments)
+  try {
+    const info = await qdrantGet(`/collections/${COLLECTION}`);
+    const collInfo = info.result;
+    console.log(`\nCollection info:`);
+    console.log(`  Segments: ${collInfo?.segments_count}`);
+    console.log(`  Points count: ${collInfo?.points_count}`);
+    console.log(`  Vectors count: ${collInfo?.vectors_count}`);
+    console.log(`  Status: ${collInfo?.status}`);
+  } catch {
+    // not critical
+  }
+}
+
+async function analyzeByYear(lvCode: string) {
+  console.log(`\n\n═══ Year distribution for ${lvCode} ═══\n`);
+
+  // Scroll BE-F vectors and collect published_at years
+  const yearCounts = new Map<string, number>();
+  const sourceIdCounts = new Map<string, number>();
+  let offset: string | number | null = null;
+  let scrolled = 0;
+  let noDate = 0;
+
+  while (true) {
+    const body: Record<string, unknown> = {
+      limit: 100,
+      with_payload: { include: ['published_at', 'source_id', 'source_url', 'content_type'] },
+      with_vector: false,
+      filter: { must: [{ key: 'landesverband', match: { value: lvCode } }] },
+    };
+    if (offset !== null) body.offset = offset;
+
+    const data = await qdrantPost(`/collections/${COLLECTION}/points/scroll`, body);
+    const points = data.result?.points ?? [];
+    if (points.length === 0) break;
+
+    for (const point of points) {
+      const publishedAt = point.payload?.published_at;
+      const sourceId = point.payload?.source_id || '__unknown__';
+
+      sourceIdCounts.set(sourceId, (sourceIdCounts.get(sourceId) || 0) + 1);
+
+      if (publishedAt) {
+        const year = String(publishedAt).substring(0, 4);
+        yearCounts.set(year, (yearCounts.get(year) || 0) + 1);
+      } else {
+        noDate++;
+      }
+    }
+
+    scrolled += points.length;
+    offset = data.result?.next_page_offset ?? null;
+    if (scrolled % 10000 === 0) console.log(`  ...scrolled ${scrolled}`);
+    if (offset === null) break;
+  }
+
+  // Print year distribution
+  const years = [...yearCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const yw = 8;
+  console.log(`${'Year'.padEnd(yw)} ${'Count'.padStart(10)} ${'%'.padStart(7)}`);
+  console.log('─'.repeat(27));
+  for (const [year, count] of years) {
+    const pct = ((count / scrolled) * 100).toFixed(1);
+    console.log(
+      `${year.padEnd(yw)} ${count.toLocaleString().padStart(10)} ${(pct + '%').padStart(7)}`
+    );
+  }
+  if (noDate > 0) {
+    console.log(
+      `${'no date'.padEnd(yw)} ${noDate.toLocaleString().padStart(10)} ${((noDate / scrolled) * 100).toFixed(1).padStart(6)}%`
+    );
+  }
+  console.log(`${'TOTAL'.padEnd(yw)} ${scrolled.toLocaleString().padStart(10)}`);
+
+  // Print source_id distribution
+  console.log(`\n${'source_id'.padEnd(40)} ${'Count'.padStart(10)} ${'%'.padStart(7)}`);
+  console.log('─'.repeat(59));
+  const sources = [...sourceIdCounts.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [src, count] of sources) {
+    const pct = ((count / scrolled) * 100).toFixed(1);
+    console.log(
+      `${src.padEnd(40)} ${count.toLocaleString().padStart(10)} ${(pct + '%').padStart(7)}`
+    );
+  }
+}
+
+// Run year analysis if --analyze flag or always for the top LV
+const targetLv = process.argv[2] || 'BE-F';
+
+analyzeByYear(targetLv).catch((err) => {
+  console.error('Year analysis error:', err);
+});
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/apps/api/scripts/dedup-lv-vectors.ts
+++ b/apps/api/scripts/dedup-lv-vectors.ts
@@ -1,0 +1,188 @@
+/**
+ * Deduplicate landesverbaende_documents vectors
+ *
+ * Finds vectors with duplicate base URLs (same path, different ?tmstv= params),
+ * keeps the newest version (by indexed_at), deletes the rest.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/dedup-lv-vectors.ts              # dry run (default)
+ *   npx tsx apps/api/scripts/dedup-lv-vectors.ts --execute     # actually delete
+ *
+ * Requires: QDRANT_URL, QDRANT_API_KEY, QDRANT_BASIC_AUTH_USERNAME, QDRANT_BASIC_AUTH_PASSWORD
+ */
+
+const QDRANT_URL = (process.env.QDRANT_URL || '').replace(/\/+$/, '');
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY || '';
+const BASIC_USER = process.env.QDRANT_BASIC_AUTH_USERNAME;
+const BASIC_PASS = process.env.QDRANT_BASIC_AUTH_PASSWORD;
+const COLLECTION = 'landesverbaende_documents';
+const DRY_RUN = !process.argv.includes('--execute');
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'api-key': QDRANT_API_KEY,
+  };
+  if (BASIC_USER && BASIC_PASS) {
+    headers['Authorization'] =
+      `Basic ${Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString('base64')}`;
+  }
+  return headers;
+}
+
+async function qdrantPost(path: string, body: Record<string, unknown> = {}): Promise<any> {
+  const resp = await fetch(`${QDRANT_URL}${path}`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Qdrant ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
+
+function stripCacheBusting(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.searchParams.delete('tmstv');
+    const search = parsed.searchParams.toString();
+    return parsed.origin + parsed.pathname + (search ? '?' + search : '');
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+interface VectorInfo {
+  id: string | number;
+  sourceUrl: string;
+  indexedAt: string;
+  chunkIndex: number;
+}
+
+async function main() {
+  if (!QDRANT_URL || !QDRANT_API_KEY) {
+    console.error('QDRANT_URL and QDRANT_API_KEY are required');
+    process.exit(1);
+  }
+
+  console.log(`\n${DRY_RUN ? '🔍 DRY RUN' : '🗑️  EXECUTE MODE'} — Deduplicating ${COLLECTION}\n`);
+
+  // Step 1: Scroll all BE-F beschluesse vectors (the problematic source)
+  console.log('Scrolling BE-F berlin-fraktion-beschluesse vectors...');
+
+  const vectorsByBaseUrl = new Map<string, VectorInfo[]>();
+  let offset: string | number | null = null;
+  let scrolled = 0;
+
+  while (true) {
+    const body: Record<string, unknown> = {
+      limit: 100,
+      with_payload: { include: ['source_url', 'indexed_at', 'chunk_index'] },
+      with_vector: false,
+      filter: {
+        must: [
+          { key: 'landesverband', match: { value: 'BE-F' } },
+          { key: 'source_id', match: { value: 'berlin-fraktion-beschluesse' } },
+        ],
+      },
+    };
+    if (offset !== null) body.offset = offset;
+
+    const data = await qdrantPost(`/collections/${COLLECTION}/points/scroll`, body);
+    const points = data.result?.points ?? [];
+    if (points.length === 0) break;
+
+    for (const point of points) {
+      const sourceUrl = (point.payload?.source_url as string) || '';
+      const baseUrl = stripCacheBusting(sourceUrl);
+
+      if (!vectorsByBaseUrl.has(baseUrl)) vectorsByBaseUrl.set(baseUrl, []);
+      vectorsByBaseUrl.get(baseUrl)!.push({
+        id: point.id,
+        sourceUrl,
+        indexedAt: (point.payload?.indexed_at as string) || '',
+        chunkIndex: (point.payload?.chunk_index as number) ?? 0,
+      });
+    }
+
+    scrolled += points.length;
+    offset = data.result?.next_page_offset ?? null;
+    if (scrolled % 20000 === 0) console.log(`  ...scrolled ${scrolled}`);
+    if (offset === null) break;
+  }
+
+  console.log(`Scrolled ${scrolled} vectors, ${vectorsByBaseUrl.size} distinct base URLs\n`);
+
+  // Step 2: For each base URL, find all distinct indexed_at timestamps (representing scrape runs)
+  // Keep the newest run's vectors, mark the rest for deletion
+  let toDelete: (string | number)[] = [];
+  let toKeep = 0;
+
+  for (const [baseUrl, vectors] of vectorsByBaseUrl) {
+    // Group by indexed_at (each scrape run produces vectors with the same timestamp)
+    const byTimestamp = new Map<string, VectorInfo[]>();
+    for (const v of vectors) {
+      const ts = v.indexedAt.substring(0, 19); // group by second precision
+      if (!byTimestamp.has(ts)) byTimestamp.set(ts, []);
+      byTimestamp.get(ts)!.push(v);
+    }
+
+    if (byTimestamp.size <= 1) {
+      toKeep += vectors.length;
+      continue;
+    }
+
+    // Sort timestamps descending, keep newest
+    const sortedTimestamps = [...byTimestamp.keys()].sort().reverse();
+    const newestTs = sortedTimestamps[0];
+
+    for (const [ts, tsVectors] of byTimestamp) {
+      if (ts === newestTs) {
+        toKeep += tsVectors.length;
+      } else {
+        toDelete.push(...tsVectors.map((v) => v.id));
+      }
+    }
+  }
+
+  console.log(`Vectors to keep:   ${toKeep.toLocaleString()}`);
+  console.log(`Vectors to delete: ${toDelete.length.toLocaleString()}`);
+  console.log(`Total:             ${scrolled.toLocaleString()}\n`);
+
+  if (toDelete.length === 0) {
+    console.log('Nothing to delete!');
+    return;
+  }
+
+  if (DRY_RUN) {
+    console.log('Run with --execute to actually delete the duplicate vectors.');
+    return;
+  }
+
+  // Step 3: Delete in batches
+  const BATCH_SIZE = 500;
+  let deleted = 0;
+
+  for (let i = 0; i < toDelete.length; i += BATCH_SIZE) {
+    const batch = toDelete.slice(i, i + BATCH_SIZE);
+    await qdrantPost(`/collections/${COLLECTION}/points/delete`, {
+      points: batch,
+    });
+    deleted += batch.length;
+    if (deleted % 5000 === 0 || deleted === toDelete.length) {
+      console.log(`  Deleted ${deleted.toLocaleString()} / ${toDelete.length.toLocaleString()}`);
+    }
+  }
+
+  console.log(`\nDone! Deleted ${deleted.toLocaleString()} duplicate vectors.`);
+  console.log('Note: Remaining vectors still have ?tmstv in source_url.');
+  console.log('The next scrape cycle will naturally replace them with clean URLs.');
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/apps/api/scripts/dedup-lv-vectors.ts
+++ b/apps/api/scripts/dedup-lv-vectors.ts
@@ -121,7 +121,7 @@ async function main() {
   let toDelete: (string | number)[] = [];
   let toKeep = 0;
 
-  for (const [baseUrl, vectors] of vectorsByBaseUrl) {
+  for (const [, vectors] of vectorsByBaseUrl) {
     // Group by indexed_at (each scrape run produces vectors with the same timestamp)
     const byTimestamp = new Map<string, VectorInfo[]>();
     for (const v of vectors) {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -715,11 +715,13 @@ export class LandesverbandScraper extends BaseScraper {
     } else {
       absolute = baseUrl + '/' + url;
     }
-    // Canonicalize: strip fragment only (preserve trailing slashes to match existing Qdrant data)
+    // Canonicalize: strip fragment and cache-busting params (preserve trailing slashes to match existing Qdrant data)
     try {
       const parsed = new URL(absolute);
       parsed.hash = '';
-      return parsed.origin + parsed.pathname + parsed.search;
+      parsed.searchParams.delete('tmstv');
+      const search = parsed.searchParams.toString();
+      return parsed.origin + parsed.pathname + (search ? '?' + search : '');
     } catch {
       return absolute;
     }


### PR DESCRIPTION
## Summary

- **Strip `?tmstv` cache-busting param** in `LandesverbandScraper#normalizeUrl()` — `gruene-fraktion.berlin` adds a changing `?tmstv=` timestamp to download URLs on every page render, which defeated the `source_url`-based dedup check. This caused 53 Berlin Fraktion PDFs to be re-ingested ~128 times, accumulating **115,292 duplicate vectors** (84% of the entire `landesverbaende_documents` collection).
- **Add 4 missing LV codes** (`BB`, `BE-F`, `BY`, `SH`) to `generate-content-stats.ts` so the per-Landesverband breakdown covers all 12 active codes.
- **Include diagnostic scripts** (`debug-lv-counts.ts`, `dedup-lv-vectors.ts`) for future Qdrant collection analysis and cleanup.
- **Data cleanup already executed**: 115,292 duplicate vectors deleted, collection reduced from 139,832 → 24,540 vectors. Closed stale PR #566 which had inflated numbers.

## Test plan

- [ ] Verify next Content Sync run produces correct stats (~24K total vectors)
- [ ] Confirm `berlin-fraktion-beschluesse` PDFs are not re-ingested as duplicates
- [ ] Run `debug-lv-counts.ts` after a sync cycle to verify no new duplicates