### PR TITLE
fix: security findings, model updates, JSON parser, and shared document 404

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/llmConfig.ts
+++ b/apps/api/agents/langgraph/ChatGraph/llmConfig.ts
@@ -26,7 +26,6 @@ const MODEL_MAP: Record<string, string> = {
   // Legacy IDs kept for backward compatibility
   'mistral-large': 'mistral-large-latest',
   'mistral-medium': 'mistral-medium-latest',
-  'magistral-medium': 'magistral-medium-latest',
   'pixtral-large': 'pixtral-large-latest',
 };
 

--- a/apps/api/prompts/antrag_experimental.json
+++ b/apps/api/prompts/antrag_experimental.json
@@ -49,7 +49,7 @@
   "options": {
     "max_tokens": 4000,
     "temperature": 0.3,
-    "model": "magistral-medium-latest",
-    "provider": "mistral"
+    "model": "gpt-oss:120b",
+    "provider": "litellm"
   }
 }

--- a/apps/api/prompts/antrag_simple.json
+++ b/apps/api/prompts/antrag_simple.json
@@ -39,7 +39,7 @@
     "max_tokens": 3000,
     "temperature": 0.5,
     "top_p": 0.9,
-    "model": "magistral-medium-latest",
-    "provider": "mistral"
+    "model": "gpt-oss:120b",
+    "provider": "litellm"
   }
 }

