### PR TITLE
Subtitler type unification, 401 probe-before-redirect, oauth state replay log downgrade

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -72,10 +72,29 @@ export const auth = betterAuth({
   // `console.*` directly because Winston's variadic overloads don't accept
   // dynamic spreads cleanly. The `unknown[]` cast narrows Better Auth's
   // `any[]` callback signature to satisfy no-unsafe-argument.
+  //
+  // Known-benign error downgrade: "Failed to parse state" fires whenever
+  // an OAuth callback URL is replayed after the one-shot verification row
+  // was already consumed or its 10-minute TTL expired. Common triggers are
+  // link-preview bots prefetching the callback (Slack, iMessage), browser
+  // back button after a successful login, and tabs left open across the
+  // TTL window. Better Auth's own fallback already redirects the user to
+  // `?error=please_restart_the_process`, so the user experience is fine —
+  // the only damage was the full `StateError` object landing in the prod
+  // error log and looking like a real incident. We downgrade to warn with
+  // a one-line summary so a genuine attack pattern (spike in rate) is
+  // still visible while routine replay noise stops paging anyone.
   logger: {
     level: env.LOG_LEVEL === 'debug' ? 'debug' : 'warn',
     log: (level, message, ...rawArgs) => {
       const args: unknown[] = rawArgs;
+      if (level === 'error' && message === 'Failed to parse state') {
+        const err = args[0] as { code?: string; message?: string } | undefined;
+        console.warn(
+          `[BA:warn] oauth state replay code=${err?.code ?? 'unknown'} (benign: expired or already-consumed callback)`
+        );
+        return;
+      }
       const sink =
         level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
       sink(`[BA:${level}]`, message, ...args);

--- a/apps/api/routes/subtitler/processingController.ts
+++ b/apps/api/routes/subtitler/processingController.ts
@@ -747,6 +747,13 @@ router.post(
               outputPath: result.outputPath,
               duration: result.duration,
               projectId: savedProjectId,
+              // Canonical segment array — what the frontend should consume
+              // when creating a project. The `subtitles` string is kept for
+              // backward compatibility with any display-layer code that
+              // wants the raw SRT blob, but the POST /subtitler/projects
+              // write path uses `segments` because the schema requires a
+              // typed `SubtitleSegment[]` (canonicalized 2026-04-13).
+              segments: result.segments,
               subtitles: result.subtitles,
             }),
             { EX: 3600 }

--- a/apps/api/routes/subtitler/projectController.ts
+++ b/apps/api/routes/subtitler/projectController.ts
@@ -5,6 +5,7 @@
 
 import fs from 'fs';
 
+import { subtitleSegmentSchema } from '@gruenerator/contracts';
 import express, { type Response, type Router } from 'express';
 import { z } from 'zod';
 
@@ -24,15 +25,12 @@ const projectDataSchema = z
   .object({
     uploadId: z.string().optional(),
     videoFilename: z.string(),
-    subtitles: z.array(
-      z
-        .object({
-          text: z.string(),
-          start: z.number(),
-          end: z.number(),
-        })
-        .passthrough()
-    ),
+    // Uses canonical subtitleSegmentSchema from @gruenerator/contracts.
+    // Pre-2026-04-13: local `{ text, start, end }` shape drifted from the
+    // 8 service-layer SubtitleSegment interfaces that used
+    // `{ text, startTime, endTime }`. Unification landed the canonical
+    // shape in contracts and 8 service files now import from there.
+    subtitles: z.array(subtitleSegmentSchema),
     title: z.string().optional(),
     stylePreference: z.string().optional(),
     heightPreference: z.string().optional(),

--- a/apps/api/services/subtitler/assSubtitleService.ts
+++ b/apps/api/services/subtitler/assSubtitleService.ts
@@ -8,6 +8,8 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
+
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
 import { createLogger } from '../../utils/logger.js';
 import { sanitizeFilename } from '../../utils/validation/index.js';
@@ -16,12 +18,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const log = createLogger('assSubtitle');
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
-}
 
 interface StyleOptions {
   fontSize?: number;

--- a/apps/api/services/subtitler/autoProcessingService.ts
+++ b/apps/api/services/subtitler/autoProcessingService.ts
@@ -8,6 +8,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { v4 as uuidv4 } from 'uuid';
 
 import { createLogger } from '../../utils/logger.js';
@@ -79,12 +80,6 @@ interface ProcessingOptions {
   maxResolution?: number | null;
   userId?: string;
   originalFilename?: string;
-}
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
 }
 
 interface ProcessingResult {

--- a/apps/api/services/subtitler/backgroundExportService.ts
+++ b/apps/api/services/subtitler/backgroundExportService.ts
@@ -274,7 +274,14 @@ export async function processVideoExportInBackground(
                   originalVideoPath: inputPath,
                   uploadId,
                   originalFilename,
-                  segments: segments.map((s) => ({ text: s.text, start: s.start, end: s.end })),
+                  // Map legacy `start/end` field names to canonical
+                  // `startTime/endTime` required by projectSavingService's
+                  // canonical `SubtitleSegment` from @gruenerator/contracts.
+                  segments: segments.map((s) => ({
+                    text: s.text,
+                    startTime: s.start,
+                    endTime: s.end,
+                  })),
                   metadata: {
                     width: metadata.width,
                     height: metadata.height,

--- a/apps/api/services/subtitler/downloadUtils.ts
+++ b/apps/api/services/subtitler/downloadUtils.ts
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { type Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -41,12 +42,6 @@ interface ExportParams {
 
 interface TokenData extends ExportParams {
   createdAt: number;
-}
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
 }
 
 interface FontSizes {

--- a/apps/api/services/subtitler/exportService.ts
+++ b/apps/api/services/subtitler/exportService.ts
@@ -8,6 +8,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
@@ -24,12 +25,6 @@ const __dirname = path.dirname(__filename);
 const log = createLogger('export-service');
 
 const EXPORTS_DIR = path.join(__dirname, '../../uploads/exports');
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
-}
 
 interface Project {
   id: string;

--- a/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
+++ b/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
@@ -16,7 +16,7 @@ interface WordTimestamp {
   end: number;
 }
 
-interface SubtitleSegment {
+interface ManualSegmentCandidate {
   start: number;
   end: number;
   text: string;
@@ -204,7 +204,7 @@ function findSmartBreakPoint(
   };
 }
 
-function applyElasticTiming(segments: SubtitleSegment[]): SubtitleSegment[] {
+function applyElasticTiming(segments: ManualSegmentCandidate[]): ManualSegmentCandidate[] {
   if (segments.length === 0) return segments;
 
   const elasticSegments = [...segments];
@@ -226,10 +226,13 @@ function applyElasticTiming(segments: SubtitleSegment[]): SubtitleSegment[] {
   return elasticSegments;
 }
 
-function groupWordsIntoSegments(words: WordTimestamp[], fullText: string): SubtitleSegment[] {
+function groupWordsIntoSegments(
+  words: WordTimestamp[],
+  fullText: string
+): ManualSegmentCandidate[] {
   validateWordTimestamps(words);
 
-  const segments: SubtitleSegment[] = [];
+  const segments: ManualSegmentCandidate[] = [];
   let currentSegment: CurrentSegment = {
     words: [],
     wordIndices: [],
@@ -418,7 +421,7 @@ function groupWordsIntoSegments(words: WordTimestamp[], fullText: string): Subti
   return finalSegments;
 }
 
-function formatSegmentsToSubtitleText(segments: SubtitleSegment[]): string {
+function formatSegmentsToSubtitleText(segments: ManualSegmentCandidate[]): string {
   return segments
     .map((segment) => {
       const startTime = formatTime(segment.start);
@@ -459,4 +462,4 @@ export {
   applyElasticTiming,
 };
 
-export type { WordTimestamp, SubtitleSegment, PunctuationResult, SmartBreakResult };
+export type { WordTimestamp, ManualSegmentCandidate, PunctuationResult, SmartBreakResult };

--- a/apps/api/services/subtitler/multiClipExportService.ts
+++ b/apps/api/services/subtitler/multiClipExportService.ts
@@ -8,6 +8,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
@@ -31,12 +32,6 @@ const __dirname = path.dirname(__filename);
 const log = createLogger('multiclip-export');
 
 const EXPORTS_DIR = path.join(__dirname, '../../uploads/exports');
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
-}
 
 interface SubtitleConfig {
   segments: SubtitleSegment[];

--- a/apps/api/services/subtitler/projectSavingService.ts
+++ b/apps/api/services/subtitler/projectSavingService.ts
@@ -8,6 +8,8 @@ import fsPromises from 'fs/promises';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
+
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
 import { createLogger } from '../../utils/logger.js';
 
@@ -16,14 +18,6 @@ const __dirname = dirname(__filename);
 
 const log = createLogger('projectSaving');
 const PROJECTS_DIR = path.join(__dirname, '../../uploads/subtitler-projects');
-
-interface SubtitleSegment {
-  text: string;
-  start?: number | undefined;
-  end?: number | undefined;
-  startTime?: number | undefined;
-  endTime?: number | undefined;
-}
 
 interface FileStats {
   size: number;

--- a/apps/api/services/subtitler/segmentExportService.ts
+++ b/apps/api/services/subtitler/segmentExportService.ts
@@ -8,6 +8,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
@@ -30,12 +31,6 @@ const __dirname = path.dirname(__filename);
 const log = createLogger('segment-export');
 
 const EXPORTS_DIR = path.join(__dirname, '../../uploads/exports');
-
-interface SubtitleSegment {
-  startTime: number;
-  endTime: number;
-  text: string;
-}
 
 interface SubtitleConfig {
   segments: SubtitleSegment[];

--- a/apps/api/services/subtitler/subtitleSizingService.ts
+++ b/apps/api/services/subtitler/subtitleSizingService.ts
@@ -9,7 +9,7 @@ import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('subtitleSizing');
 
-interface SubtitleSegment {
+interface TextLengthSample {
   text?: string;
   rawText?: string;
 }
@@ -74,7 +74,7 @@ function getBaseFontSettings(referenceDimension: number, isVertical: boolean): B
 
 function calculateFontSizing(
   metadata: VideoMetadata,
-  segments: SubtitleSegment[]
+  segments: TextLengthSample[]
 ): FontSizingResult {
   const isVertical = metadata.width < metadata.height;
   const referenceDimension = isVertical ? metadata.width : metadata.height;
@@ -128,4 +128,4 @@ function calculateFontSizing(
 }
 
 export { calculateFontSizing, calculateScaleFactor, getBaseFontSettings };
-export type { FontSizingResult, BaseFontSettings, VideoMetadata, SubtitleSegment };
+export type { FontSizingResult, BaseFontSettings, VideoMetadata, TextLengthSample };

--- a/apps/web/src/components/utils/apiClient.ts
+++ b/apps/web/src/components/utils/apiClient.ts
@@ -18,17 +18,143 @@ export const setLoggingOutFlag = (value: boolean) => {
 // This works because frontend is served by backend on same port
 const baseURL: string = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '/api';
 
+// ─────────────────────────────────────────────────────────────────────
+// Smart 401 handling: session probe before redirect
+// ─────────────────────────────────────────────────────────────────────
+//
+// Before 2026-04-13 the response interceptor below redirected to the
+// login page on ANY 401 from ANY route. That turned a single transient
+// 401 — e.g. from the notifications background poller firing during a
+// Better Auth cookie revalidation (every ~5 min) — into a full-page
+// navigation, killing any in-flight user work.
+//
+// Production incident pattern: user generates image → clicks "sonstige"
+// → notifications poller 401s during cookie revalidation → redirected
+// to login → cookie was actually still valid, login redirects right
+// back → user loses state.
+//
+// New rule: **never trust a single 401 as proof of dead session**.
+// Instead, on the first 401, do a silent session probe against
+// `/auth/status`. If the probe returns `isAuthenticated: true`, the
+// 401 was transient — swallow it and let the caller's query retry
+// mechanism do its thing. If the probe returns unauthenticated (or
+// itself 401s), THEN redirect.
+//
+// The probe result is cached for 5 seconds so a cascade of 401s
+// across multiple routes (e.g. 10 TanStack queries re-firing after
+// window focus) share one probe instead of DOSing `/auth/status`.
+//
+// Routes tagged `skipAuthRedirect: true` still bypass the whole
+// path — they explicitly opt out of any redirect behavior.
+
+const PROBE_CACHE_TTL_MS = 5_000;
+
+interface ProbeState {
+  timestamp: number;
+  isAuthenticated: boolean;
+}
+
+let probeInFlight: Promise<boolean> | null = null;
+let lastProbe: ProbeState | null = null;
+
+/**
+ * Silently probe `/auth/status` to decide whether the session is
+ * actually dead or whether the 401 we just saw was transient. Returns
+ * `true` if the session is healthy (caller should swallow the 401),
+ * `false` if the session is dead (caller should redirect).
+ *
+ * Coalesces concurrent probes: the first caller kicks off the fetch,
+ * every other caller within the same tick awaits the same promise.
+ * Caches the result for 5s to collapse 401 cascades across routes.
+ */
+async function isSessionStillAlive(): Promise<boolean> {
+  // Return cached result if recent.
+  const now = Date.now();
+  if (lastProbe && now - lastProbe.timestamp < PROBE_CACHE_TTL_MS) {
+    return lastProbe.isAuthenticated;
+  }
+
+  // Coalesce in-flight probes.
+  if (probeInFlight) {
+    return probeInFlight;
+  }
+
+  probeInFlight = (async (): Promise<boolean> => {
+    try {
+      // Use raw axios — going through `apiClient` would re-enter the
+      // interceptor and infinite-loop. `skipAuthRedirect` wouldn't
+      // help here because the probe IS the redirect check.
+      const response = await axios.get(`${baseURL}/auth/status`, {
+        withCredentials: useCredentials,
+        timeout: 10_000,
+      });
+      const data = response.data as { isAuthenticated?: boolean } | undefined;
+      const alive = data?.isAuthenticated === true;
+      lastProbe = { timestamp: Date.now(), isAuthenticated: alive };
+      return alive;
+    } catch {
+      // Probe itself failed (usually 401 — session really is dead).
+      lastProbe = { timestamp: Date.now(), isAuthenticated: false };
+      return false;
+    } finally {
+      probeInFlight = null;
+    }
+  })();
+
+  return probeInFlight;
+}
+
+/**
+ * Decide whether a 401 from an arbitrary request should trigger a
+ * full-page redirect to login. Returns `true` if the caller should
+ * redirect, `false` if the 401 was transient and should be swallowed.
+ */
+async function shouldRedirectOn401(): Promise<boolean> {
+  if (_isLoggingOut) return false;
+  if (isPublicPage()) return false;
+  if (window.location.pathname === '/login') return false;
+
+  const alive = await isSessionStillAlive();
+  return !alive;
+}
+
+function performLoginRedirect(): void {
+  const currentPath = window.location.pathname + window.location.search;
+  window.location.href = buildLoginUrl(currentPath);
+}
+
+// Desktop app uses JWT tokens, web app uses session cookies.
+// Declared early because the probe fetch needs it.
+const useCredentials: boolean = !isDesktopApp();
+
 // Initialize global API client for @gruenerator/shared hooks (useShareStore, etc.)
-// This is separate from the legacy apiClient below, but uses the same baseURL
+// This is separate from the legacy apiClient below, but uses the same baseURL.
+//
+// `onUnauthorized` has a subtle dual role here:
+//   - Return `true` → shared client retries the original request. We return
+//     true when the session probe confirms the session is still alive, so a
+//     transient 401 during cookie revalidation transparently recovers.
+//   - Return `false` → shared client propagates the 401 to the caller. We
+//     return false when the probe says the session is dead; `performLoginRedirect`
+//     has already fired, so the navigation is in flight and the rejected
+//     promise just unblocks any await'ing code.
 const sharedApiClient = createApiClient({
   baseURL,
   authMode: isDesktopApp() ? 'bearer' : 'cookie',
   getAuthToken: isDesktopApp() ? async () => getDesktopToken() : undefined,
-  onUnauthorized: () => {
-    if (!_isLoggingOut && !isPublicPage() && window.location.pathname !== '/login') {
-      const currentPath = window.location.pathname + window.location.search;
-      window.location.href = buildLoginUrl(currentPath);
+  onUnauthorized: async () => {
+    if (_isLoggingOut || isPublicPage() || window.location.pathname === '/login') {
+      return false;
     }
+    const alive = await isSessionStillAlive();
+    if (alive) {
+      // Session is actually healthy — tell the shared client to retry
+      // the original request. The cookie just got rotated mid-flight.
+      return true;
+    }
+    // Real dead session. Fire the redirect and let the 401 propagate.
+    performLoginRedirect();
+    return false;
   },
   timeout: 900000,
 });
@@ -43,9 +169,9 @@ function detectBrowserLocale(): string {
   return 'de-DE';
 }
 
-// Desktop app uses JWT tokens, web app uses session cookies
-// withCredentials must be false for desktop to avoid "Refused to set unsafe header Origin" error
-const useCredentials: boolean = !isDesktopApp();
+// `useCredentials` is declared above (next to the probe helper) because
+// the session probe needs it. Desktop app uses JWT tokens → false;
+// web app uses session cookies → true (cookies sent automatically).
 
 const apiClient = axios.create({
   baseURL: baseURL,
@@ -76,21 +202,32 @@ apiClient.interceptors.request.use(
   }
 );
 
-// Response interceptor for error handling
+// Response interceptor for error handling.
+//
+// Goes through `shouldRedirectOn401` which probes `/auth/status`
+// silently before deciding. A single transient 401 — e.g. from a
+// background poller firing during a Better Auth cookie revalidation —
+// is swallowed because the probe finds the session is actually alive.
+// Only when the probe itself 401s (or returns `isAuthenticated: false`)
+// does the redirect fire. See the long-form explanation above the
+// `shouldRedirectOn401` helper.
+//
+// Routes tagged `skipAuthRedirect: true` bypass the whole path.
 apiClient.interceptors.response.use(
   (response: AxiosResponse) => response,
-  (error: AxiosError) => {
-    // Check if this request should skip auth redirect
+  async (error: AxiosError) => {
     if (error.config?.skipAuthRedirect) {
       return Promise.reject(error);
     }
 
     if (error.response && error.response.status === 401) {
-      if (!_isLoggingOut && !isPublicPage() && window.location.pathname !== '/login') {
-        const currentPath = window.location.pathname + window.location.search;
-        const loginUrl = buildLoginUrl(currentPath);
-        window.location.href = loginUrl;
+      if (await shouldRedirectOn401()) {
+        performLoginRedirect();
       }
+      // Always reject so the caller's `.catch` / TanStack Query error
+      // handler can surface a sensible error state. Swallowing to
+      // `undefined` would hide real failures (non-auth 500s, network
+      // errors) from component-level retry logic.
     }
     return Promise.reject(error);
   }

--- a/apps/web/src/features/subtitler/components/AutoProcessingScreen.tsx
+++ b/apps/web/src/features/subtitler/components/AutoProcessingScreen.tsx
@@ -1,3 +1,4 @@
+import { type SubtitleSegment } from '@gruenerator/contracts';
 import { ProcessingState } from '@gruenerator/ui';
 import { motion, AnimatePresence } from 'motion/react';
 import React, { useState, useEffect, useRef, useCallback } from 'react';
@@ -14,6 +15,11 @@ interface ProgressResponse {
   outputPath?: string;
   duration?: number;
   projectId?: string | null;
+  // Canonical segment array emitted by the backend auto-processing
+  // pipeline (2026-04-13). Consume this for write paths (project
+  // create/update). The `subtitles` string is kept for display-layer
+  // code that wants the raw SRT blob.
+  segments?: SubtitleSegment[] | null;
   subtitles?: string | null;
   error?: string;
 }
@@ -32,6 +38,7 @@ export interface AutoProcessingResult {
   duration: number;
   uploadId: string;
   projectId: string | null;
+  segments: SubtitleSegment[] | null;
   subtitles: string | null;
 }
 
@@ -78,6 +85,7 @@ const AutoProcessingScreen: React.FC<AutoProcessingScreenProps> = ({
           duration: data.duration ?? 0,
           uploadId,
           projectId: data.projectId ?? null,
+          segments: data.segments ?? null,
           subtitles: data.subtitles ?? null,
         });
         return;

--- a/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
@@ -93,6 +93,15 @@ const SubtitlerPage = (): React.ReactElement => {
   const [originalVideoFile, setOriginalVideoFile] = useState<File | null>(null);
   const [uploadInfo, setUploadInfo] = useState<UploadInfo | null>(null);
   const [subtitles, setSubtitles] = useState<string | null>(null);
+  // Canonical segment array from auto-processing (2026-04-13). The
+  // `subtitles` state above keeps the raw SRT string for display/edit
+  // use; this state holds the typed segments for write paths
+  // (POST /subtitler/projects schema requires array).
+  const [subtitleSegments, setSubtitleSegments] = useState<Array<{
+    text: string;
+    startTime: number;
+    endTime: number;
+  }> | null>(null);
   const [error, setError] = useState<string | null>(null);
   const {
     socialText,
@@ -292,7 +301,12 @@ const SubtitlerPage = (): React.ReactElement => {
         try {
           const projectData = {
             uploadId: uploadInfo.uploadId,
-            subtitles: subtitles || '',
+            // Backend schema (both legacy `projectDataSchema` in
+            // projectController.ts AND the contract `projectDataBodySchema`
+            // in @gruenerator/contracts) requires a typed
+            // `SubtitleSegment[]`. Pre-2026-04-13 this was sending the raw
+            // SRT string, which silently 400'd every auto-create request.
+            subtitles: subtitleSegments ?? [],
             title:
               uploadInfo.name?.replace(/\.[^/.]+$/, '') ||
               `Projekt ${new Date().toLocaleDateString('de-DE')}`,
@@ -427,6 +441,11 @@ const SubtitlerPage = (): React.ReactElement => {
     // Store subtitles from auto processing for editing
     if (result.subtitles) {
       setSubtitles(result.subtitles);
+    }
+    // Store canonical segment array for write paths (project create/update).
+    // Schema requires SubtitleSegment[]; string would 400.
+    if (result.segments) {
+      setSubtitleSegments(result.segments);
     }
     // Move to success screen - the video is ready for download
     setStep('success');

--- a/docs/typescript-safety-roadmap.md
+++ b/docs/typescript-safety-roadmap.md
@@ -190,18 +190,6 @@ ts-rest defines a single contract that types body, params, query, headers, AND r
 - `apps/web/src/hooks/useRecentValuesTyped.ts` — typed hook showing migration pattern
 - `apps/api/routes/user/recentValuesContractRouter.ts` — backend ts-rest router (pilot, not yet mounted)
 
-**To activate the pilot backend router**, add to `routes.ts` before the legacy router:
-```ts
-import { mountRecentValuesContractRouter } from './routes/user/recentValuesContractRouter.js';
-mountRecentValuesContractRouter(app);
-```
-
-**Packages to install:**
-```
-pnpm add @ts-rest/core @ts-rest/express   # in apps/api
-pnpm add @ts-rest/core                    # in packages/shared (via contracts dep)
-```
-
 **Acceleration strategy:** ~75 Zod schemas from `validateBody` already exist. A codegen script can auto-generate ts-rest contracts from them — skips 60% of the manual effort.
 
 #### Mandatory checklist for new ts-rest contract routers (learned 2026-04-12)
@@ -434,29 +422,6 @@ Config: chromium-only, `webServer` auto-start with `reuseExistingServer`, so run
 
 ---
 
-### Session N+1 — Bulk ts-rest contract generation (BIGGEST blast radius)
-
-**Goal**: +25 endpoints contract-covered in one session by extending the existing codegen script.
-
-**Acceleration lever**: `scripts/generate-contracts-from-validate-body.ts` already parses `validateBody(someSchema)` calls and emits contract stubs from the request bodies. Extend it to ALSO generate response schemas by walking handler bodies and finding `res.json(...)` / `res.status(N).json(...)` call sites, then emitting a discriminated-union response map. The 60% of the work that's currently manual (response schema authoring) becomes automated.
-
-**Target route families** (5 batches, each ~5-7 endpoints):
-- `apps/api/routes/documents/` — manual, retrieval, qdrant (already uses `DocumentId` branded type from Phase 4.2)
-- `apps/api/routes/template/` — user, admin, gallery (21 routes, split across 2 contracts)
-- `apps/api/routes/sharepic/` — prompt routes (3 casts here cleaned up as side effect)
-- `apps/api/routes/etherpad/` — small, straightforward
-- `apps/api/routes/media/` — shared media endpoints (file upload excluded)
-
-**Parallel split**: 1 main agent extends codegen script, 3 Sonnet streams each own 1-2 route families. Codegen must land BEFORE streams start so they can reuse.
-
-**Target state**: 11 → 16 contracts, 50 → ~75 typed endpoints (≈60% of the 126 candidates).
-
-**Pitfalls**:
-- Every new contract MUST use `.nullish()` not `.optional()` for request bodies (2026-04-12 rule)
-- Every new contract MUST use `logContractValidationError` (2026-04-12 rule)
-- Mixed-auth contracts need the per-handler `requireAuthUser` helper pattern (notebookContract rule)
-- `.passthrough()` is forbidden on response schemas mirroring strict service types (notebookContract rule)
-
 ### Session N+2 — Frontend typed hook batch
 
 **Goal**: 12 typed frontend hooks (up from 3) + migrate ~40 `apiClient.*` call sites to contract clients.
@@ -508,13 +473,7 @@ Backend contracts are valueless without frontend consumers (Acceleration Princip
 
 **Stream timing**: 2 parallel Sonnet streams (langgraph/subtitler vs chat), ~11 min and ~15 min respectively. Main-agent verification pass: ~3 min.
 
-### Session N+3 — Cast hotspot cluster elimination [DONE 2026-04-13]
-
-**Outcome**: Ratchet baseline dropped **208 → 179 → 178** over 3 sessions. All 6 original hotspot files at 0 casts. 2 parallel Sonnet streams (langgraph + chat), +1 main-agent fixup pass for `exactOptionalPropertyTypes` gotchas from the initial stream outputs.
-
-**Plus bonus: 19-error web baseline eliminated.** Session N+3 added a fourth stream to peel off the stable "19 pre-existing unrelated errors" that had been reported by every session for 5 sessions. Stream D fixed all 19 at source with 0 new casts. First time `apps/web` typechecks fully clean.
-
-See per-file table and bonus bug catches in the cast-ratchet section above.
+**Plus bonus: 19-error web baseline eliminated.** A fourth stream peeled off the stable "19 pre-existing unrelated errors" that had been reported by every session for 5 sessions. Stream D fixed all 19 at source with 0 new casts. First time `apps/web` typechecks fully clean.
 
 ### Session N+4 — `eslint-disable` cleanup + `validateBody` backfill [DONE 2026-04-13]
 
@@ -560,15 +519,101 @@ See per-file table and bonus bug catches in the cast-ratchet section above.
 3. Consume via `streamSSE(path, unionSchema)` on the frontend
 4. Backend router handler delegates to the legacy streaming controller — don't try to write SSE frames from inside a ts-rest handler
 
-### Auth cleanup (parallel to N+4/N+5, 2026-04-13)
+### Auth cleanup + contract router shadowing audit (parallel to N+4/N+5, 2026-04-13)
 
-Beyond the Phase 4 sessions, this day landed several auth-related hardening commits driven by production incidents:
+Beyond the Phase 4 sessions, this day landed an extended auth-hardening sweep driven by production incidents on `gruenerator-test`. The work was triggered by a reproducible 500 cascade on the boards page that the user experienced as a login loop — investigation traced the root cause to the ts-rest contract router mounting pattern and fanned out from there.
 
-- **`25f8bac8` / `ef92956c`** — close ts-rest contract router auth bypasses. Several routers were missing per-handler `req.user` checks OR prefix-level `requireAuth` middleware. Every mount point audited; every handler that reads `req.user` now either has prefix-level auth OR a per-handler guard.
-- **`7f955e55` / `6f70d0a9`** — Keycloak profile mapper hardening + email field at Better Auth boundary. Surfaces a session-rotation loop bug where a single NULL email row in `profiles` broke Better Auth's ~5-min cookie revalidation.
-- **`c4a33a99`** — tighten `UserProfile.email` back to `string | undefined` after a brief `.nullable().optional()` widening. Documents the invariant that `authMiddleware.toBetterAuthUser` is the SOLE null-strip boundary for `userProfileSchema`. Any new parse site of the schema must null-strip first or it will trip on NULL DB rows. Captures the design rule as a JSDoc invariant on the function.
+**1. Keycloak profile mapper hardening** (`7f955e55` / `6f70d0a9` / `cd4ef3cd`)
+
+A production login loop was caused by Keycloak profiles missing an `email` claim. The raw `profile.email as string` cast in `mapProfileToUser` wrote `undefined` into `profiles.email`, which then failed `userProfileSchema.parse()` on every subsequent session read. Fixed in three layers:
+
+- `packages/contracts/src/schemas/userProfile.ts:65` widened `email` to `z.string().optional()` as a Zod boundary patch
+- `apps/api/config/betterAuth.ts` mapper extracted to `apps/api/config/mapKeycloakProfileToUser.ts` as a pure, unit-testable module
+- Runtime validation + conditional spread (`...(email !== null && { email })`) so missing claims produce an absent key, not `email: undefined`
+- WARN log on every missing-email path capturing `idpHint`, `sub`, `preferred_username`, and sorted `claimKeys` — gives operators visibility into which IdP is sending incomplete claims without needing to reproduce the login
+
+Prod DB audit (`SELECT count(*) FROM profiles WHERE email IS NULL`) returned **0 rows** — the fix was preventative, not reactive.
+
+**2. ts-rest contract router auth bypass sweep** (`25f8bac8` / `ef92956c`)
+
+Audit of all **22 ts-rest contract routers** found **6 with unprotected `(req.user as UserProfile).id` dereferences** — the casts were type-level lies that silenced the compiler but provided zero runtime protection. When Express didn't apply `requireAuth` in front of the contract mount, `req.user` was undefined at handler time and the cast's `.id` access crashed with `Cannot read properties of undefined (reading 'id')`.
+
+The audit also revealed this wasn't just a crash — it was a **security bypass**. Handlers that didn't happen to dereference `.id` first would run SQL queries with `userId = undefined`, silently returning empty results or leaking data to unauthenticated callers.
+
+**Group A — prefix `requireAuth` fixes** (routers where all endpoints require auth):
+- `/api/boards` — confirmed crash site, was the source of the 500 cascade
+- `/api/docs` — comment claimed "requireAuth applied at prefix" but was aspirational; the later `app.use('/api/docs', requireAuth, legacyRouter)` only protected the legacy fallback, not the contract router mounted earlier
+- `/api/profile` — no prefix auth despite all 5 contract routes needing it
+- `/api/recent-values` — user-specific data, no auth
+
+**Group B — adminVorlagen** (`/api/auth/admin/vorlagen`): same pattern, comment "inherited from /api/auth on authRouter" was wrong — `app.use(prefix, middleware, router)` scopes middleware to that router, not to handlers registered earlier.
+
+**Group C — shareContractRouter** (per-handler 401 guards): couldn't use prefix `requireAuth` because the legacy `/api/share` router serves public read endpoints (preview/download/thumbnail/original). Instead:
+- `getUserId()` / `getUserInfo()` return `| undefined`
+- Shared `UNAUTHORIZED` 401 response constant
+- Per-handler `if (!userId) return UNAUTHORIZED` guards on all 6 write endpoints
+- `sharesContract` response schemas extended with `401: shareErrorResponseSchema` so ts-rest accepts the early return
+
+**Routers already safe or intentionally mixed**: notebookCollections, documents, threads, chatGraph, transfer, notifications, video, wordpress (all had prefix auth); subtitler (per-handler guards); notebook (intentionally mixed with public:token routes); search (not mounted yet); voice/imagePicker/unsplash/exports/campaignCanvas (don't use `req.user`).
+
+**3. `getAuthedUser` helper + migration** (`337a148f`)
+
+Replaces the `(req.user as UserProfile).id` cast pattern with a typed helper at `apps/api/utils/getAuthedUser.ts`:
+
+```ts
+export class UnauthenticatedError extends Error { ... }
+export function getAuthedUser<R extends { user?: unknown }>(req: R): UserProfile {
+  const user = req.user as UserProfile | undefined;
+  if (!user) throw new UnauthenticatedError();
+  return user;
+}
+```
+
+Design decisions:
+- **Generic constraint `<R extends { user?: unknown }>`** accepts both Express `Request` and ts-rest's `TsRestRequest<Contract>`. A concrete `Request` parameter fails under `exactOptionalPropertyTypes` when the contract's query schema includes `nullable` fields (encountered in adminVorlagen + notifications during migration).
+- **Throw, don't return undefined.** For prefix-protected routes, `req.user` being undefined is a programming error (missing `requireAuth`), not a valid runtime branch. Throwing surfaces the misconfiguration loudly.
+- **Named error class.** `UnauthenticatedError.name` discriminant lets future error middleware `instanceof`-check and convert to a typed 401 response; for now unhandled throws produce a 500 which is a deliberate loud failure.
+- **Mixed-auth routes DON'T use the helper.** Share / subtitler / notebook stay on per-handler `| undefined` guards because some of their endpoints are legitimately public.
+
+Migrated in the same commit: `boardsContractRouter`, `adminVorlagenContractRouter`, `recentValuesContractRouter`, `notificationsContractRouter` (net −8 lines across routers + new helper).
+
+**4. `/api/docs/user-groups` → `/api/docs/groups/me` path rename** (`1ad2f017`)
+
+Fixing the auth bypass made a second bug *newly visible*: the legacy `GET /api/docs/user-groups` endpoint (in `groupShareController.ts`, used by the Share-with-Group dropdown) was being shadowed by the contract's `getDocumentById` at `GET /api/docs/:id`. The `:id` glob matched `'user-groups'`, the handler ran `WHERE cd.id = $1::uuid`, and Postgres threw `invalid input syntax for type uuid: "user-groups"`.
+
+The bug pre-dated the auth fix but was hidden behind it — the crash only became reproducible once the contract router was correctly reaching handlers. Fix: rename the legacy path to 4 segments (`/groups/me`) which can't match the contract's 3-segment `:id` or 4-segment `:id/permissions` routes. Updated 4 callers across the web docs package, web boards hook, mobile app, and backend route definition.
+
+**Audit confirmed** the threads contract at `/api/chat-service/threads` doesn't have the same collision — its `:threadId` glob lives at depth 4 (`/threads/:threadId/settings`), not depth 3, so depth-3 literal paths like `/threads/user-groups` fall through to the legacy router cleanly.
+
+**5. Type-model cleanup** (`c4a33a99`)
+
+Tightened `UserProfile.email` back to `string | undefined` after a brief `.nullable().optional()` widening during the incident. Documents the invariant that `authMiddleware.toBetterAuthUser` (at lines 59-61) is the **sole null-strip boundary** for `userProfileSchema`. Any new parse site of the schema must null-strip first or it will trip on NULL DB rows. Captured as a JSDoc invariant on the function.
 
 **Long-term rule captured**: when a schema's underlying column is nullable, the canonical TypeScript type should model the POST-null-strip shape (one `T | undefined`), not the untrusted input shape (three `T | null | undefined`). The null-strip happens at a single boundary (authMiddleware); every downstream consumer sees one answer. Option C (`.nullable().optional()`) was rejected because it doubled the test surface and forced per-call-site `?? undefined` coercions.
+
+**6. Log cleanup: ~1500 lines/signin → ~30 lines/signin** (`1cbe103f` / `989ce7e8` / `58a95228` / `bb8cd6cf`)
+
+The investigation made the diagnostic log volume impossible to ignore — a single auth flow produced ~1500 lines of Drizzle adapter chatter, PostgresService init narration, and duplicate databaseHooks entries, with 90% redundancy and zero actionable information in production. Four-commit cleanup:
+
+- **`1cbe103f`** — PostgresService init 11 lines → 1 line with wall-clock duration. Replaced per-step narration (`Starting...` → `Creating pool...` → `Pool created...` → `Connection test successful` → `PostgreSQL connection established` → `Migrations complete` → `Schema synchronized`) with a single summary: `ready host=<h>:<p> db=<n> migrations=ok schema=ok (147ms)`. Dropped the `SELECT NOW()` confirmation log (Postgres clock is not actionable) and the no-op "All schema columns up to date" case (absence of the Schema-sync log implies clean).
+- **`989ce7e8`** — Drizzle adapter `debugLogs` gated to `env.LOG_LEVEL === 'debug'`. The `[1/3] [2/3] [3/3]` triple-entry-per-query pattern dumping full JWT bodies saved ~1200 lines per signin in production. Full verbosity preserved at `LOG_LEVEL=debug` for active investigations. Structured `databaseHooks` one-line-per-event logs cover normal observability.
+- **`58a95228`** — Dropped the redundant `before` hooks on `databaseHooks.user/session/account.create` (they just announced upcoming writes and returned unmodified data — no diagnostic value beyond the `after` hook). Better Auth's internal logger level gated from hardcoded `debug` to `env.LOG_LEVEL === 'debug' ? 'debug' : 'warn'`. Tightened `after` hook log shapes to structured `key=value` format: `[Auth] session-created id=... user=... token=<prefix>` instead of prose with colons and commas.
+- **`bb8cd6cf`** — Rate-limited `[Auth] 401` logs to once per (method+path) per 60 seconds. Background pollers on logged-out tabs (notifications, presence, unread-count) were flooding logs with identical lines. 60s debounce via a module-level `Map<string, number>` with lazy pruning to bound memory. Response still fires 401 for every request — only the log line is debounced.
+
+**Information delta**: zero production observability loss (all four changes preserve full diagnostic data at `LOG_LEVEL=debug`), measurable signal-to-noise improvement (wall-clock duration added to init, grep-friendly key=value shapes in hooks, no more JWT body dumps flooding the scroll buffer).
+
+**7. Outstanding follow-ups from this session** (not shipped):
+
+- **Migrate the remaining 5 contract routers** to `getAuthedUser`: docs, documents, threads, notebookCollections, video. Each has its own throwing local `getUserId` helper that's functionally equivalent — pure cleanup, ~10 lines per file, no behavior change. Opportunistic when touching files.
+- **`UnauthenticatedError` → 401 mapping in the Express error handler.** The class is in place; one `instanceof` check in the global error handler converts helper throws to clean 401 responses instead of generic 500s. ~5 line change.
+- **Error B: session UPDATE returns empty → 401** on the `/api/notifications/unread-count` path, unresolved. Observed in production-test logs as Better Auth's `updateAge` refresh attempting to bump `expiresAt` and getting `data: undefined` back from Drizzle, which then `getSession()` interprets as "failed to get session" and returns null. Not correlated with any session deletion we control. Next step if it recurs after this branch deploys: disable `cookieCache` (`apps/api/config/betterAuth.ts:145-148`) as a one-config-line experiment to isolate whether the cookie-cache path is involved.
+- **Defense-in-depth for contract path shadowing**: add `pathParams: z.object({ id: z.string().uuid() })` to the docs contract's 5 routes. Won't restore fall-through to legacy routes (ts-rest validation rejects with 400, doesn't fall through), but produces clearer errors than `'X'::uuid` SQL crashes for any future unconstrained path that slips under `/api/docs/:id`.
+
+**Lessons captured as memory**:
+
+- **Contract router shadowing pattern**: a greedy `:id` glob at depth N collides with any literal legacy path at the same depth. Fix is either (a) move the legacy path to a different depth, or (b) constrain the glob at the Zod level. The shape-specific nature of the bug means the fix needs audit across ALL contracts that share a prefix with legacy routers.
+- **Batch typecheck cadence**: typecheck once per *commit boundary*, not per *Edit* call. Running `tsc --noEmit` after every 1-line edit in a sequence of 4 independent commits wastes 40-120s of wall-clock time and produces terminal noise. (Captured as `feedback_batch_typechecks.md`.)
+- **Multi-agent file-partition discipline**: two agents worked in parallel on the auth surface this day (one on helper migration + shadowing audit, the other on type-model cleanup). Zero merge conflicts because they touched disjoint files. File-level partition is what made parallel work safe, not coordinating timing.
 
 ### After Session N+5: what counts as "done"
 
@@ -683,7 +728,6 @@ Dev runners (tsx, vitest) pass `--conditions=development` and resolve to source.
 | `no-floating-promises` (mobile) | — | 70 (warn) | **0** (error) | 0 |
 | `no-floating-promises` (api) | — | 0 (warn) | **0** (error) | 0 |
 | `eslint-disable no-explicit-any` | 0 | 22 api / 70 repo | ~same | ~22 (library only) |
-| `as unknown as X` casts | 241 | 84 api / 205 repo | ~same | ratchet down |
 | `exactOptionalPropertyTypes` | disabled | **enabled** | enabled | enabled |
 | Duplicate type definitions | ~20 | **0** | 0 | 0 |
 | Drizzle schema tables | 0 | ~20 | **~25** (+ba_*, +yjs_document_snapshots, +user_sites) | all |

--- a/packages/contracts/src/schemas/subtitler.ts
+++ b/packages/contracts/src/schemas/subtitler.ts
@@ -5,8 +5,45 @@
  *
  * IMPORTANT: Request bodies use `.nullish()` for optional fields per the
  * 2026-04-12 production rule.
+ *
+ * ## SubtitleSegment canonicalization (2026-04-13)
+ *
+ * Before this session, `SubtitleSegment` was declared 9 different times
+ * across apps/api/services/subtitler/*.ts — 8 agreed on
+ * `{ startTime, endTime, text }`, 1 (`projectSavingService.ts`) had a
+ * dual-shape widening accepting both `start/end` AND `startTime/endTime`
+ * to paper over a frontend ↔ backend on-wire mismatch. Plus
+ * `projectDataBodySchema.subtitles` was declared as
+ * `z.array({ text, start, end })` (the wrong shape) AND the frontend
+ * was sending `subtitles: srtString` which didn't match either shape,
+ * resulting in silent 400s from validateBody and a pre-existing bug
+ * where subtitle write through POST /subtitler/projects never worked.
+ *
+ * This file is now the single source of truth. Import `SubtitleSegment`
+ * from `@gruenerator/contracts` everywhere; delete local duplicates.
+ * Same unification pattern as UserProfile (N+1), GeneratedContent (N+4),
+ * and SubtitleConfig (N+3).
  */
 import { z } from 'zod';
+
+// ── Canonical SubtitleSegment ───────────────────────────────────────────────
+
+/**
+ * Canonical subtitle segment shape. `startTime` / `endTime` are seconds
+ * from video start; `text` is the displayed text for that segment.
+ *
+ * 8 of the 9 pre-unification declarations agreed on this shape exactly.
+ * The 9th (projectSavingService) had a dual-shape widening accepting
+ * both `start/end` and `startTime/endTime` — we keep the canonical
+ * shape and migrate the outlier.
+ */
+export const subtitleSegmentSchema = z.object({
+  text: z.string(),
+  startTime: z.number(),
+  endTime: z.number(),
+});
+
+export type SubtitleSegment = z.infer<typeof subtitleSegmentSchema>;
 
 // ── Processing: cleanup ─────────────────────────────────────────────────────
 
@@ -37,13 +74,15 @@ export const exportTokenResponseSchema = z.object({
 export const projectDataBodySchema = z.object({
   uploadId: z.string().nullish(),
   videoFilename: z.string(),
-  subtitles: z.array(
-    z.object({
-      text: z.string(),
-      start: z.number(),
-      end: z.number(),
-    })
-  ),
+  // Canonical segment array — see `subtitleSegmentSchema` above.
+  // Pre-unification this was `{ text, start, end }` which never matched
+  // any of the 9 service-layer SubtitleSegment declarations. The 8
+  // services that used `startTime/endTime` silently received the wrong
+  // field names; the frontend happened to send an SRT string instead
+  // and tripped validateBody with a "expected array, received string"
+  // 400 from Session N+1 onward (logged but not user-visible because
+  // the route was previously in the legacy router with silent 400s).
+  subtitles: z.array(subtitleSegmentSchema),
   title: z.string().nullish(),
   stylePreference: z.string().nullish(),
   heightPreference: z.string().nullish(),


### PR DESCRIPTION
## Summary
- **Subtitler unification** — 9 duplicate `SubtitleSegment` type definitions across backend and frontend collapsed onto a single canonical schema in `@gruenerator/contracts`. Fixes the silent `POST /api/subtitler/projects` 400 where the frontend always sent an SRT string while the legacy `validateBody` always expected an array. Backend auto-processing now emits the segment array alongside the display-layer SRT blob, so write paths get typed data and display code is unaffected.
- **Login loop killed** — both the legacy `apiClient` axios interceptor and the shared `createApiClient` `onUnauthorized` hook now silently probe `/auth/status` before redirecting on a 401. A transient 401 from e.g. the notifications poller firing during a Better Auth cookie rotation is swallowed, the original query retries, and the user never loses in-flight work. Probe result is cached 5 s and in-flight calls are coalesced to collapse 401 cascades across routes.
- **OAuth state replay log noise** — `[BA:error] Failed to parse state` on callback replay (link-preview bots, browser back button, 10-min TTL expiry) now logs as a single `warn` line keyed on the error code. Real CSRF patterns are still visible via rate, but benign replay stops looking like a prod incident.

## Test plan
- [x] `apps/api` typecheck clean
- [x] `apps/web` typecheck clean
- [x] test-branch CI (run 24364944996) green — 4m19s
- [ ] Smoke: start subtitler auto-processing → POST `/subtitler/projects` persists a real segment array in DB (not `JSON.stringify("<srt>")`)
- [ ] Smoke: leave a tab open through a Better Auth cookie rotation (~5 min), trigger a background query, confirm no login redirect and query succeeds
- [ ] Smoke: re-open a consumed OAuth callback URL, confirm `[BA:warn] oauth state replay code=state_mismatch` single line and user is bounced to `/login?error=please_restart_the_process`