### PR TITLE
fix(ci): trigger Docker rebuilds on lockfile changes

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -123,13 +123,16 @@ jobs:
               - 'packages/ui/**'
               - 'packages/collab/**'
               - 'packages/wolke/**'
+              - 'pnpm-lock.yaml'
             api:
               - 'apps/api/**'
               - 'packages/shared/**'
+              - 'pnpm-lock.yaml'
             sites:
               - 'apps/sites/**'
               - 'packages/shared/**'
               - 'packages/sites-design/**'
+              - 'pnpm-lock.yaml'
             docs:
               - 'apps/docs/**'
               - 'packages/shared/**'
@@ -137,12 +140,15 @@ jobs:
               - 'packages/collab/**'
               - 'packages/ui/**'
               - 'packages/wolke/**'
+              - 'pnpm-lock.yaml'
             hocuspocus:
               - 'services/hocuspocus/**'
               - 'packages/shared/**'
+              - 'pnpm-lock.yaml'
             mcp:
               - 'services/mcp/**'
               - 'packages/shared/**'
+              - 'pnpm-lock.yaml'
             gruen-o-mat:
               - 'apps/gruen-o-mat/**'
               - 'packages/chat/**'
@@ -150,6 +156,7 @@ jobs:
               - 'packages/shared/**'
               - 'packages/ui/**'
               - 'packages/collab/**'
+              - 'pnpm-lock.yaml'
             voxtral:
               - 'services/voxtral/**'
             nlp:


### PR DESCRIPTION
## Summary
- Adds `pnpm-lock.yaml` to all service path filters in `build-images.yml`
- Without this, lockfile-only changes (like `pnpm dedupe`) don't trigger Docker rebuilds
- This caused PR #607's fix to not actually deploy — the build completed in 27s with all jobs skipped

## Test plan
- [ ] Verify a lockfile-only commit triggers `build-web` and other service builds