### PR TITLE
fix(desktop): gate devtools behind debug_assertions

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -287,10 +287,9 @@ pub fn run() {
                 });
 
                 if let Some(main_window) = app.get_webview_window("main") {
+                    #[cfg(debug_assertions)]
                     main_window.open_devtools();
-                }
 
-                if let Some(main_window) = app.get_webview_window("main") {
                     let window_clone = main_window.clone();
                     main_window.on_window_event(move |event| {
                         if let tauri::WindowEvent::ThemeChanged(theme) = event {


### PR DESCRIPTION
## Summary
- Wraps `open_devtools()` in `#[cfg(debug_assertions)]` so DevTools only opens in debug builds, not in release/production builds
- Merges two consecutive `if let Some(main_window)` blocks into one for cleaner code

## Context
Preparing desktop-v1.2.0 Windows release. Without this fix, users would see Chrome DevTools open on every app launch.