### PR TITLE
feat(docs): version history improvements, Better Auth rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ pnpm --filter @gruenerator/desktop dev           # Tauri desktop dev
 
 - **`apps/web`** — React 19 + Vite 7 frontend. Feature-sliced design with 26 feature modules in `src/features/`. Routes defined in `src/config/routes.ts`.
 - **`apps/api`** — Express 5 backend running in Node.js cluster mode. AI calls are offloaded to a dedicated worker pool (`workers/aiWorkerPool.ts`). Routes in `routes/`, business logic in `services/`. See [Express 5 Route Typing](#express-5-route-typing) below.
-- **`apps/docs`** — Collaborative document editor with Hocuspocus real-time sync.
+- **`apps/docs`** — Standalone collaborative document editor with Hocuspocus real-time sync. **Deprecated** — being replaced by the docs editor in `apps/web`. New docs features should be added to `apps/web/src/features/docs/` (and `packages/docs/`), not `apps/docs`.
 - **`apps/sites`** — Site builder/management interface.
 - **`apps/mobile`** — Expo 55 / React Native 0.83 app with Expo Router.
 - **`apps/desktop`** — Tauri 2 wrapper around the web frontend.

--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -158,6 +158,18 @@ export const auth = betterAuth({
     },
   },
 
+  rateLimit: {
+    enabled: true,
+    window: 60,
+    max: 100,
+    storage: 'secondary-storage',
+    customRules: {
+      '/sign-in/*': { window: 60, max: 10 },
+      '/sign-up/*': { window: 60, max: 5 },
+      '/forget-password': { window: 60, max: 3 },
+    },
+  },
+
   trustedOrigins: [
     'gruenerator://',
 

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -94,6 +94,53 @@ router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response)
       [req.params.id]
     )) as SnapshotRow[];
 
+    const grouped = req.query.grouped !== 'false';
+
+    if (grouped && snapshots.length > 1) {
+      const GROUP_WINDOW_MS = 30 * 60 * 1000;
+      const result: Array<{
+        id: string;
+        version: number;
+        created_at: string;
+        is_auto_save: boolean;
+        label: string | null;
+        created_by_name: string | null;
+        snapshot_count: number;
+        earliest_in_group: string;
+      }> = [];
+
+      // Snapshots are DESC — walk and group consecutive auto-saves within 30min
+      for (const s of snapshots) {
+        const prev = result[result.length - 1];
+        const canGroup =
+          prev &&
+          prev.is_auto_save &&
+          s.is_auto_save &&
+          !s.label &&
+          !prev.label &&
+          new Date(prev.earliest_in_group).getTime() - new Date(s.created_at).getTime() <
+            GROUP_WINDOW_MS;
+
+        if (canGroup) {
+          prev.snapshot_count++;
+          prev.earliest_in_group = s.created_at;
+        } else {
+          result.push({
+            id: s.id,
+            version: s.version,
+            created_at: s.created_at,
+            is_auto_save: s.is_auto_save,
+            label: s.label,
+            created_by_name: s.created_by_name,
+            snapshot_count: 1,
+            earliest_in_group: s.created_at,
+          });
+        }
+      }
+
+      return res.json({ snapshots: result });
+    }
+
     return res.json({
       snapshots: snapshots.map((s) => ({
         id: s.id,
@@ -102,6 +149,7 @@ router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response)
         is_auto_save: s.is_auto_save,
         label: s.label,
         created_by_name: s.created_by_name,
+        snapshot_count: 1,
       })),
     });
   } catch (error: unknown) {

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -158,6 +158,74 @@ router.get('/:id/snapshots', async (req: Request<{ id: string }>, res: Response)
   }
 });
 