--- a/apps/api/routes/docs/importController.ts
+++ b/apps/api/routes/docs/importController.ts
@@ -146,7 +146,11 @@ router.post(
       }
 
       console.log(
-        `[DocsImport] User ${userId} importing file: ${file.originalname} (${file.mimetype}, ${(file.size / 1024).toFixed(0)}KB)`
+        '[DocsImport] User %s importing file: %s (%s, %dKB)',
+        userId,
+        file.originalname,
+        file.mimetype,
+        Number((file.size / 1024).toFixed(0))
       );
 
       const result = await ocrBufferToDocument(
@@ -207,7 +211,10 @@ router.post('/from-wolke', requireAuth, async (req: AuthenticatedRequest, res: R
     }
 
     console.log(
-      `[DocsImport:Wolke] User ${userId} importing from Wolke: ${fileName} (share=${shareLinkId})`
+      '[DocsImport:Wolke] User %s importing from Wolke: %s (share=%s)',
+      userId,
+      fileName,
+      shareLinkId
     );
 
     const wolkeSyncService = getWolkeSyncService();
@@ -227,7 +234,9 @@ router.post('/from-wolke', requireAuth, async (req: AuthenticatedRequest, res: R
     }
 
     console.log(
-      `[DocsImport:Wolke] Downloaded ${fileName}: ${(downloaded.size / 1024).toFixed(0)}KB`
+      '[DocsImport:Wolke] Downloaded %s: %dKB',
+      fileName,
+      Number((downloaded.size / 1024).toFixed(0))
     );
 
     const result = await ocrBufferToDocument(

--- a/apps/api/services/OcrService/OcrService.ts
+++ b/apps/api/services/OcrService/OcrService.ts
@@ -427,18 +427,23 @@ export class OCRService {
     if (doclingReady) {
       try {
         console.log(
-          `[OCRService] Using Docling for base64 attachment: ${safeFilename} (${mimeType})`
+          '[OCRService] Using Docling for base64 attachment: %s (%s)',
+          safeFilename,
+          mimeType
         );
         return await extractBase64Docling(base64Data, filename);
       } catch (doclingError) {
         console.warn(
-          `[OCRService] Docling base64 failed for ${safeFilename}, falling back to Mistral OCR:`,
+          '[OCRService] Docling base64 failed for %s, falling back to Mistral OCR: %s',
+          safeFilename,
           (doclingError as Error).message
         );
       }
     } else {
       console.log(
-        `[OCRService] Docling unavailable, using Mistral OCR for: ${safeFilename} (${mimeType})`
+        '[OCRService] Docling unavailable, using Mistral OCR for: %s (%s)',
+        safeFilename,
+        mimeType
       );
     }
 
@@ -449,7 +454,8 @@ export class OCRService {
       // Last resort for PDFs: PDF.js (basic text extraction, no OCR)
       if (mimeType === 'application/pdf') {
         console.warn(
-          `[OCRService] Mistral OCR failed for ${safeFilename}, trying PDF.js as last resort:`,
+          '[OCRService] Mistral OCR failed for %s, trying PDF.js as last resort: %s',
+          safeFilename,
           (mistralError as Error).message
         );
         return this.extractTextFromBase64PDF(base64Data, filename);

--- a/apps/api/services/OcrService/OcrService.ts
+++ b/apps/api/services/OcrService/OcrService.ts
@@ -420,21 +420,25 @@ export class OCRService {
       };
     }
 
+    const safeFilename = sanitizeFilename(filename, 'unknown');
+
     // Try Docling first — self-hosted, no token cost
     const doclingReady = await checkDocling();
     if (doclingReady) {
       try {
-        console.log(`[OCRService] Using Docling for base64 attachment: ${filename} (${mimeType})`);
+        console.log(
+          `[OCRService] Using Docling for base64 attachment: ${safeFilename} (${mimeType})`
+        );
         return await extractBase64Docling(base64Data, filename);
       } catch (doclingError) {
         console.warn(
-          `[OCRService] Docling base64 failed for ${filename}, falling back to Mistral OCR:`,
+          `[OCRService] Docling base64 failed for ${safeFilename}, falling back to Mistral OCR:`,
           (doclingError as Error).message
         );
       }
     } else {
       console.log(
-        `[OCRService] Docling unavailable, using Mistral OCR for: ${filename} (${mimeType})`
+        `[OCRService] Docling unavailable, using Mistral OCR for: ${safeFilename} (${mimeType})`
       );
     }
 
@@ -445,7 +449,7 @@ export class OCRService {
       // Last resort for PDFs: PDF.js (basic text extraction, no OCR)
       if (mimeType === 'application/pdf') {
         console.warn(
-          `[OCRService] Mistral OCR failed for ${filename}, trying PDF.js as last resort:`,
+          `[OCRService] Mistral OCR failed for ${safeFilename}, trying PDF.js as last resort:`,
           (mistralError as Error).message
         );
         return this.extractTextFromBase64PDF(base64Data, filename);

--- a/apps/api/services/OcrService/doclingIntegration.ts
+++ b/apps/api/services/OcrService/doclingIntegration.ts
@@ -11,8 +11,14 @@
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+import { sanitizePath } from '../../utils/validation/security.js';
 
 import type { ExtractionResult } from './types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const DOCLING_BASE_URL = process.env.DOCLING_URL || 'http://ocr:5001';
 
@@ -107,13 +113,15 @@ async function sendBufferToDocling(
 export async function extractTextWithDocling(filePath: string): Promise<ExtractionResult> {
   const resolvedPath = path.resolve(filePath);
   const allowedBases = [
-    os.tmpdir(),
+    path.resolve(os.tmpdir()),
     path.resolve(__dirname, '../../uploads'),
     path.resolve(__dirname, '../../storage'),
   ];
-  if (!allowedBases.some((base) => resolvedPath.startsWith(base + path.sep))) {
+  const matchedBase = allowedBases.find((base) => resolvedPath.startsWith(base + path.sep));
+  if (!matchedBase) {
     throw new Error('File path outside allowed directories');
   }
+  sanitizePath(path.relative(matchedBase, resolvedPath), matchedBase);
 
   console.log(`[DoclingOCR] Starting extraction:`, { filePath });
   const fileBuffer = await fs.readFile(resolvedPath);

--- a/apps/api/services/OcrService/mistralIntegration.ts
+++ b/apps/api/services/OcrService/mistralIntegration.ts
@@ -184,7 +184,7 @@ export async function extractBase64WithMistralOCR(
   } catch (error) {
     const errorMessage = (error as Error).message;
     const safeFilename = sanitizeFilename(filename, 'unknown');
-    console.error(`[OcrService] Mistral OCR base64 failed for ${safeFilename}:`, errorMessage);
+    console.error('[OcrService] Mistral OCR base64 failed for %s: %s', safeFilename, errorMessage);
     throw new Error(`Mistral OCR extraction failed: ${errorMessage}`);
   }
 }

--- a/apps/api/services/OcrService/mistralIntegration.ts
+++ b/apps/api/services/OcrService/mistralIntegration.ts
@@ -183,7 +183,8 @@ export async function extractBase64WithMistralOCR(
     };
   } catch (error) {
     const errorMessage = (error as Error).message;
-    console.error(`[OcrService] Mistral OCR base64 failed for ${filename}:`, errorMessage);
+    const safeFilename = sanitizeFilename(filename, 'unknown');
+    console.error(`[OcrService] Mistral OCR base64 failed for ${safeFilename}:`, errorMessage);
     throw new Error(`Mistral OCR extraction failed: ${errorMessage}`);
   }
 }

--- a/apps/api/services/ai/__tests__/aiService.vitest.ts
+++ b/apps/api/services/ai/__tests__/aiService.vitest.ts
@@ -126,16 +126,16 @@ describe('AIService', () => {
     );
   });
 
-  it('routes pro mode to Mistral', async () => {
+  it('routes pro mode to LiteLLM', async () => {
     mockSelectProviderAndModel.mockReturnValue({
-      provider: 'mistral',
-      model: 'magistral-medium-latest',
+      provider: 'litellm',
+      model: 'gpt-oss:120b',
     });
     const data = makeRequest({ options: { useProMode: true } });
     await service.processRequest(data);
 
     expect(mockExecuteProvider).toHaveBeenCalledWith(
-      'mistral',
+      'litellm',
       expect.any(String),
       expect.objectContaining({
         options: expect.objectContaining({ useProMode: true }),

--- a/apps/api/services/ai/config.ts
+++ b/apps/api/services/ai/config.ts
@@ -248,7 +248,7 @@ export function applyProModeConfig(
   config: GenerationConfig,
   model: string
 ): GenerationConfig & { promptMode?: string } {
-  if (model.includes('magistral')) {
+  if (model.includes('gpt-oss')) {
     return {
       ...config,
       maxTokens: Math.max(config.maxTokens, 6000),

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -31,8 +31,6 @@ interface OpenAIModelsResponse {
 const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision: boolean }> = {
   'mistral-large-2512': { name: 'Mistral Large', reasoning: false, vision: false },
   'mistral-large-latest': { name: 'Mistral Large', reasoning: false, vision: false },
-  'magistral-medium-latest': { name: 'Magistral Medium', reasoning: true, vision: false },
-  'magistral-small-latest': { name: 'Magistral Small', reasoning: true, vision: false },
   'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
   'mistral-small-2503': { name: 'Mistral Small (Vision)', reasoning: false, vision: true },
   'qwen3-vl-32b': { name: 'Qwen3 VL 32B', reasoning: false, vision: true },
@@ -164,11 +162,7 @@ function fetchModelsForProvider(provider: ProviderName): Promise<PlaygroundModel
   return fetchProviderModels(provider, endpoint.url(), process.env[endpoint.envKey] || null);
 }
 
-const FALLBACK_MODELS: PlaygroundModel[] = [
-  'mistral-large-2512',
-  'magistral-medium-latest',
-  'mistral-small-latest',
-]
+const FALLBACK_MODELS: PlaygroundModel[] = ['mistral-large-2512', 'mistral-small-latest']
   .map((id) => enrichModel(id, 'mistral'))
   .concat(
     [

--- a/apps/api/services/providers/providerSelector.ts
+++ b/apps/api/services/providers/providerSelector.ts
@@ -19,7 +19,7 @@ import type {
 export function isLiteLLMCompatibleModel(modelName: string = ''): boolean {
   const name = String(modelName || '').toLowerCase();
   // LiteLLM models typically use prefixes like gpt-oss, or are mistral/mixtral variants
-  // Exclude Mistral API models (mistral-large-2512, magistral-*, etc.)
+  // Exclude Mistral API models (mistral-large-2512, etc.)
   if (name.includes('gpt-oss') || name.includes('gpt-4') || name.includes('gpt-3')) {
     return true;
   }
@@ -27,7 +27,7 @@ export function isLiteLLMCompatibleModel(modelName: string = ''): boolean {
     return true;
   }
   // Mistral API models are NOT litellm compatible
-  if (name.includes('mistral-') || name.includes('magistral-')) {
+  if (name.includes('mistral-')) {
     return false;
   }
   return false;
@@ -50,12 +50,11 @@ export function shouldAllowMainLlmOverride(
  */
 export function determineProviderFromModel(modelName: string = ''): ProviderName {
   const name = String(modelName || '').toLowerCase();
-  // Mistral API models (mistral-large, mistral-small, magistral-*)
+  // Mistral API models (mistral-large, mistral-small)
   if (
     name.includes('mistral-medium-') ||
     name.includes('mistral-large-') ||
-    name.includes('mistral-small-') ||
-    name.includes('magistral-')
+    name.includes('mistral-small-')
   ) {
     return 'mistral';
   }
@@ -104,10 +103,10 @@ export function selectProviderAndModel({
     provider = 'ionos';
     model = 'openai/gpt-oss-120b';
   }
-  // Pro mode (useProMode flag) - routes to high-quality Magistral model
+  // Pro mode (useProMode flag) - routes to high-quality reasoning model
   else if (options.useProMode === true) {
-    provider = 'mistral';
-    model = options.model || 'magistral-medium-latest';
+    provider = 'litellm';
+    model = options.model || 'gpt-oss:120b';
   }
 
   // Type-based defaults

--- a/apps/api/services/subtitler/ProjectService.ts
+++ b/apps/api/services/subtitler/ProjectService.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
+import { sanitizePath } from '../../utils/validation/security.js';
 
 import type {
   SubtitlerProject,
@@ -220,16 +221,10 @@ export class SubtitlerProjectService {
         throw new Error('Invalid uploadId format');
       }
       const tusVideoPath = path.join(__dirname, '../../uploads/tus-temp', uploadId);
-      const sourceVideoPath = videoSourcePath || tusVideoPath;
-
-      const allowedDirs = [
-        path.resolve(__dirname, '../../uploads/tus-temp'),
-        path.resolve(PROJECT_STORAGE_PATH),
-      ];
-      const resolvedSource = path.resolve(sourceVideoPath);
-      if (!allowedDirs.some((dir) => resolvedSource.startsWith(dir + path.sep))) {
-        throw new Error('Video source path outside allowed directory');
-      }
+      const uploadsDir = path.resolve(__dirname, '../../uploads');
+      const sourceVideoPath = videoSourcePath
+        ? sanitizePath(videoSourcePath, uploadsDir)
+        : tusVideoPath;
       const targetVideoPath = path.join(projectDir, 'video.mp4');
       const thumbnailPath = path.join(projectDir, 'thumbnail.jpg');
       const relativeVideoPath = `${userId}/${projectId}/video.mp4`;

--- a/apps/api/services/subtitler/videoUploadService.ts
+++ b/apps/api/services/subtitler/videoUploadService.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { createLogger } from '../../utils/logger.js';
+import { sanitizePath } from '../../utils/validation/security.js';
 
 import { ffmpeg, normalizeRotation, type FFprobeMetadata } from './ffmpegWrapper.js';
 
@@ -121,9 +122,14 @@ async function extractAudio(
 ): Promise<string> {
   log.debug('Starte Audio-Extraktion:', { inputPath: videoPath, outputPath });
 
-  const allowedDirs = [path.resolve(__dirname, '../../uploads'), path.resolve(os.tmpdir())];
+  const uploadsDir = path.resolve(__dirname, '../../uploads');
+  const tmpDir = path.resolve(os.tmpdir());
   const resolvedVideoPath = path.resolve(videoPath);
-  if (!allowedDirs.some((dir) => resolvedVideoPath.startsWith(dir + path.sep))) {
+  if (resolvedVideoPath.startsWith(uploadsDir + path.sep)) {
+    sanitizePath(path.relative(uploadsDir, resolvedVideoPath), uploadsDir);
+  } else if (resolvedVideoPath.startsWith(tmpDir + path.sep)) {
+    sanitizePath(path.relative(tmpDir, resolvedVideoPath), tmpDir);
+  } else {
     throw new Error('Video path outside allowed directory');
   }
 

--- a/apps/api/static-data/chat-agents/antragsschreiber.json
+++ b/apps/api/static-data/chat-agents/antragsschreiber.json
@@ -7,7 +7,7 @@
   "backgroundColor": "#316049",
   "tags": ["Politik", "Antrag", "Kommunalpolitik", "Grüne"],
   "model": "mistral-large-latest",
-  "defaultModel": "magistral-medium-latest",
+  "defaultModel": "gpt-oss:120b",
   "provider": "mistral",
   "params": {
     "max_tokens": 3000,

--- a/apps/api/static-data/chat-agents/rede-schreiber.json
+++ b/apps/api/static-data/chat-agents/rede-schreiber.json
@@ -7,7 +7,7 @@
   "backgroundColor": "#316049",
   "tags": ["Politik", "Rede", "Grüne", "Kommunikation"],
   "model": "mistral-large-latest",
-  "defaultModel": "magistral-medium-latest",
+  "defaultModel": "gpt-oss:120b",
   "provider": "mistral",
   "params": {
     "max_tokens": 4000,

--- a/apps/api/static-data/chat-agents/wahlprogramm-autor.json
+++ b/apps/api/static-data/chat-agents/wahlprogramm-autor.json
@@ -7,7 +7,7 @@
   "backgroundColor": "#316049",
   "tags": ["Politik", "Wahlprogramm", "Grüne", "Programmatik"],
   "model": "mistral-large-latest",
-  "defaultModel": "magistral-medium-latest",
+  "defaultModel": "gpt-oss:120b",
   "provider": "mistral",
   "params": {
     "max_tokens": 4000,

--- a/apps/api/utils/jsonParser.ts
+++ b/apps/api/utils/jsonParser.ts
@@ -84,11 +84,44 @@ export function extractJsonObject<T = Record<string, unknown>>(raw: unknown): T 
   // Replace smart quotes with normal quotes
   text = text.replace(/[""]/g, '"').replace(/['']/g, "'");
 
-  // Find first { and last } to slice out the JSON object if wrapped in prose
+  // Extract the first complete JSON object using brace-depth matching.
+  // The naive "first { to last }" strategy fails when LLMs output
+  // reasoning text between multiple JSON blocks (e.g. chain-of-thought).
   const firstBrace = text.indexOf('{');
-  const lastBrace = text.lastIndexOf('}');
-  if (firstBrace !== -1 && lastBrace !== -1 && lastBrace > firstBrace) {
-    text = text.slice(firstBrace, lastBrace + 1);
+  if (firstBrace !== -1) {
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    let endPos = -1;
+
+    for (let i = firstBrace; i < text.length; i++) {
+      const ch = text[i];
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+        } else if (ch === '\\') {
+          escaped = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+      } else {
+        if (ch === '"') {
+          inString = true;
+        } else if (ch === '{') {
+          depth++;
+        } else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            endPos = i;
+            break;
+          }
+        }
+      }
+    }
+
+    if (endPos !== -1) {
+      text = text.slice(firstBrace, endPos + 1);
+    }
   }
 
   log.debug('[jsonParser] Parsing JSON preview:', {

--- a/apps/docs/src/lib/docsAdapter.ts
+++ b/apps/docs/src/lib/docsAdapter.ts
@@ -27,6 +27,8 @@ export const webDocsAdapter: DocsAdapter = {
     window.location.href = `/login?redirectTo=${encodeURIComponent(currentPath)}`;
   },
 
+  getDocumentUrl: (id) => `/document/${id}`,
+
   navigateToDocument: (id) => {
     window.location.href = `/document/${id}`;
   },

--- a/apps/mobile/components/docs/DocEditorDOM.tsx
+++ b/apps/mobile/components/docs/DocEditorDOM.tsx
@@ -195,6 +195,7 @@ function createDomAdapter(
     getHocuspocusToken: async () => authToken,
     getAuthHeaders: async () => ({ Authorization: `Bearer ${authToken}` }),
     onUnauthorized: () => {},
+    getDocumentUrl: () => '',
     navigateToDocument: () => {},
     navigateToHome: () => {},
     getWebSocketPolyfill: wsBridge

--- a/apps/web/src/components/common/ShareMediaModal/ShareMediaModal.tsx
+++ b/apps/web/src/components/common/ShareMediaModal/ShareMediaModal.tsx
@@ -8,7 +8,7 @@ import {
   DialogTitle,
 } from '@gruenerator/ui';
 import { useState, useEffect } from 'react';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 
 import { cn } from '../../../utils/cn';
 import { canShare, shareContent } from '../../../utils/shareUtils';

--- a/apps/web/src/features/docs/docsAdapter.ts
+++ b/apps/web/src/features/docs/docsAdapter.ts
@@ -50,6 +50,8 @@ export const webAppDocsAdapter: DocsAdapter = {
     window.location.href = buildLoginUrl(currentPath);
   },
 
+  getDocumentUrl: (id) => `/docs/${id}`,
+
   navigateToDocument: (id) => {
     window.location.href = `/docs/${id}`;
   },

--- a/apps/web/src/features/shared-media/SharedMediaPage.tsx
+++ b/apps/web/src/features/shared-media/SharedMediaPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@gruenerator/ui';
 import { lazy, Suspense, useState, useEffect, useCallback } from 'react';
 import { FaInstagram } from 'react-icons/fa';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 import { useParams } from 'react-router-dom';
 
 import LoginRequired from '../../components/common/LoginRequired/LoginRequired';

--- a/apps/web/src/features/subtitler/components/ShareVideoModal.tsx
+++ b/apps/web/src/features/subtitler/components/ShareVideoModal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@gruenerator/ui';
 import React, { useState, useEffect } from 'react';
 import { FaCheck, FaCopy, FaShareAlt } from 'react-icons/fa';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 
 import EnhancedSelect from '../../../components/common/EnhancedSelect/EnhancedSelect';
 import { useSubtitlerShareStore, getShareUrl } from '../../../stores/subtitlerShareStore';

--- a/apps/web/src/features/subtitler/components/SharedVideoPage.tsx
+++ b/apps/web/src/features/subtitler/components/SharedVideoPage.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@gruenerator/ui';
 import React, { useState, useEffect, useCallback } from 'react';
 import { FaInstagram } from 'react-icons/fa';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 import { useParams } from 'react-router-dom';
 
 import LoginRequired from '../../../components/common/LoginRequired/LoginRequired';

--- a/apps/web/src/features/transfer/TransferPage.tsx
+++ b/apps/web/src/features/transfer/TransferPage.tsx
@@ -2,7 +2,7 @@ import { Button, FileCard, RetroGrid } from '@gruenerator/ui';
 import { useShareLinks, useWolkePreferencesStore } from '@gruenerator/wolke';
 import { useCallback, useState } from 'react';
 import { PiCheck, PiCopy, PiFile, PiPlus, PiShareNetwork, PiUploadSimple } from 'react-icons/pi';
-import QRCode from 'react-qr-code';
+import { QRCode } from 'react-qr-code';
 import { Link } from 'react-router-dom';
 
 import Spinner from '../../components/common/Spinner';

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -113,10 +113,10 @@ const NotebooksSection: React.FC = memo(() => {
       {SYSTEM_NOTEBOOKS.length > INITIAL_COUNT && (
         <button
           type="button"
-          onClick={() => navigate('/recherche')}
+          onClick={() => navigate('/research')}
           className="mt-sm text-sm text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer bg-transparent border-none transition-colors"
         >
-          Alle Notebooks anzeigen
+          Notebook Daten durchsuchen
         </button>
       )}
 

--- a/packages/chat/src/lib/formatSourcesMarkdown.ts
+++ b/packages/chat/src/lib/formatSourcesMarkdown.ts
@@ -1,7 +1,7 @@
 import type { Citation } from '../hooks/useChatGraphStream';
 
 function escapeMarkdown(text: string): string {
-  return text.replace(/[*_`~\[\]]/g, '\\$&');
+  return text.replace(/[\\*_`~\[\]#!()<>|]/g, '\\$&');
 }
 
 function truncate(text: string, max: number): string {

--- a/packages/docs/src/components/permissions/ShareModal.tsx
+++ b/packages/docs/src/components/permissions/ShareModal.tsx
@@ -112,7 +112,7 @@ export const ShareModal = ({ documentId, documentTitle, onClose }: ShareModalPro
   }, [documentId]);
 
   const copyShareLink = async () => {
-    const shareUrl = `${window.location.origin}/document/${documentId}`;
+    const shareUrl = `${window.location.origin}${adapter.getDocumentUrl(documentId)}`;
     try {
       await navigator.clipboard.writeText(shareUrl);
       setCopySuccess(true);
@@ -124,7 +124,7 @@ export const ShareModal = ({ documentId, documentTitle, onClose }: ShareModalPro
   };
 
   const directShare = async () => {
-    const shareUrl = `${window.location.origin}/document/${documentId}`;
+    const shareUrl = `${window.location.origin}${adapter.getDocumentUrl(documentId)}`;
     const title = documentTitle || 'Dokument';
     const message = userDisplayName
       ? `${userDisplayName} möchte „${title}" mit dir teilen:\n${shareUrl}`

--- a/packages/docs/src/context/DocsContext.tsx
+++ b/packages/docs/src/context/DocsContext.tsx
@@ -27,6 +27,8 @@ export interface DocsAdapter {
   navigateToHome(): void;
   /** Optional custom WebSocket constructor for environments where native WS doesn't work (e.g. Expo DOM) */
   getWebSocketPolyfill?(): (new (...args: unknown[]) => WebSocket) | undefined;
+  /** Build a shareable URL path for a document (e.g. '/docs/abc' or '/document/abc') */
+  getDocumentUrl(documentId: string): string;
   /** Get the current user's display name (for personalized sharing) */
   getCurrentUserDisplayName?(): string | null;
 }


### PR DESCRIPTION
## Summary
- **Security**: Resolve 12 CodeQL findings (path injection, format string, sanitization) + dismiss 37 false positives
- **API**: Replace deprecated magistral model with gpt-oss:120b
- **API**: Fix JSON parser for LLM chain-of-thought output using brace-depth matching
- **Docs sharing**: Fix 404 on shared document links — ShareModal hardcoded `/document/` path which doesn't exist in the web app; now uses adapter-based URLs (`/docs/{id}` on web, `/document/{id}` on docs app)
- **Web**: Fix CJS interop crash for react-qr-code (named import)
- **Web**: Link notebook section to `/research` instead of `/recherche`

## Test plan
- [ ] Share a document from `gruenerator.eu` → verify copied link uses `/docs/{id}`
- [ ] Open shared link as unauthenticated user → should load document (not 404)
- [ ] Verify AI text generation works with gpt-oss:120b model
- [ ] CodeQL re-scan should auto-close the 12 remaining open alerts