### PR TITLE
fix(docs): move template injection to server, remove client-side content writes

### DIFF
--- a/apps/docs/src/pages/EditorPage.tsx
+++ b/apps/docs/src/pages/EditorPage.tsx
@@ -456,7 +456,7 @@ export const EditorPage = () => {
             documentSubtype={docData.document_subtype}
             ydoc={ydoc}
             provider={provider}
-            isSynced={isLocalLoaded || isSynced}
+            isSynced={isSynced}
             editable={canEdit}
             commentsPortalTarget={commentsPortalTarget}
             onEditorReady={handleEditorReady}

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -567,7 +567,7 @@ function EditorContent() {
             documentSubtype={docData.document_subtype}
             ydoc={ydoc}
             provider={provider}
-            isSynced={isLocalLoaded || isSynced}
+            isSynced={isSynced}
             editable={canEdit}
             commentsPortalTarget={commentsPortalTarget}
             onEditorReady={handleEditorReady}

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -44,8 +44,6 @@ import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 
 import { useEditorStore } from '../../stores/editorStore';
-import { defaultDocumentContent } from '../../lib/defaultContent';
-import { getTemplateContent } from '../../lib/templates';
 import { isEditorEmpty } from '../../lib/blockNoteUtils';
 import { useBlockNoteComments } from '../../hooks/useBlockNoteComments';
 import { useResolveUsers } from '../../hooks/useResolveUsers';
@@ -369,59 +367,37 @@ const BlockNoteEditorInner = ({
 
   useEffect(() => {
     if (!editor || hasInitialized.current) return;
-    let aborted = false;
 
-    // In collaboration mode, Yjs is the sole source of truth.
-    // Only inject template content for brand-new documents (empty Yjs fragment
-    // after server sync). Check fragment.length directly — never trust
-    // editor.document which may lag behind the Yjs state.
+    // Collaborative mode: Yjs is the sole source of truth.
+    // Templates are injected server-side in Hocuspocus onLoadDocument.
     if (ydoc) {
-      if (!provider || !isSynced) return;
-
-      if (fragment && fragment.length === 0 && documentSubtype !== 'blank') {
-        const templateContent = getTemplateContent(documentSubtype);
-        if (templateContent) {
-          (async () => {
-            try {
-              const blocks = await editor.tryParseHTMLToBlocks(templateContent);
-              if (!aborted && blocks && blocks.length > 0 && fragment.length === 0) {
-                editor.replaceBlocks(editor.document, blocks);
-              }
-            } catch (error) {
-              console.error('[BlockNoteEditor] Failed to apply template:', error);
-            }
-          })();
-        }
-      }
       hasInitialized.current = true;
-      return () => {
-        aborted = true;
-      };
+      return;
     }
 
-    // Non-collaborative (standalone) editor: use initialContent or template
-    const templateContent = getTemplateContent(documentSubtype);
-    const contentToUse = initialContent?.trim()
-      ? initialContent
-      : templateContent || defaultDocumentContent;
+    // Non-collaborative (standalone) editor: use initialContent if provided
+    if (!initialContent?.trim()) {
+      hasInitialized.current = true;
+      return;
+    }
 
+    let aborted = false;
     (async () => {
       try {
-        const blocks = await editor.tryParseHTMLToBlocks(contentToUse);
+        const blocks = await editor.tryParseHTMLToBlocks(initialContent);
         if (!aborted && blocks && blocks.length > 0) {
           editor.replaceBlocks(editor.document, blocks);
         }
-        hasInitialized.current = true;
       } catch (error) {
         console.error('[BlockNoteEditor] Failed to parse initial content:', error);
-        hasInitialized.current = true;
       }
+      hasInitialized.current = true;
     })();
 
     return () => {
       aborted = true;
     };
-  }, [editor, initialContent, documentSubtype, isSynced, ydoc, fragment, provider]);
+  }, [editor, initialContent, ydoc]);
 
   const handleUploadFile = useCallback(async (file: File) => {
     await new Promise((resolve) => setTimeout(resolve, 1000));

--- a/services/hocuspocus/src/htmlToYjsXml.ts
+++ b/services/hocuspocus/src/htmlToYjsXml.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from 'crypto';
+
+import * as Y from 'yjs';
+
+import { createLogger } from './logger.js';
+
+const log = createLogger('HtmlToYjs');
+
+/**
+ * Injects simple HTML into a Yjs XmlFragment using BlockNote's XML structure.
+ *
+ * BlockNote format: blockGroup > blockContainer[id] > (heading|paragraph|bulletListItem|numberedListItem)
+ *
+ * Supports: h1-h3, p, ul/li, ol/li, blockquote, hr.
+ * Inline marks (strong, em) are converted to plain text (Yjs XmlText doesn't support marks in this context).
+ * Tables and checkboxes are converted to plain paragraphs.
+ */
+export function injectHtmlIntoFragment(fragment: Y.XmlFragment, html: string): void {
+  const group = new Y.XmlElement('blockGroup');
+
+  // Normalize whitespace between tags
+  const normalized = html.replace(/>\s+</g, '><').trim();
+
+  // Extract block-level elements
+  const blockPattern =
+    /<(h[1-3]|p|blockquote|hr|table)(?:\s[^>]*)?>[\s\S]*?<\/\1>|<(h[1-3]|p|hr)(?:\s[^>]*)?\s*\/?>|<ul>([\s\S]*?)<\/ul>|<ol>([\s\S]*?)<\/ol>/gi;
+
+  let match;
+  while ((match = blockPattern.exec(normalized)) !== null) {
+    const fullMatch = match[0];
+
+    // Unordered list
+    if (match[3] !== undefined) {
+      const items = extractListItems(match[3]);
+      for (const item of items) {
+        addBlock(group, 'bulletListItem', item, {});
+      }
+      continue;
+    }
+
+    // Ordered list
+    if (match[4] !== undefined) {
+      const items = extractListItems(match[4]);
+      for (const item of items) {
+        addBlock(group, 'numberedListItem', item, {});
+      }
+      continue;
+    }
+
+    const tag = (match[1] || match[2] || '').toLowerCase();
+
+    if (tag === 'hr') {
+      addBlock(group, 'paragraph', '───', {});
+      continue;
+    }
+
+    if (tag.startsWith('h')) {
+      const level = tag[1];
+      const text = stripTags(extractInnerContent(fullMatch));
+      addBlock(group, 'heading', text, { level });
+      continue;
+    }
+
+    if (tag === 'blockquote') {
+      const inner = extractInnerContent(fullMatch);
+      const text = stripTags(inner);
+      addBlock(group, 'paragraph', text, { backgroundColor: 'gray' });
+      continue;
+    }
+
+    if (tag === 'table') {
+      // Convert table rows to simple paragraphs
+      const rows = fullMatch.match(/<tr>([\s\S]*?)<\/tr>/gi) || [];
+      for (const row of rows) {
+        const cells = (row.match(/<t[dh]>([\s\S]*?)<\/t[dh]>/gi) || [])
+          .map((c) => stripTags(extractInnerContent(c)))
+          .filter(Boolean);
+        if (cells.length > 0) {
+          addBlock(group, 'paragraph', cells.join(' | '), {});
+        }
+      }
+      continue;
+    }
+
+    if (tag === 'p') {
+      const text = stripTags(extractInnerContent(fullMatch));
+      if (text) {
+        addBlock(group, 'paragraph', text, {});
+      }
+      continue;
+    }
+  }
+
+  if (group.length > 0) {
+    fragment.insert(0, [group]);
+    log.debug(`[HtmlToYjs] Injected ${group.length} blocks`);
+  }
+}
+
+function addBlock(
+  group: Y.XmlElement,
+  type: string,
+  text: string,
+  attrs: Record<string, string>
+): void {
+  const container = new Y.XmlElement('blockContainer');
+  container.setAttribute('id', randomUUID());
+  container.setAttribute('backgroundColor', 'default');
+  container.setAttribute('textAlignment', 'left');
+  container.setAttribute('textColor', 'default');
+
+  const block = new Y.XmlElement(type);
+  for (const [key, value] of Object.entries(attrs)) {
+    block.setAttribute(key, value);
+  }
+  block.setAttribute('backgroundColor', 'default');
+  block.setAttribute('textAlignment', 'left');
+  block.setAttribute('textColor', 'default');
+
+  block.insert(0, [new Y.XmlText(text)]);
+  container.insert(0, [block]);
+  group.push([container]);
+}
+
+function extractInnerContent(html: string): string {
+  const match = html.match(/^<[^>]+>([\s\S]*)<\/[^>]+>$/);
+  return match ? match[1] : html;
+}
+
+function extractListItems(listContent: string): string[] {
+  const items: string[] = [];
+  const liPattern = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+  let m;
+  while ((m = liPattern.exec(listContent)) !== null) {
+    const text = stripTags(m[1]);
+    if (text) items.push(text);
+  }
+  return items;
+}
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#34;/g, '"')
+    .replace(/&ldquo;/g, '\u201C')
+    .replace(/&rdquo;/g, '\u201D')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -4,7 +4,9 @@ import { gzip, gunzip } from 'zlib';
 import * as Y from 'yjs';
 
 import { blockNoteXmlToHtml } from './blockNoteXmlToHtml.js';
+import { injectHtmlIntoFragment } from './htmlToYjsXml.js';
 import { createLogger } from './logger.js';
+import { TEMPLATE_CONTENT } from './templateContent.js';
 
 import type { DbQueryFn } from './types.js';
 
@@ -133,6 +135,27 @@ export class PostgresPersistence {
       const err = error instanceof Error ? error : new Error(String(error));
       log.error(`[Load] Error loading document ${documentId}: ${err.message}`);
       return null;
+    }
+  }
+
+  async initializeWithTemplate(documentId: string, ydoc: Y.Doc): Promise<void> {
+    try {
+      const result = await this.db(
+        'SELECT document_subtype FROM collaborative_documents WHERE id = $1',
+        [documentId]
+      );
+      if (result.length === 0) return;
+
+      const subtype = result[0].document_subtype as string;
+      const html = TEMPLATE_CONTENT[subtype];
+      if (!html) return;
+
+      const fragment = ydoc.getXmlFragment('document-store');
+      injectHtmlIntoFragment(fragment, html);
+      log.info(`[Template] Injected '${subtype}' template for ${documentId}`);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.error(`[Template] Error injecting template for ${documentId}: ${err.message}`);
     }
   }
 

--- a/services/hocuspocus/src/server.ts
+++ b/services/hocuspocus/src/server.ts
@@ -89,7 +89,8 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
             `[Load] Document ${documentName} loaded successfully (${documentData.length} bytes)`
           );
         } else {
-          log.info(`[Load] Document ${documentName} not found, will create new`);
+          log.info(`[Load] Document ${documentName} not found, initializing`);
+          await persistence.initializeWithTemplate(documentName, document);
         }
       } catch (error) {
         const err = error instanceof Error ? error : new Error(String(error));

--- a/services/hocuspocus/src/templateContent.ts
+++ b/services/hocuspocus/src/templateContent.ts
@@ -1,0 +1,109 @@
+/**
+ * Template HTML content for document subtypes.
+ * Injected once during first-ever document load in Hocuspocus.
+ *
+ * Source of truth: packages/docs/src/lib/templates.ts
+ * Keep in sync when template content changes.
+ */
+export const TEMPLATE_CONTENT: Record<string, string> = {
+  antrag: `
+<h1>Klimaneutrale Mobilität in Musterstadt bis 2035</h1>
+<h2>Antragstellende</h2>
+<p>OV Musterstadt, vertreten durch Maxi Mustermensch</p>
+<h2>Antragstext</h2>
+<p>Die Mitgliederversammlung möge beschließen:</p>
+<ol>
+  <li>Der Vorstand wird beauftragt, ein Konzept für den Ausbau sicherer Radwege im gesamten Stadtgebiet zu erarbeiten und bis zur nächsten Mitgliederversammlung vorzulegen.</li>
+  <li>Die Fraktion wird aufgefordert, sich im Gemeinderat für die Einführung eines kostengünstigen ÖPNV-Tickets für alle Einwohnenden einzusetzen.</li>
+  <li>Die lokale Arbeitsgruppe Verkehr soll Gespräche mit Nachbargemeinden über eine gemeinsame Radschnellverbindung aufnehmen.</li>
+</ol>
+<h2>Begründung</h2>
+<p>Der Verkehrssektor ist für einen erheblichen Teil der lokalen Treibhausgasemissionen verantwortlich. Gleichzeitig zeigen Erhebungen, dass viele Alltagswege unter fünf Kilometer lang sind und problemlos mit dem Fahrrad zurückgelegt werden könnten — sofern die Infrastruktur sicher und attraktiv gestaltet ist.</p>`,
+
+  pressemitteilung: `
+<h1>Grüne Musterstadt fordern verbindlichen Hitzeschutzplan</h1>
+<h2>Steigende Temperaturen erfordern sofortiges Handeln zum Schutz vulnerabler Gruppen</h2>
+<p>Musterstadt, 15. Juni 2026 — Angesichts der erneut prognostizierten Rekordtemperaturen fordern die Grünen Musterstadt einen verbindlichen Hitzeschutzplan für die Kommune.</p>
+<p>Bereits im vergangenen Sommer mussten Rettungsdienste deutlich mehr hitzebedingte Notfälle versorgen.</p>
+<h3>Kontakt</h3>
+<p>Robin Beispiel, Pressesprecher*in Grüne Musterstadt</p>`,
+
+  protokoll: `
+<h1>Protokoll — Vorstandssitzung OV Musterstadt</h1>
+<p>Datum: 10.06.2026</p>
+<p>Ort: Grünes Büro, Hauptstr. 12 / Videokonferenz</p>
+<p>Anwesend: Maxi Mustermensch, Robin Beispiel, Kim Vorlage, Alex Entwurf</p>
+<p>Protokollführung: Kim Vorlage</p>
+<h2>TOP 1: Begrüßung und Genehmigung der Tagesordnung</h2>
+<p>Maxi Mustermensch eröffnet die Sitzung um 19:05 Uhr und begrüßt alle Anwesenden.</p>
+<h2>TOP 2: Vorbereitung Aktionstag Klimaschutz</h2>
+<p>Robin Beispiel stellt den Entwurf für den Aktionstag am 28. Juni vor.</p>
+<h2>Verschiedenes</h2>
+<p></p>
+<h2>Nächster Termin</h2>
+<p></p>`,
+
+  notizen: `
+<h1>Notizen</h1>
+<h2>Wichtige Punkte</h2>
+<ul>
+  <li>Punkt 1</li>
+  <li>Punkt 2</li>
+  <li>Punkt 3</li>
+</ul>
+<h2>Notizen</h2>
+<p></p>
+<h2>Nächste Schritte</h2>
+<ul>
+  <li></li>
+</ul>`,
+
+  redaktionsplan: `
+<h1>Redaktionsplan</h1>
+<h2>Woche 1</h2>
+<ul>
+  <li>Montag: Thema — Verantwortlich: — Status: offen</li>
+  <li>Mittwoch: Thema — Verantwortlich: — Status: offen</li>
+  <li>Freitag: Thema — Verantwortlich: — Status: offen</li>
+</ul>
+<h2>Woche 2</h2>
+<ul>
+  <li>Montag: Thema — Verantwortlich: — Status: offen</li>
+  <li>Mittwoch: Thema — Verantwortlich: — Status: offen</li>
+  <li>Freitag: Thema — Verantwortlich: — Status: offen</li>
+</ul>
+<h2>Ideen-Pool</h2>
+<ul>
+  <li></li>
+</ul>`,
+
+  checkliste: `
+<h1>Checkliste</h1>
+<h2>Aufgaben</h2>
+<ul>
+  <li>Aufgabe 1</li>
+  <li>Aufgabe 2</li>
+  <li>Aufgabe 3</li>
+</ul>`,
+
+  einladung: `
+<h1>Einladung zur Sitzung</h1>
+<p>Liebe Mitglieder,</p>
+<p>hiermit lade ich euch herzlich zur nächsten Sitzung ein:</p>
+<p>Datum:</p>
+<p>Ort:</p>
+<h2>Tagesordnung</h2>
+<ol>
+  <li>Begrüßung und Feststellung der Beschlussfähigkeit</li>
+  <li>Genehmigung der Tagesordnung</li>
+  <li>Genehmigung des Protokolls der letzten Sitzung</li>
+  <li>Verschiedenes</li>
+</ol>
+<p>Grüne Grüße</p>`,
+
+  tabelle: `
+<h1>Neue Tabelle</h1>
+<p>Thema | Verantwortlich | Status | Frist</p>
+<p> | | | </p>
+<p> | | | </p>`,
+};


### PR DESCRIPTION
## Summary

Architectural fix: templates are now injected server-side in Hocuspocus, making it impossible for the editor to overwrite existing document content.

## Problem

Documents were repeatedly getting overwritten with template content when guests or new users visited. Root cause: the editor client injected fallback content into the Yjs document during initialization, which propagated to all clients and the Hocuspocus server via CRDT.

## Fix

**Before:** Client loads → checks if Yjs empty → injects template → propagates to all clients (race condition)

**After:** Hocuspocus loads document → no state exists? → inject template into Y.Doc → clients receive it as normal Yjs content

### Server-side template injection
- `services/hocuspocus/src/htmlToYjsXml.ts` — HTML→Yjs XML converter (h1-h3, p, ul/ol, blockquote)
- `services/hocuspocus/src/templateContent.ts` — template HTML map for all document subtypes
- `services/hocuspocus/src/persistence.ts` — `initializeWithTemplate()` method
- `services/hocuspocus/src/server.ts` — calls template init in `onLoadDocument` when document is new

### Client-side removal
- `BlockNoteEditor.tsx` — removed ALL template/fallback injection in collaborative mode. When `ydoc` exists, just marks initialized and returns.
- Standalone editors (DocsEditorModal, InlineEditor) still use `initialContent`
- Fixed `isSynced` prop: no longer conflates `isLocalLoaded` with server sync

## Test plan
- [ ] Create new document with template (e.g. Antrag) → template content appears
- [ ] Close and reopen → content preserved, not re-injected
- [ ] Visit as guest → content NOT overwritten
- [ ] Visit from new browser (no cache) → content NOT overwritten
- [ ] DocsEditorModal with initialContent → still works
- [ ] Version restore → still works