### PR TITLE
fix(docs): resolve guest mode deadlock for Hocuspocus

### DIFF
--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -136,7 +136,7 @@ function EditorContent() {
   const apiClient = useMemo(() => createDocsApiClient(adapter), [adapter]);
   const user = useAuthStore((s) => s.user);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
-  const isGuest = !user && !isAuthLoading;
+  const isGuest = !user;
 
   const guestIdentity = useMemo(() => (isGuest ? getOrCreateGuestIdentity() : null), [isGuest]);
 


### PR DESCRIPTION
## Summary
- Fixes Hocuspocus showing "offline" for guests on shared public documents
- `isGuest` was `!user && !isAuthLoading`, but `isAuthLoading` never resolves on the docs page (nobody calls `useAuth()`), so guests could never connect
- Changed to `!user` — guests connect immediately, cached-auth users connect as authenticated

## Test plan
- [ ] Open `/docs/{shared-public-doc}` in incognito → connects as guest, shows guest banner
- [ ] Open same URL logged in → connects as authenticated user
- [ ] Open `/docs/{private-doc}` in incognito → shows "not found" message
- [ ] Check console for `[Collab] Init | isGuest: true` confirming guest mode