### PR TITLE
fix(desktop): include web deps in CI install for release builds

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'
-        run: pnpm install --frozen-lockfile --filter @gruenerator/desktop...
+        run: pnpm install --frozen-lockfile --filter @gruenerator/desktop... --filter @gruenerator/web...
 
       - name: Build Tauri app
         if: steps.check.outputs.should_run == 'true'


### PR DESCRIPTION
## Summary
- Adds `--filter @gruenerator/web...` to the pnpm install step in the desktop release workflow
- The `beforeBuildCommand` builds `@gruenerator/web`, but the install filter only covered `@gruenerator/desktop` dependencies — so `@gruenerator/ui` (a web dependency) was never installed, causing Vite to fail with: `failed to resolve import "@gruenerator/ui"`

## Context
All desktop-v1.2.0 builds failed after the plugin version fix because the web frontend couldn't build.