### PR TITLE
fix(docs): apply restored content via editor instead of page reload

### DIFF
--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -502,7 +502,18 @@ export const EditorPage = () => {
             )}
 
             {sidebarTab === 'versions' && id && (
-              <VersionHistory documentId={id} apiClient={apiClient} canEdit={canEdit} />
+              <VersionHistory
+                documentId={id}
+                apiClient={apiClient}
+                canEdit={canEdit}
+                onRestore={(html) => {
+                  if (!editor) return;
+                  const blocks = editor.tryParseHTMLToBlocks(html);
+                  if (blocks && blocks.length > 0) {
+                    editor.replaceBlocks(editor.document, blocks);
+                  }
+                }}
+              />
             )}
           </aside>
         )}

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -620,7 +620,18 @@ function EditorContent() {
             )}
 
             {sidebarTab === 'versions' && id && (
-              <VersionHistory documentId={id} apiClient={apiClient} canEdit={canEdit} />
+              <VersionHistory
+                documentId={id}
+                apiClient={apiClient}
+                canEdit={canEdit}
+                onRestore={(html) => {
+                  if (!editor) return;
+                  const blocks = editor.tryParseHTMLToBlocks(html);
+                  if (blocks && blocks.length > 0) {
+                    editor.replaceBlocks(editor.document, blocks);
+                  }
+                }}
+              />
             )}
           </aside>
         )}

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -28,9 +28,10 @@ interface VersionHistoryProps {
   documentId: string;
   apiClient: DocsApiClient;
   canEdit: boolean;
+  onRestore?: (html: string) => void;
 }
 
-export function VersionHistory({ documentId, apiClient, canEdit }: VersionHistoryProps) {
+export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: VersionHistoryProps) {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -65,16 +66,21 @@ export function VersionHistory({ documentId, apiClient, canEdit }: VersionHistor
   );
 
   const handleRestore = useCallback(async () => {
-    if (selectedVersion === null) return;
+    if (selectedVersion === null || !preview) return;
     setRestoring(true);
     try {
       await apiClient.post(`/docs/${documentId}/snapshots/${selectedVersion}/restore`);
-      window.location.reload();
+      if (onRestore) {
+        onRestore(preview.html);
+      }
+      setSelectedVersion(null);
+      setPreview(null);
+      setRestoring(false);
     } catch {
       setError('Wiederherstellung fehlgeschlagen');
       setRestoring(false);
     }
-  }, [documentId, selectedVersion, apiClient]);
+  }, [documentId, selectedVersion, apiClient, preview, onRestore]);
 
   if (selectedVersion !== null) {
     return (


### PR DESCRIPTION
## Summary

Fixes version history restore not working — Hocuspocus keeps documents in memory, so writing to the DB and reloading the page served the stale in-memory Yjs state.

Now the restore applies content directly through `editor.replaceBlocks()`, which writes to the live Yjs document and propagates to Hocuspocus and all connected clients instantly.

## Changes
- Add `onRestore` callback prop to `VersionHistory` component
- Both `EditorPage.tsx` (apps/docs) and `DocsEditorPage.tsx` (apps/web) pass editor-based restore callback
- No more `window.location.reload()` — content updates in-place

## Test plan
- [ ] Open a document with version history
- [ ] Click a version → preview → "Wiederherstellen"
- [ ] Verify content changes immediately without page reload
- [ ] Verify other connected clients see the restored content