### PR TITLE
fix(shared): unblock master CI by resolving floating-promise lint error

### DIFF
--- a/packages/shared/src/media-library/hooks/useMediaLibrary.ts
+++ b/packages/shared/src/media-library/hooks/useMediaLibrary.ts
@@ -77,7 +77,7 @@ export function useMediaLibrary(options: UseMediaLibraryOptions = {}): UseMediaL
     (newFilters: Partial<MediaFilters>) => {
       const updatedFilters = { ...filters, ...newFilters, offset: 0 };
       setFiltersState(updatedFilters);
-      fetchMedia(updatedFilters);
+      void fetchMedia(updatedFilters);
     },
     [filters, fetchMedia]
   );


### PR DESCRIPTION
## Summary
Master's Quality Checks step has been failing on a single `@typescript-eslint/no-floating-promises` error in `@gruenerator/shared`. Every PR for the last few days has had to be admin-merged through a red CI.

**One-line fix**: `fetchMedia(updatedFilters)` → `void fetchMedia(updatedFilters)` in `useMediaLibrary.setFilters`.

\`setFilters\` is a synchronous callback, so the returned Promise was floating. `fetchMedia` already handles errors via its own `try/catch` (setting `error` state on failure), so fire-and-forget is the intended semantics — just needed to be explicit so the lint rule doesn't trip.

## Why this matters
- Unblocks Dependabot's auto-merge workflow (it won't merge PRs with red CI).
- Restores CI as a useful signal instead of noise that devs learn to ignore.
- Removes the need for admin-override merges on routine dep bumps.

## What this does NOT do
- Does not touch the 9 pre-existing warnings in `@gruenerator/shared` — those are `no-console` and `no-unused-vars` on files authored by others (notably `projectsStore.ts:87` has a deliberate 10-line comment explaining *why* the `console.log` exists). Those deserve individual authorial judgment, not a bulk sweep.

## Test plan
- [x] `pnpm --filter @gruenerator/shared lint` locally now reports 0 errors from committed files (remaining error is in a local-only untracked file unrelated to master).
- [ ] CI: Quality Checks step should now pass on this PR, and on all subsequent PRs merging from master.