### PR TITLE
fix(web): resolve auth redirect loop between /login and /desk

### DIFF
--- a/apps/web/src/components/common/LoginRequired/withAuthRequired.tsx
+++ b/apps/web/src/components/common/LoginRequired/withAuthRequired.tsx
@@ -25,14 +25,18 @@ const withAuthRequired = <P extends Record<string, unknown>>(
     const user = useAuthStore((s) => s.user);
 
     if (!user) {
-      return (
-        <>
-          <div className="protected-content-blur">
-            {fallback ?? <Component {...props} user={null} />}
-          </div>
-          <LoginRequired title={title} message={message} variant="fullpage" />
-        </>
-      );
+      if (fallback) {
+        return (
+          <>
+            <div className="protected-content-blur">{fallback}</div>
+            <LoginRequired title={title} message={message} variant="fullpage" />
+          </>
+        );
+      }
+      // Don't render <Component> when unauthenticated — it mounts the full tree,
+      // triggers API calls that return 401, and the interceptor redirects to /login,
+      // causing redirect loops during auth initialization
+      return <LoginRequired title={title} message={message} variant="fullpage" />;
     }
 
     return <Component {...props} user={user} />;

--- a/apps/web/src/components/routing/GuestRoute.tsx
+++ b/apps/web/src/components/routing/GuestRoute.tsx
@@ -4,6 +4,11 @@ import { useAuthStore } from '../../stores/authStore';
 
 const GuestRoute = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
+
+  // Don't redirect during logout — store may momentarily show authenticated from stale cache
+  if (isLoggingOut) return <Outlet />;
+
   return isAuthenticated ? <Navigate to="/desk" replace /> : <Outlet />;
 };
 

--- a/apps/web/src/components/utils/apiClient.ts
+++ b/apps/web/src/components/utils/apiClient.ts
@@ -6,6 +6,14 @@ import { buildLoginUrl, isPublicPage } from '../../utils/authRedirect';
 import { getDesktopToken } from '../../utils/desktopAuth';
 import { isDesktopApp } from '../../utils/platform';
 
+// Module-level flag to suppress 401 redirects during logout.
+// Set by authStore.logout() to prevent redirect loops.
+// Using a simple flag avoids circular dependency (authStore ↔ apiClient).
+let _isLoggingOut = false;
+export const setLoggingOutFlag = (value: boolean) => {
+  _isLoggingOut = value;
+};
+
 // Use relative URL by default (same as AUTH_BASE_URL in useAuth.js)
 // This works because frontend is served by backend on same port
 const baseURL: string = import.meta.env.VITE_API_BASE_URL || '/api';
