### PR TITLE
fix(docker): add packages/shared to hocuspocus Docker build

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -139,6 +139,7 @@ jobs:
               - 'packages/wolke/**'
             hocuspocus:
               - 'services/hocuspocus/**'
+              - 'packages/shared/**'
             mcp:
               - 'services/mcp/**'
               - 'packages/shared/**'

--- a/services/hocuspocus/Dockerfile
+++ b/services/hocuspocus/Dockerfile
@@ -13,12 +13,14 @@ WORKDIR /app
 # Copy workspace config
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY services/hocuspocus/package.json ./services/hocuspocus/
+COPY packages/shared/package.json ./packages/shared/
 
 # Install dependencies
 RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --filter @gruenerator/hocuspocus...
 
 # Copy source and compile
+COPY packages/shared ./packages/shared
 COPY services/hocuspocus ./services/hocuspocus
 
 WORKDIR /app/services/hocuspocus
@@ -54,6 +56,7 @@ COPY --from=builder --chown=gruenerator:gruenerator /app/pnpm-lock.yaml ./
 
 # Copy package.json for workspace structure
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/hocuspocus/package.json ./services/hocuspocus/
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/package.json ./packages/shared/
 
 # Switch to non-root user before install (files written as gruenerator, no chown needed)
 USER gruenerator
@@ -62,8 +65,9 @@ USER gruenerator
 RUN --mount=type=cache,id=pnpm-prod,target=/home/gruenerator/.local/share/pnpm/store \
     pnpm install --prod --frozen-lockfile --filter @gruenerator/hocuspocus
 
-# Copy compiled server
+# Copy compiled server and workspace dependencies
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/hocuspocus/dist ./services/hocuspocus/dist
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared ./packages/shared
 
 # Set working directory
 WORKDIR /app/services/hocuspocus


### PR DESCRIPTION
## Summary
- Hocuspocus Docker build fails because `htmlToYjsXml.ts` imports `stripHtmlTags` from `@gruenerator/shared/utils` but `packages/shared` was never copied into the Docker context
- Adds `packages/shared` to both builder (for tsc) and production (for runtime require) stages
- Adds `packages/shared/**` to hocuspocus path filter in CI so shared changes trigger a rebuild

## Test plan
- [ ] Verify `build-hocuspocus` job passes on this PR
- [ ] Verify hocuspocus container starts and healthcheck passes