### PR TITLE
fix(notebook): stabilize source filtering for Landesverband notebooks

### DIFF
--- a/apps/api/config/qdrantCollectionsSchema.ts
+++ b/apps/api/config/qdrantCollectionsSchema.ts
@@ -368,6 +368,7 @@ export const COLLECTION_SCHEMAS: Record<string, CollectionSchema> = {
       { field: 'content_type', type: 'keyword' },
       { field: 'primary_category', type: 'keyword' },
       { field: 'landesverband', type: 'keyword' },
+      { field: 'source_id', type: 'keyword' },
       { field: 'published_at', type: 'keyword' },
       { field: 'indexed_at', type: 'keyword' },
       { field: 'chunk_text', type: 'text' },

--- a/apps/api/routes/chat/agents/directSearchExecutors.ts
+++ b/apps/api/routes/chat/agents/directSearchExecutors.ts
@@ -137,32 +137,42 @@ export async function executeDirectSearch(params: {
     });
 
     if (!response.success || !response.results || response.results.length === 0) {
-      // If we had user filters, retry without them (over-filtering fallback)
+      // If we had user filters, consider retrying without them
       if (userFilter) {
-        log.info(
-          `[Direct Search] No results with filters, retrying without user filters for "${query}" in ${collection}`
-        );
-        const fallbackFilter = collectionDefault;
-        const fallbackResponse = await documentSearchService.search({
-          query,
-          userId: undefined,
-          options: {
-            limit: Math.min(limit * 2, 30),
-            mode: 'hybrid',
-            vectorWeight: searchParams.vectorWeight,
-            textWeight: searchParams.textWeight,
-            threshold: searchParams.threshold,
-            searchCollection: qdrantCollection,
-            recallLimit: searchParams.recallLimit,
-            qualityMin: searchParams.qualityMin,
-            additionalFilter: fallbackFilter,
-          },
-        });
-        if (fallbackResponse.success && fallbackResponse.results?.length > 0) {
-          log.info(
-            `[Direct Search] Fallback without filters found ${fallbackResponse.results.length} results`
+        const hasExplicitFilters = filters && Object.keys(filters).length > 0;
+        if (hasExplicitFilters) {
+          // Explicit user-selected filters (e.g. notebook source filter) — respect them
+          console.warn(
+            `[Direct Search] No results with explicit user filters for "${query}" in ${collection}. ` +
+              `NOT falling back to unfiltered search. Filters: ${JSON.stringify(filters)}`
           );
-          response = fallbackResponse;
+        } else {
+          // Auto-detected/heuristic filters — safe to retry without
+          log.info(
+            `[Direct Search] No results with auto-detected filters, retrying without for "${query}" in ${collection}`
+          );
+          const fallbackFilter = collectionDefault;
+          const fallbackResponse = await documentSearchService.search({
+            query,
+            userId: undefined,
+            options: {
+              limit: Math.min(limit * 2, 30),
+              mode: 'hybrid',
+              vectorWeight: searchParams.vectorWeight,
+              textWeight: searchParams.textWeight,
+              threshold: searchParams.threshold,
+              searchCollection: qdrantCollection,
+              recallLimit: searchParams.recallLimit,
+              qualityMin: searchParams.qualityMin,
+              additionalFilter: fallbackFilter,
+            },
+          });
+          if (fallbackResponse.success && fallbackResponse.results?.length > 0) {
+            log.info(
+              `[Direct Search] Fallback without auto-detected filters found ${fallbackResponse.results.length} results`
+            );
+            response = fallbackResponse;
+          }
         }
       }
 

--- a/apps/api/services/BaseSearchService/BaseSearchService.ts
+++ b/apps/api/services/BaseSearchService/BaseSearchService.ts
@@ -352,6 +352,7 @@ export class BaseSearchService {
           filename: this.extractDocumentFilename(chunk),
           created_at: this.extractDocumentCreatedAt(chunk),
           source_url: (chunk as any).url || undefined,
+          source_id: chunk.source_id ?? null,
           chunks: [],
           maxSimilarity: 0,
           avgSimilarity: 0,
@@ -361,6 +362,9 @@ export class BaseSearchService {
       const docData = documentMap.get(docId)!;
       if (!docData.source_url && (chunk as any).url) {
         docData.source_url = (chunk as any).url;
+      }
+      if (!docData.source_id && chunk.source_id) {
+        docData.source_id = chunk.source_id;
       }
       const chunkData = this.extractChunkData(chunk);
 
@@ -443,6 +447,7 @@ export class BaseSearchService {
         filename: doc.filename,
         created_at: doc.created_at,
         source_url: doc.source_url,
+        source_id: doc.source_id ?? null,
         relevant_content: relevantContent,
         similarity_score: enhancedScore.finalScore - noTermMatchPenalty,
         max_similarity: enhancedScore.maxSimilarity,
@@ -714,6 +719,7 @@ export class BaseSearchService {
           filename: this.extractDocumentFilename(chunk),
           created_at: this.extractDocumentCreatedAt(chunk),
           source_url: (chunk as any).url || undefined,
+          source_id: chunk.source_id ?? null,
           chunks: [],
           maxSimilarity: 0,
           avgSimilarity: 0,
@@ -730,6 +736,9 @@ export class BaseSearchService {
       const docData = documentMap.get(docId)!;
       if (!docData.source_url && (chunk as any).url) {
         docData.source_url = (chunk as any).url;
+      }
+      if (!docData.source_id && chunk.source_id) {
+        docData.source_id = chunk.source_id;
       }
       const chunkData = this.extractChunkData(chunk);
 
@@ -835,6 +844,7 @@ export class BaseSearchService {
         filename: doc.filename,
         created_at: doc.created_at,
         source_url: doc.source_url,
+        source_id: doc.source_id ?? null,
         relevant_content: relevantContent,
         similarity_score: Math.max(0, enhancedScore.finalScore - noTermMatchPenalty),
         max_similarity: enhancedScore.maxSimilarity,

--- a/apps/api/services/BaseSearchService/types.ts
+++ b/apps/api/services/BaseSearchService/types.ts
@@ -102,6 +102,7 @@ export interface TransformedChunk {
   similarity: number;
   token_count?: number;
   created_at?: string;
+  source_id?: string | null;
   documents: {
     id: string;
     title?: string;
@@ -153,6 +154,7 @@ export interface DocumentData {
   filename?: string;
   created_at?: string;
   source_url?: string;
+  source_id?: string | null;
   chunks: ChunkData[];
   maxSimilarity: number;
   avgSimilarity: number;
@@ -175,6 +177,7 @@ export interface DocumentResult {
   filename?: string;
   created_at?: string;
   source_url?: string;
+  source_id?: string | null;
   relevant_content: string;
   similarity_score: number;
   max_similarity: number;

--- a/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
+++ b/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
@@ -244,6 +244,7 @@ export async function findSimilarChunks(
     content_type: (result.payload.content_type as string) ?? null,
     page_number: (result.payload.page_number as number) ?? null,
     created_at: result.payload.created_at as string | undefined,
+    source_id: (result.payload.source_id as string) ?? null,
     url: (result.payload.source_url as string) || (result.payload.url as string) || undefined,
     documents: {
       id:
@@ -343,6 +344,7 @@ export async function findHybridChunks(
       content_type: (result.payload.content_type as string) ?? null,
       page_number: (result.payload.page_number as number) ?? null,
       created_at: result.payload.created_at as string | undefined,
+      source_id: (result.payload.source_id as string) ?? null,
       url: (result.payload.source_url as string) || (result.payload.url as string) || undefined,
       searchMethod: result.searchMethod || 'hybrid',
       originalVectorScore: result.originalVectorScore ?? null,

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -302,7 +302,7 @@ export class NotebookQAService {
     };
 
     if (Object.keys(effectiveFilters).length > 0) {
-      log.debug(`[QA Single] Subcategory filters: ${JSON.stringify(effectiveFilters)}`);
+      log.info(`[QA Single] Effective filters: ${JSON.stringify(effectiveFilters)}`);
     }
 
     // Search
@@ -327,7 +327,11 @@ export class NotebookQAService {
 
     const collectionName = systemConfig?.name || collection?.name || collectionId;
     const expanded = expandResultsToChunks(searchResults, collectionId, collectionName);
-    const deduped = deduplicateResults(expanded, false);
+
+    // Post-filter: validate results match requested source_id filter (defense-in-depth)
+    const postFiltered = this._applySourceIdPostFilter(expanded, effectiveFilters);
+
+    const deduped = deduplicateResults(postFiltered, false);
     const sorted = filterAndSortResults(deduped, { threshold: 0.35, limit: 30 });
 
     if (sorted.length === 0) {
@@ -575,7 +579,11 @@ export class NotebookQAService {
 
     const singleCollectionName = systemConfig?.name || collection?.name || collectionId;
     const expanded = expandResultsToChunks(searchResults, collectionId, singleCollectionName);
-    const deduped = deduplicateResults(expanded, false);
+
+    // Post-filter: validate results match requested source_id filter (defense-in-depth)
+    const postFiltered = this._applySourceIdPostFilter(expanded, effectiveFilters);
+
+    const deduped = deduplicateResults(postFiltered, false);
     const sortedResults = filterAndSortResults(deduped, { threshold: 0.35, limit: 30 });
 
     if (sortedResults.length === 0) {
@@ -662,15 +670,44 @@ export class NotebookQAService {
         },
       });
 
-      return expandResultsToChunks(
+      const expanded = expandResultsToChunks(
         (resp.results as unknown as Parameters<typeof expandResultsToChunks>[0]) || [],
         collectionId,
         config.name
       );
+
+      // Post-filter: validate results match requested source_id filter (defense-in-depth)
+      return this._applySourceIdPostFilter(expanded, filters);
     } catch (error: any) {
       log.error(`[QA] Search error for ${collectionId}:`, error);
       return [];
     }
+  }
+
+  /**
+   * Post-filter: validate results match requested source_id filter.
+   * Defense-in-depth — catches any leakage from Qdrant or hybrid search edge cases.
+   */
+  private _applySourceIdPostFilter(
+    results: ExpandedChunkResult[],
+    filters: RequestFilters
+  ): ExpandedChunkResult[] {
+    const sourceIdFilter = filters.source_id;
+    if (!sourceIdFilter) return results;
+
+    const allowedSourceIds: string[] = Array.isArray(sourceIdFilter)
+      ? sourceIdFilter
+      : [sourceIdFilter];
+
+    const before = results.length;
+    const filtered = results.filter((r) => !r.source_id || allowedSourceIds.includes(r.source_id));
+    if (filtered.length < before) {
+      console.warn(
+        `[NotebookQA] Post-filter removed ${before - filtered.length} results ` +
+          `not matching source_id: ${JSON.stringify(allowedSourceIds)}`
+      );
+    }
+    return filtered;
   }
 
   /**

--- a/apps/api/services/search/SearchResultProcessor.ts
+++ b/apps/api/services/search/SearchResultProcessor.ts
@@ -42,6 +42,7 @@ export function expandResultsToChunks(
         expanded.push({
           document_id: docId,
           source_url: sourceUrl,
+          source_id: r.source_id ?? null,
           title,
           snippet: chunk.preview || '',
           filename: r.filename || null,
@@ -56,6 +57,7 @@ export function expandResultsToChunks(
       expanded.push({
         document_id: docId,
         source_url: sourceUrl,
+        source_id: r.source_id ?? null,
         title,
         snippet: r.relevant_content || r.chunk_text || '',
         filename: r.filename || null,

--- a/apps/api/services/search/types.ts
+++ b/apps/api/services/search/types.ts
@@ -111,6 +111,7 @@ export interface SearchResultInput {
   source_url?: string;
   url?: string;
   document_id?: string;
+  source_id?: string | null;
   similarity_score?: number;
   relevant_content?: string;
   chunk_text?: string;
@@ -120,6 +121,7 @@ export interface SearchResultInput {
 export interface ExpandedChunkResult {
   document_id: string;
   source_url: string | null;
+  source_id?: string | null;
   title: string;
   snippet: string;
   filename: string | null;


### PR DESCRIPTION
## Summary

- **Add `source_id` keyword index** to `landesverbaende_documents` Qdrant schema — all LV share one collection, filtering by `source_id` was unindexed causing unreliable match filtering in hybrid search
- **Guard fallback retry** in `directSearchExecutors.ts` — when explicit user-selected filters (notebook UI) yield 0 results, no longer silently retries without filters (which leaked results from other sources)
- **Propagate `source_id`** through entire search result pipeline (`TransformedChunk` → `DocumentData` → `DocumentResult` → `ExpandedChunkResult`) to enable downstream validation
- **Defense-in-depth post-filter** in `NotebookQAService` — validates all returned results match the requested `source_id` filter, with `console.warn` when leaking results are caught

## Test plan

- [ ] In Berlin notebook, select only "LV Wahlprogramm" → ask a question → verify all results are wahlprogramm, zero beschluss/presse
- [ ] Select "LV Wahlprogramm" → ask a topic unlikely to match → verify 0 results (not fallback from other sources)
- [ ] Check backend logs for `[NotebookQA] Post-filter removed` warnings (should be absent when Qdrant filter works correctly)
- [ ] Verify `source_id` index is created on next `ensureCollections()` run (check Qdrant dashboard)