### PR TITLE
fix(api): prevent cross-user document/board data leak

### DIFF
--- a/apps/api/routes/boards/boardCommentsController.ts
+++ b/apps/api/routes/boards/boardCommentsController.ts
@@ -41,7 +41,7 @@ async function checkBoardAccess(boardId: string, userId: string): Promise<BoardA
 
   const groupAccess = (await db.query(
     `SELECT 1 FROM group_content_shares gcs
-     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
      WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2
      LIMIT 1`,
     [userId, boardId]
@@ -210,7 +210,10 @@ router.get(
 router.post(
   '/:boardId/cards/:cardId/comments',
   validateBody(postCommentSchema),
-  async (req: TypedRequest<z.infer<typeof postCommentSchema>, { boardId: string; cardId: string }>, res: Response) => {
+  async (
+    req: TypedRequest<z.infer<typeof postCommentSchema>, { boardId: string; cardId: string }>,
+    res: Response
+  ) => {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'Nicht authentifiziert' });
@@ -285,7 +288,9 @@ router.post(
         parentId: parentId ?? null,
         mentionedUserIds,
       }).catch((err: unknown) => {
-        log.warn('Failed to send comment notifications', { error: err instanceof Error ? err.message : String(err) });
+        log.warn('Failed to send comment notifications', {
+          error: err instanceof Error ? err.message : String(err),
+        });
       });
 
       return res.status(201).json(result);
@@ -304,7 +309,10 @@ router.post(
 router.put(
   '/:boardId/comments/:commentId',
   validateBody(putCommentSchema),
-  async (req: TypedRequest<z.infer<typeof putCommentSchema>, { boardId: string; commentId: string }>, res: Response) => {
+  async (
+    req: TypedRequest<z.infer<typeof putCommentSchema>, { boardId: string; commentId: string }>,
+    res: Response
+  ) => {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'Nicht authentifiziert' });
@@ -397,7 +405,10 @@ router.delete(
 router.post(
   '/:boardId/comments/:commentId/reactions',
   validateBody(postReactionSchema),
-  async (req: TypedRequest<z.infer<typeof postReactionSchema>, { boardId: string; commentId: string }>, res: Response) => {
+  async (
+    req: TypedRequest<z.infer<typeof postReactionSchema>, { boardId: string; commentId: string }>,
+    res: Response
+  ) => {
     try {
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'Nicht authentifiziert' });
@@ -440,7 +451,10 @@ router.delete(
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'Nicht authentifiziert' });
 
-      const { commentId, emoji } = req.params;
+      const { boardId, commentId, emoji } = req.params;
+
+      const { hasAccess } = await checkBoardAccess(boardId, userId);
+      if (!hasAccess) return res.status(403).json({ error: 'Kein Zugriff' });
 
       await db.query(
         `DELETE FROM board_comment_reactions WHERE comment_id = $1 AND user_id = $2 AND emoji = $3`,
@@ -468,6 +482,9 @@ router.get(
       if (!userId) return res.status(401).json({ error: 'Nicht authentifiziert' });
 
       const { boardId, cardId } = req.params;
+
+      const { hasAccess } = await checkBoardAccess(boardId, userId);
+      if (!hasAccess) return res.status(403).json({ error: 'Kein Zugriff' });
 
       const rows = (await db.query(
         `SELECT COUNT(*)::int AS count FROM board_comments WHERE board_id = $1 AND card_id = $2`,

--- a/apps/api/routes/boards/boardsContractRouter.ts
+++ b/apps/api/routes/boards/boardsContractRouter.ts
@@ -72,11 +72,10 @@ export const boardsContractRouter = s.router(boardsContract, {
           AND (
             cd.created_by = $2
             OR cd.permissions ? $3::text
-            OR cd.is_public = true
             OR cd.id IN (
               SELECT gcs.content_id::uuid
               FROM group_content_shares gcs
-              INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2
+              INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2 AND gm.is_active = TRUE
               WHERE gcs.content_type = 'collaborative_documents'
             )
           )

--- a/apps/api/routes/boards/boardsController.ts
+++ b/apps/api/routes/boards/boardsController.ts
@@ -67,11 +67,10 @@ router.get('/', async (req: Request, res: Response) => {
         AND (
           cd.created_by = $2
           OR cd.permissions ? $3::text
-          OR cd.is_public = true
           OR cd.id IN (
             SELECT gcs.content_id::uuid
             FROM group_content_shares gcs
-            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2
+            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2 AND gm.is_active = TRUE
             WHERE gcs.content_type = 'collaborative_documents'
           )
         )
@@ -197,7 +196,7 @@ router.get('/:id', async (req: Request<{ id: string }>, res: Response) => {
     if (!hasAccess) {
       const groupAccess = (await db.query(
         `SELECT gcs.permissions FROM group_content_shares gcs
-         INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+         INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
          WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
         [userId, id]
       )) as { permissions: { read: boolean; write: boolean } | null }[];

--- a/apps/api/routes/chat/confirmController.ts
+++ b/apps/api/routes/chat/confirmController.ts
@@ -50,7 +50,7 @@ async function hasWriteAccess(documentId: string, userId: string): Promise<boole
 
   const groupAccess = (await pg.query(
     `SELECT gcs.permissions FROM group_content_shares gcs
-     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
      WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
     [userId, documentId]
   )) as { permissions: { read: boolean; write: boolean } | null }[];

--- a/apps/api/routes/chat/services/contextEnrichmentService.ts
+++ b/apps/api/routes/chat/services/contextEnrichmentService.ts
@@ -130,7 +130,7 @@ export async function enrichContext(opts: {
          WHERE id = ANY($1::uuid[]) AND is_deleted = false AND document_subtype != 'boards'
          AND (created_by = $2 OR permissions ? $2::text OR is_public = true
               OR id IN (SELECT gcs.content_id FROM group_content_shares gcs
-                        INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2
+                        INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $2 AND gm.is_active = TRUE
                         WHERE gcs.content_type = 'collaborative_documents'))`,
         [rawDocMentionIds, userId]
       );

--- a/apps/api/routes/chat/threadsContractRouter.ts
+++ b/apps/api/routes/chat/threadsContractRouter.ts
@@ -85,7 +85,7 @@ export const threadsContractRouter = s.router(threadsContract, {
            OR t.is_public = true
            OR t.id IN (
              SELECT gcs.content_id::uuid FROM group_content_shares gcs
-             INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id::text = $1
+             INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id::text = $1 AND gm.is_active = TRUE
              WHERE gcs.content_type = 'chat_threads'
            )
          )${statusClause}

--- a/apps/api/routes/chat/threadsController.ts
+++ b/apps/api/routes/chat/threadsController.ts
@@ -82,7 +82,7 @@ router.get('/', async (req, res) => {
          OR t.is_public = true
          OR t.id IN (
            SELECT gcs.content_id::uuid FROM group_content_shares gcs
-           INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id::text = $1
+           INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id::text = $1 AND gm.is_active = TRUE
            WHERE gcs.content_type = 'chat_threads'
          )
        )${statusClause}

--- a/apps/api/routes/docs/documentAccess.ts
+++ b/apps/api/routes/docs/documentAccess.ts
@@ -31,7 +31,7 @@ export function checkDirectAccess(document: CollaborativeDocument, userId: strin
 export async function checkGroupAccess(userId: string, documentId: string): Promise<AccessResult> {
   const groupAccess = (await db.query(
     `SELECT gcs.permissions FROM group_content_shares gcs
-     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
      WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
     [userId, documentId]
   )) as { permissions: { read: boolean; write: boolean } | null }[];

--- a/apps/api/routes/docs/documentController.ts
+++ b/apps/api/routes/docs/documentController.ts
@@ -170,7 +170,7 @@ router.get('/', async (req: Request, res: Response) => {
           WHEN cd.id IN (
             SELECT gcs.content_id::uuid
             FROM group_content_shares gcs
-            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
             WHERE gcs.content_type = 'collaborative_documents'
               AND (gcs.permissions->>'read')::boolean IS NOT FALSE
           ) THEN 'group'
@@ -196,7 +196,7 @@ router.get('/', async (req: Request, res: Response) => {
           OR cd.id IN (
             SELECT gcs.content_id::uuid
             FROM group_content_shares gcs
-            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+            INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
             WHERE gcs.content_type = 'collaborative_documents'
               AND (gcs.permissions->>'read')::boolean IS NOT FALSE
           )
@@ -329,7 +329,7 @@ router.put(
       if (!canEdit) {
         const groupAccess = (await db.query(
           `SELECT gcs.permissions FROM group_content_shares gcs
-         INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+         INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
          WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
           [userId, id]
         )) as { permissions: { read: boolean; write: boolean } | null }[];

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -55,7 +55,7 @@ async function getAccessibleDocument(
   if (!hasAccess) {
     const groupAccess = (await db.query(
       `SELECT gcs.permissions FROM group_content_shares gcs
-       INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+       INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
        WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2 LIMIT 1`,
       [userId, id]
     )) as { permissions: { read: boolean } | null }[];

--- a/apps/api/routes/workplace/recentActivityController.ts
+++ b/apps/api/routes/workplace/recentActivityController.ts
@@ -96,7 +96,7 @@ export async function fetchRecentDocs(
         WHEN cd.id IN (
           SELECT gcs.content_id::uuid
           FROM group_content_shares gcs
-          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
           WHERE gcs.content_type = 'collaborative_documents'
         ) THEN 'group'
       END AS access_type
@@ -111,7 +111,7 @@ export async function fetchRecentDocs(
         OR cd.id IN (
           SELECT gcs.content_id::uuid
           FROM group_content_shares gcs
-          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
           WHERE gcs.content_type = 'collaborative_documents'
         )
       )
@@ -161,11 +161,10 @@ export async function fetchRecentBoards(
       AND (
         cd.created_by = $1
         OR cd.permissions ? $2::text
-        OR cd.is_public = true
         OR cd.id IN (
           SELECT gcs.content_id::uuid
           FROM group_content_shares gcs
-          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1
+          INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
           WHERE gcs.content_type = 'collaborative_documents'
         )
       )
@@ -186,7 +185,9 @@ export async function fetchRecentBoards(
   ).map((row) => {
     let boardType: 'kanban' | 'whiteboard' = 'kanban';
     try {
-      const content = (typeof row.content === 'string' ? JSON.parse(row.content) : row.content) as { boardType?: string } | null;
+      const content = (typeof row.content === 'string' ? JSON.parse(row.content) : row.content) as {
+        boardType?: string;
+      } | null;
       if (content?.boardType === 'whiteboard') boardType = 'whiteboard';
     } catch {
       // default to kanban
@@ -341,7 +342,6 @@ export async function fetchRecentPresentations(
     WHERE
       cp.user_id = $1
       OR cp.permissions ? $2::text
-      OR cp.is_public = true
     ORDER BY cp.updated_at DESC
     LIMIT $3`,
     [userId, userId, limit]

--- a/apps/api/services/boards/BoardService.ts
+++ b/apps/api/services/boards/BoardService.ts
@@ -141,9 +141,9 @@ export async function loadBoardState(boardId: string, userId: string): Promise<B
   const boardResult = await db.query(
     `SELECT title, content FROM collaborative_documents
      WHERE id = $1::uuid AND document_subtype = $2 AND is_deleted = false
-     AND (created_by = $3 OR permissions ? $3::text OR is_public = true
+     AND (created_by = $3 OR permissions ? $3::text
           OR id IN (SELECT gcs.content_id FROM group_content_shares gcs
-                    INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $3
+                    INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $3 AND gm.is_active = TRUE
                     WHERE gcs.content_type = 'collaborative_documents'))`,
     [boardId, BOARDS_SUBTYPE, userId]
   );

--- a/apps/api/services/notifications/groupNotifications.ts
+++ b/apps/api/services/notifications/groupNotifications.ts
@@ -24,10 +24,10 @@ export async function notifyGroupMembers(params: NotifyGroupParams): Promise<voi
     const db = getPostgresInstance();
 
     const [members, group] = await Promise.all([
-      db.query('SELECT user_id FROM group_memberships WHERE group_id = $1 AND user_id != $2', [
-        groupId,
-        excludeUserId,
-      ]) as Promise<Array<{ user_id: string }>>,
+      db.query(
+        'SELECT user_id FROM group_memberships WHERE group_id = $1 AND user_id != $2 AND is_active = TRUE',
+        [groupId, excludeUserId]
+      ) as Promise<Array<{ user_id: string }>>,
       db.queryOne('SELECT name FROM groups WHERE id = $1', [groupId], {
         table: 'groups',
       }) as Promise<{ name: string } | null>,

--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -277,7 +277,7 @@ const GroupInfoSection = memo(
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                className="w-80 p-sm"
+                className="w-80 p-sm max-h-[min(70vh,480px)] overflow-y-auto"
                 onMouseEnter={handleMembersMouseEnter}
                 onMouseLeave={handleMembersMouseLeave}
               >

--- a/apps/web/src/features/groups/components/GroupMembersList.tsx
+++ b/apps/web/src/features/groups/components/GroupMembersList.tsx
@@ -45,7 +45,7 @@ const GroupMembersList = ({
   const { updateMemberRole, isUpdatingRole } = useUpdateMemberRole(groupId);
 
   const header = !hideHeader && (
-    <div className="flex items-center justify-between py-xs">
+    <div className="sticky top-0 z-10 bg-background-pure flex items-center justify-between py-xs -mx-sm px-sm">
       <h4 className="flex items-center gap-sm text-xs font-medium uppercase tracking-wide text-grey-500 m-0">
         <HiUsers className="text-base text-primary-500" />
         Gruppenmitglieder{members && members.length > 0 ? ` (${members.length})` : ''}


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `OR cd.is_public = true` in list queries caused 16 public documents/boards to appear in the personal lists of all 3,172 users. Public items remain accessible via their share links (`/api/boards/public/:id`, `/api/docs/public/:id`).
- **`is_active` enforcement**: All 18 `group_memberships` JOINs across 13 files now include `AND gm.is_active = TRUE`. Previously, deactivated group members retained full access to group-shared content.
- **Missing access checks**: Added `checkBoardAccess()` to the comment-count and delete-reaction endpoints in `boardCommentsController.ts`.

## Production data that confirmed the issue

```
 share_mode    | is_public | count
---------------+-----------+-------
 public        | t         |    16   ← visible to ALL 3,172 users
 private       | f         |   412
 authenticated | f         |     5
```

Only 26 of 3,172 users are in groups, and only 2 docs are shared via groups — so groups were not the leak vector. The 16 `is_public = true` documents (including 2 boards) appearing in every user's personal list was the root cause.

## Files changed

**is_public removal (4 files):**
- `boardsController.ts`, `boardsContractRouter.ts` — boards list queries
- `recentActivityController.ts` — workplace recent boards + presentations
- `BoardService.ts` — board state loader

**is_active enforcement (13 files):**
- `documentController.ts`, `documentAccess.ts`, `snapshotController.ts` — docs
- `boardsController.ts`, `boardsContractRouter.ts`, `boardCommentsController.ts`, `BoardService.ts` — boards
- `threadsController.ts`, `threadsContractRouter.ts`, `confirmController.ts`, `contextEnrichmentService.ts` — chat
- `recentActivityController.ts` — workplace
- `groupNotifications.ts` — notifications

## Test plan

- [ ] Log in as user A, create a doc + board → only visible in user A's list
- [ ] Log in as user B → should NOT see user A's private items
- [ ] Set a board to public via share dialog → still accessible via share link, but not in other users' lists
- [ ] Share a doc with a group → members see it; deactivated members do not
- [ ] Board comment-count endpoint returns 403 for non-members