### PR TITLE
fix(web): keep group members popover open while admin menu is active

### DIFF
--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -158,6 +158,7 @@ const GroupInfoSection = memo(
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showAddContent, setShowAddContent] = useState(false);
     const popoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const memberActionOpenRef = useRef(false);
     const avatarInputRef = useRef<HTMLInputElement>(null);
     const [avatarTimestamp, setAvatarTimestamp] = useState(Date.now());
 
@@ -179,7 +180,23 @@ const GroupInfoSection = memo(
     }, []);
 
     const handleMembersMouseLeave = useCallback(() => {
-      popoverTimeoutRef.current = setTimeout(() => setMembersPopoverOpen(false), 200);
+      popoverTimeoutRef.current = setTimeout(() => {
+        if (memberActionOpenRef.current) return;
+        setMembersPopoverOpen(false);
+      }, 200);
+    }, []);
+
+    const handleMemberActionOpenChange = useCallback((open: boolean) => {
+      memberActionOpenRef.current = open;
+      if (open && popoverTimeoutRef.current) {
+        clearTimeout(popoverTimeoutRef.current);
+        popoverTimeoutRef.current = null;
+      }
+    }, []);
+
+    const handleMembersPopoverOpenChange = useCallback((next: boolean) => {
+      if (!next && memberActionOpenRef.current) return;
+      setMembersPopoverOpen(next);
     }, []);
 
     const memberCount = members?.length ?? 0;
@@ -241,7 +258,7 @@ const GroupInfoSection = memo(
       <>
         <div className="relative mb-xl">
           <div className="absolute right-0 top-0 flex items-center gap-sm">
-            <Popover open={membersPopoverOpen} onOpenChange={setMembersPopoverOpen}>
+            <Popover open={membersPopoverOpen} onOpenChange={handleMembersPopoverOpenChange}>
               <PopoverTrigger asChild>
                 <button
                   className="inline-flex items-center -space-x-1.5 cursor-pointer"
@@ -287,6 +304,7 @@ const GroupInfoSection = memo(
                   isCurrentUserAdmin={data?.isAdmin}
                   currentUserId={currentUserId}
                   createdBy={data?.groupInfo?.created_by}
+                  onMemberActionOpenChange={handleMemberActionOpenChange}
                 />
               </PopoverContent>
             </Popover>

--- a/apps/web/src/features/groups/components/GroupMembersList.tsx
+++ b/apps/web/src/features/groups/components/GroupMembersList.tsx
@@ -28,6 +28,7 @@ interface GroupMembersListProps {
   isCurrentUserAdmin?: boolean;
   currentUserId?: string;
   createdBy?: string;
+  onMemberActionOpenChange?: (open: boolean) => void;
 }
 
 const GroupMembersList = ({
@@ -38,6 +39,7 @@ const GroupMembersList = ({
   isCurrentUserAdmin = false,
   currentUserId,
   createdBy,
+  onMemberActionOpenChange,
 }: GroupMembersListProps) => {
   const { members, isLoadingMembers, isErrorMembers, errorMembers } = useGroupMembers(groupId, {
     isActive,
@@ -124,7 +126,7 @@ const GroupMembersList = ({
                 </Badge>
               )}
               {canChangeRole && (
-                <DropdownMenu>
+                <DropdownMenu onOpenChange={onMemberActionOpenChange}>
                   <DropdownMenuTrigger asChild>
                     <button
                       type="button"


### PR DESCRIPTION
## Summary
- Clicking **Zum Admin machen** / **Admin-Rechte entfernen** in the group members popover dismissed the entire popover and the role mutation never completed.
- Root cause: the popover is hover-controlled (200 ms close on `onMouseLeave`), but the per-row `DropdownMenu` uses `DropdownMenuPrimitive.Portal`, so its content mounts as a DOM sibling of `PopoverContent`. Moving the cursor into the dropdown fires `onMouseLeave` on the popover and schedules the close before the item-click lands.
- Fix: pin the popover open while any per-row action menu is open.
  - `GroupMembersList` gains an optional `onMemberActionOpenChange` callback wired to each `<DropdownMenu onOpenChange=…>`.
  - `GroupInfoSection` tracks that state via a ref (so the already-scheduled `setTimeout` can bail at fire-time), cancels any pending close when the menu opens, and also guards `<Popover onOpenChange>` so Radix outside-press detection can't close it while a menu is active.

## Test plan
- [ ] Hover the member-avatar stack → Gruppenmitglieder popover opens.
- [ ] Open the three-dot menu on a non-admin, non-self, non-creator member → popover stays visible.
- [ ] Click **Zum Admin machen** → dropdown closes, popover stays open, row re-renders with the **Admin** badge and now offers **Admin-Rechte entfernen**.
- [ ] Click **Admin-Rechte entfernen** on an admin → symmetric behaviour, row reverts to non-admin.
- [ ] Move mouse away → popover still closes after ~200 ms (no regression in hover-close).
- [ ] Hover back in before 200 ms → popover stays open (no regression).
- [ ] `npx tsc --noEmit --project apps/web/tsconfig.json` passes.