### PR TITLE
fix(web): correct notebook section link path and label

### DIFF
--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -113,10 +113,10 @@ const NotebooksSection: React.FC = memo(() => {
       {SYSTEM_NOTEBOOKS.length > INITIAL_COUNT && (
         <button
           type="button"
-          onClick={() => navigate('/research')}
+          onClick={() => navigate('/recherche')}
           className="mt-sm text-sm text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer bg-transparent border-none transition-colors"
         >
-          Notebook Daten durchsuchen
+          Weitere Notebooks
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Fixed NotebooksSection link pointing to `/research` (non-existent route) → `/recherche`
- Changed link label from "Notebook Daten durchsuchen" to "Weitere Notebooks"
- The "Notebook-Daten durchsuchen" tool in ToolsSection already pointed to `/recherche` correctly — no change needed there

## Test plan
- [ ] Verify "Weitere Notebooks" link on the workplace page navigates to `/recherche`
- [ ] Verify "Notebook-Daten durchsuchen" in "Weitere Tools" still navigates to `/recherche`