### PR TITLE
refactor: unified rerank pipeline with score normalization

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -1,37 +1,38 @@
 /**
  * Rerank Node
  *
- * Uses Regolo's dedicated Rerank API (Qwen3-Reranker-4B cross-encoder)
+ * Uses the shared rerankPipeline (Regolo cross-encoder + MMR diversity)
  * to rerank search results by semantic relevance. Sits between the search
  * and respond nodes in the graph pipeline.
  *
- * After cross-encoder scoring, applies MMR diversity filtering to reduce
- * redundancy in the final result set.
+ * Adds source-type tags so the cross-encoder can leverage provenance info.
  */
 
-import { applyMMR } from '../../../../services/search/DiversityReranker.js';
-import { regoloRerankService } from '../../../../services/search/RegoloRerankService.js';
+import { vectorConfig } from '../../../../config/vectorConfig.js';
+import { rerankPipeline, type RerankableItem } from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
 
-import type { ChatGraphState, SearchResult } from '../types.js';
+import type { ChatGraphState } from '../types.js';
 
 const log = createLogger('ChatGraph:Rerank');
 
-const RERANK_INPUT_LIMIT = 12;
-const RERANK_OUTPUT_LIMIT = 8;
+function getSourceTag(source: string): string {
+  if (source.startsWith('gruenerator:')) return 'Parteidokument';
+  if (source.startsWith('document')) return 'Nutzerdokument';
+  if (source === 'web') return 'Web';
+  if (source === 'examples') return 'Beispiel';
+  if (source === 'research') return 'Recherche';
+  return 'Quelle';
+}
 
