### PR TITLE
chore: debug notebook filter pipeline

### DIFF
--- a/apps/api/routes/chat/notebookStreamController.ts
+++ b/apps/api/routes/chat/notebookStreamController.ts
@@ -46,6 +46,8 @@ router.post('/', async (req, res) => {
     threadId: existingThreadId,
   } = req.body;
 
+  console.log('[NotebookController] 🔍 req.body.filters:', JSON.stringify(filters));
+
   const lastUserMessage = Array.isArray(messages)
     ? messages.filter((m: { role: string }) => m.role === 'user').pop()
     : null;

--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -125,6 +125,11 @@ export async function handleNotebookStream(
 
     sse.send('search_start', { message: 'Suche in Dokumenten...' });
 
+    console.log(
+      '[NotebookStreamCore] 🔍 filters passed to getSearchContext:',
+      JSON.stringify(filters)
+    );
+
     let searchContext: SearchContext | null;
     try {
       searchContext = await notebookQAService.getSearchContext({

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -430,6 +430,15 @@ export class NotebookQAService {
       throw new Error('Question is required');
     }
 
+    console.log(
+      '[NotebookQA] 🔍 getSearchContext requestFilters:',
+      JSON.stringify(requestFilters),
+      'collectionId:',
+      collectionId,
+      'collectionIds:',
+      collectionIds
+    );
+
     const isMulti = !!collectionIds && collectionIds.length > 0;
 
     if (isMulti) {

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -139,6 +139,9 @@ export function createNotebookModelAdapter(
         ...config.extraParams,
       };
 
+      console.debug('[Notebook] 🔍 config.filters:', JSON.stringify(config.filters));
+      console.debug('[Notebook] 🔍 payload.filters:', JSON.stringify(payload.filters));
+
       const { fetch: configFetch } = useChatConfigStore.getState();
       const endpoint = config.endpoint || '/api/chat-service/notebook/stream';
       const c0 = performance.now();


### PR DESCRIPTION
## Summary
- Adds temporary debug logs at 4 points in the notebook filter pipeline to trace why user-selected category filters (e.g. "LV Wahlprogramm" in Berlin notebook) are not reaching the Qdrant query
- Logs in: frontend adapter, backend controller, stream core, and QA service

## Context
When selecting a category filter in the notebook UI, the Qdrant query only shows the default `landesverband` filter — the user-selected `source_id` filter is missing.

## Test plan
- [ ] Select "LV Wahlprogramm" filter in Berlin notebook
- [ ] Send a query
- [ ] Check browser console for `[Notebook] 🔍` lines
- [ ] Check API logs for `[NotebookController]`, `[NotebookStreamCore]`, `[NotebookQA]` lines
- [ ] Identify where filters drop to `undefined`