+router.post('/:id/snapshots', async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+    const doc = await getAccessibleDocument(req.params.id, userId, res);
+    if (!doc) return;
+
+    if (!canEditDoc(doc, userId)) {
+      return res.status(403).json({ error: 'Edit permission required' });
+    }
+
+    const { label } = req.body as { label?: string };
+
+    // Load current document state from latest snapshot + updates
+    const snapshotResult = (await db.query(
+      `SELECT snapshot_data, version, created_at
+       FROM yjs_document_snapshots WHERE document_id = $1
+       ORDER BY version DESC LIMIT 1`,
+      [req.params.id]
+    )) as { snapshot_data: Buffer; version: number; created_at: string }[];
+
+    const ydoc = new Y.Doc();
+
+    if (snapshotResult.length > 0) {
+      const decompressed = gunzipSync(snapshotResult[0].snapshot_data);
+      Y.applyUpdate(ydoc, decompressed);
+
+      const updates = (await db.query(
+        `SELECT update_data FROM yjs_document_updates
+         WHERE document_id = $1 AND created_at > $2
+         ORDER BY created_at ASC`,
+        [req.params.id, snapshotResult[0].created_at]
+      )) as { update_data: Buffer }[];
+
+      for (const u of updates) {
+        Y.applyUpdate(ydoc, gunzipSync(u.update_data));
+      }
+    }
+
+    const state = Y.encodeStateAsUpdate(ydoc);
+    const compressed = gzipSync(Buffer.from(state));
+
+    const versionResult = (await db.query(
+      `SELECT COALESCE(MAX(version), 0) + 1 as next_version
+       FROM yjs_document_snapshots WHERE document_id = $1`,
+      [req.params.id]
+    )) as { next_version: number }[];
+
+    const nextVersion = versionResult[0].next_version;
+
+    await db.query(
+      `INSERT INTO yjs_document_snapshots
+        (document_id, snapshot_data, version, created_at, is_auto_save, label, created_by)
+       VALUES ($1, $2, $3, CURRENT_TIMESTAMP, false, $4, $5)`,
+      [req.params.id, compressed, nextVersion, label || null, userId]
+    );
+
+    return res.status(201).json({
+      version: nextVersion,
+      created_at: new Date().toISOString(),
+    });
+  } catch (error: unknown) {
+    console.error('[Docs] Error creating snapshot:', error);
+    return res.status(500).json({ error: 'Failed to create snapshot' });
+  }
+});
+
 router.get(
   '/:id/snapshots/:version/preview',
   async (req: Request<{ id: string; version: string }>, res: Response) => {

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -16,7 +16,6 @@ import { fileURLToPath } from 'url';
 import compression from 'compression';
 import cors from 'cors';
 import express, { type Express, type Request, type Response, type NextFunction } from 'express';
-import rateLimit from 'express-rate-limit';
 import helmet from 'helmet';
 import { isHttpError } from 'http-errors';
 import morgan from 'morgan';
@@ -368,15 +367,12 @@ async function startWorker(): Promise<void> {
   }
 
   // Better Auth handler (must be before express.json middleware)
+  // Rate limiting is handled by Better Auth internally (Redis-backed via secondaryStorage)
   const { betterAuthHandler } = await import('./routes/auth/betterAuthHandler.js');
-  const authV2Limiter = rateLimit({
-    windowMs: 15 * 60 * 1000,
-    max: 100,
-    standardHeaders: true,
-    legacyHeaders: false,
-    message: { error: 'Too many authentication requests, please try again later.' },
-  });
-  app.all('/api/auth/v2/*splat', authV2Limiter, (req, res, next) => {
+  app.all('/api/auth/v2/*splat', (req, res, next) => {
+    if (!req.headers['x-forwarded-for'] && !req.headers['x-real-ip']) {
+      req.headers['x-forwarded-for'] = req.socket.remoteAddress || '0.0.0.0';
+    }
     Promise.resolve(betterAuthHandler(req, res)).catch(next);
   });
 

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -7,6 +7,7 @@ import {
   useDocumentChat,
   BlockNoteEditor as BlockNoteEditorComponent,
   VersionHistory,
+  useVersionHistoryShortcut,
   useDocsAdapter,
   createDocsApiClient,
   lazyWithRetry,
@@ -286,21 +287,7 @@ export const EditorPage = () => {
     setSidebarOpen((prev) => !prev);
   }, []);
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'h') {
-        e.preventDefault();
-        if (sidebarOpen && sidebarTab === 'versions') {
-          setSidebarOpen(false);
-        } else {
-          setSidebarTab('versions');
-          setSidebarOpen(true);
-        }
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [sidebarOpen, sidebarTab]);
+  useVersionHistoryShortcut(sidebarOpen, sidebarTab, setSidebarOpen, setSidebarTab);
 
   useEffect(() => {
     setCommentsPortalTarget(

--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -287,6 +287,22 @@ export const EditorPage = () => {
   }, []);
 
   useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'h') {
+        e.preventDefault();
+        if (sidebarOpen && sidebarTab === 'versions') {
+          setSidebarOpen(false);
+        } else {
+          setSidebarTab('versions');
+          setSidebarOpen(true);
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [sidebarOpen, sidebarTab]);
+
+  useEffect(() => {
     setCommentsPortalTarget(
       sidebarOpen && sidebarTab === 'comments' ? commentsPortalRef.current : null
     );

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -154,10 +154,12 @@ function EditorContent() {
     staleTime: 30_000,
   });
 
-  // Authenticated fetch — only when logged in and auth resolved
-  const { data: authData, isLoading: authDocLoading } = useQuery<Document>({
+  // Authenticated fetch — only when logged in and auth resolved.
+  // skipUnauthorized: expired sessions return null instead of redirecting to login,
+  // allowing fallback to publicData for shared documents.
+  const { data: authData, isLoading: authDocLoading } = useQuery<Document | null>({
     queryKey: ['document-auth', id],
-    queryFn: () => apiClient.get<Document>(`/docs/${id}`),
+    queryFn: () => apiClient.get<Document>(`/docs/${id}`, { skipUnauthorized: true }),
     enabled: !!id && !isAuthLoading && !isGuest,
     retry: false,
   });
@@ -329,6 +331,22 @@ function EditorContent() {
   const toggleSidebar = useCallback(() => {
     setSidebarOpen((prev) => !prev);
   }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'h') {
+        e.preventDefault();
+        if (sidebarOpen && sidebarTab === 'versions') {
+          setSidebarOpen(false);
+        } else {
+          setSidebarTab('versions');
+          setSidebarOpen(true);
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [sidebarOpen, sidebarTab]);
 
   useEffect(() => {
     setCommentsPortalTarget(

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -9,6 +9,7 @@ import {
   useDocumentChat,
   BlockNoteEditor as BlockNoteEditorComponent,
   VersionHistory,
+  useVersionHistoryShortcut,
   useDocsAdapter,
   createDocsApiClient,
   lazyWithRetry,
@@ -332,21 +333,7 @@ function EditorContent() {
     setSidebarOpen((prev) => !prev);
   }, []);
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'h') {
-        e.preventDefault();
-        if (sidebarOpen && sidebarTab === 'versions') {
-          setSidebarOpen(false);
-        } else {
-          setSidebarTab('versions');
-          setSidebarOpen(true);
-        }
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [sidebarOpen, sidebarTab]);
+  useVersionHistoryShortcut(sidebarOpen, sidebarTab, setSidebarOpen, setSidebarTab);
 
   useEffect(() => {
     setCommentsPortalTarget(

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -47,6 +47,8 @@ interface VersionHistoryProps {
 
 export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: VersionHistoryProps) {
   const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const snapshotsRef = useRef(snapshots);
+  snapshotsRef.current = snapshots;
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -105,7 +107,7 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
 
   const handleRestore = useCallback(async () => {
     if (selectedVersion === null || !preview) return;
-    const previousLatest = snapshots[0]?.version;
+    const previousLatest = snapshotsRef.current[0]?.version;
     setRestoring(true);
     try {
       await apiClient.post(`/docs/${documentId}/snapshots/${selectedVersion}/restore`);
@@ -141,7 +143,7 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
       setError('Wiederherstellung fehlgeschlagen');
       setRestoring(false);
     }
-  }, [documentId, selectedVersion, apiClient, preview, onRestore, snapshots, fetchSnapshots]);
+  }, [documentId, selectedVersion, apiClient, preview, onRestore, fetchSnapshots]);
 
   if (selectedVersion !== null) {
     return (

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -1,4 +1,16 @@
-import { Badge, Button, cn } from '@gruenerator/ui';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  cn,
+} from '@gruenerator/ui';
 import { formatRelativeTime } from '@gruenerator/shared/utils';
 import { useCallback, useEffect, useState } from 'react';
 import { FiArrowLeft, FiClock, FiRotateCcw } from 'react-icons/fi';
@@ -12,6 +24,7 @@ interface Snapshot {
   is_auto_save: boolean;
   label: string | null;
   created_by_name: string | null;
+  snapshot_count?: number;
 }
 
 interface SnapshotsResponse {
@@ -40,6 +53,7 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
   const [preview, setPreview] = useState<PreviewResponse | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [restoring, setRestoring] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -126,10 +140,37 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
             </div>
             {canEdit && (
               <div className="border-t border-grey-200 p-md dark:border-grey-700">
-                <Button onClick={handleRestore} disabled={restoring} className="w-full" size="sm">
+                <Button
+                  onClick={() => setConfirmOpen(true)}
+                  disabled={restoring}
+                  className="w-full"
+                  size="sm"
+                >
                   <FiRotateCcw size={14} />
                   {restoring ? 'Wird wiederhergestellt...' : 'Diese Version wiederherstellen'}
                 </Button>
+                <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                  <AlertDialogContent size="sm">
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Version wiederherstellen?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Der aktuelle Inhalt wird durch Version {selectedVersion} ersetzt. Eine
+                        Sicherungskopie wird automatisch als neue Version gespeichert.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => {
+                          setConfirmOpen(false);
+                          handleRestore();
+                        }}
+                      >
+                        Wiederherstellen
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </div>
             )}
           </div>
@@ -178,6 +219,9 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
                   <div className="text-xs text-grey-500 dark:text-grey-400">
                     {formatRelativeTime(s.created_at)}
                     {s.created_by_name && ` · ${s.created_by_name}`}
+                    {s.snapshot_count &&
+                      s.snapshot_count > 1 &&
+                      ` · ${s.snapshot_count} Änderungen`}
                   </div>
                 </div>
               </button>

--- a/packages/docs/src/components/version/VersionHistory.tsx
+++ b/packages/docs/src/components/version/VersionHistory.tsx
@@ -12,8 +12,9 @@ import {
   cn,
 } from '@gruenerator/ui';
 import { formatRelativeTime } from '@gruenerator/shared/utils';
-import { useCallback, useEffect, useState } from 'react';
-import { FiArrowLeft, FiClock, FiRotateCcw } from 'react-icons/fi';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FiArrowLeft, FiClock, FiRotateCcw, FiSave } from 'react-icons/fi';
+import { toast } from 'sonner';
 
 import type { DocsApiClient } from '../../context/DocsContext';
 
@@ -54,8 +55,11 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
   const [previewLoading, setPreviewLoading] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [showLabelInput, setShowLabelInput] = useState(false);
+  const labelInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
+  const fetchSnapshots = useCallback(() => {
     setLoading(true);
     setError(null);
     apiClient
@@ -64,6 +68,10 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
       .catch(() => setError('Versionen konnten nicht geladen werden'))
       .finally(() => setLoading(false));
   }, [documentId, apiClient]);
+
+  useEffect(() => {
+    fetchSnapshots();
+  }, [fetchSnapshots]);
 
   const handleSelectVersion = useCallback(
     (version: number) => {
@@ -79,8 +87,25 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
     [documentId, apiClient]
   );
 
+  const handleSaveVersion = useCallback(async () => {
+    setSaving(true);
+    const label = labelInputRef.current?.value.trim() || null;
+    try {
+      await apiClient.post(`/docs/${documentId}/snapshots`, { label });
+      setShowLabelInput(false);
+      if (labelInputRef.current) labelInputRef.current.value = '';
+      fetchSnapshots();
+      toast.success('Version gespeichert');
+    } catch {
+      setError('Version konnte nicht gespeichert werden');
+    } finally {
+      setSaving(false);
+    }
+  }, [documentId, apiClient, fetchSnapshots]);
+
   const handleRestore = useCallback(async () => {
     if (selectedVersion === null || !preview) return;
+    const previousLatest = snapshots[0]?.version;
     setRestoring(true);
     try {
       await apiClient.post(`/docs/${documentId}/snapshots/${selectedVersion}/restore`);
@@ -90,11 +115,33 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
       setSelectedVersion(null);
       setPreview(null);
       setRestoring(false);
+      fetchSnapshots();
+      toast.success('Version wiederhergestellt', {
+        action: previousLatest
+          ? {
+              label: 'Rückgängig',
+              onClick: async () => {
+                try {
+                  const prev = await apiClient.get<PreviewResponse>(
+                    `/docs/${documentId}/snapshots/${previousLatest}/preview`
+                  );
+                  await apiClient.post(`/docs/${documentId}/snapshots/${previousLatest}/restore`);
+                  if (onRestore) onRestore(prev.html);
+                  fetchSnapshots();
+                  toast.success('Wiederherstellung rückgängig gemacht');
+                } catch {
+                  toast.error('Rückgängig fehlgeschlagen');
+                }
+              },
+            }
+          : undefined,
+        duration: 10000,
+      });
     } catch {
       setError('Wiederherstellung fehlgeschlagen');
       setRestoring(false);
     }
-  }, [documentId, selectedVersion, apiClient, preview, onRestore]);
+  }, [documentId, selectedVersion, apiClient, preview, onRestore, snapshots, fetchSnapshots]);
 
   if (selectedVersion !== null) {
     return (
@@ -181,6 +228,38 @@ export function VersionHistory({ documentId, apiClient, canEdit, onRestore }: Ve
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
+      {canEdit && (
+        <div className="border-b border-grey-200 px-md py-sm dark:border-grey-700">
+          {showLabelInput ? (
+            <div className="flex gap-xs">
+              <input
+                ref={labelInputRef}
+                type="text"
+                placeholder="Bezeichnung (optional)"
+                className="flex-1 rounded-md border border-grey-200 bg-background px-2 py-1 text-sm text-foreground placeholder:text-grey-400 dark:border-grey-600"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleSaveVersion();
+                  if (e.key === 'Escape') setShowLabelInput(false);
+                }}
+                autoFocus
+              />
+              <Button size="sm" onClick={handleSaveVersion} disabled={saving}>
+                {saving ? '...' : 'Speichern'}
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => setShowLabelInput(true)}
+            >
+              <FiSave size={14} />
+              Version speichern
+            </Button>
+          )}
+        </div>
+      )}
       <div className="flex-1 overflow-y-auto">
         {loading ? (
           <div className="flex items-center justify-center py-12">

--- a/packages/docs/src/context/DocsContext.tsx
+++ b/packages/docs/src/context/DocsContext.tsx
@@ -33,22 +33,35 @@ export interface DocsAdapter {
   getCurrentUserDisplayName?(): string | null;
 }
 
+export interface DocsRequestOptions {
+  /** When true, 401 responses return null instead of triggering onUnauthorized redirect */
+  skipUnauthorized?: boolean;
+}
+
 /**
  * Typed API client derived from a DocsAdapter.
  * Used by Zustand stores which can't call React hooks.
  */
 export interface DocsApiClient {
   get<T>(url: string): Promise<T>;
+  get<T>(url: string, options: DocsRequestOptions): Promise<T | null>;
   post<T>(url: string, data?: unknown): Promise<T>;
+  post<T>(url: string, data: unknown, options: DocsRequestOptions): Promise<T | null>;
   put<T>(url: string, data?: unknown): Promise<T>;
+  put<T>(url: string, data: unknown, options: DocsRequestOptions): Promise<T | null>;
   delete<T>(url: string): Promise<T>;
+  delete<T>(url: string, options: DocsRequestOptions): Promise<T | null>;
 }
 
 /**
  * Create a DocsApiClient from a DocsAdapter.
  */
 export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
-  async function request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  async function request<T>(
+    endpoint: string,
+    options: RequestInit = {},
+    docsOptions: DocsRequestOptions = {}
+  ): Promise<T> {
     const url = endpoint.startsWith('http') ? endpoint : `${adapter.getApiBaseUrl()}${endpoint}`;
 
     const isRename = options.method === 'PUT' && endpoint.startsWith('/docs/');
@@ -70,6 +83,9 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
     });
 
     if (response.status === 401) {
+      if (docsOptions.skipUnauthorized) {
+        return null as T;
+      }
       if (isRename) console.error('[docs-rename] apiClient: 401 Unauthorized for %s', url);
       adapter.onUnauthorized();
       throw new Error('Unauthorized');
@@ -109,18 +125,22 @@ export function createDocsApiClient(adapter: DocsAdapter): DocsApiClient {
   }
 
   return {
-    get: <T,>(endpoint: string) => request<T>(endpoint, { method: 'GET' }),
-    post: <T,>(endpoint: string, data?: unknown) =>
-      request<T>(endpoint, {
-        method: 'POST',
-        body: data ? JSON.stringify(data) : undefined,
-      }),
-    put: <T,>(endpoint: string, data?: unknown) =>
-      request<T>(endpoint, {
-        method: 'PUT',
-        body: data ? JSON.stringify(data) : undefined,
-      }),
-    delete: <T,>(endpoint: string) => request<T>(endpoint, { method: 'DELETE' }),
+    get: <T,>(endpoint: string, docsOptions?: DocsRequestOptions) =>
+      request<T>(endpoint, { method: 'GET' }, docsOptions),
+    post: <T,>(endpoint: string, data?: unknown, docsOptions?: DocsRequestOptions) =>
+      request<T>(
+        endpoint,
+        { method: 'POST', body: data ? JSON.stringify(data) : undefined },
+        docsOptions
+      ),
+    put: <T,>(endpoint: string, data?: unknown, docsOptions?: DocsRequestOptions) =>
+      request<T>(
+        endpoint,
+        { method: 'PUT', body: data ? JSON.stringify(data) : undefined },
+        docsOptions
+      ),
+    delete: <T,>(endpoint: string, docsOptions?: DocsRequestOptions) =>
+      request<T>(endpoint, { method: 'DELETE' }, docsOptions),
   };
 }
 

--- a/packages/docs/src/hooks/useVersionHistoryShortcut.ts
+++ b/packages/docs/src/hooks/useVersionHistoryShortcut.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+
+export function useVersionHistoryShortcut(
+  sidebarOpen: boolean,
+  sidebarTab: string,
+  setSidebarOpen: (open: boolean) => void,
+  setSidebarTab: (tab: 'versions') => void
+) {
+  const sidebarOpenRef = useRef(sidebarOpen);
+  const sidebarTabRef = useRef(sidebarTab);
+  sidebarOpenRef.current = sidebarOpen;
+  sidebarTabRef.current = sidebarTab;
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'h') {
+        e.preventDefault();
+        if (sidebarOpenRef.current && sidebarTabRef.current === 'versions') {
+          setSidebarOpen(false);
+        } else {
+          setSidebarTab('versions');
+          setSidebarOpen(true);
+        }
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [setSidebarOpen, setSidebarTab]);
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -5,6 +5,7 @@ export {
   createDocsApiClient,
   type DocsAdapter,
   type DocsApiClient,
+  type DocsRequestOptions,
 } from './context/DocsContext';
 
 // Components — Editor
@@ -46,6 +47,7 @@ export {
 } from './hooks/useDocuments';
 export { useResolveUsers } from './hooks/useResolveUsers';
 export { useIsTouchDevice } from './hooks/useIsTouchDevice';
+export { useVersionHistoryShortcut } from './hooks/useVersionHistoryShortcut';
 
 // Stores
 export { useDocumentStore, type Document } from './stores/documentStore';

--- a/packages/shared/src/components/EditorTopBar/EditorTopBar.css
+++ b/packages/shared/src/components/EditorTopBar/EditorTopBar.css
@@ -150,9 +150,25 @@
   background: #f59e0b;
 }
 
+.status-dot.connected {
+  background: #22c55e;
+}
+
+.status-dot.syncing {
+  background: #f59e0b;
+  animation: editorTopBarPulse 1.5s ease-in-out infinite;
+}
+
 @keyframes editorTopBarPulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.5; }
+}
+
+.status-label {
+  font-size: 0.6875rem;
+  color: var(--grey-400);
+  white-space: nowrap;
+  user-select: none;
 }
 
 /* ─────────────────────────────────────────────

--- a/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
+++ b/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
@@ -121,7 +121,17 @@ export const EditorTopBar = ({
             )}
           </>
         )}
-        {connectionStatus && <div className={`status-dot ${connectionStatus}`} />}
+        {connectionStatus && (
+          <>
+            <div className={`status-dot ${connectionStatus}`} />
+            <span className="status-label">
+              {connectionStatus === 'connected' && 'Gespeichert'}
+              {connectionStatus === 'syncing' && 'Speichert...'}
+              {connectionStatus === 'disconnected' && 'Offline'}
+              {connectionStatus === 'offline-cached' && 'Lokal gespeichert'}
+            </span>
+          </>
+        )}
       </div>
 
       {rightActions && <div className="editor-topbar__right">{rightActions}</div>}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -21,6 +21,17 @@ export {
   AccordionContent,
 } from './components/accordion';
 export { Alert, AlertTitle, AlertDescription } from './components/alert';
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from './components/alert-dialog';
 export { FeatureToggle, type FeatureToggleProps } from './components/feature-toggle';
 export { FileCard } from './components/file-card';
 export { Ripple } from './components/ripple';

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -49,8 +49,11 @@ function extractAutoTitle(html: string): string | null {
  */
 export class PostgresPersistence {
   private readonly UPDATE_BATCH_SIZE = 100;
-  private readonly SNAPSHOT_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+  private readonly SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+  private readonly SNAPSHOT_RETENTION_DAYS = 90;
   private readonly db: DbQueryFn;
+  private lastSnapshotSizes = new Map<string, number>();
+  private snapshotCounter = 0;
 
   constructor(db: DbQueryFn) {
     this.db = db;
@@ -156,6 +159,12 @@ export class PostgresPersistence {
 
   private async maybeCreateSnapshot(documentId: string, state: Uint8Array): Promise<void> {
     try {
+      // Skip if document state hasn't meaningfully changed
+      const lastSize = this.lastSnapshotSizes.get(documentId);
+      if (lastSize !== undefined && Math.abs(state.length - lastSize) < 50) {
+        return;
+      }
+
       const result = await this.db(
         `SELECT created_at, version
          FROM yjs_document_snapshots
@@ -179,11 +188,40 @@ export class PostgresPersistence {
           [documentId, compressed, nextVersion]
         );
 
+        this.lastSnapshotSizes.set(documentId, state.length);
         log.info(`[Snapshot] Created snapshot for ${documentId}, version ${nextVersion}`);
+
+        this.snapshotCounter++;
+        if (this.snapshotCounter % 100 === 0) {
+          this.cleanupOldSnapshots().catch((err) => {
+            log.error(`[Cleanup] Snapshot retention cleanup failed: ${err}`);
+          });
+        }
       }
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log.error(`[Snapshot] Error creating snapshot: ${err.message}`);
+    }
+  }
+
+  private async cleanupOldSnapshots(): Promise<void> {
+    try {
+      const result = await this.db(
+        `DELETE FROM yjs_document_snapshots
+         WHERE is_auto_save = true
+           AND label IS NULL
+           AND created_at < CURRENT_TIMESTAMP - interval '${this.SNAPSHOT_RETENTION_DAYS} days'
+         RETURNING id`,
+        []
+      );
+      if (result.length > 0) {
+        log.info(
+          `[Cleanup] Deleted ${result.length} auto-snapshots older than ${this.SNAPSHOT_RETENTION_DAYS} days`
+        );
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.error(`[Cleanup] Error cleaning old snapshots: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Better Auth rate limiting**: Replace redundant Express rate limiter on `/api/auth/v2/*` with Better Auth's built-in Redis-backed rate limiting. Adds per-endpoint custom rules (sign-in: 10/min, sign-up: 5/min, password reset: 3/min) and IP fallback for internal requests bypassing nginx — fixes production warning about missing client IP.
- **Docs version history**: Activity-based snapshots, grouping, restore confirmation, manual save with keyboard shortcut (Ctrl+Shift+S), undo toast, save indicator in toolbar.
- **DocsApiClient**: Add `skipUnauthorized` option to gracefully handle 401 responses without redirecting.
- **CLAUDE.md**: Mark `apps/docs` as deprecated in favor of `apps/web` docs editor.

## Test plan
- [ ] Verify no "Rate limiting skipped" warning in production logs after deploy
- [ ] Confirm auth endpoints work: `GET /api/auth/v2/ok`
- [ ] Check Redis rate limit keys appear: `KEYS 'ba:*'`
- [ ] Test docs version history: create snapshots, restore, verify grouping
- [ ] Test Ctrl+Shift+S manual save in docs editor
- [ ] Verify 401 handling with `skipUnauthorized` doesn't redirect