### PR TITLE
fix(auth): add DEFAULT to ba_* table id columns

### DIFF
--- a/apps/api/database/postgres/migrations/fix_better_auth_id_defaults.sql
+++ b/apps/api/database/postgres/migrations/fix_better_auth_id_defaults.sql
@@ -1,0 +1,7 @@
+-- Fix Better Auth ID defaults
+-- The ba_* tables were created without DEFAULT on their id columns,
+-- but generateId: false delegates ID generation to the database.
+
+ALTER TABLE ba_accounts ALTER COLUMN id SET DEFAULT gen_random_uuid()::TEXT;
+ALTER TABLE ba_sessions ALTER COLUMN id SET DEFAULT gen_random_uuid()::TEXT;
+ALTER TABLE ba_verification ALTER COLUMN id SET DEFAULT gen_random_uuid()::TEXT;


### PR DESCRIPTION
## Summary
- Adds `DEFAULT gen_random_uuid()::TEXT` to `ba_accounts`, `ba_sessions`, and `ba_verification` id columns
- Fixes null constraint violation that blocks all new user logins since `generateId: false` delegates ID generation to PostgreSQL

## Test plan
- [ ] Restart API server, confirm migration applies (`1 pending` → `complete`)
- [ ] Log in via Keycloak — account linking should succeed without null constraint errors
- [ ] Verify: `SELECT id FROM ba_accounts ORDER BY created_at DESC LIMIT 5` — all non-null