### PR TITLE
fix(notebook): stabilize source filtering for Landesverband notebooks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1713,6 +1713,9 @@ importers:
 
   services/hocuspocus:
     dependencies:
+      '@gruenerator/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@hocuspocus/extension-logger':
         specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
@@ -30782,9 +30785,7 @@ snapshots:
       metro-runtime: 0.83.5
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89':


### PR DESCRIPTION
## Summary

- **Add `source_id` keyword index** to `landesverbaende_documents` Qdrant schema — all LV share one collection, filtering by `source_id` was unindexed causing unreliable match filtering in hybrid search
- **Guard fallback retry** in `directSearchExecutors.ts` — when explicit user-selected filters (notebook UI) yield 0 results, no longer silently retries without filters (which leaked results from other sources)
- **Propagate `source_id`** through entire search result pipeline (`TransformedChunk` → `DocumentData` → `DocumentResult` → `ExpandedChunkResult`) to enable downstream validation
- **Defense-in-depth post-filter** in `NotebookQAService` — validates all returned results match the requested `source_id` filter, with `console.warn` when leaking results are caught
- **Fix pre-existing lockfile mismatch** for `services/hocuspocus` shared dependency

## Test plan

- [ ] In Berlin notebook, select only "LV Wahlprogramm" → ask a question → verify all results are wahlprogramm, zero beschluss/presse
- [ ] Select "LV Wahlprogramm" → ask a topic unlikely to match → verify 0 results (not fallback from other sources)
- [ ] Check backend logs for `[NotebookQA] Post-filter removed` warnings (should be absent when Qdrant filter works correctly)
- [ ] Verify `source_id` index is created on next `ensureCollections()` run