### PR TITLE
fix(web): scroll group members popover and make header sticky

### DIFF
--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -277,7 +277,7 @@ const GroupInfoSection = memo(
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                className="w-80 p-sm"
+                className="w-80 p-sm max-h-[min(70vh,480px)] overflow-y-auto"
                 onMouseEnter={handleMembersMouseEnter}
                 onMouseLeave={handleMembersMouseLeave}
               >

--- a/apps/web/src/features/groups/components/GroupMembersList.tsx
+++ b/apps/web/src/features/groups/components/GroupMembersList.tsx
@@ -45,7 +45,7 @@ const GroupMembersList = ({
   const { updateMemberRole, isUpdatingRole } = useUpdateMemberRole(groupId);
 
   const header = !hideHeader && (
-    <div className="flex items-center justify-between py-xs">
+    <div className="sticky top-0 z-10 bg-background-pure flex items-center justify-between py-xs -mx-sm px-sm">
       <h4 className="flex items-center gap-sm text-xs font-medium uppercase tracking-wide text-grey-500 m-0">
         <HiUsers className="text-base text-primary-500" />
         Gruppenmitglieder{members && members.length > 0 ? ` (${members.length})` : ''}


### PR DESCRIPTION
## Summary

- On `/gruppen/{groupId}`, the Gruppenmitglieder popover had no height cap or scroll container, so in groups with many members the list grew past the viewport with rows unreachable.
- Cap `PopoverContent` at `min(70vh, 480px)` and enable `overflow-y-auto` so the popover itself scrolls.
- Make the "Gruppenmitglieder (N)" header `sticky top-0` with a bleed-padded background so the count stays visible while scrolling and rows don't peek at the popover edges.

## Why this approach

Scoped the fix to the consumer (`GroupInfoSection`) + the list's own header rather than:
- changing the shared `PopoverContent` primitive (would force overflow on every popover in the codebase, including dropdown-inside-popover cases where clipping would break positioning), or
- hardcoding a max-height inside `GroupMembersList`'s body (the list is deliberately layout-agnostic via its `className` prop and may be used full-page elsewhere).

## Files

- `apps/web/src/features/groups/components/GroupInfoSection.tsx` — `PopoverContent` className
- `apps/web/src/features/groups/components/GroupMembersList.tsx` — header wrapper sticky + bleed padding

## Test plan

- [ ] Open `/gruppen/{groupId}` for a group with 20+ members, hover the top-right avatars
- [ ] Popover height is capped (doesn't extend past viewport)
- [ ] Member list scrolls inside the popover
- [ ] `Gruppenmitglieder (N)` header stays pinned while scrolling — no rows peek through it at top or edges
- [ ] Admin `...` dropdown on member rows still works (portaled, should render above clipped popover)
- [ ] Groups with <5 members still shrink naturally (no awkward fixed height)
- [ ] Short viewport (~600px) → ~70vh cap; tall viewport (1400px+) → 480px cap
- [ ] Dark mode header background matches popover surface (both use `bg-background-pure`)