### PR TITLE
feat(docs): version history, metadata dialog, fix template overwrite

### DIFF
--- a/apps/api/routes/docs/index.ts
+++ b/apps/api/routes/docs/index.ts
@@ -8,6 +8,7 @@ import groupShareController from './groupShareController.js';
 import importController from './importController.js';
 import permissionsController from './permissionsController.js';
 import shareController from './shareController.js';
+import snapshotController from './snapshotController.js';
 
 const router = Router();
 
@@ -19,6 +20,7 @@ router.use('/', shareController);
 router.use('/', exportController);
 router.use('/', exportToDocsController);
 router.use('/', importController);
+router.use('/', snapshotController);
 router.use('/', aiController);
 router.use('/', documentController);
 

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -76,11 +76,6 @@ function canEditDoc(doc: DocumentRow, userId: string): boolean {
   return false;
 }
 
-/**
- * @route   GET /api/docs/:id/snapshots
- * @desc    List all snapshots for a document
- * @access  Private
- */
 router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response) => {
   try {
     const userId = req.user?.id;
@@ -115,11 +110,6 @@ router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response)
   }
 });
 
-/**
- * @route   GET /api/docs/:id/snapshots/:version/preview
- * @desc    Get HTML preview of a specific snapshot version
- * @access  Private
- */
 router.get(
   '/:id/snapshots/:version/preview',
   async (req: Request<{ id: string; version: string }>, res: Response) => {
@@ -166,11 +156,6 @@ router.get(
   }
 );
 
-/**
- * @route   POST /api/docs/:id/snapshots/:version/restore
- * @desc    Restore a document to a specific snapshot version
- * @access  Private (owner or editor)
- */
 router.post(
   '/:id/snapshots/:version/restore',
   async (req: Request<{ id: string; version: string }>, res: Response) => {

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -1,0 +1,255 @@
+import { gunzipSync, gzipSync } from 'zlib';
+
+import { blockNoteXmlToHtml } from '@gruenerator/hocuspocus';
+import { Router, type Request, type Response } from 'express';
+import * as Y from 'yjs';
+
+import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+
+import { DOCS_SUBTYPES } from './constants.js';
+
+interface DocumentRow {
+  id: string;
+  created_by: string;
+  permissions: Record<string, { level: string }> | null;
+  is_public: boolean;
+  share_mode: string;
+}
+
+interface SnapshotRow {
+  id: string;
+  version: number;
+  created_at: string;
+  is_auto_save: boolean;
+  label: string | null;
+  created_by: string | null;
+  created_by_name: string | null;
+  snapshot_data?: Buffer;
+}
+
+const router = Router();
+const db = getPostgresInstance();
+
+async function getAccessibleDocument(
+  id: string,
+  userId: string,
+  res: Response
+): Promise<DocumentRow | null> {
+  const result = (await db.query(
+    `SELECT id, created_by, permissions, is_public, share_mode
+     FROM collaborative_documents
+     WHERE id = $1 AND is_deleted = false AND document_subtype = ANY($2::text[])`,
+    [id, DOCS_SUBTYPES]
+  )) as DocumentRow[];
+
+  if (result.length === 0) {
+    res.status(404).json({ error: 'Document not found' });
+    return null;
+  }
+
+  const doc = result[0];
+  const isOwner = doc.created_by === userId;
+  const hasDirectPerm = !!(doc.permissions && doc.permissions[userId]);
+  const hasAccess = isOwner || doc.is_public || doc.share_mode === 'authenticated' || hasDirectPerm;
+
+  if (!hasAccess) {
+    const groupAccess = (await db.query(
+      `SELECT gcs.permissions FROM group_content_shares gcs
+       INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+       WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
+      [userId, id]
+    )) as { permissions: { read: boolean } | null }[];
+
+    if (groupAccess.length === 0 || groupAccess[0].permissions?.read === false) {
+      res.status(403).json({ error: 'Access denied' });
+      return null;
+    }
+  }
+
+  return doc;
+}
+
+function canEditDoc(doc: DocumentRow, userId: string): boolean {
+  if (doc.created_by === userId) return true;
+  const perm = doc.permissions?.[userId];
+  if (perm) return ['owner', 'editor'].includes(perm.level);
+  return false;
+}
+
+/**
+ * @route   GET /api/docs/:id/snapshots
+ * @desc    List all snapshots for a document
+ * @access  Private
+ */
+router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+    const doc = await getAccessibleDocument(req.params.id, userId, res);
+    if (!doc) return;
+
+    const snapshots = (await db.query(
+      `SELECT s.id, s.version, s.created_at, s.is_auto_save, s.label, s.created_by,
+              p.display_name as created_by_name
+       FROM yjs_document_snapshots s
+       LEFT JOIN profiles p ON s.created_by = p.id
+       WHERE s.document_id = $1
+       ORDER BY s.version DESC`,
+      [req.params.id]
+    )) as SnapshotRow[];
+
+    return res.json({
+      snapshots: snapshots.map((s) => ({
+        id: s.id,
+        version: s.version,
+        created_at: s.created_at,
+        is_auto_save: s.is_auto_save,
+        label: s.label,
+        created_by_name: s.created_by_name,
+      })),
+    });
+  } catch (error: unknown) {
+    console.error('[Docs] Error listing snapshots:', error);
+    return res.status(500).json({ error: 'Failed to list snapshots' });
+  }
+});
+
+/**
+ * @route   GET /api/docs/:id/snapshots/:version/preview
+ * @desc    Get HTML preview of a specific snapshot version
+ * @access  Private
+ */
+router.get(
+  '/:id/snapshots/:version/preview',
+  async (req: Request<{ id: string; version: string }>, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const doc = await getAccessibleDocument(req.params.id, userId, res);
+      if (!doc) return;
+
+      const version = parseInt(req.params.version, 10);
+      if (!Number.isFinite(version)) {
+        return res.status(400).json({ error: 'Invalid version number' });
+      }
+
+      const result = (await db.query(
+        `SELECT snapshot_data, created_at
+         FROM yjs_document_snapshots
+         WHERE document_id = $1 AND version = $2`,
+        [req.params.id, version]
+      )) as { snapshot_data: Buffer; created_at: string }[];
+
+      if (result.length === 0) {
+        return res.status(404).json({ error: 'Snapshot not found' });
+      }
+
+      const decompressed = gunzipSync(result[0].snapshot_data);
+      const ydoc = new Y.Doc();
+      Y.applyUpdate(ydoc, decompressed);
+
+      const fragment = ydoc.getXmlFragment('document-store');
+      const xml = fragment.toString();
+      const html = blockNoteXmlToHtml(xml);
+
+      return res.json({
+        version,
+        html,
+        created_at: result[0].created_at,
+      });
+    } catch (error: unknown) {
+      console.error('[Docs] Error getting snapshot preview:', error);
+      return res.status(500).json({ error: 'Failed to get snapshot preview' });
+    }
+  }
+);
+
+/**
+ * @route   POST /api/docs/:id/snapshots/:version/restore
+ * @desc    Restore a document to a specific snapshot version
+ * @access  Private (owner or editor)
+ */
+router.post(
+  '/:id/snapshots/:version/restore',
+  async (req: Request<{ id: string; version: string }>, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const doc = await getAccessibleDocument(req.params.id, userId, res);
+      if (!doc) return;
+
+      if (!canEditDoc(doc, userId)) {
+        return res.status(403).json({ error: 'Edit permission required to restore' });
+      }
+
+      const version = parseInt(req.params.version, 10);
+      if (!Number.isFinite(version)) {
+        return res.status(400).json({ error: 'Invalid version number' });
+      }
+
+      const result = (await db.query(
+        `SELECT snapshot_data
+         FROM yjs_document_snapshots
+         WHERE document_id = $1 AND version = $2`,
+        [req.params.id, version]
+      )) as { snapshot_data: Buffer }[];
+
+      if (result.length === 0) {
+        return res.status(404).json({ error: 'Snapshot not found' });
+      }
+
+      const decompressed = gunzipSync(result[0].snapshot_data);
+      const ydoc = new Y.Doc();
+      Y.applyUpdate(ydoc, decompressed);
+
+      const state = Y.encodeStateAsUpdate(ydoc);
+      const compressedState = gzipSync(Buffer.from(state));
+
+      await db.query(
+        `INSERT INTO yjs_document_updates (document_id, update_data, created_at)
+         VALUES ($1, $2, CURRENT_TIMESTAMP)`,
+        [req.params.id, compressedState]
+      );
+
+      const versionResult = (await db.query(
+        `SELECT COALESCE(MAX(version), 0) + 1 as next_version
+         FROM yjs_document_snapshots WHERE document_id = $1`,
+        [req.params.id]
+      )) as { next_version: number }[];
+
+      const nextVersion = versionResult[0].next_version;
+
+      await db.query(
+        `INSERT INTO yjs_document_snapshots
+          (document_id, snapshot_data, version, created_at, is_auto_save, label, created_by)
+         VALUES ($1, $2, $3, CURRENT_TIMESTAMP, false, $4, $5)`,
+        [req.params.id, compressedState, nextVersion, `Wiederhergestellt von v${version}`, userId]
+      );
+
+      const fragment = ydoc.getXmlFragment('document-store');
+      const xml = fragment.toString();
+      const html = blockNoteXmlToHtml(xml).slice(0, 2000);
+
+      await db.query(
+        `UPDATE collaborative_documents
+         SET content = $2, updated_at = CURRENT_TIMESTAMP, last_edited_by = $3
+         WHERE id = $1`,
+        [req.params.id, html, userId]
+      );
+
+      return res.json({
+        success: true,
+        new_version: nextVersion,
+        message: 'Dokument wurde wiederhergestellt. Bitte Seite neu laden.',
+      });
+    } catch (error: unknown) {
+      console.error('[Docs] Error restoring snapshot:', error);
+      return res.status(500).json({ error: 'Failed to restore snapshot' });
+    }
+  }
+);
+
+export default router;

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -6,6 +6,7 @@ import {
 import {
   useDocumentChat,
   BlockNoteEditor as BlockNoteEditorComponent,
+  VersionHistory,
   useDocsAdapter,
   createDocsApiClient,
   lazyWithRetry,
@@ -15,7 +16,7 @@ import { EditorTopBar } from '@gruenerator/shared/components/EditorTopBar';
 import { WolkeSaveModal, uploadToWolke } from '@gruenerator/wolke';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
-import { FiCloud, FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
+import { FiClock, FiCloud, FiDownload, FiShare2, FiSidebar } from 'react-icons/fi';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { EditorFAB } from '../components/EditorFAB';
@@ -89,6 +90,7 @@ function getOrCreateGuestIdentity(): { guestId: string; guestName: string; guest
 const SIDEBAR_TABS = [
   { label: 'Chat', value: 'chat' as const },
   { label: 'Kommentare', value: 'comments' as const },
+  { label: 'Versionen', value: 'versions' as const },
 ];
 
 export const EditorPage = () => {
@@ -150,7 +152,7 @@ export const EditorPage = () => {
   const [showWolkeModal, setShowWolkeModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<'chat' | 'comments'>('chat');
+  const [sidebarTab, setSidebarTab] = useState<'chat' | 'comments' | 'versions'>('chat');
   const [editor, setEditor] = useState<BlockNoteEditor | null>(null);
 
   const exportMenuRef = useRef<HTMLDivElement>(null);
@@ -410,6 +412,22 @@ export const EditorPage = () => {
                     </button>
                   )}
 
+                  <button
+                    className={`glass-btn ${sidebarOpen && sidebarTab === 'versions' ? 'active' : ''}`}
+                    onClick={() => {
+                      if (sidebarOpen && sidebarTab === 'versions') {
+                        setSidebarOpen(false);
+                      } else {
+                        setSidebarTab('versions');
+                        setSidebarOpen(true);
+                      }
+                    }}
+                    aria-label="Versionshistorie"
+                    title="Versionshistorie"
+                  >
+                    <FiClock />
+                  </button>
+
                   <span className="glass-divider" />
                 </>
               )}
@@ -481,6 +499,10 @@ export const EditorPage = () => {
               <div className="flex-1 overflow-y-auto">
                 <div className="comments-portal-content" ref={commentsPortalRef} />
               </div>
+            )}
+
+            {sidebarTab === 'versions' && id && (
+              <VersionHistory documentId={id} apiClient={apiClient} canEdit={canEdit} />
             )}
           </aside>
         )}

--- a/packages/docs/src/components/document/DocumentCard.tsx
+++ b/packages/docs/src/components/document/DocumentCard.tsx
@@ -4,13 +4,15 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@gruenerator/ui';
-import { memo } from 'react';
-import { FiEdit2, FiMoreVertical, FiShare2, FiTrash2 } from 'react-icons/fi';
+import { memo, useState } from 'react';
+import { FiEdit2, FiInfo, FiMoreVertical, FiShare2, FiTrash2 } from 'react-icons/fi';
 
 import type { Document } from '../../stores/documentStore';
 import { templates, getTemplateContent } from '../../lib/templates';
+import { MetadataDialog } from './MetadataDialog';
 
 interface DocumentCardProps {
   doc: Document;
@@ -22,6 +24,7 @@ interface DocumentCardProps {
 
 export const DocumentCard = memo(
   ({ doc, onNavigate, onRename, onDelete, onShare }: DocumentCardProps) => {
+    const [metadataOpen, setMetadataOpen] = useState(false);
     const template = templates.find((t) => t.id === doc.document_subtype);
     const emoji = template?.icon || '📄';
     const templateHtml = getTemplateContent(doc.document_subtype);
@@ -106,6 +109,16 @@ export const DocumentCard = memo(
                   Teilen
                 </DropdownMenuItem>
                 <DropdownMenuItem
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    setMetadataOpen(true);
+                  }}
+                >
+                  <FiInfo size={14} />
+                  Metadaten
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
                   variant="destructive"
                   onClick={(e: React.MouseEvent) => onDelete(doc.id, e)}
                 >
@@ -114,6 +127,7 @@ export const DocumentCard = memo(
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            <MetadataDialog doc={doc} open={metadataOpen} onOpenChange={setMetadataOpen} />
           </div>
           <div className="mt-0.5 flex items-center gap-1 text-xs text-grey-500 dark:text-grey-400">
             <span>

--- a/packages/docs/src/components/document/MetadataDialog.tsx
+++ b/packages/docs/src/components/document/MetadataDialog.tsx
@@ -1,0 +1,139 @@
+import { Badge, Dialog, DialogContent, DialogHeader, DialogTitle } from '@gruenerator/ui';
+
+import type { Document } from '../../stores/documentStore';
+
+interface MetadataDialogProps {
+  doc: Document;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SHARE_MODE_LABELS: Record<string, string> = {
+  private: 'Privat',
+  authenticated: 'Angemeldete Nutzer*innen',
+  public: 'Öffentlich',
+};
+
+const ACCESS_TYPE_LABELS: Record<string, string> = {
+  owner: 'Eigentümer*in',
+  direct: 'Direkt geteilt',
+  group: 'Über Gruppe',
+  public: 'Öffentlich',
+};
+
+const PERMISSION_LEVEL_LABELS: Record<string, string> = {
+  owner: 'Eigentümer*in',
+  editor: 'Bearbeiter*in',
+  viewer: 'Betrachter*in',
+};
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  if (!value) return null;
+  return (
+    <div className="flex items-baseline justify-between gap-md py-1.5">
+      <span className="shrink-0 text-sm text-grey-500 dark:text-grey-400">{label}</span>
+      <span className="text-right text-sm text-foreground">{value}</span>
+    </div>
+  );
+}
+
+export function MetadataDialog({ doc, open, onOpenChange }: MetadataDialogProps) {
+  const permissionEntries = Object.entries(doc.permissions || {});
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[28rem]">
+        <DialogHeader>
+          <DialogTitle>Dokumentdetails</DialogTitle>
+        </DialogHeader>
+
+        <div className="divide-y divide-grey-100 dark:divide-grey-700">
+          <div className="pb-3">
+            <Row label="Titel" value={doc.title} />
+            <Row label="Typ" value={doc.document_subtype} />
+            <Row
+              label="ID"
+              value={<code className="text-xs text-grey-500 dark:text-grey-400">{doc.id}</code>}
+            />
+          </div>
+
+          <div className="py-3">
+            <Row label="Erstellt von" value={doc.creator_name || doc.created_by} />
+            <Row label="Erstellt am" value={formatDateTime(doc.created_at)} />
+            <Row
+              label="Zuletzt bearbeitet von"
+              value={doc.last_editor_name || doc.last_edited_by}
+            />
+            <Row label="Zuletzt bearbeitet am" value={formatDateTime(doc.updated_at)} />
+          </div>
+
+          <div className="py-3">
+            <Row
+              label="Zugriff"
+              value={
+                doc.access_type ? (
+                  <Badge variant="outline">
+                    {ACCESS_TYPE_LABELS[doc.access_type] || doc.access_type}
+                  </Badge>
+                ) : null
+              }
+            />
+            <Row label="Freigabemodus" value={SHARE_MODE_LABELS[doc.share_mode || 'private']} />
+            <Row
+              label="Freigabeberechtigung"
+              value={
+                doc.share_mode && doc.share_mode !== 'private'
+                  ? PERMISSION_LEVEL_LABELS[doc.share_permission || 'editor']
+                  : null
+              }
+            />
+          </div>
+
+          {permissionEntries.length > 0 && (
+            <div className="pt-3">
+              <p className="mb-2 text-sm font-medium text-foreground">
+                Berechtigungen ({permissionEntries.length})
+              </p>
+              <div className="max-h-[160px] space-y-1 overflow-y-auto">
+                {permissionEntries.map(([userId, perm]) => (
+                  <div
+                    key={userId}
+                    className="flex items-center justify-between rounded-md bg-grey-50 px-2.5 py-1.5 text-xs dark:bg-grey-800"
+                  >
+                    <span className="truncate text-grey-600 dark:text-grey-300">{userId}</span>
+                    <Badge variant="outline" className="ml-2 shrink-0 text-[0.625rem]">
+                      {PERMISSION_LEVEL_LABELS[perm.level] || perm.level}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {doc.group_shares && doc.group_shares.length > 0 && (
+            <div className="pt-3">
+              <p className="mb-2 text-sm font-medium text-foreground">Gruppenfreigaben</p>
+              <div className="flex flex-wrap gap-1.5">
+                {doc.group_shares.map((g) => (
+                  <Badge key={g.group_id} variant="outline">
+                    {g.group_name}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -369,6 +369,7 @@ const BlockNoteEditorInner = ({
 
   useEffect(() => {
     if (!editor || hasInitialized.current) return;
+    let aborted = false;
 
     // In collaboration mode, Yjs is the sole source of truth.
     // Only inject template content for brand-new documents (empty Yjs fragment
@@ -383,7 +384,7 @@ const BlockNoteEditorInner = ({
           (async () => {
             try {
               const blocks = await editor.tryParseHTMLToBlocks(templateContent);
-              if (blocks && blocks.length > 0 && fragment.length === 0) {
+              if (!aborted && blocks && blocks.length > 0 && fragment.length === 0) {
                 editor.replaceBlocks(editor.document, blocks);
               }
             } catch (error) {
@@ -393,7 +394,9 @@ const BlockNoteEditorInner = ({
         }
       }
       hasInitialized.current = true;
-      return;
+      return () => {
+        aborted = true;
+      };
     }
 
     // Non-collaborative (standalone) editor: use initialContent or template
@@ -402,10 +405,10 @@ const BlockNoteEditorInner = ({
       ? initialContent
       : templateContent || defaultDocumentContent;
 
-    const initializeWithContent = async () => {
+    (async () => {
       try {
         const blocks = await editor.tryParseHTMLToBlocks(contentToUse);
-        if (blocks && blocks.length > 0) {
+        if (!aborted && blocks && blocks.length > 0) {
           editor.replaceBlocks(editor.document, blocks);
         }
         hasInitialized.current = true;
@@ -413,9 +416,11 @@ const BlockNoteEditorInner = ({
         console.error('[BlockNoteEditor] Failed to parse initial content:', error);
         hasInitialized.current = true;
       }
-    };
+    })();
 
-    initializeWithContent();
+    return () => {
+      aborted = true;
+    };
   }, [editor, initialContent, documentSubtype, isSynced, ydoc, fragment, provider]);
 
   const handleUploadFile = useCallback(async (file: File) => {

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -370,17 +370,33 @@ const BlockNoteEditorInner = ({
   useEffect(() => {
     if (!editor || hasInitialized.current) return;
 
+    // In collaboration mode, Yjs is the sole source of truth.
+    // Only inject template content for brand-new documents (empty Yjs fragment
+    // after server sync). Check fragment.length directly — never trust
+    // editor.document which may lag behind the Yjs state.
     if (ydoc) {
       if (!provider || !isSynced) return;
-    }
 
-    if (ydoc && fragment) {
-      if (!isEditorEmpty(editor as unknown as BlockNoteEditorCore)) {
-        hasInitialized.current = true;
-        return;
+      if (fragment && fragment.length === 0 && documentSubtype !== 'blank') {
+        const templateContent = getTemplateContent(documentSubtype);
+        if (templateContent) {
+          (async () => {
+            try {
+              const blocks = await editor.tryParseHTMLToBlocks(templateContent);
+              if (blocks && blocks.length > 0 && fragment.length === 0) {
+                editor.replaceBlocks(editor.document, blocks);
+              }
+            } catch (error) {
+              console.error('[BlockNoteEditor] Failed to apply template:', error);
+            }
+          })();
+        }
       }
+      hasInitialized.current = true;
+      return;
     }
 
+    // Non-collaborative (standalone) editor: use initialContent or template
     const templateContent = getTemplateContent(documentSubtype);
     const contentToUse = initialContent?.trim()
       ? initialContent

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -1,0 +1,201 @@
+import { Badge, Button, cn } from '@gruenerator/ui';
+import { useCallback, useEffect, useState } from 'react';
+import { FiArrowLeft, FiClock, FiRotateCcw } from 'react-icons/fi';
+
+import type { DocsApiClient } from '../../context/DocsContext';
+
+interface Snapshot {
+  id: string;
+  version: number;
+  created_at: string;
+  is_auto_save: boolean;
+  label: string | null;
+  created_by_name: string | null;
+}
+
+interface SnapshotsResponse {
+  snapshots: Snapshot[];
+}
+
+interface PreviewResponse {
+  version: number;
+  html: string;
+  created_at: string;
+}
+
+interface VersionHistoryProps {
+  documentId: string;
+  apiClient: DocsApiClient;
+  canEdit: boolean;
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'Gerade eben';
+  if (minutes < 60) return `Vor ${minutes} Min.`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `Vor ${hours} Std.`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `Vor ${days} Tag${days > 1 ? 'en' : ''}`;
+  return new Date(iso).toLocaleDateString('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function VersionHistory({ documentId, apiClient, canEdit }: VersionHistoryProps) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [selectedVersion, setSelectedVersion] = useState<number | null>(null);
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    apiClient
+      .get<SnapshotsResponse>(`/docs/${documentId}/snapshots`)
+      .then((data) => setSnapshots(data.snapshots))
+      .catch(() => setError('Versionen konnten nicht geladen werden'))
+      .finally(() => setLoading(false));
+  }, [documentId, apiClient]);
+
+  const handleSelectVersion = useCallback(
+    (version: number) => {
+      setSelectedVersion(version);
+      setPreviewLoading(true);
+      setPreview(null);
+      apiClient
+        .get<PreviewResponse>(`/docs/${documentId}/snapshots/${version}/preview`)
+        .then(setPreview)
+        .catch(() => setError('Vorschau konnte nicht geladen werden'))
+        .finally(() => setPreviewLoading(false));
+    },
+    [documentId, apiClient]
+  );
+
+  const handleRestore = useCallback(async () => {
+    if (selectedVersion === null) return;
+    setRestoring(true);
+    try {
+      await apiClient.post(`/docs/${documentId}/snapshots/${selectedVersion}/restore`);
+      window.location.reload();
+    } catch {
+      setError('Wiederherstellung fehlgeschlagen');
+      setRestoring(false);
+    }
+  }, [documentId, selectedVersion, apiClient]);
+
+  if (selectedVersion !== null) {
+    return (
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex items-center gap-xs border-b border-grey-200 px-md py-sm dark:border-grey-700">
+          <button
+            onClick={() => {
+              setSelectedVersion(null);
+              setPreview(null);
+            }}
+            className="flex items-center gap-1 text-sm text-grey-500 hover:text-foreground dark:text-grey-400"
+          >
+            <FiArrowLeft size={14} />
+            Zurück
+          </button>
+          <span className="ml-auto text-xs font-medium text-foreground">
+            Version {selectedVersion}
+          </span>
+        </div>
+
+        {previewLoading ? (
+          <div className="flex flex-1 items-center justify-center">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-grey-300 border-t-primary-600" />
+          </div>
+        ) : preview ? (
+          <div className="flex flex-1 flex-col overflow-hidden">
+            <div className="flex-1 overflow-y-auto p-md">
+              <div className="mb-sm text-xs text-grey-500 dark:text-grey-400">
+                {formatRelativeTime(preview.created_at)}
+              </div>
+              <div
+                className={cn(
+                  'rounded-lg border border-grey-200 bg-background-alt p-md dark:border-grey-700',
+                  'text-sm leading-relaxed text-foreground',
+                  '[&_h1]:text-lg [&_h1]:font-bold [&_h1]:mb-2',
+                  '[&_h2]:text-base [&_h2]:font-semibold [&_h2]:mb-1.5',
+                  '[&_h3]:text-sm [&_h3]:font-semibold [&_h3]:mb-1',
+                  '[&_p]:mb-2 [&_ul]:mb-2 [&_ul]:pl-5 [&_ol]:mb-2 [&_ol]:pl-5',
+                  '[&_li]:mb-0.5'
+                )}
+                dangerouslySetInnerHTML={{ __html: preview.html }}
+              />
+            </div>
+            {canEdit && (
+              <div className="border-t border-grey-200 p-md dark:border-grey-700">
+                <Button onClick={handleRestore} disabled={restoring} className="w-full" size="sm">
+                  <FiRotateCcw size={14} />
+                  {restoring ? 'Wird wiederhergestellt...' : 'Diese Version wiederherstellen'}
+                </Button>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-grey-300 border-t-primary-600" />
+          </div>
+        ) : error ? (
+          <div className="px-md py-8 text-center text-sm text-red-500">{error}</div>
+        ) : snapshots.length === 0 ? (
+          <div className="px-md py-8 text-center text-sm text-grey-500 dark:text-grey-400">
+            Noch keine Versionen vorhanden.
+          </div>
+        ) : (
+          <div className="divide-y divide-grey-100 dark:divide-grey-700">
+            {snapshots.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => handleSelectVersion(s.version)}
+                className="flex w-full items-start gap-sm px-md py-sm text-left transition-colors hover:bg-grey-50 dark:hover:bg-grey-800"
+              >
+                <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-grey-100 dark:bg-grey-700">
+                  <FiClock size={13} className="text-grey-500 dark:text-grey-400" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-xs">
+                    <span className="text-sm font-medium text-foreground">v{s.version}</span>
+                    {s.label ? (
+                      <Badge variant="outline" className="text-[0.625rem]">
+                        {s.label}
+                      </Badge>
+                    ) : s.is_auto_save ? (
+                      <Badge variant="outline" className="text-[0.625rem]">
+                        Auto
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <div className="text-xs text-grey-500 dark:text-grey-400">
+                    {formatRelativeTime(s.created_at)}
+                    {s.created_by_name && ` · ${s.created_by_name}`}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -1,4 +1,5 @@
 import { Badge, Button, cn } from '@gruenerator/ui';
+import { formatRelativeTime } from '@gruenerator/shared/utils';
 import { useCallback, useEffect, useState } from 'react';
 import { FiArrowLeft, FiClock, FiRotateCcw } from 'react-icons/fi';
 
@@ -27,24 +28,6 @@ interface VersionHistoryProps {
   documentId: string;
   apiClient: DocsApiClient;
   canEdit: boolean;
-}
-
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return 'Gerade eben';
-  if (minutes < 60) return `Vor ${minutes} Min.`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `Vor ${hours} Std.`;
-  const days = Math.floor(hours / 24);
-  if (days < 7) return `Vor ${days} Tag${days > 1 ? 'en' : ''}`;
-  return new Date(iso).toLocaleDateString('de-DE', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
 }
 
 export function VersionHistory({ documentId, apiClient, canEdit }: VersionHistoryProps) {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -25,6 +25,9 @@ export { ChatComposer } from './components/chat/ChatComposer';
 // Components — Permissions
 export { ShareModal } from './components/permissions/ShareModal';
 
+// Components — Version History
+export { VersionHistory } from './components/version/VersionHistory';
+
 // Components — Common
 export { ErrorBoundary } from './components/common/ErrorBoundary';
 

--- a/packages/docs/src/stores/documentStore.ts
+++ b/packages/docs/src/stores/documentStore.ts
@@ -20,6 +20,7 @@ export interface Document {
   metadata?: Record<string, unknown>;
   access_type?: 'owner' | 'direct' | 'group' | 'public';
   creator_name?: string;
+  last_editor_name?: string;
   group_shares?: Array<{ group_id: string; group_name: string }>;
 }
 


### PR DESCRIPTION
## Summary

- **Version History UI**: Snapshot API + sidebar component to browse and restore document versions via a clock button in the editor top bar
- **Metadata Dialog**: 3-dot menu item on document cards showing all document details (creator, timestamps, permissions, share mode, group shares)
- **Fix template overwrite race condition**: In collaboration mode, Yjs is now the sole source of truth — templates are only injected for brand-new documents with empty Yjs fragments, preventing content loss

## Version History

New API endpoints for Yjs document snapshots:
- `GET /api/docs/:id/snapshots` — list all snapshots with metadata (version, timestamp, auto/manual, creator name)
- `GET /api/docs/:id/snapshots/:version/preview` — decompress gzipped Yjs state → convert XML to HTML preview
- `POST /api/docs/:id/snapshots/:version/restore` — restore document to a version, creates new snapshot with audit label ("Wiederhergestellt von v2"), updates content preview

Frontend:
- Clock icon button in `EditorTopBar` opens sidebar to "Versionen" tab
- `VersionHistory` component: timeline list → click for HTML preview → "Wiederherstellen" button (reloads page after restore)
- New sidebar tab alongside Chat and Kommentare

## Metadata Dialog

- New "Metadaten" item in document card 3-dot menu (with separator before "Löschen")
- Shows: title, type, ID, creator, creation date, last editor, last edit date, access type, share mode, share permission, individual permissions list, group shares
- Uses shadcn `Dialog` component from `@gruenerator/ui`
- Added `last_editor_name` to `Document` interface (backend already returns it)

## Template Overwrite Fix (Critical)

**Root cause:** `BlockNoteEditor.tsx` initialization effect checked `isEditorEmpty()` on the editor DOM, which could return `true` while Yjs content was still syncing from the server. This injected template HTML via `editor.replaceBlocks()`, which propagated through Yjs and permanently overwrote the real document content.

**Fix:** In collaboration mode (`ydoc` exists):
- Check `fragment.length` on the Yjs XML fragment directly (authoritative state, not the editor DOM)
- Only inject template for `fragment.length === 0` AND `documentSubtype !== 'blank'`
- Double-check `fragment.length === 0` after async HTML parsing to guard against late-arriving server content
- Set `hasInitialized.current = true` immediately to prevent re-entry

## Files changed

| File | Change |
|------|--------|
| `apps/api/routes/docs/snapshotController.ts` | New — snapshot API endpoints |
| `apps/api/routes/docs/index.ts` | Mount snapshot controller |
| `packages/docs/src/components/version/VersionHistory.tsx` | New — version history sidebar |
| `packages/docs/src/components/document/MetadataDialog.tsx` | New — metadata dialog |
| `packages/docs/src/components/document/DocumentCard.tsx` | Add metadata menu item |
| `packages/docs/src/components/editor/BlockNoteEditor.tsx` | Fix template overwrite race condition |
| `packages/docs/src/stores/documentStore.ts` | Add `last_editor_name` to Document |
| `packages/docs/src/index.ts` | Export VersionHistory |
| `apps/docs/src/pages/EditorPage.tsx` | Add clock button + versions tab + sidebar render |

## Test plan

- [ ] Open a document with existing content → verify content is NOT overwritten by template
- [ ] Create a new document with template (e.g. Redaktionsplan) → verify template loads correctly
- [ ] Open sidebar → Versionen tab → verify snapshots list loads
- [ ] Click a version → verify HTML preview renders correctly
- [ ] Click "Wiederherstellen" → verify document restores and page reloads with restored content
- [ ] Document overview → 3-dot menu → Metadaten → verify dialog shows all fields correctly
- [ ] Verify dark mode works for all new UI components