### PR TITLE
fix(desktop): align tauri-plugin-fs version for release build

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -4183,13 +4183,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri = { version = "2", features = ["tray-icon", "image-png", "protocol-asset",
 tauri-plugin-opener = "2.5"
 tauri-plugin-deep-link = "2"
 tauri-plugin-shell = "2.3"
-tauri-plugin-fs = "2.4"
+tauri-plugin-fs = "2.5"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-notification = "2.3"
 tauri-plugin-window-state = "2"


### PR DESCRIPTION
## Summary
- Bumps `tauri-plugin-fs` Rust crate from `"2.4"` to `"2.5"` to match NPM `@tauri-apps/plugin-fs` `^2.5.0`
- Updates `Cargo.lock` accordingly (2.4.5 → 2.5.0)

## Context
All 4 desktop-v1.2.0 release builds failed with:
```
Error: Found version mismatched Tauri packages.
tauri-plugin-fs (v2.4.5) : @tauri-apps/plugin-fs (v2.5.0)
```

After merging, delete the `desktop-v1.2.0` tag and re-tag to trigger a fresh release build.