### PR TITLE
fix: docs sharing, presence avatars, UI typechecks, vite security

### DIFF
--- a/apps/api/middleware/authMiddleware.ts
+++ b/apps/api/middleware/authMiddleware.ts
@@ -71,8 +71,8 @@ async function requireAuth(
       req.user = toBetterAuthUser(session.user);
       return next();
     }
-  } catch {
-    // Session check failed
+  } catch (err) {
+    console.warn('[Auth] Session check failed for %s: %s', req.originalUrl, (err as Error).message);
   }
 
   if (
@@ -80,6 +80,7 @@ async function requireAuth(
     req.headers.accept === 'application/json' ||
     req.originalUrl.startsWith('/api/')
   ) {
+    console.warn('[Auth] 401 — %s %s (no valid session)', req.method, req.originalUrl);
     res.status(401).json({
       error: 'Authentication required',
       redirectUrl: '/auth/login',

--- a/apps/api/routes/docs/documentController.ts
+++ b/apps/api/routes/docs/documentController.ts
@@ -247,11 +247,19 @@ router.get('/:id', async (req: Request, res: Response) => {
 
     const document = result[0];
 
+    const isOwner = document.created_by === userId;
+    const hasDirectPerm = !!(document.permissions && document.permissions[userId]);
     let hasAccess =
-      document.created_by === userId ||
-      document.is_public ||
-      document.share_mode === 'authenticated' ||
-      (document.permissions && document.permissions[userId]);
+      isOwner || document.is_public || document.share_mode === 'authenticated' || hasDirectPerm;
+    let accessMethod = isOwner
+      ? 'owner'
+      : document.is_public
+        ? 'public'
+        : document.share_mode === 'authenticated'
+          ? 'authenticated'
+          : hasDirectPerm
+            ? `direct:${document.permissions[userId]?.level}`
+            : 'none';
 
     if (!hasAccess) {
       const groupAccess = (await db.query(
@@ -263,10 +271,25 @@ router.get('/:id', async (req: Request, res: Response) => {
 
       if (groupAccess.length > 0 && groupAccess[0].permissions?.read !== false) {
         hasAccess = true;
+        accessMethod = 'group:read';
+      } else if (groupAccess.length > 0) {
+        console.warn(
+          '[Docs] GET /api/docs/%s — group access denied (read=false) for userId=%s',
+          id,
+          userId
+        );
       }
     }
 
     if (!hasAccess) {
+      console.warn(
+        '[Docs] GET /api/docs/%s — 403: userId=%s, accessMethod=%s, share_mode=%s, is_public=%s',
+        id,
+        userId,
+        accessMethod,
+        document.share_mode,
+        document.is_public
+      );
       return res.status(403).json({ error: 'Access denied' });
     }
 
@@ -506,10 +529,22 @@ router.post('/:id/duplicate', async (req: Request, res: Response) => {
 
       if (groupAccess.length > 0 && groupAccess[0].permissions?.read !== false) {
         hasAccessToDuplicate = true;
+      } else if (groupAccess.length > 0) {
+        console.warn(
+          '[Docs] POST /api/docs/%s/duplicate — group access denied (read=false) for userId=%s',
+          id,
+          userId
+        );
       }
     }
 
     if (!hasAccessToDuplicate) {
+      console.warn(
+        '[Docs] POST /api/docs/%s/duplicate — 403: userId=%s, share_mode=%s',
+        id,
+        userId,
+        original.share_mode
+      );
       return res.status(403).json({ error: 'Access denied' });
     }
 

--- a/apps/api/routes/docs/publicDocController.ts
+++ b/apps/api/routes/docs/publicDocController.ts
@@ -38,15 +38,23 @@ router.get('/:id', async (req: Request, res: Response) => {
     }[];
 
     if (result.length === 0) {
+      console.warn('[Docs] Public check 404: docId=%s — not found, deleted, or private', id);
       return res.status(404).json({ error: 'Document not found or not publicly accessible' });
     }
 
     const doc = result[0];
 
     if (doc.share_mode === 'authenticated') {
+      console.log('[Docs] Public check: docId=%s — authenticated mode, returning title only', id);
       return res.json({ share_mode: 'authenticated', title: doc.title });
     }
 
+    console.log(
+      '[Docs] Public check: docId=%s — share_mode=%s, subtype=%s',
+      id,
+      doc.share_mode,
+      doc.document_subtype
+    );
     return res.json(doc);
   } catch (error: any) {
     console.error('[Docs] Error checking public document:', error);

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -124,7 +124,7 @@ function EditorContent() {
   const apiClient = useMemo(() => createDocsApiClient(adapter), [adapter]);
   const user = useAuthStore((s) => s.user);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
-  const isGuest = !user;
+  const isGuest = !user && !isAuthLoading;
 
   const guestIdentity = useMemo(() => (isGuest ? getOrCreateGuestIdentity() : null), [isGuest]);
 

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -1,5 +1,6 @@
 import {
   useCollaboration,
+  useCollaborators,
   getAuthErrorMessage,
   type CollaborationConfig,
 } from '@gruenerator/collab';
@@ -13,8 +14,16 @@ import {
   ErrorBoundary,
   type Document,
 } from '@gruenerator/docs';
+import { getRobotAvatarPath } from '@gruenerator/shared/avatar';
 import { EditorTopBar } from '@gruenerator/shared/components/EditorTopBar';
-import { Skeleton } from '@gruenerator/ui';
+import {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  Skeleton,
+} from '@gruenerator/ui';
 import { WolkeSaveModal, uploadToWolke } from '@gruenerator/wolke';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
@@ -207,6 +216,8 @@ function EditorContent() {
     guestId: guestIdentity?.guestId,
     guestName: guestIdentity?.guestName,
   });
+  const collaborators = useCollaborators(provider);
+
   const { messages, sendMessage, getLocalUser, setTyping, typingUsers } = useDocumentChat({
     ydoc,
     provider,
@@ -432,6 +443,26 @@ function EditorContent() {
           onTitleChange={handleTitleChange}
           rightActions={
             <>
+              {collaborators.length > 0 && (
+                <>
+                  <AvatarGroup>
+                    {collaborators.slice(0, 5).map((c) => (
+                      <Avatar key={c.id} size="sm" title={c.name}>
+                        {c.avatarRobotId ? (
+                          <AvatarImage src={getRobotAvatarPath(c.avatarRobotId)} alt={c.name} />
+                        ) : null}
+                        <AvatarFallback style={{ backgroundColor: c.color, color: 'white' }}>
+                          {c.name.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                    ))}
+                    {collaborators.length > 5 && (
+                      <AvatarGroupCount>+{collaborators.length - 5}</AvatarGroupCount>
+                    )}
+                  </AvatarGroup>
+                  <span className="glass-divider" />
+                </>
+              )}
               {!isGuest && (
                 <>
                   <div ref={exportMenuRef} className="relative">

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -24,7 +24,14 @@ export { Alert, AlertTitle, AlertDescription } from './components/alert';
 export { FeatureToggle, type FeatureToggleProps } from './components/feature-toggle';
 export { FileCard } from './components/file-card';
 export { Ripple } from './components/ripple';
-export { Avatar, AvatarImage, AvatarFallback } from './components/avatar';
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+} from './components/avatar';
 export { Badge, badgeVariants } from './components/badge';
 export { Button, buttonVariants } from './components/button';
 export { Checkbox } from './components/checkbox';


### PR DESCRIPTION
## Summary
- **Parallel public document fetch**: Public check fires at T0 independently of auth — no more "Dokument nicht gefunden" flash for guests
- **Guest banner fix**: `isGuest` requires auth to be resolved — prevents "Du bearbeitest als Gast" flash for logged-in users
- **Presence avatars**: Show collaborator avatars (with robot avatar support) in docs editor top bar using `@gruenerator/ui` Avatar
- **Group permissions**: Validate `permissions.read !== false` before granting group access
- **Debug logging**: Auth middleware, public doc endpoint, and document access denials
- **UI typecheck fixes**: Fix all pre-existing errors in `packages/ui` (broken imports, Zod v3 compat, calendar index signatures, question-flow)
- **UI exports**: Export `AvatarBadge`, `AvatarGroup`, `AvatarGroupCount` from `@gruenerator/ui`
- **Vite 8.0.5**: Fix 3 security vulnerabilities (2 high, 1 medium)

## Test plan
- [ ] Guest visits public doc → skeleton → content (no error flash)
- [ ] Logged-in user opens doc → no guest banner flash, presence avatars visible
- [ ] `pnpm typecheck` passes (including `packages/ui`)
- [ ] Dependabot alerts 388, 389, 390 auto-close after merge