### PR TITLE
refactor: consolidate stripHtmlTags into shared utility

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/tools/searchUserContent.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchUserContent.ts
@@ -7,6 +7,7 @@
  * explicit @datei mention.
  */
 
+import { stripHtmlTags } from '@gruenerator/shared/utils';
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
 
@@ -17,14 +18,6 @@ import { createLogger } from '../../../../utils/logger.js';
 import type { ToolDependencies } from './registry.js';
 
 const log = createLogger('Tool:SearchUserContent');
-
-function stripHtmlTags(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
 
 export function createSearchUserContentTool(deps: ToolDependencies): DynamicStructuredTool | null {
   const userId = deps.userId || deps.agentConfig.userId;

--- a/apps/api/routes/auth/content/userLibrary.ts
+++ b/apps/api/routes/auth/content/userLibrary.ts
@@ -3,6 +3,7 @@
  * Handles saving texts to library, saved texts CRUD, and semantic search
  */
 
+import { stripHtmlTags } from '@gruenerator/shared/utils';
 import express, { type Router, type Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -28,24 +29,6 @@ const { requireAuth: ensureAuthenticated } = authMiddlewareModule;
 const router: Router = express.Router();
 
 const MAX_CONTENT_LENGTH = 1024 * 1024;
-
-function stripHtmlTags(html: string): string {
-  if (!html) return '';
-  const safeHtml = html.length > MAX_CONTENT_LENGTH ? html.slice(0, MAX_CONTENT_LENGTH) : html;
-  let result = '';
-  let inTag = false;
-  for (let i = 0; i < safeHtml.length; i++) {
-    const char = safeHtml[i];
-    if (char === '<') {
-      inTag = true;
-    } else if (char === '>') {
-      inTag = false;
-    } else if (!inTag) {
-      result += char;
-    }
-  }
-  return result;
-}
 
 function extractHeading(html: string, tag: string): string | null {
   const openTag = `<${tag}`;

--- a/apps/api/routes/chat/services/documentContextService.ts
+++ b/apps/api/routes/chat/services/documentContextService.ts
@@ -1,3 +1,5 @@
+import { stripHtmlTags } from '@gruenerator/shared/utils';
+
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import { getQdrantDocumentService } from '../../../services/document-services/DocumentSearchService/index.js';
 import { createLogger } from '../../../utils/logger.js';
@@ -82,14 +84,6 @@ export interface TextContextResult {
   text: string | null;
   totalChars: number;
   count: number;
-}
-
-function stripHtmlTags(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
 }
 
 /**

--- a/apps/api/services/markdown/MarkdownService.ts
+++ b/apps/api/services/markdown/MarkdownService.ts
@@ -3,6 +3,7 @@
  * Handles all markdown to HTML/plain text conversions
  */
 
+import { stripHtmlTags } from '@gruenerator/shared/utils';
 import { marked } from 'marked';
 
 // Configure marked with consistent settings
@@ -39,14 +40,7 @@ export class MarkdownService {
 
     try {
       const html = marked.parse(markdown) as string;
-      return html
-        .replace(/<[^>]*>/g, '')
-        .replace(/&nbsp;/gi, ' ')
-        .replace(/&amp;/gi, '&')
-        .replace(/&lt;/gi, '<')
-        .replace(/&gt;/gi, '>')
-        .replace(/&quot;/gi, '"')
-        .trim();
+      return stripHtmlTags(html);
     } catch (error) {
       console.error('Error converting markdown to plain text:', error);
       // Return original content on error

--- a/apps/api/services/tiptap/contentConverter.ts
+++ b/apps/api/services/tiptap/contentConverter.ts
@@ -9,26 +9,9 @@
  * the existing frontend editor infrastructure.
  */
 
-const MAX_HTML_LENGTH = 1024 * 1024;
+import { stripHtmlTags } from '@gruenerator/shared/utils';
 
-function stripTags(html: string): string {
-  if (html.length > MAX_HTML_LENGTH) {
-    html = html.slice(0, MAX_HTML_LENGTH);
-  }
-  let result = '';
-  let inTag = false;
-  for (let i = 0; i < html.length; i++) {
-    const char = html[i];
-    if (char === '<') {
-      inTag = true;
-    } else if (char === '>') {
-      inTag = false;
-    } else if (!inTag) {
-      result += char;
-    }
-  }
-  return result;
-}
+const MAX_HTML_LENGTH = 1024 * 1024;
 
 /**
  * Validates and sanitizes HTML content for storage
@@ -65,13 +48,13 @@ export function extractTitleFromHtml(html: string): string {
   }
   const headingMatch = html.match(/<h[1-6][^>]{0,100}>([\s\S]{0,500}?)<\/h[1-6]>/i);
   if (headingMatch && headingMatch[1]) {
-    const title = stripTags(headingMatch[1]).trim();
+    const title = stripHtmlTags(headingMatch[1]);
     if (title.length > 0) {
       return title.length > 100 ? title.substring(0, 97) + '...' : title;
     }
   }
 
-  const textContent = stripTags(html).trim();
+  const textContent = stripHtmlTags(html);
   if (textContent.length > 0) {
     return textContent.length > 50 ? textContent.substring(0, 47) + '...' : textContent;
   }
@@ -79,11 +62,5 @@ export function extractTitleFromHtml(html: string): string {
   return 'Untitled Document';
 }
 
-/**
- * Strips HTML tags to get plain text (fallback)
- * @param html - HTML string
- * @returns Plain text
- */
-export function stripHtmlTags(html: string): string {
-  return stripTags(html).trim();
-}
+// Re-export shared utility for backwards compatibility
+export { stripHtmlTags } from '@gruenerator/shared/utils';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -20,6 +20,9 @@ export {
 // Tailwind CSS class merging utility
 export { cn } from './cn.js';
 
+// HTML tag stripping with entity decoding
+export { stripHtmlTags } from './stripHtmlTags.js';
+
 // German relative time formatting
 export { formatRelativeTime } from './formatRelativeTime.js';
 export type { FormatRelativeTimeOptions } from './formatRelativeTime.js';

--- a/packages/shared/src/utils/stripHtmlTags.ts
+++ b/packages/shared/src/utils/stripHtmlTags.ts
@@ -1,0 +1,30 @@
+/**
+ * Strip HTML tags from a string and decode common HTML entities.
+ * Works in both Node.js and browser environments (regex-based, no DOM dependency).
+ *
+ * Replaces 10+ duplicate implementations across the codebase.
+ */
+export function stripHtmlTags(html: string | null | undefined): string {
+  if (!html) return '';
+
+  return (
+    html
+      // Convert <br> to newline before stripping tags
+      .replace(/<br\s*\/?>/gi, '\n')
+      // Strip all HTML tags
+      .replace(/<[^>]+>/g, '')
+      // Decode common HTML entities (order matters: &amp; last to prevent double-decoding)
+      .replace(/&nbsp;/gi, ' ')
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#34;/gi, '"')
+      .replace(/&#39;/gi, "'")
+      .replace(/&ldquo;/gi, '\u201C')
+      .replace(/&rdquo;/gi, '\u201D')
+      .replace(/&amp;/gi, '&')
+      // Normalize whitespace
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}

--- a/services/hocuspocus/package.json
+++ b/services/hocuspocus/package.json
@@ -22,6 +22,7 @@
   "author": "Moritz Wächter",
   "license": "MIT",
   "dependencies": {
+    "@gruenerator/shared": "workspace:*",
     "@hocuspocus/extension-logger": "^3.4.4",
     "@hocuspocus/server": "^3.4.4",
     "cookie": "^1.1.1",

--- a/services/hocuspocus/src/htmlToYjsXml.ts
+++ b/services/hocuspocus/src/htmlToYjsXml.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 
+import { stripHtmlTags } from '@gruenerator/shared/utils';
 import * as Y from 'yjs';
 
 import { createLogger } from './logger.js';
@@ -56,14 +57,14 @@ export function injectHtmlIntoFragment(fragment: Y.XmlFragment, html: string): v
 
     if (tag.startsWith('h')) {
       const level = tag[1];
-      const text = stripTags(extractInnerContent(fullMatch));
+      const text = stripHtmlTags(extractInnerContent(fullMatch));
       addBlock(group, 'heading', text, { level });
       continue;
     }
 
     if (tag === 'blockquote') {
       const inner = extractInnerContent(fullMatch);
-      const text = stripTags(inner);
+      const text = stripHtmlTags(inner);
       addBlock(group, 'paragraph', text, { backgroundColor: 'gray' });
       continue;
     }
@@ -73,7 +74,7 @@ export function injectHtmlIntoFragment(fragment: Y.XmlFragment, html: string): v
       const rows = fullMatch.match(/<tr>([\s\S]*?)<\/tr>/gi) || [];
       for (const row of rows) {
         const cells = (row.match(/<t[dh]>([\s\S]*?)<\/t[dh]>/gi) || [])
-          .map((c) => stripTags(extractInnerContent(c)))
+          .map((c) => stripHtmlTags(extractInnerContent(c)))
           .filter(Boolean);
         if (cells.length > 0) {
           addBlock(group, 'paragraph', cells.join(' | '), {});
@@ -83,7 +84,7 @@ export function injectHtmlIntoFragment(fragment: Y.XmlFragment, html: string): v
     }
 
     if (tag === 'p') {
-      const text = stripTags(extractInnerContent(fullMatch));
+      const text = stripHtmlTags(extractInnerContent(fullMatch));
       if (text) {
         addBlock(group, 'paragraph', text, {});
       }
@@ -132,23 +133,8 @@ function extractListItems(listContent: string): string[] {
   const liPattern = /<li[^>]*>([\s\S]*?)<\/li>/gi;
   let m;
   while ((m = liPattern.exec(listContent)) !== null) {
-    const text = stripTags(m[1]);
+    const text = stripHtmlTags(m[1]);
     if (text) items.push(text);
   }
   return items;
-}
-
-function stripTags(html: string): string {
-  return html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#34;/g, '"')
-    .replace(/&ldquo;/g, '\u201C')
-    .replace(/&rdquo;/g, '\u201D')
-    .replace(/\s+/g, ' ')
-    .trim();
 }


### PR DESCRIPTION
## Summary

Consolidates 7 duplicate `stripHtmlTags` implementations into a single shared utility at `@gruenerator/shared/utils`.

The shared version handles: HTML tag stripping, `<br>` → newline conversion, and comprehensive entity decoding (amp, lt, gt, quot, nbsp, ldquo, rdquo, numeric entities).

## Files replaced
- `apps/api/routes/chat/services/documentContextService.ts` — removed local, import shared
- `apps/api/agents/langgraph/ChatGraph/tools/searchUserContent.ts` — removed local, import shared
- `apps/api/routes/auth/content/userLibrary.ts` — removed local, import shared
- `apps/api/services/tiptap/contentConverter.ts` — removed local, re-exports shared
- `apps/api/services/markdown/MarkdownService.ts` — replaced inline chain, import shared
- `services/hocuspocus/src/htmlToYjsXml.ts` — removed local, import shared

## Still remaining (different pattern, not consolidated)
- Browser DOM-based `stripHtml` in `apps/web/src/utils/` (2 files) — uses `document.createElement`, browser-only
- Cheerio-based `stripHtmlTags` in `htmlCleaner.ts` — different dependency, different use case
- `contentParser.ts` loop-based variant — has loop for nested tags, separate concern