### PR TITLE
Mobile keyboard handling: docs editor + chat sidebar

### DIFF
--- a/packages/chat/src/components/ToolCallUI.tsx
+++ b/packages/chat/src/components/ToolCallUI.tsx
@@ -87,7 +87,7 @@ export const ToolCallUI = memo(function ToolCallUI({
         )}
         <span className="font-medium text-foreground">{config.label}</span>
         {query && (
-          <span className="text-foreground-muted max-w-[200px] truncate">
+          <span className="text-foreground-muted max-w-[120px] sm:max-w-[200px] truncate">
             &bdquo;{query}&ldquo;
           </span>
         )}

--- a/packages/chat/src/components/message-parts/SourceCard.tsx
+++ b/packages/chat/src/components/message-parts/SourceCard.tsx
@@ -84,7 +84,7 @@ export function SourceCard(props: SourceMessagePartProps) {
           </span>
 
           {metaLine && (
-            <span className="text-xs text-foreground-muted mt-0.5 block">{metaLine}</span>
+            <span className="text-xs text-foreground-muted mt-0.5 block truncate">{metaLine}</span>
           )}
 
           {citation?.snippet && (

--- a/packages/chat/src/components/thread/AssistantMessage.tsx
+++ b/packages/chat/src/components/thread/AssistantMessage.tsx
@@ -23,7 +23,7 @@ import type { ChatMessageMetadata } from '../../types/messageMetadata';
 
 function AssistantMessageTextPart() {
   return (
-    <div className="prose prose-sm max-w-none break-words">
+    <div className="prose prose-sm max-w-none min-w-0 break-words">
       <CitationMarkdownText />
     </div>
   );

--- a/packages/chat/src/components/tool-ui/citation/citation.tsx
+++ b/packages/chat/src/components/tool-ui/citation/citation.tsx
@@ -185,7 +185,7 @@ export function Citation(props: CitationProps) {
   // Default variant: full card
   return (
     <article
-      className={cn('relative w-full max-w-[28rem] min-w-72', className)}
+      className={cn('relative w-full max-w-[28rem] min-w-0 sm:min-w-72', className)}
       lang={locale}
       data-tool-ui-id={id}
       data-slot="citation"

--- a/packages/chat/src/components/tool-ui/link-preview/link-preview.tsx
+++ b/packages/chat/src/components/tool-ui/link-preview/link-preview.tsx
@@ -55,7 +55,7 @@ export function LinkPreview(props: LinkPreviewProps) {
 
   return (
     <article
-      className={cn('relative w-full max-w-[28rem] min-w-80', className)}
+      className={cn('relative w-full max-w-[28rem] min-w-0 sm:min-w-80', className)}
       lang={locale}
       data-tool-ui-id={id}
       data-slot="link-preview"

--- a/packages/chat/src/lib/citationMarkdownComponents.tsx
+++ b/packages/chat/src/lib/citationMarkdownComponents.tsx
@@ -12,7 +12,7 @@ export function makeCitationComponents(citationMap: Map<number, Citation>) {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-primary underline hover:text-primary-dark break-words"
+        className="text-primary underline hover:text-primary-dark break-words [overflow-wrap:anywhere]"
       >
         {children}
       </a>

--- a/packages/docs/src/components/chat/ChatSidebar.tsx
+++ b/packages/docs/src/components/chat/ChatSidebar.tsx
@@ -29,7 +29,8 @@ export const ChatSidebar = ({
   onTypingChange,
   embedded = false,
 }: ChatSidebarProps) => {
-  const keyboardRef = useMobileKeyboardOffset<HTMLDivElement>();
+  const keyboardRef = useRef<HTMLDivElement>(null);
+  useMobileKeyboardOffset(keyboardRef);
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
 

--- a/packages/docs/src/components/chat/ChatSidebar.tsx
+++ b/packages/docs/src/components/chat/ChatSidebar.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect, useCallback } from 'react';
 import { FiX, FiMessageCircle } from 'react-icons/fi';
 import { ChatMessageComponent } from './ChatMessage';
 import { ChatComposer } from './ChatComposer';
+import { useMobileKeyboardOffset } from '../../hooks/useMobileKeyboardOffset';
 import type { ChatMessage } from '../../hooks/useDocumentChat';
 
 interface ChatSidebarProps {
@@ -28,6 +29,7 @@ export const ChatSidebar = ({
   onTypingChange,
   embedded = false,
 }: ChatSidebarProps) => {
+  const keyboardRef = useMobileKeyboardOffset<HTMLDivElement>();
   const viewportRef = useRef<HTMLDivElement>(null);
   const isAtBottomRef = useRef(true);
 
@@ -45,12 +47,14 @@ export const ChatSidebar = ({
 
   return (
     <div
+      ref={keyboardRef}
       className={cn(
         'flex flex-col overflow-hidden',
         embedded
           ? 'w-full min-w-0 max-w-none flex-1 border-l-0'
           : 'w-80 min-w-80 max-w-80 border-l border-grey-200 bg-background dark:border-grey-700 dark:bg-background max-md:fixed max-md:inset-0 max-md:z-[200] max-md:w-full max-md:min-w-full max-md:max-w-full max-md:border-l-0'
       )}
+      style={{ paddingBottom: 'var(--mobile-keyboard-offset, 0px)' }}
     >
       {!hideHeader && (
         <>

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -49,6 +49,7 @@ import { useResolveUsers } from '../../hooks/useResolveUsers';
 import { useMentionUsers } from '../../hooks/useMentionUsers';
 import { useDocsAdapter } from '../../context/DocsContext';
 import { useIsTouchDevice } from '../../hooks/useIsTouchDevice';
+import { useMobileKeyboardOffset } from '../../hooks/useMobileKeyboardOffset';
 import { useEditorPreferencesStore } from '../../stores/editorPreferencesStore';
 import { ErrorBoundary } from '../common/ErrorBoundary';
 import { Mention } from './Mention';
@@ -175,14 +176,11 @@ const BlockNoteEditorInner = ({
   const getMentionMenuItems = useMentionUsers(provider ?? null);
   const hasInitialized = useRef(false);
   const [isReady, setIsReady] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useMobileKeyboardOffset<HTMLDivElement>();
 
+  // Editor-specific: toggle selection class + scroll selection into view
   useEffect(() => {
     if (!isTouchDevice) return;
-
-    const setOffset = (px: number) => {
-      wrapperRef.current?.style.setProperty('--mobile-keyboard-offset', px > 0 ? `${px}px` : '0px');
-    };
 
     const updateSelectionClass = () => {
       const sel = window.getSelection();
@@ -209,74 +207,18 @@ const BlockNoteEditorInner = ({
       }
     };
 
-    // Prefer VirtualKeyboard API (Chrome/Edge 93+) — gives exact geometry, no delay
-    const vk = (navigator as any).virtualKeyboard;
-    if (vk) {
-      vk.overlaysContent = true;
-      const onGeometryChange = () => {
-        setOffset(vk.boundingRect.height);
-        scrollTimer = setTimeout(scrollSelectionIntoView, 100);
-      };
-      vk.addEventListener('geometrychange', onGeometryChange);
-      const onSelectionChange = () => {
-        updateSelectionClass();
-        scrollSelectionIntoView();
-      };
-      document.addEventListener('selectionchange', onSelectionChange);
-      return () => {
-        vk.removeEventListener('geometrychange', onGeometryChange);
-        document.removeEventListener('selectionchange', onSelectionChange);
-        clearTimeout(scrollTimer);
-      };
-    }
-
-    // Fallback: Visual Viewport API (Safari, older browsers)
-    const vp = window.visualViewport;
-    if (!vp) return;
-
-    let lastKnownKeyboardHeight = 0;
-
-    const update = () => {
-      const layoutHeight = document.documentElement.clientHeight;
-      const keyboardHeight = layoutHeight - vp.height - vp.offsetTop;
-      if (keyboardHeight > 50) lastKnownKeyboardHeight = keyboardHeight;
-      setOffset(keyboardHeight);
+    const onSelectionChange = () => {
+      updateSelectionClass();
       clearTimeout(scrollTimer);
       scrollTimer = setTimeout(scrollSelectionIntoView, 100);
     };
 
-    const onFocusIn = (e: FocusEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.isContentEditable || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
-        if (lastKnownKeyboardHeight > 0) {
-          setOffset(lastKnownKeyboardHeight);
-        }
-      }
-    };
-
-    const onFocusOut = () => {
-      setOffset(0);
-    };
-
-    const onSelectionChange = () => {
-      updateSelectionClass();
-      scrollSelectionIntoView();
-    };
-
-    vp.addEventListener('resize', update);
-    vp.addEventListener('scroll', update);
-    document.addEventListener('focusin', onFocusIn);
-    document.addEventListener('focusout', onFocusOut);
     document.addEventListener('selectionchange', onSelectionChange);
     return () => {
-      vp.removeEventListener('resize', update);
-      vp.removeEventListener('scroll', update);
-      document.removeEventListener('focusin', onFocusIn);
-      document.removeEventListener('focusout', onFocusOut);
       document.removeEventListener('selectionchange', onSelectionChange);
       clearTimeout(scrollTimer);
     };
-  }, [isTouchDevice]);
+  }, [isTouchDevice, wrapperRef]);
 
   const collaborationUser = useMemo(() => {
     if (!provider?.awareness) return null;

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -176,9 +176,28 @@ const BlockNoteEditorInner = ({
   const getMentionMenuItems = useMentionUsers(provider ?? null);
   const hasInitialized = useRef(false);
   const [isReady, setIsReady] = useState(false);
-  const wrapperRef = useMobileKeyboardOffset<HTMLDivElement>();
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
-  // Editor-specific: toggle selection class + scroll selection into view
+  const scrollSelectionIntoView = useCallback(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    const vp = window.visualViewport;
+    if (!vp) return;
+    const toolbarHeight =
+      wrapperRef.current?.querySelector('.bn-formatting-toolbar')?.getBoundingClientRect().height ||
+      44;
+    const visibleBottom = vp.offsetTop + vp.height - toolbarHeight;
+    if (rect.bottom > visibleBottom) {
+      window.scrollBy({ top: rect.bottom - visibleBottom + 16, behavior: 'smooth' });
+    } else if (rect.top < vp.offsetTop) {
+      window.scrollBy({ top: rect.top - vp.offsetTop - 16, behavior: 'smooth' });
+    }
+  }, []);
+
+  useMobileKeyboardOffset(wrapperRef, { onOffsetChange: scrollSelectionIntoView });
+
+  // Editor-specific: toggle selection class + scroll selection into view on text select
   useEffect(() => {
     if (!isTouchDevice) return;
 
@@ -189,23 +208,6 @@ const BlockNoteEditorInner = ({
     };
 
     let scrollTimer: ReturnType<typeof setTimeout>;
-
-    const scrollSelectionIntoView = () => {
-      const sel = window.getSelection();
-      if (!sel || sel.rangeCount === 0) return;
-      const rect = sel.getRangeAt(0).getBoundingClientRect();
-      const vp = window.visualViewport;
-      if (!vp) return;
-      const toolbarHeight =
-        wrapperRef.current?.querySelector('.bn-formatting-toolbar')?.getBoundingClientRect()
-          .height || 44;
-      const visibleBottom = vp.offsetTop + vp.height - toolbarHeight;
-      if (rect.bottom > visibleBottom) {
-        window.scrollBy({ top: rect.bottom - visibleBottom + 16, behavior: 'smooth' });
-      } else if (rect.top < vp.offsetTop) {
-        window.scrollBy({ top: rect.top - vp.offsetTop - 16, behavior: 'smooth' });
-      }
-    };
 
     const onSelectionChange = () => {
       updateSelectionClass();
@@ -218,7 +220,7 @@ const BlockNoteEditorInner = ({
       document.removeEventListener('selectionchange', onSelectionChange);
       clearTimeout(scrollTimer);
     };
-  }, [isTouchDevice, wrapperRef]);
+  }, [isTouchDevice, scrollSelectionIntoView]);
 
   const collaborationUser = useMemo(() => {
     if (!provider?.awareness) return null;

--- a/packages/docs/src/hooks/useMobileKeyboardOffset.ts
+++ b/packages/docs/src/hooks/useMobileKeyboardOffset.ts
@@ -1,22 +1,37 @@
-import { useEffect, useRef, type RefObject } from 'react';
+import { useEffect, useRef } from 'react';
 import { useIsTouchDevice } from './useIsTouchDevice';
 
+import type { RefObject } from 'react';
+
+interface MobileKeyboardOffsetOptions {
+  /** Called (debounced 100ms) when the keyboard offset changes. */
+  onOffsetChange?: () => void;
+}
+
 /**
- * Sets CSS custom property `--mobile-keyboard-offset` on the target element
+ * Sets CSS custom property `--mobile-keyboard-offset` on the referenced element
  * to reflect the virtual keyboard height. Uses VirtualKeyboard API (Chrome/Edge)
  * with VisualViewport fallback (Safari/Firefox).
- *
- * Returns a ref to attach to the container element.
  */
-export function useMobileKeyboardOffset<T extends HTMLElement>(): RefObject<T | null> {
-  const ref = useRef<T | null>(null);
+export function useMobileKeyboardOffset<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  options?: MobileKeyboardOffsetOptions
+): void {
   const isTouchDevice = useIsTouchDevice();
+  const callbackRef = useRef(options?.onOffsetChange);
+  callbackRef.current = options?.onOffsetChange;
 
   useEffect(() => {
     if (!isTouchDevice) return;
 
+    let debounceTimer: ReturnType<typeof setTimeout>;
+
     const setOffset = (px: number) => {
       ref.current?.style.setProperty('--mobile-keyboard-offset', px > 0 ? `${px}px` : '0px');
+      if (callbackRef.current) {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(() => callbackRef.current?.(), 100);
+      }
     };
 
     // Prefer VirtualKeyboard API (Chrome/Edge 94+)
@@ -25,7 +40,10 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(): RefObject<T | 
       vk.overlaysContent = true;
       const onGeometryChange = () => setOffset(vk.boundingRect.height);
       vk.addEventListener('geometrychange', onGeometryChange);
-      return () => vk.removeEventListener('geometrychange', onGeometryChange);
+      return () => {
+        vk.removeEventListener('geometrychange', onGeometryChange);
+        clearTimeout(debounceTimer);
+      };
     }
 
     // Fallback: Visual Viewport API (Safari, older browsers)
@@ -61,8 +79,7 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(): RefObject<T | 
       vp.removeEventListener('scroll', update);
       document.removeEventListener('focusin', onFocusIn);
       document.removeEventListener('focusout', onFocusOut);
+      clearTimeout(debounceTimer);
     };
-  }, [isTouchDevice]);
-
-  return ref;
+  }, [isTouchDevice, ref]);
 }

--- a/packages/docs/src/hooks/useMobileKeyboardOffset.ts
+++ b/packages/docs/src/hooks/useMobileKeyboardOffset.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, type RefObject } from 'react';
+import { useIsTouchDevice } from './useIsTouchDevice';
+
+/**
+ * Sets CSS custom property `--mobile-keyboard-offset` on the target element
+ * to reflect the virtual keyboard height. Uses VirtualKeyboard API (Chrome/Edge)
+ * with VisualViewport fallback (Safari/Firefox).
+ *
+ * Returns a ref to attach to the container element.
+ */
+export function useMobileKeyboardOffset<T extends HTMLElement>(): RefObject<T | null> {
+  const ref = useRef<T | null>(null);
+  const isTouchDevice = useIsTouchDevice();
+
+  useEffect(() => {
+    if (!isTouchDevice) return;
+
+    const setOffset = (px: number) => {
+      ref.current?.style.setProperty('--mobile-keyboard-offset', px > 0 ? `${px}px` : '0px');
+    };
+
+    // Prefer VirtualKeyboard API (Chrome/Edge 94+)
+    const vk = (navigator as any).virtualKeyboard;
+    if (vk) {
+      vk.overlaysContent = true;
+      const onGeometryChange = () => setOffset(vk.boundingRect.height);
+      vk.addEventListener('geometrychange', onGeometryChange);
+      return () => vk.removeEventListener('geometrychange', onGeometryChange);
+    }
+
+    // Fallback: Visual Viewport API (Safari, older browsers)
+    const vp = window.visualViewport;
+    if (!vp) return;
+
+    let lastKnownKeyboardHeight = 0;
+
+    const update = () => {
+      const layoutHeight = document.documentElement.clientHeight;
+      const keyboardHeight = layoutHeight - vp.height - vp.offsetTop;
+      if (keyboardHeight > 50) lastKnownKeyboardHeight = keyboardHeight;
+      setOffset(keyboardHeight);
+    };
+
+    const onFocusIn = (e: FocusEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.isContentEditable || target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+        if (lastKnownKeyboardHeight > 0) {
+          setOffset(lastKnownKeyboardHeight);
+        }
+      }
+    };
+
+    const onFocusOut = () => setOffset(0);
+
+    vp.addEventListener('resize', update);
+    vp.addEventListener('scroll', update);
+    document.addEventListener('focusin', onFocusIn);
+    document.addEventListener('focusout', onFocusOut);
+    return () => {
+      vp.removeEventListener('resize', update);
+      vp.removeEventListener('scroll', update);
+      document.removeEventListener('focusin', onFocusIn);
+      document.removeEventListener('focusout', onFocusOut);
+    };
+  }, [isTouchDevice]);
+
+  return ref;
+}

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -161,13 +161,12 @@ const defaultComponents = memoizeMarkdownComponents({
     <hr className={cn('aui-md-hr my-2 border-muted-foreground/20', className)} {...props} />
   ),
   table: ({ className, ...props }) => (
-    <table
-      className={cn(
-        'aui-md-table my-2 w-full border-separate border-spacing-0 overflow-y-auto',
-        className
-      )}
-      {...props}
-    />
+    <div className="my-2 overflow-x-auto">
+      <table
+        className={cn('aui-md-table w-full border-separate border-spacing-0', className)}
+        {...props}
+      />
+    </div>
   ),
   th: ({ className, ...props }) => (
     <th

--- a/packages/ui/src/components/notifications/notification-bell.tsx
+++ b/packages/ui/src/components/notifications/notification-bell.tsx
@@ -50,7 +50,7 @@ function NotificationBell({
         </TooltipTrigger>
         <TooltipContent>{label}</TooltipContent>
       </Tooltip>
-      <PopoverContent align="end" className="w-[380px] p-0" sideOffset={8}>
+      <PopoverContent align="end" className="w-[calc(100vw-2rem)] sm:w-[380px] p-0" sideOffset={8}>
         {children}
       </PopoverContent>
     </Popover>

--- a/packages/ui/src/components/tool-ui/link-preview/link-preview.tsx
+++ b/packages/ui/src/components/tool-ui/link-preview/link-preview.tsx
@@ -55,7 +55,7 @@ export function LinkPreview(props: LinkPreviewProps) {
 
   return (
     <article
-      className={cn('relative w-full max-w-md min-w-80', className)}
+      className={cn('relative w-full max-w-md min-w-0 sm:min-w-80', className)}
       lang={locale}
       data-tool-ui-id={id}
       data-slot="link-preview"


### PR DESCRIPTION
## Summary
- **Keyboard-aware chat sidebar**: Extract `useMobileKeyboardOffset` hook from BlockNoteEditor, apply to ChatSidebar so the composer stays above the virtual keyboard on mobile
- **Scroll cursor into view on keyboard open**: When tapping in the lower third of a document, the cursor is scrolled into view after the keyboard appears (via `onOffsetChange` callback)
- **Overflow fix**: Prevent horizontal overflow on narrow viewports in chat/UI components

## Test plan
- [ ] Open docs editor on mobile, tap in the lower third of the document — cursor should scroll into view when keyboard opens
- [ ] Open chat sidebar in docs editor on mobile — composer input should stay above keyboard
- [ ] Select text on mobile — formatting toolbar should slide up, deselect should slide it down
- [ ] Verify no horizontal scrollbar appears on narrow viewports in chat