### PR TITLE
fix(security): resolve 9 CodeQL high-severity alerts

### DIFF
--- a/apps/api/services/OcrService/doclingIntegration.ts
+++ b/apps/api/services/OcrService/doclingIntegration.ts
@@ -121,11 +121,11 @@ export async function extractTextWithDocling(filePath: string): Promise<Extracti
   if (!matchedBase) {
     throw new Error('File path outside allowed directories');
   }
-  sanitizePath(path.relative(matchedBase, resolvedPath), matchedBase);
+  const safePath = sanitizePath(path.relative(matchedBase, resolvedPath), matchedBase);
 
-  console.log(`[DoclingOCR] Starting extraction:`, { filePath });
-  const fileBuffer = await fs.readFile(resolvedPath);
-  const fileName = path.basename(filePath);
+  console.log(`[DoclingOCR] Starting extraction:`, { filePath: safePath });
+  const fileBuffer = await fs.readFile(safePath);
+  const fileName = path.basename(safePath);
   return sendBufferToDocling(fileBuffer, fileName, '[DoclingOCR]');
 }
 

--- a/apps/api/services/subtitler/ProjectService.ts
+++ b/apps/api/services/subtitler/ProjectService.ts
@@ -214,14 +214,14 @@ export class SubtitlerProjectService {
 
       const projectId = crypto.randomUUID();
       validatePathId(userId, 'userId');
-      const projectDir = path.join(PROJECT_STORAGE_PATH, userId, projectId);
+      const projectDir = sanitizePath(path.join(userId, projectId), PROJECT_STORAGE_PATH);
       await fs.mkdir(projectDir, { recursive: true });
 
       if (!/^[a-zA-Z0-9_-]+$/.test(uploadId)) {
         throw new Error('Invalid uploadId format');
       }
-      const tusVideoPath = path.join(__dirname, '../../uploads/tus-temp', uploadId);
       const uploadsDir = path.resolve(__dirname, '../../uploads');
+      const tusVideoPath = sanitizePath(path.join('tus-temp', uploadId), uploadsDir);
       const sourceVideoPath = videoSourcePath
         ? sanitizePath(videoSourcePath, uploadsDir)
         : tusVideoPath;
@@ -416,7 +416,7 @@ export class SubtitlerProjectService {
 
       validatePathId(userId, 'userId');
       validatePathId(projectId, 'projectId');
-      const projectDir = path.join(PROJECT_STORAGE_PATH, userId, projectId);
+      const projectDir = sanitizePath(path.join(userId, projectId), PROJECT_STORAGE_PATH);
       try {
         await fs.rm(projectDir, { recursive: true, force: true });
         console.log(`[SubtitlerProjectService] Deleted project files at ${projectDir}`);

--- a/apps/api/services/subtitler/videoUploadService.ts
+++ b/apps/api/services/subtitler/videoUploadService.ts
@@ -125,25 +125,26 @@ async function extractAudio(
   const uploadsDir = path.resolve(__dirname, '../../uploads');
   const tmpDir = path.resolve(os.tmpdir());
   const resolvedVideoPath = path.resolve(videoPath);
+  let safeVideoPath: string;
   if (resolvedVideoPath.startsWith(uploadsDir + path.sep)) {
-    sanitizePath(path.relative(uploadsDir, resolvedVideoPath), uploadsDir);
+    safeVideoPath = sanitizePath(path.relative(uploadsDir, resolvedVideoPath), uploadsDir);
   } else if (resolvedVideoPath.startsWith(tmpDir + path.sep)) {
-    sanitizePath(path.relative(tmpDir, resolvedVideoPath), tmpDir);
+    safeVideoPath = sanitizePath(path.relative(tmpDir, resolvedVideoPath), tmpDir);
   } else {
     throw new Error('Video path outside allowed directory');
   }
 
-  if (!fs.existsSync(videoPath)) {
-    throw new Error(`Video-Datei nicht gefunden: ${videoPath}`);
+  if (!fs.existsSync(safeVideoPath)) {
+    throw new Error(`Video-Datei nicht gefunden: ${safeVideoPath}`);
   }
 
-  const duration = await getDuration(videoPath);
+  const duration = await getDuration(safeVideoPath);
   if (duration) {
     log.debug(`Video-Dauer: ${duration.toFixed(1)}s`);
   }
 
   return new Promise((resolve, reject) => {
-    const command = ffmpeg(videoPath).outputOptions([
+    const command = ffmpeg(safeVideoPath).outputOptions([
       '-vn',
       '-ar',
       '16000',

--- a/packages/shared/src/utils/stripHtmlTags.ts
+++ b/packages/shared/src/utils/stripHtmlTags.ts
@@ -7,24 +7,35 @@
 export function stripHtmlTags(html: string | null | undefined): string {
   if (!html) return '';
 
-  return (
-    html
-      // Convert <br> to newline before stripping tags
-      .replace(/<br\s*\/?>/gi, '\n')
-      // Strip all HTML tags
-      .replace(/<[^>]+>/g, '')
-      // Decode common HTML entities (order matters: &amp; last to prevent double-decoding)
-      .replace(/&nbsp;/gi, ' ')
-      .replace(/&lt;/gi, '<')
-      .replace(/&gt;/gi, '>')
-      .replace(/&quot;/gi, '"')
-      .replace(/&#34;/gi, '"')
-      .replace(/&#39;/gi, "'")
-      .replace(/&ldquo;/gi, '\u201C')
-      .replace(/&rdquo;/gi, '\u201D')
-      .replace(/&amp;/gi, '&')
-      // Normalize whitespace
-      .replace(/\s+/g, ' ')
-      .trim()
-  );
+  let result = html
+    // Convert <br> to newline before stripping tags
+    .replace(/<br\s*\/?>/gi, '\n');
+
+  // Strip all HTML tags — loop until stable to prevent incomplete sanitization
+  // (e.g. "<<script>script>" → first pass removes "<script>" → leaves "<script>")
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]+>/g, '');
+  } while (result !== prev);
+
+  result = result
+    // Decode common HTML entities (order matters: &amp; last to prevent double-decoding)
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#34;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&ldquo;/gi, '\u201C')
+    .replace(/&rdquo;/gi, '\u201D')
+    .replace(/&amp;/gi, '&');
+
+  // Second pass: entity decoding may have produced new tags (e.g. &lt;script&gt; → <script>)
+  do {
+    prev = result;
+    result = result.replace(/<[^>]+>/g, '');
+  } while (result !== prev);
+
+  return result.replace(/\s+/g, ' ').trim();
 }


### PR DESCRIPTION
## Summary
- **stripHtmlTags**: Loop tag stripping until stable + second pass after entity decoding to prevent incomplete multi-character sanitization (#1331)
- **doclingIntegration**: Use `sanitizePath()` return value for `fs.readFile` so CodeQL taint analysis sees validated path flowing to sink (#1306)
- **ProjectService**: Route `projectDir` and `tusVideoPath` through `sanitizePath()` instead of raw `path.join` with user-derived IDs (#1271, #1109, #662, #658, #657, #656)
- **videoUploadService**: Use `sanitizePath()` return as `safeVideoPath` for all downstream fs/ffmpeg operations (#1166)

Alert #1328 (missing rate limiting on Better Auth) is already resolved on master via `6eb44c4e` — CodeQL just hasn't re-scanned yet.

## Test plan
- [ ] Verify subtitler project create/delete still works
- [ ] Verify OCR document extraction still works
- [ ] Verify video upload and audio extraction still works
- [ ] Verify HTML stripping handles edge cases: `<<script>script>`, `&lt;script&gt;`