### PR TITLE
Subtitler save-edit-download flow fixes + controlled SubtitleEditor refactor

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -457,11 +457,14 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/custom_prompt', aiGenerationLimiter, customPromptRoute);
   app.use('/api/auth/custom_prompt', aiGenerationLimiter, customPromptRoute);
   app.use('/api/claude/generate-short-subtitles', aiGenerationLimiter, claudeSubtitlesRoute);
-  // ts-rest contract router — mount before legacy subtitler routers
+  // requireAuth must run before the contract mount — createExpressEndpoints
+  // registers handlers directly on the app, bypassing the legacy prefix
+  // middleware. Same pattern as /api/transfer below.
+  app.use('/api/subtitler/projects', requireAuth);
   mountSubtitlerContractRouter(app);
   app.use('/api/subtitler', standardMutationLimiter, subtitlerRouter);
   app.use('/api/subtitler', standardMutationLimiter, subtitlerSocialRouter);
-  app.use('/api/subtitler/projects', requireAuth, standardMutationLimiter, subtitlerProjectRouter);
+  app.use('/api/subtitler/projects', standardMutationLimiter, subtitlerProjectRouter);
   app.use('/api/subtitler/share', publicReadLimiter, subtitlerShareRouter);
   // ts-rest contract router — mount before legacy shareRouter
   mountShareContractRouter(app);

--- a/apps/mobile/app/(tabs)/(media)/reel.tsx
+++ b/apps/mobile/app/(tabs)/(media)/reel.tsx
@@ -1,4 +1,5 @@
 import { type Project, getVideoUrl, saveProject, useProjectsStore } from '@gruenerator/shared';
