### PR TITLE
fix(docs): allow guest access to shared documents

### DIFF
--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -5,7 +5,7 @@
 
 const PUBLIC_PATHS = ['/datenschutz', '/impressum', '/support', '/login', '/auth'];
 
-const PUBLIC_PREFIXES = ['/auth/', '/shared/', '/subtitler/shared/', '/texte'];
+const PUBLIC_PREFIXES = ['/auth/', '/shared/', '/subtitler/shared/', '/texte', '/docs/'];
 
 export const isPublicPage = (pathname: string = window.location.pathname): boolean =>
   pathname === '/' ||


### PR DESCRIPTION
## Summary
- Adds `/docs/` to `PUBLIC_PREFIXES` in `authRedirect.ts` so 401 interceptors skip the login redirect on document editor pages
- Prevents stale cached auth from triggering redirects before `DocsEditorPage` can fall back to public data
- Works together with the `skipUnauthorized` option on `DocsApiClient` (already merged)

**Why this is needed:** Multiple 401 redirect sources (global axios interceptor, shared API client, GlobalChatProvider) all gate on `isPublicPage()`. Since `/docs/{id}` wasn't listed, any 401 from layout components (Sidebar, GlobalBridges) redirected to login before the page could check if the document is public.

**Security unchanged:** Document access is still enforced by the backend API (`/api/docs/public/:id` only returns documents with `share_mode != 'private'`) and Hocuspocus auth (`onAuthenticate` checks `is_public`). The `/docs` list page is unaffected — `'/docs'.startsWith('/docs/')` is `false`.

## Test plan
- [ ] Clear localStorage + cookies → visit `/docs/{shared-doc-id}` → renders as guest
- [ ] Log in → clear cookies (keep localStorage) → visit same URL → renders with public data, NOT redirect
- [ ] Log in normally → visit same URL → renders with full auth data + Sidebar
- [ ] Visit `/docs` (list page) → still shows login overlay
- [ ] Visit `/docs/{private-doc-id}` unauthenticated → shows "not found" message (no content leak)