### PR TITLE
fix(auth): correct Better Auth UUID generation

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -6,6 +6,7 @@ import pg from 'pg';
 import { loadConfig } from '../database/services/PostgresService/config.js';
 import { mobileTokenExchange } from '../plugins/mobileTokenExchange.js';
 import { redisClient } from '../utils/redis/client.js';
+import { createLogger } from '../utils/logger.js';
 
 const KC_BASE = process.env.KEYCLOAK_BASE_URL || 'https://user.netzbegruenung.de';
 const KC_REALM = process.env.KEYCLOAK_REALM || 'gruenerator';
@@ -31,6 +32,8 @@ function keycloakProvider(id: string, idpHint: string, locale: 'de-DE' | 'de-AT'
     }),
   };
 }
+
+const log = createLogger('BetterAuth');
 
 const pgConfig = loadConfig();
 const pool = new pg.Pool(pgConfig);
@@ -183,10 +186,42 @@ export const auth = betterAuth({
       ipAddressHeaders: ['x-forwarded-for', 'x-real-ip'],
     },
     cookiePrefix: 'ba',
-    generateId: false,
+    database: {
+      generateId: false,
+    },
     crossSubDomainCookies: {
       enabled: true,
       domain: process.env.NODE_ENV === 'production' ? '.gruenerator.eu' : undefined,
+    },
+  },
+
+  databaseHooks: {
+    user: {
+      create: {
+        before: async (user) => {
+          log.info(`[Auth] Creating user: email=${user.email}, name=${user.name}`);
+          return { data: user };
+        },
+        after: async (user) => {
+          log.info(`[Auth] User created: id=${user.id}, email=${user.email}`);
+        },
+      },
+    },
+    session: {
+      create: {
+        before: async (session) => {
+          log.info(`[Auth] Creating session for user_id=${session.userId}`);
+          return { data: session };
+        },
+      },
+    },
+    account: {
+      create: {
+        before: async (account) => {
+          log.info(`[Auth] Linking account: provider=${account.providerId}, accountId=${account.accountId}, userId=${account.userId}`);
+          return { data: account };
+        },
+      },
     },
   },
 

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -551,7 +551,11 @@ async function startWorker(): Promise<void> {
     });
 
     if (req.path.startsWith('/api/auth/v2/')) {
-      log.warn(`[BetterAuth] Error on ${req.path}: ${err.message}`);
+      log.error(`[BetterAuth] Error on ${req.path}: ${err.message}`, {
+        stack: err.stack,
+        query: req.query,
+        params: req.params,
+      });
       res.redirect('/auth/login?error=auth_failed');
       return;
     }


### PR DESCRIPTION
## Summary
- **Fix login error** `unable_to_create_user`: Move `generateId: false` from `advanced.generateId` to `advanced.database.generateId` so Better Auth lets PostgreSQL generate UUIDs instead of inserting random base62 strings
- **Add auth logging**: `databaseHooks` on user/session/account creation for traceability, and improved error handler with stack traces for Better Auth routes

## Root Cause
Better Auth's `create-context.mjs` checks `advanced.generateId` only if it's a **function**. When set to `false` at the top level, it falls through to the default random string generator, producing IDs like `CS5ov1zBaTllf609dMnjzzO8UTS1GKtN` which PostgreSQL rejects because `profiles.id` is `UUID`.

Production error:
```
ERROR [Better Auth]: error: invalid input syntax for type uuid: "CS5ov1zBaTllf609dMnjzzO8UTS1GKtN"
```

## Test plan
- [ ] Deploy to test environment
- [ ] Test login with Netzbegrünung account
- [ ] Test login with Grünes Netz account
- [ ] Verify new user creation works (new UUID in profiles table)
- [ ] Verify existing user login works (session creation)
- [ ] Check API logs for new `[Auth]` log lines