@@ -17,7 +25,7 @@ const sharedApiClient = createApiClient({
   authMode: isDesktopApp() ? 'bearer' : 'cookie',
   getAuthToken: isDesktopApp() ? async () => getDesktopToken() : undefined,
   onUnauthorized: () => {
-    if (!isPublicPage() && window.location.pathname !== '/login') {
+    if (!_isLoggingOut && !isPublicPage() && window.location.pathname !== '/login') {
       const currentPath = window.location.pathname + window.location.search;
       window.location.href = buildLoginUrl(currentPath);
     }
@@ -78,7 +86,7 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response && error.response.status === 401) {
-      if (!isPublicPage() && window.location.pathname !== '/login') {
+      if (!_isLoggingOut && !isPublicPage() && window.location.pathname !== '/login') {
         const currentPath = window.location.pathname + window.location.search;
         const loginUrl = buildLoginUrl(currentPath);
         window.location.href = loginUrl;

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -409,6 +409,13 @@ export const useAuth = (options: AuthOptions = {}) => {
   useEffect(() => {
     // Don't process auth data if user recently logged out (unless on login page)
     if (hasRecentlyLoggedOut && !isOnLoginPage) {
+      // Clear stale instant-auth cache to prevent useInstantAuth from
+      // restoring authenticated state after logout
+      try {
+        localStorage.removeItem('authState');
+      } catch {
+        // Ignore localStorage errors
+      }
       // Only clear auth if user is currently authenticated
       // This prevents unnecessary clearAuth calls that would reset the logout timestamp
       const { isAuthenticated: currentIsAuthenticated } = useAuthStore.getState();
@@ -420,7 +427,7 @@ export const useAuth = (options: AuthOptions = {}) => {
       if (!isOnLoginPage && !skipAuth && !lazy) {
         try {
           localStorage.removeItem('gruenerator_logout_timestamp');
-        } catch (error) {
+        } catch {
           // Ignore localStorage errors
         }
       }

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import apiClient from '../components/utils/apiClient';
+import apiClient, { setLoggingOutFlag } from '../components/utils/apiClient';
 import { openDesktopLogin, type AuthSource } from '../utils/desktopAuth';
 import { isDesktopApp } from '../utils/platform';
 
@@ -266,6 +266,10 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     localStorage.removeItem(AUTH_STORAGE_KEY);
     localStorage.removeItem(AUTH_VERSION_KEY);
 
+    // Clear the instant-auth cache used by useInstantAuth() / getCachedAuthState()
+    // Without this, LoginPage reads stale cached auth and causes redirect loops
+    localStorage.removeItem('authState');
+
     // Clear React Query cache to prevent stale auth data
     if (
       typeof window !== 'undefined' &&
@@ -388,6 +392,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     try {
       // Step 1: Set logging out state immediately for smooth UX
       set({ isLoggingOut: true });
+      setLoggingOutFlag(true);
 
       // Step 2: Call backend logout API FIRST (before clearing local state)
       let backendResponse: Record<string, unknown> | null = null;
@@ -472,7 +477,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       // Step 6: Verify logout completion (optional verification)
       try {
         console.log('[AuthStore] Verifying logout completion...');
-        const statusResponse = await apiClient.get('/auth/status');
+        const statusResponse = await apiClient.get('/auth/status', { skipAuthRedirect: true });
 
         const statusData = statusResponse.data;
         if (statusData.isAuthenticated) {
@@ -509,6 +514,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     } finally {
       // Always reset the logging out state
       set({ isLoggingOut: false });
+      setLoggingOutFlag(false);
     }
   },
 


### PR DESCRIPTION
## Summary

Fixes the redirect loop between `/login?redirectTo=%2Fdesk` and `/desk` that occurs after logout and sometimes after login. Three independent issues compound to create the loop:

- **Stale `authState` cache**: `clearAuth()` didn't clear the `authState` localStorage key used by `useInstantAuth()`. LoginPage read stale cached auth data, set `isAuthenticated=true`, and GuestRoute redirected to `/desk` — where the real auth check would fail and redirect back to `/login`
- **`withAuthRequired` rendering full component tree**: When unauthenticated, it rendered `<Component user={null}>` inside a blurred div. Child components mounted, made API calls that returned 401, and the interceptor forced redirects to `/login`
- **No logout transition awareness**: GuestRoute and the 401 interceptor had no concept of "currently logging out", so they'd fight the logout flow by redirecting during it

## Changes

- Clear `authState` cache in `clearAuth()` and in `useAuth`'s logout handler
- `withAuthRequired` now only renders `<LoginRequired>` overlay when unauthenticated (no blurred component preview that triggers 401 cascades)
- GuestRoute checks `isLoggingOut` to prevent premature redirects during logout
- 401 interceptor suppressed during logout via a module-level flag (avoids circular dependency)
- Logout verification API call uses `skipAuthRedirect: true`

## Test plan

- [ ] Log in → navigate to `/desk` → log out → should land on `/` without looping
- [ ] From `/login?redirectTo=/desk` → complete OAuth → should land on `/desk` without looping  
- [ ] Navigate to `/desk` while logged out → should see login overlay, no redirect loop
- [ ] Log out → immediately log back in → should complete without loop
- [ ] Full login/navigate/logout cycle works smoothly