### PR TITLE
fix(web): resolve auth redirect loop and update notebook link

### DIFF
--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -113,10 +113,10 @@ const NotebooksSection: React.FC = memo(() => {
       {SYSTEM_NOTEBOOKS.length > INITIAL_COUNT && (
         <button
           type="button"
-          onClick={() => navigate('/recherche')}
+          onClick={() => navigate('/research')}
           className="mt-sm text-sm text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer bg-transparent border-none transition-colors"
         >
-          Alle Notebooks anzeigen
+          Notebook Daten durchsuchen
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Fix infinite redirect loop between `/login` and `/desk` caused by race conditions in auth state initialization
- Update notebook section link from `/recherche` to `/research` with label "Notebook Daten durchsuchen"

## Test plan
- [ ] Log in and verify no redirect loop between `/login` and `/desk`
- [ ] Visit `/desk` while logged out — should redirect to `/login` once
- [ ] Click "Notebook Daten durchsuchen" on workplace page — should navigate to `/research`