-/**
- * Rerank search results using Regolo's cross-encoder reranker.
- * Applies MMR diversity filtering as a second pass.
- */
 export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGraphState>> {
   const startTime = Date.now();
   const { searchResults, searchQuery, hasTemporal, researchBrief } = state;
+  const rerankCfg = vectorConfig.get('rerank');
 
-  // Notebook-scoped searches get higher limits for deeper recall
   const isNotebookScoped = (state.notebookCollectionIds?.length ?? 0) > 0;
-  const inputLimit = isNotebookScoped ? 20 : RERANK_INPUT_LIMIT;
-  const outputLimit = isNotebookScoped ? 12 : RERANK_OUTPUT_LIMIT;
+  const inputLimit = isNotebookScoped ? 20 : rerankCfg.inputLimit;
+  const outputLimit = isNotebookScoped ? 12 : rerankCfg.outputLimit;
 
   if (searchResults.length <= 2) {
     log.info(`[Rerank] Skipping — only ${searchResults.length} results`);
@@ -44,54 +45,40 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
     `[Rerank] Reranking ${candidates.length} results for query: "${searchQuery?.slice(0, 50)}..."`
   );
 
-  try {
-    const documents = candidates.map((r) => `${r.title}\n${r.content.slice(0, 300)}`);
+  const baseInstruct = 'Given a search query, retrieve relevant passages that answer the query.';
+  const sourceHint = ' Prefer official party documents and verified sources over web snippets.';
+  const temporalHint = hasTemporal ? ' Prefer recent sources.' : '';
+  const instruct = `${baseInstruct}${sourceHint}${temporalHint}`;
 
-    const instruct = hasTemporal
-      ? 'Given a search query, retrieve relevant and current passages that answer the query. Prefer recent sources.'
-      : undefined;
+  const queryStr = researchBrief ? `${searchQuery}\n${researchBrief}` : searchQuery || '';
 
-    const queryStr = researchBrief ? `${searchQuery}\n${researchBrief}` : searchQuery || '';
+  const items: RerankableItem[] = candidates.map((r) => ({
+    title: r.title,
+    content: r.content.slice(0, 300),
+    source: r.source,
+    relevance: r.relevance,
+  }));
 
-    const rerankResults = await regoloRerankService.rerank({
-      query: queryStr,
-      documents,
-      topN: inputLimit,
-      instruct,
-    });
+  const { rankedIndices, scores, rerankTimeMs } = await rerankPipeline({
+    query: queryStr,
+    items,
+    inputLimit,
+    outputLimit,
+    instruct,
+    sourceTagFn: (item) => getSourceTag(item.source || ''),
+  });
 
-    const rerankTimeMs = Date.now() - startTime;
+  const reranked = rankedIndices.map((i) => ({
+    ...candidates[i],
+    relevance: scores.get(i) ?? candidates[i].relevance ?? 0.5,
+  }));
 
-    // Map scores back onto SearchResult objects
-    const scoreMap = new Map<number, number>();
-    for (const r of rerankResults) {
-      scoreMap.set(r.originalIndex, r.relevanceScore);
-    }
+  log.info(
+    `[Rerank] Complete: ${candidates.length} → ${reranked.length} results (diversity applied) in ${rerankTimeMs}ms`
+  );
 
-    const scoredResults: SearchResult[] = candidates.map((r, i) => ({
-      ...r,
-      relevance: scoreMap.get(i) ?? r.relevance ?? 0.5,
-    }));
-
-    scoredResults.sort((a, b) => (b.relevance || 0) - (a.relevance || 0));
-
-    // Filter out low-relevance results
-    const filtered = scoredResults.filter((r) => (r.relevance || 0) > 0.2);
-
-    // Apply MMR diversity reranking as second pass
-    const diverse = filtered.length > 3 ? applyMMR(filtered, 0.7, 2) : filtered;
-    const reranked = diverse.slice(0, outputLimit);
-
-    log.info(
-      `[Rerank] Complete: ${candidates.length} → ${reranked.length} results (diversity applied) in ${rerankTimeMs}ms`
-    );
-
-    return {
-      searchResults: reranked,
-      rerankTimeMs,
-    };
-  } catch (error: any) {
-    log.error('[Rerank] Error:', error.message);
-    return { rerankTimeMs: Date.now() - startTime };
-  }
+  return {
+    searchResults: reranked,
+    rerankTimeMs,
+  };
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -9,7 +9,11 @@
  */
 
 import { vectorConfig } from '../../../../config/vectorConfig.js';
-import { rerankPipeline, type RerankableItem } from '../../../../services/search/rerankPipeline.js';
+import {
+  DEFAULT_RELEVANCE,
+  rerankPipeline,
+  type RerankableItem,
+} from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
 
 import type { ChatGraphState } from '../types.js';
@@ -70,7 +74,7 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
 
   const reranked = rankedIndices.map((i) => ({
     ...candidates[i],
-    relevance: scores.get(i) ?? candidates[i].relevance ?? 0.5,
+    relevance: scores.get(i) ?? candidates[i].relevance ?? DEFAULT_RELEVANCE,
   }));
 
   log.info(

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -15,17 +15,16 @@ import {
   type RerankableItem,
 } from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
-
-import type { ChatGraphState } from '../types.js';
+import { SOURCE_PREFIX, type ChatGraphState } from '../types.js';
 
 const log = createLogger('ChatGraph:Rerank');
 
 function getSourceTag(source: string): string {
-  if (source.startsWith('gruenerator:')) return 'Parteidokument';
-  if (source.startsWith('document')) return 'Nutzerdokument';
-  if (source === 'web') return 'Web';
-  if (source === 'examples') return 'Beispiel';
-  if (source === 'research') return 'Recherche';
+  if (source.startsWith(SOURCE_PREFIX.GRUENERATOR)) return 'Parteidokument';
+  if (source.startsWith(SOURCE_PREFIX.DOCUMENT)) return 'Nutzerdokument';
+  if (source === SOURCE_PREFIX.WEB) return 'Web';
+  if (source === SOURCE_PREFIX.EXAMPLES) return 'Beispiel';
+  if (source === SOURCE_PREFIX.RESEARCH) return 'Recherche';
   return 'Quelle';
 }
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -5,6 +5,7 @@
  * Uses the direct search functions from the chat agents module.
  */
 
+import { vectorConfig } from '../../../../config/vectorConfig.js';
 import {
   executeDirectSearch,
   // executeDirectPersonSearch, // DISABLED: Person search not production ready
@@ -203,10 +204,40 @@ export async function executeWebSearchParallel(
 }
 
 /**
+ * Normalize relevance scores across source types to a comparable [0, 1] scale.
+ *
+ * Documents: uses raw similarityScore (from Qdrant hybrid search) when available,
+ * avoiding the lossy text-label mapping (0.5/0.7/0.9).
+ * Web: compresses rank-decay scores with a configurable ceiling so web results
+ * don't dominate over high-quality docs before the cross-encoder runs.
+ */
+export function normalizeScore(r: SearchResult): number {
+  const { webScoreCeiling } = vectorConfig.get('rerank');
+
+  if (r.similarityScore != null && r.source.startsWith('gruenerator:')) {
+    return Math.min(1.0, r.similarityScore * 1.05);
+  }
+
+  if (r.source.startsWith('document')) {
+    return r.relevance ?? 0.5;
+  }
+
+  if (r.source === 'web') {
+    const raw = r.relevance ?? 0.5;
+    return Math.min(webScoreCeiling, raw * webScoreCeiling);
+  }
+
+  return r.relevance ?? 0.5;
+}
+
+/**
  * Merge results from multiple search sources, deduplicating by URL.
- * Returns top results sorted by relevance for the reranker.
+ * Normalizes scores across source types before sorting so the cross-encoder
+ * receives a fair set of candidates. Over-fetches (default 16) to give the
+ * reranker more candidates — inspired by SurfSense's 2x retrieval pattern.
  */
 export function mergeSearchResults(...resultSets: SearchResult[][]): SearchResult[] {
+  const { mergeOverfetch } = vectorConfig.get('rerank');
   const seenUrls = new Set<string>();
   const merged: SearchResult[] = [];
 
@@ -214,12 +245,12 @@ export function mergeSearchResults(...resultSets: SearchResult[][]): SearchResul
     for (const r of results) {
       if (r.url && seenUrls.has(r.url)) continue;
       if (r.url) seenUrls.add(r.url);
-      merged.push(r);
+      merged.push({ ...r, relevance: normalizeScore(r) });
     }
   }
 
   merged.sort((a, b) => (b.relevance || 0) - (a.relevance || 0));
-  return merged.slice(0, 12);
+  return merged.slice(0, mergeOverfetch);
 }
 
 /**

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../routes/chat/agents/directSearch.js';
 import { selectAndCrawlTopUrls } from '../../../../services/search/CrawlingService.js';
 import { expandQuery } from '../../../../services/search/QueryExpansionService.js';
+import { DEFAULT_RELEVANCE } from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
 
 import {
@@ -219,15 +220,15 @@ export function normalizeScore(r: SearchResult): number {
   }
 
   if (r.source.startsWith('document')) {
-    return r.relevance ?? 0.5;
+    return r.relevance ?? DEFAULT_RELEVANCE;
   }
 
   if (r.source === 'web') {
-    const raw = r.relevance ?? 0.5;
+    const raw = r.relevance ?? DEFAULT_RELEVANCE;
     return Math.min(webScoreCeiling, raw * webScoreCeiling);
   }
 
-  return r.relevance ?? 0.5;
+  return r.relevance ?? DEFAULT_RELEVANCE;
 }
 
 /**

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -17,6 +17,13 @@ import { selectAndCrawlTopUrls } from '../../../../services/search/CrawlingServi
 import { expandQuery } from '../../../../services/search/QueryExpansionService.js';
 import { DEFAULT_RELEVANCE } from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
+import {
+  SOURCE_PREFIX,
+  type ChatGraphState,
+  type SearchResult,
+  type SearchSource,
+  type Citation,
+} from '../types.js';
 
 import {
   COLLECTION_LABELS,
@@ -29,7 +36,6 @@ import {
 
 import type { SubcategoryFilters } from '../../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../../routes/chat/agents/types.js';
-import type { ChatGraphState, SearchResult, SearchSource, Citation } from '../types.js';
 
 // Re-export for backward compatibility and reuse by SearchGraph
 export {
@@ -42,19 +48,6 @@ export {
 };
 
 const log = createLogger('ChatGraph:Search');
-
-/**
- * Convert various search result formats to unified SearchResult structure.
- */
-function normalizeResults(results: any[], source: string): SearchResult[] {
-  return results.map((r: any, i: number) => ({
-    source,
-    title: r.title || r.name || r.source || 'Unknown',
-    content: r.content || r.snippet || r.excerpt || r.text || '',
-    url: r.url || r.source_url || undefined,
-    relevance: r.relevance || r.score || r.similarity || 1 - i * 0.1,
-  }));
-}
 
 /**
  * Return default Qdrant collections based on user locale.
@@ -215,15 +208,15 @@ export async function executeWebSearchParallel(
 export function normalizeScore(r: SearchResult): number {
   const { webScoreCeiling } = vectorConfig.get('rerank');
 
-  if (r.similarityScore != null && r.source.startsWith('gruenerator:')) {
+  if (r.similarityScore != null && r.source.startsWith(SOURCE_PREFIX.GRUENERATOR)) {
     return Math.min(1.0, r.similarityScore * 1.05);
   }
 
-  if (r.source.startsWith('document')) {
+  if (r.source.startsWith(SOURCE_PREFIX.DOCUMENT)) {
     return r.relevance ?? DEFAULT_RELEVANCE;
   }
 
-  if (r.source === 'web') {
+  if (r.source === SOURCE_PREFIX.WEB) {
     const raw = r.relevance ?? DEFAULT_RELEVANCE;
     return Math.min(webScoreCeiling, raw * webScoreCeiling);
   }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.vitest.ts
@@ -1,0 +1,200 @@
+/**
+ * SearchNode Unit Tests — normalizeScore + mergeSearchResults
+ *
+ * Tests the score normalization and cross-source merge logic that feeds
+ * candidates into the rerank pipeline. These are pure functions (aside
+ * from vectorConfig reads).
+ *
+ * Run with: pnpm --filter @gruenerator/api test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../config/vectorConfig.js', () => ({
+  vectorConfig: {
+    get: vi.fn(() => ({
+      inputLimit: 16,
+      outputLimit: 8,
+      minRelevance: 0.2,
+      mmrLambda: 0.7,
+      mmrKeepTop: 2,
+      mergeOverfetch: 16,
+      webScoreCeiling: 0.8,
+    })),
+  },
+}));
+
+vi.mock('../../../../routes/chat/agents/directSearch.js', () => ({}));
+vi.mock('../../../../services/search/CrawlingService.js', () => ({}));
+vi.mock('../../../../services/search/QueryExpansionService.js', () => ({}));
+vi.mock('../../../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+vi.mock('./citationUtils.js', () => ({
+  COLLECTION_LABELS: {},
+  CONTENT_TYPE_LABELS: {},
+  buildCitations: vi.fn(() => []),
+  deriveCitationTitle: vi.fn(() => 'Title'),
+  extractDomain: vi.fn(() => 'example.com'),
+  resolveCollectionName: vi.fn(() => 'collection'),
+}));
+
+import { normalizeScore, mergeSearchResults } from './searchNode.js';
+
+import type { SearchResult } from '../types.js';
+
+function makeResult(overrides: Partial<SearchResult> & { source: string }): SearchResult {
+  return {
+    title: 'Test',
+    content: 'Test content',
+    ...overrides,
+  };
+}
+
+describe('normalizeScore', () => {
+  it('prefers similarityScore for gruenerator docs', () => {
+    const r = makeResult({
+      source: 'gruenerator:deutschland',
+      relevance: 0.7,
+      similarityScore: 0.79,
+    });
+    const score = normalizeScore(r);
+    expect(score).toBeCloseTo(0.79 * 1.05, 2);
+  });
+
+  it('falls back to relevance when similarityScore is missing', () => {
+    const r = makeResult({
+      source: 'gruenerator:deutschland',
+      relevance: 0.7,
+    });
+    const score = normalizeScore(r);
+    expect(score).toBe(0.7);
+  });
+
+  it('caps similarityScore at 1.0', () => {
+    const r = makeResult({
+      source: 'gruenerator:deutschland',
+      similarityScore: 0.99,
+    });
+    const score = normalizeScore(r);
+    expect(score).toBeLessThanOrEqual(1.0);
+  });
+
+  it('caps web scores at webScoreCeiling', () => {
+    const r = makeResult({
+      source: 'web',
+      relevance: 1.0,
+    });
+    const score = normalizeScore(r);
+    expect(score).toBe(0.8);
+  });
+
+  it('compresses web scores proportionally', () => {
+    const r = makeResult({
+      source: 'web',
+      relevance: 0.5,
+    });
+    const score = normalizeScore(r);
+    expect(score).toBeCloseTo(0.5 * 0.8, 2);
+  });
+
+  it('preserves examples scores', () => {
+    const r = makeResult({
+      source: 'examples',
+      relevance: 0.8,
+    });
+    expect(normalizeScore(r)).toBe(0.8);
+  });
+
+  it('preserves document-scoped search scores', () => {
+    const r = makeResult({
+      source: 'document:abc123',
+      relevance: 0.65,
+    });
+    expect(normalizeScore(r)).toBe(0.65);
+  });
+
+  it('defaults to 0.5 when no relevance', () => {
+    const r = makeResult({ source: 'unknown' });
+    expect(normalizeScore(r)).toBe(0.5);
+  });
+});
+
+describe('mergeSearchResults', () => {
+  it('deduplicates by URL', () => {
+    const set1: SearchResult[] = [
+      makeResult({ source: 'web', url: 'https://a.com', relevance: 0.8 }),
+    ];
+    const set2: SearchResult[] = [
+      makeResult({ source: 'web', url: 'https://a.com', relevance: 0.9 }),
+    ];
+    const merged = mergeSearchResults(set1, set2);
+    expect(merged.length).toBe(1);
+  });
+
+  it('keeps results without URLs (no dedup)', () => {
+    const set1: SearchResult[] = [
+      makeResult({ source: 'examples', relevance: 0.8 }),
+      makeResult({ source: 'examples', relevance: 0.7 }),
+    ];
+    const merged = mergeSearchResults(set1);
+    expect(merged.length).toBe(2);
+  });
+
+  it('returns up to mergeOverfetch (16)', () => {
+    const results: SearchResult[] = Array.from({ length: 20 }, (_, i) =>
+      makeResult({ source: 'web', url: `https://example.com/${i}`, relevance: 0.5 })
+    );
+    const merged = mergeSearchResults(results);
+    expect(merged.length).toBe(16);
+  });
+
+  it('sorts by normalized score descending', () => {
+    const docResult = makeResult({
+      source: 'gruenerator:deutschland',
+      url: 'https://doc.com',
+      similarityScore: 0.85,
+      relevance: 0.7,
+    });
+    const webResult = makeResult({
+      source: 'web',
+      url: 'https://web.com',
+      relevance: 1.0,
+    });
+    const merged = mergeSearchResults([webResult], [docResult]);
+    // Doc: 0.85 * 1.05 = 0.8925; Web: min(0.80, 1.0 * 0.80) = 0.80
+    expect(merged[0].url).toBe('https://doc.com');
+    expect(merged[1].url).toBe('https://web.com');
+  });
+
+  it('handles mixed sources in correct order', () => {
+    const doc = makeResult({
+      source: 'gruenerator:deutschland',
+      url: 'https://doc.com',
+      similarityScore: 0.9,
+    });
+    const web = makeResult({
+      source: 'web',
+      url: 'https://web.com',
+      relevance: 1.0,
+    });
+    const example = makeResult({
+      source: 'examples',
+      relevance: 0.8,
+    });
+    const merged = mergeSearchResults([doc], [web], [example]);
+    // Doc: 0.90 * 1.05 = 0.945; Examples: 0.8; Web: 0.80
+    expect(merged[0].url).toBe('https://doc.com');
+    expect(merged.length).toBe(3);
+  });
+
+  it('handles empty input', () => {
+    const merged = mergeSearchResults([], []);
+    expect(merged.length).toBe(0);
+  });
+});

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -86,6 +86,20 @@ export interface GeneratedImageResult {
 }
 
 /**
+ * Source prefixes used in SearchResult.source to identify result provenance.
+ * Use these instead of raw strings to avoid silent mismatches across the pipeline.
+ */
+export const SOURCE_PREFIX = {
+  GRUENERATOR: 'gruenerator:',
+  WEB: 'web',
+  EXAMPLES: 'examples',
+  RESEARCH: 'research',
+  RESEARCH_SYNTHESIS: 'research_synthesis',
+  DOCUMENT: 'document',
+  DOCUMENT_CHAT: 'documentchat:',
+} as const;
+
+/**
  * Unified search result structure from any tool.
  */
 export interface SearchResult {

--- a/apps/api/config/vectorConfig.ts
+++ b/apps/api/config/vectorConfig.ts
@@ -150,6 +150,16 @@ interface RetrievalConfig {
   };
 }
 
+interface RerankConfig {
+  inputLimit: number;
+  outputLimit: number;
+  minRelevance: number;
+  mmrLambda: number;
+  mmrKeepTop: number;
+  mergeOverfetch: number;
+  webScoreCeiling: number;
+}
+
 interface FullConfig {
   [key: string]: unknown;
   search: SearchConfig;
@@ -166,6 +176,7 @@ interface FullConfig {
   metadata: MetadataConfig;
   chunking: ChunkingConfig;
   retrieval: RetrievalConfig;
+  rerank: RerankConfig;
 }
 
 class VectorConfig {
@@ -321,6 +332,16 @@ class VectorConfig {
           germanPatterns: process.env.USE_GERMAN_PATTERNS !== 'false',
         },
       },
+
+      rerank: {
+        inputLimit: parseInt(process.env.RERANK_INPUT_LIMIT || '16'),
+        outputLimit: parseInt(process.env.RERANK_OUTPUT_LIMIT || '8'),
+        minRelevance: parseFloat(process.env.RERANK_MIN_RELEVANCE || '0.2'),
+        mmrLambda: parseFloat(process.env.RERANK_MMR_LAMBDA || '0.7'),
+        mmrKeepTop: parseInt(process.env.RERANK_MMR_KEEP_TOP || '2'),
+        mergeOverfetch: parseInt(process.env.RERANK_MERGE_OVERFETCH || '16'),
+        webScoreCeiling: parseFloat(process.env.RERANK_WEB_SCORE_CEILING || '0.80'),
+      },
     };
   }
 
@@ -377,6 +398,18 @@ class VectorConfig {
       ) {
         throw new Error('QUALITY_MIN_RETRIEVAL must be between 0 and 1');
       }
+    }
+
+    if (config.rerank.mmrLambda < 0 || config.rerank.mmrLambda > 1) {
+      throw new Error('RERANK_MMR_LAMBDA must be between 0 and 1');
+    }
+
+    if (config.rerank.mergeOverfetch < config.rerank.outputLimit) {
+      console.warn('[VectorConfig] RERANK_MERGE_OVERFETCH should be >= RERANK_OUTPUT_LIMIT');
+    }
+
+    if (config.rerank.webScoreCeiling < 0 || config.rerank.webScoreCeiling > 1) {
+      throw new Error('RERANK_WEB_SCORE_CEILING must be between 0 and 1');
     }
 
     const positiveValues = [
@@ -472,4 +505,4 @@ class VectorConfig {
 const vectorConfig = new VectorConfig();
 
 export { vectorConfig, VectorConfig };
-export type { FullConfig, SearchConfig, HybridConfig, CacheConfig, CacheEntry };
+export type { FullConfig, SearchConfig, HybridConfig, RerankConfig, CacheConfig, CacheEntry };

--- a/apps/api/services/notebook/rerankNotebookResults.ts
+++ b/apps/api/services/notebook/rerankNotebookResults.ts
@@ -1,12 +1,13 @@
 /**
  * Rerank utility for notebook search results.
  *
- * Uses Regolo's dedicated Rerank API (Qwen3-Reranker-4B cross-encoder)
- * to score search results by relevance, then filters and returns the top N.
+ * Uses the shared rerankPipeline (Regolo cross-encoder + MMR diversity)
+ * to score search results by relevance, then filters, applies diversity
+ * reranking, and renumbers citations.
  */
 
 import { createLogger } from '../../utils/logger.js';
-import { regoloRerankService } from '../search/RegoloRerankService.js';
+import { rerankPipeline } from '../search/rerankPipeline.js';
 
 import type { ExpandedChunkResult } from '../search/types.js';
 
@@ -49,26 +50,23 @@ export async function rerankNotebookResults({
   const candidates = results.slice(0, inputLimit);
 
   try {
-    const documents = candidates.map((r) => `${r.title}\n${r.snippet.slice(0, 300)}`);
+    const items = candidates.map((r) => ({
+      title: r.title,
+      content: r.snippet.slice(0, 300),
+      relevance: r.similarity,
+    }));
 
-    const rerankResults = await regoloRerankService.rerank({
+    const { rankedIndices, rerankTimeMs } = await rerankPipeline({
       query: question,
-      documents,
-      topN: limit,
+      items,
+      inputLimit,
+      outputLimit: limit,
+      minRelevance: 0.05,
+      minKeep: Math.min(5, candidates.length),
+      applyDiversity: true,
     });
 
-    const rerankTimeMs = Date.now() - startTime;
-
-    // Map back to candidates, keeping at least MIN_KEEP results for LLM breadth
-    const MIN_KEEP = Math.min(5, rerankResults.length);
-    const scored = rerankResults
-      .filter((r, i) => r.relevanceScore > 0.05 || i < MIN_KEEP)
-      .map((r) => ({
-        result: candidates[r.originalIndex],
-        relevanceScore: r.relevanceScore,
-      }));
-
-    const rerankedResults = scored.map((s) => s.result);
+    const rerankedResults = rankedIndices.map((i) => candidates[i]);
 
     // Build a set of kept document_ids to filter the referencesMap
     const keptDocIds = new Set(rerankedResults.map((r) => r.document_id));

--- a/apps/api/services/notebook/rerankNotebookResults.ts
+++ b/apps/api/services/notebook/rerankNotebookResults.ts
@@ -49,61 +49,50 @@ export async function rerankNotebookResults({
 
   const candidates = results.slice(0, inputLimit);
 
-  try {
-    const items = candidates.map((r) => ({
-      title: r.title,
-      content: r.snippet.slice(0, 300),
-      relevance: r.similarity,
-    }));
+  const items = candidates.map((r) => ({
+    title: r.title,
+    content: r.snippet.slice(0, 300),
+    relevance: r.similarity,
+  }));
 
-    const { rankedIndices, rerankTimeMs } = await rerankPipeline({
-      query: question,
-      items,
-      inputLimit,
-      outputLimit: limit,
-      minRelevance: 0.05,
-      minKeep: Math.min(5, candidates.length),
-      applyDiversity: true,
-    });
+  // Pipeline handles errors internally with graceful degradation
+  const { rankedIndices, rerankTimeMs } = await rerankPipeline({
+    query: question,
+    items,
+    inputLimit,
+    outputLimit: limit,
+    minRelevance: 0.05,
+    minKeep: Math.min(5, candidates.length),
+    applyDiversity: true,
+  });
 
-    const rerankedResults = rankedIndices.map((i) => candidates[i]);
+  const rerankedResults = rankedIndices.map((i) => candidates[i]);
 
-    // Build a set of kept document_ids to filter the referencesMap
-    const keptDocIds = new Set(rerankedResults.map((r) => r.document_id));
-    const filteredReferencesMap: Record<string, any> = {};
-    for (const [key, ref] of Object.entries(referencesMap)) {
-      if (keptDocIds.has(ref.document_id)) {
-        filteredReferencesMap[key] = ref;
-      }
+  const keptDocIds = new Set(rerankedResults.map((r) => r.document_id));
+  const filteredReferencesMap: Record<string, any> = {};
+  for (const [key, ref] of Object.entries(referencesMap)) {
+    if (keptDocIds.has(ref.document_id)) {
+      filteredReferencesMap[key] = ref;
     }
-
-    // Renumber references 1..N sequentially
-    const renumberedMap: Record<string, any> = {};
-    let newIndex = 1;
-    for (const ref of Object.values(filteredReferencesMap)) {
-      renumberedMap[String(newIndex)] = ref;
-      newIndex++;
-    }
-
-    log.info(
-      `[Rerank] ${candidates.length} → ${rerankedResults.length} results in ${rerankTimeMs}ms`
-    );
-
-    return {
-      results: rerankedResults,
-      referencesMap: renumberedMap,
-      contextSummary: buildContextSummary(renumberedMap),
-      rerankTimeMs,
-    };
-  } catch (error: any) {
-    log.error('[Rerank] Error:', error.message);
-    return {
-      results,
-      referencesMap,
-      contextSummary: buildContextSummary(referencesMap),
-      rerankTimeMs: Date.now() - startTime,
-    };
   }
+
+  const renumberedMap: Record<string, any> = {};
+  let newIndex = 1;
+  for (const ref of Object.values(filteredReferencesMap)) {
+    renumberedMap[String(newIndex)] = ref;
+    newIndex++;
+  }
+
+  log.info(
+    `[Rerank] ${candidates.length} → ${rerankedResults.length} results in ${rerankTimeMs}ms`
+  );
+
+  return {
+    results: rerankedResults,
+    referencesMap: renumberedMap,
+    contextSummary: buildContextSummary(renumberedMap),
+    rerankTimeMs,
+  };
 }
 
 function buildContextSummary(referencesMap: Record<string, any>): string {

--- a/apps/api/services/search/__manual_tests__/rerankPipeline.test.ts
+++ b/apps/api/services/search/__manual_tests__/rerankPipeline.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Tests for rerankPipeline (shared rerank logic)
+ *
+ * Mocks RegoloRerankService to test the pipeline orchestration:
+ * filtering, MMR routing, index mapping, and error handling.
+ *
+ * Run with: npx tsx apps/api/services/search/__manual_tests__/rerankPipeline.test.ts
+ */
+
+import { regoloRerankService } from '../RegoloRerankService.js';
+import { rerankPipeline, type RerankableItem } from '../rerankPipeline.js';
+
+let passed = 0;
+let failed = 0;
+let mockRerankFn: ((req: any) => Promise<any>) | null = null;
+
+// Mock the rerank service
+const originalRerank = regoloRerankService.rerank.bind(regoloRerankService);
+regoloRerankService.rerank = async (req: any) => {
+  if (mockRerankFn) return mockRerankFn(req);
+  return originalRerank(req);
+};
+
+function setMockRerank(fn: (req: any) => Promise<any>) {
+  mockRerankFn = fn;
+}
+
+function clearMock() {
+  mockRerankFn = null;
+}
+
+async function test(name: string, fn: () => Promise<void>) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failed++;
+    console.error(`  ✗ ${name}: ${err.message}`);
+  } finally {
+    clearMock();
+  }
+}
+
+function expect(actual: any) {
+  return {
+    toBe(expected: any) {
+      if (actual !== expected)
+        throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    },
+    toBeGreaterThan(expected: number) {
+      if (!(actual > expected)) throw new Error(`Expected ${actual} > ${expected}`);
+    },
+    toBeLessThanOrEqual(expected: number) {
+      if (actual > expected) throw new Error(`Expected ${actual} <= ${expected}`);
+    },
+    toContain(expected: any) {
+      if (!actual.includes(expected))
+        throw new Error(`Expected array to contain ${expected}, got ${JSON.stringify(actual)}`);
+    },
+    toHaveLength(expected: number) {
+      if (actual.length !== expected)
+        throw new Error(`Expected length ${expected}, got ${actual.length}`);
+    },
+  };
+}
+
+function makeItems(count: number, contentPrefix = 'content'): RerankableItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    title: `Item ${i}`,
+    content: `${contentPrefix} ${i}`,
+    source: `source-${i}`,
+    relevance: 0.5 + i * 0.03,
+  }));
+}
+
+function mockScores(scores: number[]) {
+  setMockRerank(async (req: any) =>
+    scores.map((score, i) => ({
+      originalIndex: i,
+      relevanceScore: score,
+      text: req.documents[i] || '',
+    }))
+  );
+}
+
+console.log('rerankPipeline Tests');
+console.log('====================');
+
+await test('skips reranking when ≤ 2 items', async () => {
+  const items = makeItems(2);
+  const result = await rerankPipeline({ query: 'test', items });
+  expect(result.rankedIndices).toHaveLength(2);
+  expect(result.rankedIndices[0]).toBe(0);
+  expect(result.rankedIndices[1]).toBe(1);
+});
+
+await test('returns rankedIndices in cross-encoder score order', async () => {
+  const items = makeItems(5);
+  // Reverse order: item 4 gets highest score, item 0 gets lowest
+  mockScores([0.1, 0.3, 0.5, 0.7, 0.9]);
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    applyDiversity: false,
+  });
+  // Should be sorted by score descending: index 4, 3, 2, 1, 0
+  expect(result.rankedIndices[0]).toBe(4);
+  expect(result.rankedIndices[1]).toBe(3);
+});
+
+await test('filters by minRelevance', async () => {
+  const items = makeItems(5);
+  mockScores([0.05, 0.08, 0.5, 0.7, 0.9]);
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    minRelevance: 0.2,
+    minKeep: 0,
+    applyDiversity: false,
+  });
+  // Only items with scores > 0.2 should remain (0.5, 0.7, 0.9)
+  expect(result.rankedIndices).toHaveLength(3);
+});
+
+await test('minKeep preserves low-scoring items', async () => {
+  const items = makeItems(5);
+  // All scores below minRelevance
+  mockScores([0.01, 0.02, 0.03, 0.04, 0.05]);
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    minRelevance: 0.5,
+    minKeep: 3,
+    applyDiversity: false,
+  });
+  // Should keep at least 3 despite all being below 0.5
+  expect(result.rankedIndices).toHaveLength(3);
+});
+
+await test('applies MMR when applyDiversity=true', async () => {
+  // Create items where 0,1,2 are similar (same content) and 3 is diverse
+  const items: RerankableItem[] = [
+    { title: 'A', content: 'Klimaschutz Umweltpolitik Grüne Deutschland', relevance: 0.9 },
+    { title: 'B', content: 'Klimaschutz Umweltpolitik Grüne Partei', relevance: 0.8 },
+    { title: 'C', content: 'Klimaschutz Umweltpolitik Grüne Nachhaltigkeit', relevance: 0.7 },
+    { title: 'D', content: 'Verkehrswende ÖPNV Fahrrad Mobilität', relevance: 0.6 },
+  ];
+  mockScores([0.9, 0.8, 0.7, 0.6]);
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    applyDiversity: true,
+    mmrKeepTop: 1,
+  });
+  // D (diverse) should be promoted above its original position
+  const dPos = result.rankedIndices.indexOf(3);
+  expect(dPos).toBeGreaterThan(-1);
+});
+
+await test('skips MMR when applyDiversity=false', async () => {
+  const items = makeItems(5);
+  mockScores([0.9, 0.8, 0.7, 0.6, 0.5]);
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    applyDiversity: false,
+  });
+  // Should be pure score order
+  expect(result.rankedIndices[0]).toBe(0);
+  expect(result.rankedIndices[1]).toBe(1);
+  expect(result.rankedIndices[2]).toBe(2);
+});
+
+await test('respects inputLimit', async () => {
+  const items = makeItems(30);
+  let sentDocCount = 0;
+  setMockRerank(async (req: any) => {
+    sentDocCount = req.documents.length;
+    return req.documents.map((_: any, i: number) => ({
+      originalIndex: i,
+      relevanceScore: 0.5,
+      text: '',
+    }));
+  });
+  await rerankPipeline({
+    query: 'test',
+    items,
+    inputLimit: 10,
+    applyDiversity: false,
+  });
+  expect(sentDocCount).toBe(10);
+});
+
+await test('respects outputLimit', async () => {
+  const items = makeItems(15);
+  mockScores(Array(15).fill(0.5));
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    inputLimit: 15,
+    outputLimit: 5,
+    applyDiversity: false,
+  });
+  expect(result.rankedIndices).toHaveLength(5);
+});
+
+await test('adds source tags when sourceTagFn provided', async () => {
+  const items: RerankableItem[] = [
+    { title: 'Doc', content: 'Content A', source: 'gruenerator:deutschland' },
+    { title: 'Web', content: 'Content B', source: 'web' },
+    { title: 'Ex', content: 'Content C', source: 'examples' },
+  ];
+  let receivedDocs: string[] = [];
+  setMockRerank(async (req: any) => {
+    receivedDocs = req.documents;
+    return req.documents.map((_: any, i: number) => ({
+      originalIndex: i,
+      relevanceScore: 0.5,
+      text: '',
+    }));
+  });
+  await rerankPipeline({
+    query: 'test',
+    items,
+    sourceTagFn: (item) => {
+      if (item.source?.startsWith('gruenerator:')) return 'Parteidokument';
+      if (item.source === 'web') return 'Web';
+      return 'Sonstige';
+    },
+    applyDiversity: false,
+  });
+  expect(receivedDocs[0]).toContain('[Parteidokument]');
+  expect(receivedDocs[1]).toContain('[Web]');
+  expect(receivedDocs[2]).toContain('[Sonstige]');
+});
+
+await test('graceful fallback on Regolo error', async () => {
+  const items = makeItems(5);
+  setMockRerank(async () => {
+    throw new Error('API unavailable');
+  });
+  const result = await rerankPipeline({
+    query: 'test',
+    items,
+    applyDiversity: false,
+  });
+  // Should return original indices as fallback
+  expect(result.rankedIndices[0]).toBe(0);
+  expect(result.rankedIndices).toHaveLength(5);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/apps/api/services/search/index.ts
+++ b/apps/api/services/search/index.ts
@@ -45,6 +45,14 @@ export type { ExpandedQuery } from './QueryExpansionService.js';
 // Export diversity reranker (MMR)
 export { applyMMR } from './DiversityReranker.js';
 
+// Export shared rerank pipeline
+export { rerankPipeline } from './rerankPipeline.js';
+export type {
+  RerankableItem,
+  RerankPipelineOptions,
+  RerankPipelineResult,
+} from './rerankPipeline.js';
+
 // Export citation grounder
 export { validateCitations, stripUngroundedCitations } from './CitationGrounder.js';
 export type { GroundingResult } from './CitationGrounder.js';

--- a/apps/api/services/search/index.ts
+++ b/apps/api/services/search/index.ts
@@ -46,7 +46,7 @@ export type { ExpandedQuery } from './QueryExpansionService.js';
 export { applyMMR } from './DiversityReranker.js';
 
 // Export shared rerank pipeline
-export { rerankPipeline } from './rerankPipeline.js';
+export { DEFAULT_RELEVANCE, rerankPipeline } from './rerankPipeline.js';
 export type {
   RerankableItem,
   RerankPipelineOptions,

--- a/apps/api/services/search/rerankPipeline.ts
+++ b/apps/api/services/search/rerankPipeline.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared Rerank Pipeline
+ *
+ * Unified reranking logic used by both ChatGraph (rerankNode) and Notebook
+ * (rerankNotebookResults). Calls Regolo's cross-encoder, filters by relevance,
+ * and optionally applies MMR diversity reranking.
+ *
+ * Returns ranked indices (not items) so callers can map back to their own types.
+ */
+
+import { vectorConfig } from '../../config/vectorConfig.js';
+import { createLogger } from '../../utils/logger.js';
+
+import { applyMMR } from './DiversityReranker.js';
+import { regoloRerankService } from './RegoloRerankService.js';
+
+const log = createLogger('RerankPipeline');
+
+export interface RerankableItem {
+  title: string;
+  content: string;
+  source?: string;
+  relevance?: number;
+}
+
+export interface RerankPipelineOptions {
+  query: string;
+  items: RerankableItem[];
+  inputLimit?: number;
+  outputLimit?: number;
+  minRelevance?: number;
+  minKeep?: number;
+  applyDiversity?: boolean;
+  mmrLambda?: number;
+  mmrKeepTop?: number;
+  instruct?: string;
+  sourceTagFn?: (item: RerankableItem) => string;
+}
+
+export interface RerankPipelineResult {
+  rankedIndices: number[];
+  scores: Map<number, number>;
+  rerankTimeMs: number;
+}
+
+const SKIP_THRESHOLD = 2;
+
+export async function rerankPipeline(
+  options: RerankPipelineOptions
+): Promise<RerankPipelineResult> {
+  const startTime = Date.now();
+  const rerankCfg = vectorConfig.get('rerank');
+
+  const {
+    query,
+    items,
+    inputLimit = rerankCfg.inputLimit,
+    outputLimit = rerankCfg.outputLimit,
+    minRelevance = rerankCfg.minRelevance,
+    minKeep = 0,
+    applyDiversity = true,
+    mmrLambda = rerankCfg.mmrLambda,
+    mmrKeepTop = rerankCfg.mmrKeepTop,
+    instruct,
+    sourceTagFn,
+  } = options;
+
+  if (items.length <= SKIP_THRESHOLD) {
+    log.info(`Skipping — only ${items.length} items`);
+    return {
+      rankedIndices: items.map((_, i) => i),
+      scores: new Map(items.map((item, i) => [i, item.relevance ?? 0.5])),
+      rerankTimeMs: Date.now() - startTime,
+    };
+  }
+
+  const candidates = items.slice(0, inputLimit);
+
+  try {
+    const documents = candidates.map((item) => {
+      const tag = sourceTagFn ? `[${sourceTagFn(item)}] ` : '';
+      return `${tag}${item.title}\n${item.content}`;
+    });
+
+    const rerankResults = await regoloRerankService.rerank({
+      query,
+      documents,
+      topN: inputLimit,
+      instruct,
+    });
+
+    const scoreMap = new Map<number, number>();
+    for (const r of rerankResults) {
+      scoreMap.set(r.originalIndex, r.relevanceScore);
+    }
+
+    // Build scored items with original indices for filtering + MMR
+    const scored = candidates.map((item, i) => ({
+      index: i,
+      relevance: scoreMap.get(i) ?? item.relevance ?? 0.5,
+      title: item.title,
+      content: item.content,
+    }));
+
+    scored.sort((a, b) => b.relevance - a.relevance);
+
+    // Filter by minRelevance, but always keep at least minKeep
+    const filtered = scored.filter((s, i) => s.relevance > minRelevance || i < minKeep);
+
+    let finalOrder: typeof filtered;
+
+    if (applyDiversity && filtered.length > 3) {
+      const mmrInput = filtered.map((s) => ({
+        title: s.title,
+        content: s.content,
+        relevance: s.relevance,
+        _originalIndex: s.index,
+      }));
+
+      const mmrResult = applyMMR(mmrInput, mmrLambda, mmrKeepTop);
+      finalOrder = mmrResult.map((r) => ({
+        index: r._originalIndex,
+        relevance: r.relevance,
+        title: r.title,
+        content: r.content,
+      }));
+    } else {
+      finalOrder = filtered;
+    }
+
+    const result = finalOrder.slice(0, outputLimit);
+    const rerankTimeMs = Date.now() - startTime;
+
+    log.info(
+      `${candidates.length} → ${result.length} results (diversity=${applyDiversity}) in ${rerankTimeMs}ms`
+    );
+
+    return {
+      rankedIndices: result.map((r) => r.index),
+      scores: scoreMap,
+      rerankTimeMs,
+    };
+  } catch (error: any) {
+    log.error('Rerank error:', error.message);
+    return {
+      rankedIndices: candidates.map((_, i) => i).slice(0, outputLimit),
+      scores: new Map(candidates.map((item, i) => [i, item.relevance ?? 0.5])),
+      rerankTimeMs: Date.now() - startTime,
+    };
+  }
+}

--- a/apps/api/services/search/rerankPipeline.ts
+++ b/apps/api/services/search/rerankPipeline.ts
@@ -44,6 +44,7 @@ export interface RerankPipelineResult {
 }
 
 const SKIP_THRESHOLD = 2;
+export const DEFAULT_RELEVANCE = 0.5;
 
 export async function rerankPipeline(
   options: RerankPipelineOptions
@@ -69,7 +70,7 @@ export async function rerankPipeline(
     log.info(`Skipping — only ${items.length} items`);
     return {
       rankedIndices: items.map((_, i) => i),
-      scores: new Map(items.map((item, i) => [i, item.relevance ?? 0.5])),
+      scores: new Map(items.map((item, i) => [i, item.relevance ?? DEFAULT_RELEVANCE])),
       rerankTimeMs: Date.now() - startTime,
     };
   }
@@ -97,7 +98,7 @@ export async function rerankPipeline(
     // Build scored items with original indices for filtering + MMR
     const scored = candidates.map((item, i) => ({
       index: i,
-      relevance: scoreMap.get(i) ?? item.relevance ?? 0.5,
+      relevance: scoreMap.get(i) ?? item.relevance ?? DEFAULT_RELEVANCE,
       title: item.title,
       content: item.content,
     }));
@@ -110,18 +111,18 @@ export async function rerankPipeline(
     let finalOrder: typeof filtered;
 
     if (applyDiversity && filtered.length > 3) {
-      const mmrInput = filtered.map((s) => ({
-        title: s.title,
-        content: s.content,
-        relevance: s.relevance,
-        _originalIndex: s.index,
-      }));
+      const indexByIdentity = new Map(filtered.map((s) => [`${s.title}\0${s.content}`, s.index]));
 
-      const mmrResult = applyMMR(mmrInput, mmrLambda, mmrKeepTop);
+      const mmrResult = applyMMR(
+        filtered.map((s) => ({ title: s.title, content: s.content, relevance: s.relevance })),
+        mmrLambda,
+        mmrKeepTop
+      );
+
       finalOrder = mmrResult.map((r) => ({
-        index: r._originalIndex,
-        relevance: r.relevance,
-        title: r.title,
+        index: indexByIdentity.get(`${r.title}\0${r.content}`) ?? 0,
+        relevance: r.relevance ?? DEFAULT_RELEVANCE,
+        title: r.title ?? '',
         content: r.content,
       }));
     } else {
@@ -144,7 +145,7 @@ export async function rerankPipeline(
     log.error('Rerank error:', error.message);
     return {
       rankedIndices: candidates.map((_, i) => i).slice(0, outputLimit),
-      scores: new Map(candidates.map((item, i) => [i, item.relevance ?? 0.5])),
+      scores: new Map(candidates.map((item, i) => [i, item.relevance ?? DEFAULT_RELEVANCE])),
       rerankTimeMs: Date.now() - startTime,
     };
   }


### PR DESCRIPTION
## Summary

- **Shared `rerankPipeline.ts`**: Extracts the common Regolo cross-encoder → score filtering → MMR diversity logic into one function, eliminating duplication between ChatGraph and Notebook reranking
- **Cross-source score normalization**: Uses raw `similarityScore` for documents (instead of lossy text-label mapping) and caps web scores at a configurable ceiling — prevents web results from dominating the pre-rerank cutoff
- **Notebook gains MMR diversity**: Fast-mode notebook search now applies the same MMR diversity pass as ChatGraph, reducing redundant chunks from overlapping documents
- **Source-aware reranking**: Cross-encoder now sees `[Parteidokument]`/`[Web]` tags with an instruct preferring official sources
- **All params configurable**: `RERANK_INPUT_LIMIT`, `RERANK_MMR_LAMBDA`, `RERANK_WEB_SCORE_CEILING`, etc. via env vars in `vectorConfig`
- **`SOURCE_PREFIX` constants**: Replaces scattered raw string comparisons across the pipeline
- **`DEFAULT_RELEVANCE` constant**: Replaces magic `0.5` fallback in 8+ locations

Inspired by SurfSense (over-fetch 2x candidates, RRF fusion) and Open Notebook (use raw numeric scores, keep pre-rerank simple).

## Test plan

- [x] 14/14 Vitest tests for `normalizeScore` + `mergeSearchResults`
- [x] 10/10 manual tests for `rerankPipeline` (mocked Regolo)
- [x] 6/6 existing `DiversityReranker` tests pass
- [x] 30/30 existing `searchDocuments` vitest tests pass
- [x] TypeScript check passes
- [ ] E2E: `gruenerator_ask` with mixed doc+web query — verify docs rank correctly
- [ ] E2E: `gruenerator_notebook_ask` in fast mode — verify MMR diversity applied
- [ ] E2E: Notebook deep mode — verify no reranking (unchanged)