+import { parseSubtitlesText } from '@gruenerator/shared/subtitle-editor';
 import { useFocusEffect, router } from 'expo-router';
 import { useState, useCallback, useEffect } from 'react';
 import {
@@ -118,9 +119,20 @@ export default function ReelScreen() {
       const saveAndNavigate = async () => {
         setIsSavingProject(true);
         try {
+          // `transcribedSubtitles` is the raw SRT blob from the
+          // transcription flow. The POST /subtitler/projects contract now
+          // requires a `SubtitleSegment[]` on the wire (canonicalized
+          // 2026-04-13 — see packages/contracts/src/schemas/subtitler.ts),
+          // so parse the SRT into segments and strip the client-only `id`
+          // field at the save boundary before sending.
+          const parsedSegments = parseSubtitlesText(transcribedSubtitles);
           const { project: savedProject } = await saveProject({
             uploadId,
-            subtitles: transcribedSubtitles,
+            subtitles: parsedSegments.map((s) => ({
+              text: s.text,
+              startTime: s.startTime,
+              endTime: s.endTime,
+            })),
             stylePreference: 'shadow',
             heightPreference: 'tief',
             modePreference: 'manual',

--- a/apps/mobile/hooks/useSubtitleEditor.ts
+++ b/apps/mobile/hooks/useSubtitleEditor.ts
@@ -249,9 +249,18 @@ export function useSubtitleEditor({ player, timelineRef }: UseSubtitleEditorOpti
       if (isTempProject) {
         const uploadId = projectId.replace('temp-', '');
 
+        // Create path requires the canonical `SubtitleSegment[]` wire
+        // shape per `@gruenerator/contracts` — the local segment type
+        // carries an `id` for React-key stability that must be stripped
+        // before leaving the client. Update path (below) still takes the
+        // SRT string because the update contract hasn't been migrated.
         const { project: newProject } = await saveProject({
           uploadId,
-          subtitles: subtitlesText,
+          subtitles: segments.map((s) => ({
+            text: s.text,
+            startTime: s.startTime,
+            endTime: s.endTime,
+          })),
           stylePreference,
           heightPreference,
           title: 'Neues Reel',

--- a/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
@@ -207,7 +207,14 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
   const user = useAuthStore((state) => state.user);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const segmentRefs = useRef<Record<number, HTMLElement>>({});
-  const [videoUrl, setVideoUrl] = useState<string | null>(null);
+  // `videoUrl` either mirrors the prop (remote streaming URL for loaded
+  // projects) or points at a freshly minted `URL.createObjectURL(...)`
+  // over the local File/Blob when the user just uploaded. The blob path
+  // requires an effect (lifecycle + revoke); the prop path is pure
+  // derivation. Keeping the blob URL in a dedicated state lets us
+  // combine them via a render-time ternary below.
+  const [blobVideoUrl, setBlobVideoUrl] = useState<string | null>(null);
+  const videoUrl = videoUrlProp ?? blobVideoUrl;
   const [error, setError] = useState<string | null>(null);
   const [currentTimeInSeconds, setCurrentTimeInSeconds] = useState<number>(0);
   const [videoMetadata, setVideoMetadata] = useState<VideoMetadata | null>(null);
@@ -255,42 +262,19 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
     );
   };
 
+  // Blob URL lifecycle: create an object URL when we have a File/Blob
+  // (no remote URL), revoke it on cleanup. If `videoUrlProp` is set, the
+  // render-time ternary above picks it over any blob URL, but we still
+  // avoid creating a blob URL we wouldn't use.
   useEffect(() => {
-    if (videoUrlProp) {
-      console.log('[SubtitleEditor] Using streaming video URL');
-      setVideoUrl(videoUrlProp);
-      return;
-    }
-
-    if (!videoFile) {
-      console.log('[SubtitleEditor] No video file or URL provided');
-      return;
-    }
-
+    if (videoUrlProp || !videoFile) return;
     if (!(videoFile instanceof File || videoFile instanceof Blob)) {
-      console.error('[SubtitleEditor] Invalid video file type:', typeof videoFile);
       setError('Ungültiges Video-Format');
       return;
     }
-
-    try {
-      console.log('[SubtitleEditor] Creating video URL for file:', {
-        name: (videoFile as File).name,
-        type: (videoFile as File).type,
-        size: (videoFile as File).size,
-      });
-
-      const url = URL.createObjectURL(videoFile);
-      setVideoUrl(url);
-
-      return () => {
-        console.log('[SubtitleEditor] Cleaning up video URL');
-        URL.revokeObjectURL(url);
-      };
-    } catch (error) {
-      console.error('[SubtitleEditor] Error creating video URL:', error);
-      setError('Fehler beim Laden der Video-Vorschau');
-    }
+    const url = URL.createObjectURL(videoFile);
+    setBlobVideoUrl(url);
+    return () => URL.revokeObjectURL(url);
   }, [videoFile, videoUrlProp]);
 
   useEffect(() => {
@@ -305,22 +289,6 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
 
     observer.observe(videoRef.current);
     return () => observer.disconnect();
-  }, [videoUrl]);
-
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return;
-
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
-
-    video.addEventListener('play', handlePlay);
-    video.addEventListener('pause', handlePause);
-
-    return () => {
-      video.removeEventListener('play', handlePlay);
-      video.removeEventListener('pause', handlePause);
-    };
   }, [videoUrl]);
 
   const togglePlayPause = useCallback(() => {
@@ -585,6 +553,8 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
                     src={videoUrl}
                     onLoadedMetadata={handleVideoLoadedMetadata}
                     onTimeUpdate={handleVideoTimeUpdate}
+                    onPlay={() => setIsPlaying(true)}
+                    onPause={() => setIsPlaying(false)}
                   >
                     Dein Browser unterstützt keine Video-Wiedergabe.
                   </video>

--- a/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
@@ -533,9 +533,18 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
               height: videoMetadataFromUpload.height ?? 0,
             }
           : undefined;
+        // The POST /subtitler/projects contract expects a canonical
+        // `SubtitleSegment[]` (text/startTime/endTime) on the wire. The
+        // local editor state additionally carries a client-only `id` for
+        // React keys; strip it here at the save boundary so nothing
+        // client-specific leaks into the persisted shape.
         const projectData = {
           uploadId,
-          subtitles: subtitlesText,
+          subtitles: editableSubtitles.map((s) => ({
+            text: s.text,
+            startTime: s.startTime,
+            endTime: s.endTime,
+          })),
           title: videoFilename
             ? videoFilename.replace(/\.[^.]+$/, '')
             : `Projekt ${new Date().toLocaleDateString('de-DE')}`,

--- a/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
@@ -8,7 +8,7 @@ import Spinner from '../../../components/common/Spinner';
 import FloatingActionButton from '../../../components/common/UI/FloatingActionButton';
 import { useAuthStore } from '../../../stores/authStore';
 import { useSubtitlerExportStore } from '../../../stores/subtitlerExportStore';
-import { parseSubtitleBlocks, formatSubtitleBlocks } from '../utils/subtitleSegmentUtils';
+import { formatSubtitleBlocks } from '../utils/subtitleSegmentUtils';
 
 import LiveSubtitlePreview from './LiveSubtitlePreview';
 import Timeline from './Timeline';
@@ -66,7 +66,8 @@ interface UploadVideoMetadata {
 interface SubtitleEditorProps {
   videoFile?: File | Blob | null;
   videoUrl?: string | null;
-  subtitles: string;
+  segments: SubtitleSegment[];
+  onSegmentsChange: (segments: SubtitleSegment[]) => void;
   uploadId: string;
   subtitlePreference: SubtitlePreference;
   stylePreference?: StylePreference;
@@ -85,7 +86,8 @@ interface SubtitleEditorProps {
 const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
   videoFile,
   videoUrl: videoUrlProp,
-  subtitles,
+  segments,
+  onSegmentsChange,
   uploadId,
   subtitlePreference,
   stylePreference = 'shadow' as StylePreference,
@@ -206,7 +208,6 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const segmentRefs = useRef<Record<number, HTMLElement>>({});
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
-  const [editableSubtitles, setEditableSubtitles] = useState<SubtitleSegment[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [currentTimeInSeconds, setCurrentTimeInSeconds] = useState<number>(0);
   const [videoMetadata, setVideoMetadata] = useState<VideoMetadata | null>(null);
@@ -291,29 +292,6 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
       setError('Fehler beim Laden der Video-Vorschau');
     }
   }, [videoFile, videoUrlProp]);
-
-  useEffect(() => {
-    if (!subtitles) {
-      console.log('[SubtitleEditor] No subtitles provided');
-      return;
-    }
-
-    if (typeof subtitles !== 'string') {
-      console.error('[SubtitleEditor] Invalid subtitles type:', typeof subtitles);
-      setError('Ungültiges Untertitel-Format');
-      return;
-    }
-
-    try {
-      console.log('[SubtitleEditor] Processing subtitles:', subtitles);
-      const segments = parseSubtitleBlocks(subtitles);
-      console.log('[SubtitleEditor] Processed segments:', segments.length);
-      setEditableSubtitles(segments);
-    } catch (error) {
-      console.error('[SubtitleEditor] Error processing subtitles:', error);
-      setError('Fehler beim Verarbeiten der Untertitel');
-    }
-  }, [subtitles]);
 
   useEffect(() => {
     if (!videoRef.current) return;
@@ -406,31 +384,26 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
   const handleSegmentClick = useCallback(
     (segmentId: number): void => {
       setSelectedSegmentId(segmentId);
-      const segment = editableSubtitles.find((s) => s.id === segmentId);
+      const segment = segments.find((s) => s.id === segmentId);
       if (segment && videoRef.current) {
         videoRef.current.currentTime = segment.startTime;
       }
     },
-    [editableSubtitles]
+    [segments]
   );
 
-  const handleTextChange = useCallback((segmentId: number, newText: string): void => {
-    setEditableSubtitles((prev) =>
-      prev.map((segment) => (segment.id === segmentId ? { ...segment, text: newText } : segment))
-    );
-  }, []);
+  const handleTextChange = useCallback(
+    (segmentId: number, newText: string): void => {
+      onSegmentsChange(
+        segments.map((segment) =>
+          segment.id === segmentId ? { ...segment, text: newText } : segment
+        )
+      );
+    },
+    [segments, onSegmentsChange]
+  );
 
-  useEffect(() => {
-    if (window.innerWidth <= 768 && (videoFile || videoUrlProp) && subtitles) {
-      const textareas = document.querySelectorAll('.segment-text');
-      textareas.forEach((element) => {
-        (element as HTMLElement).style.height = 'auto';
-        (element as HTMLElement).style.height = (element as HTMLElement).scrollHeight + 'px';
-      });
-    }
-  }, [editableSubtitles, videoFile, videoUrlProp, subtitles]);
-
-  if ((!videoFile && !videoUrlProp) || !subtitles) {
+  if ((!videoFile && !videoUrlProp) || segments.length === 0) {
     console.log('[SubtitleEditor] Missing required props');
     return (
       <div className="w-full">
@@ -438,25 +411,6 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
       </div>
     );
   }
-
-  const adjustTextareaHeight = (element: HTMLElement): void => {
-    element.style.height = 'auto';
-    element.style.height = element.scrollHeight + 'px';
-  };
-
-  const handleSubtitleEdit = (
-    id: number,
-    newText: string,
-    event: React.ChangeEvent<HTMLTextAreaElement>
-  ): void => {
-    setEditableSubtitles((prev) =>
-      prev.map((segment) => (segment.id === id ? { ...segment, text: newText } : segment))
-    );
-
-    if (window.innerWidth <= 768) {
-      adjustTextareaHeight(event.target);
-    }
-  };
 
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
@@ -466,18 +420,17 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
   };
 
   const handleExport = async (maxResolution: number | null = null): Promise<void> => {
-    if (!uploadId || !editableSubtitles.length) {
+    if (!uploadId || !segments.length) {
       setError('Fehlende Upload-ID oder keine Untertitel zum Exportieren.');
       return;
     }
 
     try {
       setError(null);
-      const subtitlesText = formatSubtitleBlocks(editableSubtitles);
-
       console.log('[SubtitleEditor] Starting export via store:', {
         uploadId,
-        subtitlesLength: subtitlesText.length,
+        segmentCount: segments.length,
+        firstSegmentText: segments[0]?.text,
         stylePreference: localStyle,
         heightPreference: localHeight,
         locale,
@@ -486,7 +439,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
         userId: user?.id,
       });
 
-      const subtitlesForExport = editableSubtitles.map((segment) => ({
+      const subtitlesForExport = segments.map((segment) => ({
         start: segment.startTime,
         end: segment.endTime,
         text: segment.text,
@@ -508,19 +461,27 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
     }
   };
 
+  // `segments` is stripped of the client-only `id` field at the save
+  // boundary — server persistence shouldn't carry a React-key concept.
+  const toWireSegments = (): { text: string; startTime: number; endTime: number }[] =>
+    segments.map((s) => ({ text: s.text, startTime: s.startTime, endTime: s.endTime }));
+
   const handleSaveProject = async (): Promise<void> => {
-    if (!uploadId || !editableSubtitles.length) {
+    if (!uploadId || !segments.length) {
       setError('Keine Daten zum Speichern vorhanden.');
       return;
     }
 
     try {
       setError(null);
-      const subtitlesText = formatSubtitleBlocks(editableSubtitles);
 
       if (loadedProject) {
+        // Update contract currently types `subtitles` as string. Serialize
+        // to SRT so the existing server side stays untouched. Follow-up
+        // to align the update contract to `SubtitleSegment[]` tracked
+        // separately.
         await updateProject(loadedProject.id, {
-          subtitles: subtitlesText,
+          subtitles: formatSubtitleBlocks(segments),
           stylePreference: localStyle,
           heightPreference: localHeight,
         });
@@ -533,18 +494,9 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
               height: videoMetadataFromUpload.height ?? 0,
             }
           : undefined;
-        // The POST /subtitler/projects contract expects a canonical
-        // `SubtitleSegment[]` (text/startTime/endTime) on the wire. The
-        // local editor state additionally carries a client-only `id` for
-        // React keys; strip it here at the save boundary so nothing
-        // client-specific leaks into the persisted shape.
-        const projectData = {
+        await saveProject({
           uploadId,
-          subtitles: editableSubtitles.map((s) => ({
-            text: s.text,
-            startTime: s.startTime,
-            endTime: s.endTime,
-          })),
+          subtitles: toWireSegments(),
           title: videoFilename
             ? videoFilename.replace(/\.[^.]+$/, '')
             : `Projekt ${new Date().toLocaleDateString('de-DE')}`,
@@ -554,8 +506,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
           videoMetadata: formattedVideoMetadata,
           videoFilename: videoFilename || 'video.mp4',
           videoSize: videoSize || 0,
-        };
-        await saveProject(projectData);
+        });
       }
     } catch (err) {
       console.error('[SubtitleEditor] Save project error:', err);
@@ -639,7 +590,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
                   </video>
 
                   <LiveSubtitlePreview
-                    editableSubtitles={editableSubtitles}
+                    editableSubtitles={segments}
                     currentTimeInSeconds={currentTimeInSeconds}
                     videoMetadata={videoMetadata}
                     stylePreference={localStyle}
@@ -676,7 +627,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
                 size="icon"
                 className={cn(saveSuccess && 'border-primary-500 text-primary-500')}
                 onClick={handleSaveProject}
-                disabled={!editableSubtitles.length}
+                disabled={!segments.length}
                 title="Projekt speichern"
               >
                 {saveSuccess ? <FaCheck /> : <FaSave />}
@@ -782,7 +733,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
               <Timeline
                 duration={videoDuration}
                 currentTime={currentTimeInSeconds}
-                segments={editableSubtitles}
+                segments={segments}
                 selectedSegmentId={selectedSegmentId}
                 onSeek={handleTimelineSeek}
                 onSegmentClick={handleSegmentClick}

--- a/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
@@ -92,7 +92,17 @@ interface LoadedProject {
 }
 
 const SubtitlerPage = (): React.ReactElement => {
-  const [step, setStep] = useState<string>('upload');
+  // Lazy initializer writes the first history entry exactly once per
+  // mount — replaces a dedicated `useEffect` that did the same. The
+  // hash reflects the current step so the back button restores it via
+  // the popstate listener below.
+  const [step, setStep] = useState<string>(() => {
+    const initial = 'upload';
+    if (typeof window !== 'undefined') {
+      window.history.replaceState({ step: initial }, '', `#${initial}`);
+    }
+    return initial;
+  });
   const [uploadProgress, setUploadProgress] = useState<number>(0);
   const [isUploading, setIsUploading] = useState(false);
   const currentUploadRef = useRef<tus.Upload | null>(null);
@@ -125,6 +135,15 @@ const SubtitlerPage = (): React.ReactElement => {
   const { user } = useAuthStore();
   const [searchParams, setSearchParams] = useSearchParams();
 
+  // User-initiated step transitions push a new history entry. The
+  // popstate listener below bypasses this helper and calls `setStep`
+  // directly — otherwise back/forward would push new entries instead
+  // of traversing existing ones.
+  const goToStep = useCallback((next: string): void => {
+    setStep(next);
+    window.history.pushState({ step: next }, '', `#${next}`);
+  }, []);
+
   // Deep-link: load project from ?project=<id> query param
   const deepLinkLoadedRef = useRef(false);
   useEffect(() => {
@@ -152,7 +171,7 @@ const SubtitlerPage = (): React.ReactElement => {
           setStylePreference(project.style_preference as StylePreference);
         if (project.height_preference)
           setHeightPreference(project.height_preference as HeightPreference);
-        setStep('edit');
+        goToStep('edit');
         setSearchParams({}, { replace: true });
       })
       .catch((err) => {
@@ -160,19 +179,7 @@ const SubtitlerPage = (): React.ReactElement => {
         setError('Projekt konnte nicht geladen werden.');
         setSearchParams({}, { replace: true });
       });
-  }, [searchParams, user?.id, setSearchParams]);
-
-  // Browser history navigation - push state when step changes
-  const isInitialMount = useRef(true);
-  useEffect(() => {
-    if (isInitialMount.current) {
-      // On initial mount, replace state instead of pushing
-      window.history.replaceState({ step }, '', `#${step}`);
-      isInitialMount.current = false;
-    } else {
-      window.history.pushState({ step }, '', `#${step}`);
-    }
-  }, [step]);
+  }, [searchParams, user?.id, setSearchParams, goToStep]);
 
   // Browser history navigation - handle back button
   useEffect(() => {
@@ -237,8 +244,11 @@ const SubtitlerPage = (): React.ReactElement => {
     setUploadInfo(newUploadInfo);
     setError(null);
 
-    // Auto-start processing immediately after upload
-    setStep('auto-processing');
+    // Step transition + auto-processing kickoff are one logical action,
+    // triggered by the same user event. Pass the fresh uploadId explicitly
+    // to dodge the stale-closure risk on `uploadInfo`.
+    goToStep('auto-processing');
+    void handleStartAutoProcessing(uploadData.uploadId);
   };
 
   // Start tus upload when user selects a file
@@ -339,7 +349,7 @@ const SubtitlerPage = (): React.ReactElement => {
         }
       }
 
-      setStep('success');
+      goToStep('success');
     },
     [
       loadedProject?.id,
@@ -349,6 +359,7 @@ const SubtitlerPage = (): React.ReactElement => {
       stylePreference,
       heightPreference,
       modePreference,
+      goToStep,
     ]
   );
 
@@ -370,7 +381,7 @@ const SubtitlerPage = (): React.ReactElement => {
     resetExport();
 
     setTimeout(() => {
-      setStep('upload');
+      goToStep('upload');
       setOriginalVideoFile(null);
       setUploadInfo(null);
       setSegments([]);
@@ -378,15 +389,15 @@ const SubtitlerPage = (): React.ReactElement => {
       setAutoSavedProjectId(null);
       resetSocialText();
     }, 300);
-  }, [resetSocialText, uploadInfo?.uploadId, baseURL, resetExport]);
+  }, [resetSocialText, uploadInfo?.uploadId, baseURL, resetExport, goToStep]);
 
   // Function to go back to the editor without resetting everything
   const handleEditAgain = useCallback(() => {
     // Reset export state so user must re-export after making changes
     // This prevents downloading old video after editing
     resetExport();
-    setStep('edit');
-  }, [resetExport]);
+    goToStep('edit');
+  }, [resetExport, goToStep]);
 
   // New handlers for styling step
   const handleStyleSelect = useCallback((style: string) => {
@@ -397,79 +408,73 @@ const SubtitlerPage = (): React.ReactElement => {
     setHeightPreference(height as HeightPreference);
   }, []);
 
-  // Handler for starting automatic processing
-  const handleStartAutoProcessing = useCallback(async () => {
-    if (!uploadInfo?.uploadId) {
-      setError('Keine Upload-ID vorhanden.');
-      return;
-    }
-
-    try {
-      const response = await apiClient.post('/subtitler/process-auto', {
-        uploadId: uploadInfo.uploadId,
-        locale: 'de-DE',
-        userId: user?.id || null,
-      });
-
-      if (response.status === 202) {
-        console.log('[SubtitlerPage] Auto processing started for:', uploadInfo.uploadId);
+  // Takes `uploadId` as an explicit argument so callers don't race the
+  // `setUploadInfo` commit. Previously a `useEffect([step, uploadId])`
+  // + ref-based one-shot guard translated the step transition into a
+  // call to this function; doing it directly in the step-transition
+  // handler is both simpler and correct.
+  const handleStartAutoProcessing = useCallback(
+    async (uploadId: string): Promise<void> => {
+      try {
+        const response = await apiClient.post('/subtitler/process-auto', {
+          uploadId,
+          locale: 'de-DE',
+          userId: user?.id || null,
+        });
+        if (response.status === 202) {
+          console.log('[SubtitlerPage] Auto processing started for:', uploadId);
+        }
+      } catch (error) {
+        console.error('[SubtitlerPage] Error starting auto processing:', error);
+        const axiosError = error as AxiosError<{ error?: string }>;
+        setError(
+          axiosError.response?.data?.error || 'Fehler beim Starten der automatischen Verarbeitung.'
+        );
+        goToStep('upload');
       }
-    } catch (error) {
-      console.error('[SubtitlerPage] Error starting auto processing:', error);
-      const axiosError = error as AxiosError<{ error?: string }>;
-      setError(
-        axiosError.response?.data?.error || 'Fehler beim Starten der automatischen Verarbeitung.'
-      );
-      setStep('upload');
-    }
-  }, [uploadInfo?.uploadId, user?.id]);
-
-  // Auto-start processing when transitioning to auto-processing step
-  const autoProcessingStartedRef = useRef(false);
-  useEffect(() => {
-    if (step === 'auto-processing' && uploadInfo?.uploadId) {
-      if (!autoProcessingStartedRef.current) {
-        autoProcessingStartedRef.current = true;
-        void handleStartAutoProcessing();
-      }
-    } else {
-      autoProcessingStartedRef.current = false;
-    }
-  }, [step, uploadInfo?.uploadId, handleStartAutoProcessing]);
+    },
+    [user?.id, goToStep]
+  );
 
   // Handler for automatic processing completion
-  const handleAutoProcessingComplete = useCallback((result: AutoProcessingResult) => {
-    console.log('[SubtitlerPage] Auto processing complete:', result);
-    if (result.projectId) {
-      setAutoSavedProjectId(result.projectId);
-    }
-    // Ingest segments into the hoisted state. The contract segment type
-    // has no `id`; the local type uses `id` for React keys in Timeline.
-    // We add ids here once at ingest so the parent is the source of
-    // truth from this point forward.
-    if (result.segments && result.segments.length > 0) {
-      setSegments(
-        result.segments.map((s, i) => ({
-          id: i,
-          text: s.text,
-          startTime: s.startTime,
-          endTime: s.endTime,
-        }))
-      );
-    } else if (result.subtitles) {
-      // Fallback: parse SRT blob if the backend didn't include a segment
-      // array (older auto-processing responses).
-      setSegments(parseSubtitleBlocks(result.subtitles));
-    }
-    setStep('success');
-  }, []);
+  const handleAutoProcessingComplete = useCallback(
+    (result: AutoProcessingResult) => {
+      console.log('[SubtitlerPage] Auto processing complete:', result);
+      if (result.projectId) {
+        setAutoSavedProjectId(result.projectId);
+      }
+      // Ingest segments into the hoisted state. The contract segment type
+      // has no `id`; the local type uses `id` for React keys in Timeline.
+      // We add ids here once at ingest so the parent is the source of
+      // truth from this point forward.
+      if (result.segments && result.segments.length > 0) {
+        setSegments(
+          result.segments.map((s, i) => ({
+            id: i,
+            text: s.text,
+            startTime: s.startTime,
+            endTime: s.endTime,
+          }))
+        );
+      } else if (result.subtitles) {
+        // Fallback: parse SRT blob if the backend didn't include a segment
+        // array (older auto-processing responses).
+        setSegments(parseSubtitleBlocks(result.subtitles));
+      }
+      goToStep('success');
+    },
+    [goToStep]
+  );
 
   // Handler for automatic processing error
-  const handleAutoProcessingError = useCallback((errorMsg: string) => {
-    console.error('[SubtitlerPage] Auto processing error:', errorMsg);
-    setError(errorMsg);
-    setStep('upload');
-  }, []);
+  const handleAutoProcessingError = useCallback(
+    (errorMsg: string) => {
+      console.error('[SubtitlerPage] Auto processing error:', errorMsg);
+      setError(errorMsg);
+      goToStep('upload');
+    },
+    [goToStep]
+  );
 
   return (
     <ErrorBoundary>

--- a/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
@@ -12,6 +12,7 @@ import apiClient from '../../../components/utils/apiClient';
 import { useAuthStore } from '../../../stores/authStore';
 import { useSubtitlerExportStore } from '../../../stores/subtitlerExportStore';
 import useSocialTextGenerator from '../hooks/useSocialTextGenerator';
+import { parseSubtitleBlocks, formatSubtitleBlocks } from '../utils/subtitleSegmentUtils';
 import { getVideoMetadata, TUS_UPLOAD_ENDPOINT, type VideoMetadata } from '../utils/videoUtils';
 
 import AutoProcessingScreen from './AutoProcessingScreen';
@@ -19,7 +20,12 @@ import SubtitleEditor from './SubtitleEditor';
 import VideoSuccessScreen from './VideoSuccessScreen';
 
 import type { AutoProcessingResult } from './AutoProcessingScreen';
-import type { SubtitlePreference, StylePreference, HeightPreference } from '../types';
+import type {
+  SubtitlePreference,
+  StylePreference,
+  HeightPreference,
+  SubtitleSegment,
+} from '../types';
 import type { AxiosError } from 'axios';
 import type { Accept } from 'react-dropzone';
 
@@ -92,16 +98,14 @@ const SubtitlerPage = (): React.ReactElement => {
   const currentUploadRef = useRef<tus.Upload | null>(null);
   const [originalVideoFile, setOriginalVideoFile] = useState<File | null>(null);
   const [uploadInfo, setUploadInfo] = useState<UploadInfo | null>(null);
-  const [subtitles, setSubtitles] = useState<string | null>(null);
-  // Canonical segment array from auto-processing (2026-04-13). The
-  // `subtitles` state above keeps the raw SRT string for display/edit
-  // use; this state holds the typed segments for write paths
-  // (POST /subtitler/projects schema requires array).
-  const [subtitleSegments, setSubtitleSegments] = useState<Array<{
-    text: string;
-    startTime: number;
-    endTime: number;
-  }> | null>(null);
+  // Single source of truth for the subtitle segments. Populated from
+  // auto-processing or deep-link load, mutated in place by the editor
+  // through `setSegments`, consumed directly by the export and save
+  // paths. The previous split (`subtitles: string` + `subtitleSegments`
+  // + SubtitleEditor's local `editableSubtitles`) drifted on every
+  // edit — losing user changes through prop→state resync inside
+  // SubtitleEditor on remount.
+  const [segments, setSegments] = useState<SubtitleSegment[]>([]);
   const [error, setError] = useState<string | null>(null);
   const {
     socialText,
@@ -135,7 +139,7 @@ const SubtitlerPage = (): React.ReactElement => {
         if (!project) return;
 
         setLoadedProject(project);
-        if (project.subtitles) setSubtitles(project.subtitles);
+        if (project.subtitles) setSegments(parseSubtitleBlocks(project.subtitles));
         setUploadInfo({
           uploadId: project.id,
           metadata: project.video_metadata ?? undefined,
@@ -296,17 +300,19 @@ const SubtitlerPage = (): React.ReactElement => {
     async (receivedExportToken: string) => {
       console.log('[SubtitlerPage] Export initiated with token:', receivedExportToken);
 
-      // Auto-create project if one doesn't exist (for share functionality)
+      // Auto-create project if one doesn't exist (for share functionality).
+      // Uses the hoisted `segments` state which reflects the user's edits
+      // — the earlier version sent the original auto-processing output
+      // and silently persisted the pre-edit version to the DB.
       if (!loadedProject?.id && !autoSavedProjectId && uploadInfo?.uploadId) {
         try {
           const projectData = {
             uploadId: uploadInfo.uploadId,
-            // Backend schema (both legacy `projectDataSchema` in
-            // projectController.ts AND the contract `projectDataBodySchema`
-            // in @gruenerator/contracts) requires a typed
-            // `SubtitleSegment[]`. Pre-2026-04-13 this was sending the raw
-            // SRT string, which silently 400'd every auto-create request.
-            subtitles: subtitleSegments ?? [],
+            subtitles: segments.map((s) => ({
+              text: s.text,
+              startTime: s.startTime,
+              endTime: s.endTime,
+            })),
             title:
               uploadInfo.name?.replace(/\.[^/.]+$/, '') ||
               `Projekt ${new Date().toLocaleDateString('de-DE')}`,
@@ -339,7 +345,7 @@ const SubtitlerPage = (): React.ReactElement => {
       loadedProject?.id,
       autoSavedProjectId,
       uploadInfo,
-      subtitles,
+      segments,
       stylePreference,
       heightPreference,
       modePreference,
@@ -367,7 +373,7 @@ const SubtitlerPage = (): React.ReactElement => {
       setStep('upload');
       setOriginalVideoFile(null);
       setUploadInfo(null);
-      setSubtitles(null);
+      setSegments([]);
       setError(null);
       setAutoSavedProjectId(null);
       resetSocialText();
@@ -434,20 +440,27 @@ const SubtitlerPage = (): React.ReactElement => {
   // Handler for automatic processing completion
   const handleAutoProcessingComplete = useCallback((result: AutoProcessingResult) => {
     console.log('[SubtitlerPage] Auto processing complete:', result);
-    // Store the auto-saved project ID if available
     if (result.projectId) {
       setAutoSavedProjectId(result.projectId);
     }
-    // Store subtitles from auto processing for editing
-    if (result.subtitles) {
-      setSubtitles(result.subtitles);
+    // Ingest segments into the hoisted state. The contract segment type
+    // has no `id`; the local type uses `id` for React keys in Timeline.
+    // We add ids here once at ingest so the parent is the source of
+    // truth from this point forward.
+    if (result.segments && result.segments.length > 0) {
+      setSegments(
+        result.segments.map((s, i) => ({
+          id: i,
+          text: s.text,
+          startTime: s.startTime,
+          endTime: s.endTime,
+        }))
+      );
+    } else if (result.subtitles) {
+      // Fallback: parse SRT blob if the backend didn't include a segment
+      // array (older auto-processing responses).
+      setSegments(parseSubtitleBlocks(result.subtitles));
     }
-    // Store canonical segment array for write paths (project create/update).
-    // Schema requires SubtitleSegment[]; string would 400.
-    if (result.segments) {
-      setSubtitleSegments(result.segments);
-    }
-    // Move to success screen - the video is ready for download
     setStep('success');
   }, []);
 
@@ -535,11 +548,12 @@ const SubtitlerPage = (): React.ReactElement => {
                 />
               )}
 
-              {step === 'edit' && subtitles && uploadInfo?.uploadId && (
+              {step === 'edit' && segments.length > 0 && uploadInfo?.uploadId && (
                 <SubtitleEditor
                   videoFile={originalVideoFile}
                   videoUrl={uploadInfo.videoUrl ?? undefined}
-                  subtitles={subtitles}
+                  segments={segments}
+                  onSegmentsChange={setSegments}
                   uploadId={uploadInfo.uploadId}
                   subtitlePreference={subtitlePreference}
                   stylePreference={stylePreference}
@@ -568,7 +582,7 @@ const SubtitlerPage = (): React.ReactElement => {
                   socialText={socialText}
                   uploadId={exportToken || uploadInfo?.uploadId || undefined}
                   isGeneratingSocialText={isGenerating}
-                  onGenerateSocialText={() => generateSocialText(subtitles ?? '')}
+                  onGenerateSocialText={() => generateSocialText(formatSubtitleBlocks(segments))}
                   projectId={loadedProject?.id || autoSavedProjectId || undefined}
                   projectTitle={
                     loadedProject?.title || (autoSavedProjectId ? 'Auto-Video' : undefined)

--- a/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
@@ -574,10 +574,15 @@ const SubtitlerPage = (): React.ReactElement => {
                     loadedProject?.title || (autoSavedProjectId ? 'Auto-Video' : undefined)
                   }
                   videoUrl={
-                    uploadInfo?.uploadId
-                      ? `${baseURL}/subtitler/auto-download/${uploadInfo.uploadId}`
-                      : exportToken
-                        ? `${baseURL}/subtitler/export-download/${exportToken}`
+                    // exportToken wins over auto-download — once the user
+                    // has edited subtitles and run an export, that export
+                    // contains their edits. The auto-download path serves
+                    // the pre-edit transcription and is only correct for
+                    // users who skipped the editor entirely.
+                    exportToken
+                      ? `${baseURL}/subtitler/export-download/${exportToken}`
+                      : uploadInfo?.uploadId
+                        ? `${baseURL}/subtitler/auto-download/${uploadInfo.uploadId}`
                         : undefined
                   }
                 />

--- a/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
+++ b/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
@@ -434,18 +434,45 @@ const RecentlyCreatedSection: React.FC = memo(() => {
 
       if (!window.confirm(messages[item.type])) return;
 
-      if (item.type === 'board') {
-        void deleteBoard.mutateAsync(item.id).then(() => {
-          void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+      // Both delete paths need an explicit `.catch()` — a bare `.then()`
+      // escapes rejections to `window.onunhandledrejection`, which Sentry
+      // captures as an unhandled error (the earlier DELETE 401 incident
+      // on stale recent-activity entries). On 401/403/404 we invalidate
+      // the list so the ghost entry disappears from the UI.
+      const onDeleteError = (err: unknown, endpoint: string) => {
+        const status =
+          typeof err === 'object' && err !== null && 'response' in err
+            ? (err as { response?: { status?: number } }).response?.status
+            : undefined;
+        console.warn('[RecentlyCreatedSection] delete failed', {
+          endpoint,
+          status,
+          itemType: item.type,
+          itemId: item.id,
         });
+        if (status === 401 || status === 403 || status === 404) {
+          void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+        }
+      };
+
+      if (item.type === 'board') {
+        void deleteBoard
+          .mutateAsync(item.id)
+          .then(() => {
+            void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+          })
+          .catch((err: unknown) => onDeleteError(err, `board:${String(item.id)}`));
         return;
       }
 
       if (item.deleteEndpoint) {
         const endpoint = item.deleteEndpoint.replace(/^\/api/, '');
-        void apiClient.delete(endpoint).then(() => {
-          void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
-        });
+        void apiClient
+          .delete(endpoint)
+          .then(() => {
+            void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+          })
+          .catch((err: unknown) => onDeleteError(err, endpoint));
       }
     },
     [deleteBoard, queryClient]

--- a/apps/web/src/features/workplace/components/ReelsSection.tsx
+++ b/apps/web/src/features/workplace/components/ReelsSection.tsx
@@ -77,12 +77,31 @@ const ReelsSection: React.FC = memo(() => {
   const handleDelete = useCallback(
     (item: RecentItem) => {
       if (!window.confirm('Video wirklich löschen?')) return;
-      if (item.deleteEndpoint) {
-        const endpoint = item.deleteEndpoint.replace(/^\/api/, '');
-        void apiClient.delete(endpoint).then(() => {
+      if (!item.deleteEndpoint) return;
+      const endpoint = item.deleteEndpoint.replace(/^\/api/, '');
+      // Must `.catch()` — bare `.then()` lets rejections escape to
+      // `window.onunhandledrejection`, which then routes through Sentry
+      // as a pagey-looking "unhandled promise rejection". 401s here are
+      // expected when a cached recent-activity entry references a reel
+      // the current session no longer owns (post-profile-deletion replay
+      // being the most common trigger).
+      void apiClient
+        .delete(endpoint)
+        .then(() => {
           void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+        })
+        .catch((err: unknown) => {
+          const status =
+            typeof err === 'object' && err !== null && 'response' in err
+              ? (err as { response?: { status?: number } }).response?.status
+              : undefined;
+          console.warn('[ReelsSection] delete failed', { endpoint, status, itemId: item.id });
+          if (status === 401 || status === 403 || status === 404) {
+            // Entry is stale — drop it from the list so the user isn't
+            // stuck clicking a ghost.
+            void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
+          }
         });
-      }
     },
     [queryClient]
   );

--- a/packages/shared/src/projects/types.ts
+++ b/packages/shared/src/projects/types.ts
@@ -3,6 +3,8 @@
  * Shared between web frontend and mobile app
  */
 
+import type { SubtitleSegment } from '@gruenerator/contracts';
+
 export interface VideoMetadata {
   duration: number;
   width: number;
@@ -60,7 +62,14 @@ export interface ProjectsApiResponse {
 
 export interface SaveProjectData {
   uploadId: string;
-  subtitles?: string;
+  // Canonical segment array from @gruenerator/contracts. The backend
+  // `projectDataBodySchema.subtitles` is `z.array(subtitleSegmentSchema)`,
+  // so the on-wire shape is `SubtitleSegment[]`, not an SRT string. The
+  // pre-2026-04-13 type had this as `string`, which silently let the
+  // frontend send an unparseable SRT blob and silently 400'd the save.
+  // See `packages/contracts/src/schemas/subtitler.ts` for the unification
+  // history — this is the final missing piece of that migration.
+  subtitles?: SubtitleSegment[];
   title?: string;
   stylePreference?: string;
   heightPreference?: string;

--- a/packages/shared/src/stores/projectsStore.ts
+++ b/packages/shared/src/stores/projectsStore.ts
@@ -70,6 +70,26 @@ const createProjectsStoreSlice: StateCreator<ProjectsStore> = (set, get) => ({
   },
 
   saveProject: async (projectData: SaveProjectData) => {
+    // Debug logging for the subtitler save shape. The 2026-04-13
+    // canonicalization made `subtitles` a `SubtitleSegment[]` on the
+    // wire, but multiple call sites (SubtitleEditor web, useSubtitleEditor
+    // mobile, reel.tsx mobile post-transcription) historically sent the
+    // raw SRT string. If a stale bundle ships after a future refactor
+    // sends the wrong shape, this log tells us immediately from the
+    // browser console whether the client or the server is at fault —
+    // no DevTools network panel required.
+    const subtitles = projectData.subtitles;
+    const subtitlesShape = Array.isArray(subtitles)
+      ? `array(${subtitles.length})`
+      : subtitles == null
+        ? 'null/undefined'
+        : typeof subtitles;
+    console.log('[ProjectsStore] saveProject sending', {
+      uploadId: projectData.uploadId,
+      subtitlesShape,
+      firstSegment: Array.isArray(subtitles) && subtitles.length > 0 ? subtitles[0] : undefined,
+    });
+
     set({ isSaving: true, error: null, saveSuccess: false });
 
     try {


### PR DESCRIPTION
## Summary

Six atomic commits fixing a cluster of entangled bugs in the subtitler and doing a follow-up refactor that eliminates three unnecessary useEffects.

**User-visible symptom** that started the thread: edit subtitles → Save → Download → the exported video still shows the *original* auto-transcribed text, not the user's edits. Multiple root causes stacked on top of each other, each one shadowing the next.

### Commits in merge order

1. `fix(subtitler): send SubtitleSegment[] through shared save path` — `SaveProjectData.subtitles` was typed as `string` in `@gruenerator/shared`, so three call sites (web `SubtitleEditor`, mobile `useSubtitleEditor`, mobile `reel.tsx`) kept sending the SRT blob even after the earlier canonicalization. Backend contract validation caught it as a 400/500 at runtime.
2. `fix(workplace): handle delete rejections + log subtitler save shape` — `ReelsSection` and `RecentlyCreatedSection` both did `void .delete().then()` without `.catch()`, so DELETE 401s on stale recent-activity entries escaped to `window.onunhandledrejection` → Sentry. Added catch + invalidate on 401/403/404 so ghost entries drop out of the list. Also added a `[ProjectsStore] saveProject sending { subtitlesShape }` debug log.
3. `fix(api): apply requireAuth before subtitler contract mount` — `createExpressEndpoints` registers handlers directly on the Express app, so the legacy `app.use('/api/subtitler/projects', requireAuth, ...)` at a later line never reached contract routes. Mirrored the `/api/transfer` pattern.
4. `fix(subtitler): prefer exportToken over auto-download on success screen` — success screen's videoUrl ternary had reversed priority: `uploadId ? auto-download : exportToken ? export-download` always served the pre-edit auto-generated video because `uploadId` was always truthy by that point. Flipped to `exportToken` first.
5. `refactor(subtitler): hoist segments state, make SubtitleEditor controlled` — the real root cause of "edits disappear". `SubtitleEditor` owned `editableSubtitles` as local state, synced from a `subtitles: string` prop via `useEffect([subtitles])`. Every remount (edit→success→edit-again) re-parsed the stale parent prop and clobbered the edits. Hoisted segments to `SubtitlerPage` as single source of truth, made `SubtitleEditor` fully controlled via `segments` + `onSegmentsChange` props. Collapsed three parallel states (`subtitles` string, `subtitleSegments` array, `editableSubtitles` local) into one.
6. `refactor(subtitler): kill 3 unnecessary useEffects` — follow-up to the hoist. Killed the `<video>` play/pause `addEventListener` effect (JSX `onPlay`/`onPause` props), the `[step] → pushState` effect (folded into a `goToStep(next)` helper + lazy `useState` initializer for the first `replaceState`), and the auto-start-processing guarded effect (direct call in `handleUploadComplete` with `uploadId` passed explicitly).

Net for the subtitler files: **-34 lines** on the hoist refactor, **-25 more** on the useEffect kill, 10 → 7 useEffects across both files. The 7 remaining are all legit external-system integration (zustand subscribe, createObjectURL lifecycle, IntersectionObserver, popstate, beforeunload) plus two flagged for future cleanup.

## Test plan

- [x] `apps/web` typecheck clean after each commit
- [x] `apps/api` typecheck clean
- [x] `apps/mobile` typecheck clean
- [ ] Smoke: upload → auto-process → edit subtitles → Save → Download → confirm downloaded video reflects edits
- [ ] Smoke: upload → auto-process → edit → Save → Download → Edit again → confirm edits still visible in the editor
- [ ] Smoke: delete a reel from Workplace — confirm 401 no longer produces unhandled rejection in the console
- [ ] Smoke: POST `/api/subtitler/projects` returns 2xx (not 401) after the requireAuth hoist
- [ ] Smoke: back button within the subtitler step flow still navigates correctly (popstate listener)