### PR TITLE
fix(web): keep notifications visible when opening profile menu

### DIFF
--- a/apps/web/src/components/layout/Header/ProfileButton.tsx
+++ b/apps/web/src/components/layout/Header/ProfileButton.tsx
@@ -8,10 +8,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useProfile } from '../../../features/auth/hooks/useProfileData';
 import { getAvatarDisplayProps } from '../../../features/auth/services/profileApiService';
 import NotificationList from '../../../features/notifications/components/NotificationList';
-import {
-  useUnreadCount,
-  useMarkAllAsRead,
-} from '../../../features/notifications/hooks/useNotifications';
+import { useUnreadCount } from '../../../features/notifications/hooks/useNotifications';
 import { useBetaFeatures } from '../../../hooks/useBetaFeatures';
 import { useAuthStore } from '../../../stores/authStore';
 
@@ -158,7 +155,7 @@ const ProfileDropdownContent = memo(({ user, unreadCount }: ProfileDropdownConte
         </button>
       </div>
 
-      {unreadCount > 0 && <NotificationList unreadCount={unreadCount} />}
+      <NotificationList unreadCount={unreadCount} />
     </>
   );
 });
@@ -170,7 +167,6 @@ const ProfileButton = () => {
   const [open, setOpen] = useState(false);
 
   const { data: unreadCount = 0 } = useUnreadCount();
-  const markAllAsRead = useMarkAllAsRead();
 
   const { data: profile, isPlaceholderData } = useProfile(user?.id);
   const avatarRobotId = profile?.avatar_robot_id ?? null;
@@ -196,13 +192,7 @@ const ProfileButton = () => {
   }
 
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={(isOpen) => {
-        setOpen(isOpen);
-        if (isOpen && unreadCount > 0) markAllAsRead.mutate();
-      }}
-    >
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <button
           className="relative flex items-center justify-center size-[38px] rounded-full border border-grey-200 dark:border-grey-700 bg-background hover:border-primary-500 hover:bg-hover-alt transition-colors"


### PR DESCRIPTION
## Summary

- **Bug:** Opening the profile dropdown fired `markAllAsRead.mutate()` in `onOpenChange`, which optimistically zeroed `unreadCount` in the Zustand store. Because `<NotificationList>` was rendered behind a `{unreadCount > 0 && ...}` gate, it unmounted while the menu was still visible — users saw their badge vanish and the list disappear before they could read anything.
- **Fix:** Remove the eager `markAllAsRead` call on open, and remove the redundant outer visibility gate. `NotificationList` already self-hides when `notifications.length === 0` (it's its single source of truth for visibility). Users still have the existing "Alle gelesen" button and per-item check icon to explicitly mark things read — matching standard notification UX (Slack, Gmail, GitHub).
- **Scope:** One file (`apps/web/src/components/layout/Header/ProfileButton.tsx`). No API, store, SSE, or hook changes.

## Test plan

- [ ] Seed an unread notification: `PGPASSWORD=gruenerator psql -h localhost -U gruenerator -d gruenerator -c "INSERT INTO notifications (id, user_id, type, title, body, is_read) VALUES (gen_random_uuid(), '<user-id>', 'system', 'Test', 'Body', FALSE);"`
- [ ] `pnpm dev:web` and open `http://localhost:3000`
- [ ] Verify red badge shows count on the profile avatar
- [ ] Click profile icon → dropdown opens, **badge still visible**, notification list rendered with the unread item
- [ ] Verify **no** `PATCH /api/notifications/read-all` request fires on open (DevTools network tab)
- [ ] Click "Alle gelesen" → badge drops to 0, items still rendered (now styled read)
- [ ] Close dropdown without acting → reopening does not fire any mark-read mutation, unread count unchanged in DB
- [ ] New notifications arriving via SSE still increment the badge (regression check)