### PR TITLE
fix: notebook category filters not applied to search queries

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -183,7 +183,9 @@ const NotebookPageContent = ({
     return {};
   }, [config.useSystemUserId, config.systemUserId]);
 
-  const filters = useMemo(() => {
+  // Getter that reads filters directly from the Zustand store at call time,
+  // bypassing React's render pipeline which can produce stale values
+  const getFilters = useCallback((): Record<string, unknown> | undefined => {
     if (isMulti) {
       const aggregated: Record<string, unknown> = {};
       selectedCollections.forEach((c) => {
@@ -194,7 +196,7 @@ const NotebookPageContent = ({
     }
     const f = getFiltersForCollection(selectedCollections[0]?.id);
     return Object.keys(f).length > 0 ? f : undefined;
-  }, [isMulti, selectedCollections, getFiltersForCollection, activeFiltersStore]);
+  }, [isMulti, selectedCollections, getFiltersForCollection]);
 
   const { initialMessages, onComplete } = useNotebookChatBridge({
     collections: selectedCollections,
@@ -283,7 +285,7 @@ const NotebookPageContent = ({
     <NotebookChatProvider
       collections={providerCollections}
       locale={locale}
-      filters={filters}
+      getFilters={getFilters}
       extraParams={extraParams}
       initialMessages={initialMessages}
       onComplete={onComplete as (metadata: NotebookMessageMetadata) => void}

--- a/packages/chat/src/runtime/NotebookChatProvider.tsx
+++ b/packages/chat/src/runtime/NotebookChatProvider.tsx
@@ -26,6 +26,8 @@ export interface NotebookChatProviderProps {
   collections: NotebookCollection[];
   locale?: string;
   filters?: Record<string, unknown>;
+  /** Getter that reads filters directly from the store at request time — bypasses React render pipeline */
+  getFilters?: () => Record<string, unknown> | undefined;
   extraParams?: Record<string, unknown>;
   initialMessages?: readonly ThreadMessageLike[];
   onComplete?: (metadata: NotebookMessageMetadata) => void;
@@ -51,6 +53,7 @@ function NotebookChatProviderInner({
   collections,
   locale,
   filters,
+  getFilters,
   extraParams,
   initialMessages,
   onComplete,
@@ -63,6 +66,12 @@ function NotebookChatProviderInner({
   const isMulti = collections.length > 1;
   // Use a ref for threadId so adapter is not recreated when it changes mid-conversation
   const threadIdRef = useRef<string | null>(initialThreadId || null);
+  // Use a ref for getFilters so adapter reads latest filters directly from store at request time
+  const getFiltersRef = useRef(getFilters);
+  getFiltersRef.current = getFilters;
+  // Keep filters ref as fallback for consumers that pass static filters prop
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
 
   const handleThreadCreated = useCallback(
     (newThreadId: string) => {
@@ -78,7 +87,7 @@ function NotebookChatProviderInner({
         ? { collectionIds: collections.map((c) => c.id) }
         : { collectionId: collections[0]?.id }),
       collectionLinkType: isMulti ? 'url' : collections[0]?.linkType,
-      filters,
+      filters: getFiltersRef.current?.() ?? filtersRef.current,
       locale,
       extraParams,
       mode,
@@ -86,7 +95,7 @@ function NotebookChatProviderInner({
       documentIds,
       threadId: threadIdRef.current,
     }),
-    [collections, isMulti, filters, locale, extraParams, mode, endpoint, documentIds]
+    [collections, isMulti, locale, extraParams, mode, endpoint, documentIds]
   );
 
   const onCompleteRef = useRef(onComplete);


### PR DESCRIPTION
## Summary
- Fixes notebook category filters (e.g. "LV Wahlprogramm" in Berlin notebook) being silently dropped — never reaching the backend search query
- Root cause: React's render pipeline produced stale filter values due to `useSyncExternalStore` snapshot vs live Zustand store state divergence during batched renders
- Fix: pass a `getFilters` callback that reads directly from the Zustand store at request time, bypassing `useMemo`/props/refs entirely

## Changes
- `NotebookChatProvider`: added `getFilters` callback prop, adapter calls it at request time via ref
- `NotebookPage`: replaced `filters` useMemo with stable `getFilters` useCallback (no `activeFiltersStore` dependency needed)
- Backwards compatible: static `filters` prop still works as fallback

## Test plan
- [ ] Open Berlin notebook → select "LV Wahlprogramm" filter → send query
- [ ] Verify results are scoped to Wahlprogramm documents only (fewer citations)
- [ ] Verify multi-collection notebooks (e.g. Grundsatz) still work without filters
- [ ] Verify date range filters still work