### PR TITLE
fix(boards): include all shared-group members in assignee and mention pickers

### DIFF
--- a/apps/api/routes/boards/boardAccess.ts
+++ b/apps/api/routes/boards/boardAccess.ts
@@ -1,0 +1,42 @@
+import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+
+const db = getPostgresInstance();
+
+export interface BoardAccessResult {
+  hasAccess: boolean;
+  boardTitle: string | null;
+}
+
+export async function checkBoardAccess(
+  boardId: string,
+  userId: string
+): Promise<BoardAccessResult> {
+  const rows = (await db.query(
+    `SELECT cd.title, cd.created_by, cd.permissions, cd.is_public
+     FROM collaborative_documents cd
+     WHERE cd.id = $1 AND cd.document_subtype = 'boards' AND cd.is_deleted = false`,
+    [boardId]
+  )) as Array<{
+    title: string;
+    created_by: string;
+    permissions: Record<string, { level: string }> | null;
+    is_public: boolean;
+  }>;
+
+  if (rows.length === 0) return { hasAccess: false, boardTitle: null };
+
+  const board = rows[0];
+  if (board.created_by === userId || board.is_public || board.permissions?.[userId]) {
+    return { hasAccess: true, boardTitle: board.title };
+  }
+
+  const groupAccess = (await db.query(
+    `SELECT 1 FROM group_content_shares gcs
+     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
+     WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2
+     LIMIT 1`,
+    [userId, boardId]
+  )) as unknown[];
+
+  return { hasAccess: groupAccess.length > 0, boardTitle: board.title };
+}

--- a/apps/api/routes/boards/boardCommentsController.ts
+++ b/apps/api/routes/boards/boardCommentsController.ts
@@ -6,49 +6,11 @@ import { validateBody, type TypedRequest } from '../../middleware/validateBody.j
 import { createNotification } from '../../services/notifications/NotificationService.js';
 import { createLogger } from '../../utils/logger.js';
 
+import { checkBoardAccess } from './boardAccess.js';
+
 const router = Router();
 const db = getPostgresInstance();
 const log = createLogger('BoardComments');
-
-// ════════════════════════════════════════════════════════════════════════════
-// Helpers
-// ════════════════════════════════════════════════════════════════════════════
-
-interface BoardAccessResult {
-  hasAccess: boolean;
-  boardTitle: string | null;
-}
-
-async function checkBoardAccess(boardId: string, userId: string): Promise<BoardAccessResult> {
-  const rows = (await db.query(
-    `SELECT cd.title, cd.created_by, cd.permissions, cd.is_public
-     FROM collaborative_documents cd
-     WHERE cd.id = $1 AND cd.document_subtype = 'boards' AND cd.is_deleted = false`,
-    [boardId]
-  )) as Array<{
-    title: string;
-    created_by: string;
-    permissions: Record<string, { level: string }> | null;
-    is_public: boolean;
-  }>;
-
-  if (rows.length === 0) return { hasAccess: false, boardTitle: null };
-
-  const board = rows[0];
-  if (board.created_by === userId || board.is_public || board.permissions?.[userId]) {
-    return { hasAccess: true, boardTitle: board.title };
-  }
-
-  const groupAccess = (await db.query(
-    `SELECT 1 FROM group_content_shares gcs
-     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
-     WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2
-     LIMIT 1`,
-    [userId, boardId]
-  )) as unknown[];
-
-  return { hasAccess: groupAccess.length > 0, boardTitle: board.title };
-}
 
 interface CommentBlock {
   type: 'text' | 'mention' | 'link' | 'code';

--- a/apps/api/routes/boards/boardsController.ts
+++ b/apps/api/routes/boards/boardsController.ts
@@ -12,6 +12,8 @@ import {
 } from '../../services/boards/BoardService.js';
 import { getAIWorkerPool } from '../../utils/getAIWorkerPool.js';
 
+import { checkBoardAccess } from './boardAccess.js';
+
 const BOARDS_SUBTYPE = 'boards';
 
 interface BoardDocument {
@@ -239,6 +241,75 @@ router.get('/:id/state', async (req: Request<{ id: string }>, res: Response) => 
     console.error('[Boards] Error fetching board state:', error);
     return res.status(500).json({
       error: 'Failed to fetch board state',
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+});
+
+interface AssignableMemberRow {
+  user_id: string;
+  source: 'owner' | 'direct' | 'group';
+  first_name: string | null;
+  display_name: string | null;
+  avatar_robot_id: number;
+}
+
+router.get('/:id/assignable-members', async (req: Request<{ id: string }>, res: Response) => {
+  try {
+    const { id } = req.params;
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+
+    const { hasAccess } = await checkBoardAccess(id, userId);
+    if (!hasAccess) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+
+    const members = (await db.query(
+      `WITH assignable AS (
+           SELECT cd.created_by AS user_id, 'owner'::text AS source
+           FROM collaborative_documents cd
+           WHERE cd.id = $1 AND cd.document_subtype = $2 AND cd.is_deleted = false
+
+           UNION
+
+           SELECT perm_key::uuid AS user_id, 'direct'::text AS source
+           FROM collaborative_documents cd,
+                LATERAL jsonb_object_keys(COALESCE(cd.permissions, '{}'::jsonb)) AS perm_key
+           WHERE cd.id = $1 AND cd.document_subtype = $2 AND cd.is_deleted = false
+             AND perm_key ~ '^[0-9a-f-]{36}$'
+
+           UNION
+
+           SELECT gm.user_id, 'group'::text AS source
+           FROM group_content_shares gcs
+           INNER JOIN group_memberships gm
+             ON gm.group_id = gcs.group_id
+            AND gm.is_active = TRUE
+           WHERE gcs.content_type = 'collaborative_documents'
+             AND gcs.content_id = $1
+         )
+         SELECT DISTINCT ON (a.user_id)
+           a.user_id,
+           a.source,
+           p.first_name,
+           p.display_name,
+           COALESCE(p.avatar_robot_id, 1) AS avatar_robot_id
+         FROM assignable a
+         INNER JOIN profiles p ON p.id = a.user_id
+         ORDER BY a.user_id,
+                  CASE a.source WHEN 'owner' THEN 0 WHEN 'direct' THEN 1 ELSE 2 END`,
+      [id, BOARDS_SUBTYPE]
+    )) as AssignableMemberRow[];
+
+    return res.json(members);
+  } catch (error: unknown) {
+    console.error('[Boards] Error listing assignable members:', error);
+    return res.status(500).json({
+      error: 'Failed to list assignable members',
       details: error instanceof Error ? error.message : String(error),
     });
   }

--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -20,7 +20,6 @@ import { PlannerKanban } from './components/PlannerKanban';
 import { ViewSwitcher } from './components/ViewSwitcher';
 import { ViewToolbar } from './components/ViewToolbar';
 import { useBoardCollaboration } from './hooks/useBoardCollaboration';
-import { useBoardSharing } from './hooks/useBoardSharing';
 import { useBoardState } from './hooks/useBoardState';
 import { useViewData } from './hooks/useViewData';
 import { FIELD_IDS, getBoardType, isBoardArchived } from './types';
@@ -82,7 +81,6 @@ function BoardContent() {
   );
 
   const { ydoc, provider, isConnected, isSynced } = useBoardCollaboration(id || '');
-  const { boardGroups } = useBoardSharing(id || '');
 
   if (isLoading) {
     return (
@@ -145,7 +143,7 @@ function BoardContent() {
           provider={provider}
           generatedStructure={generatedStructure}
           currentUserId={String(user?.id || '')}
-          groupId={boardGroups[0]?.group_id}
+          boardId={board.id}
           expertMode={expertMode}
         />
       )}
@@ -159,7 +157,7 @@ function BoardViewContent({
   provider,
   generatedStructure,
   currentUserId,
-  groupId,
+  boardId,
   expertMode,
 }: {
   ydoc: Doc;
@@ -167,7 +165,7 @@ function BoardViewContent({
   provider: HocuspocusProvider | null;
   generatedStructure: BoardInitialStructure | null;
   currentUserId: string;
-  groupId?: string;
+  boardId: string;
   expertMode: boolean;
 }) {
   const boardState = useBoardState(ydoc, isSynced, generatedStructure);
@@ -263,7 +261,7 @@ function BoardViewContent({
           removeField={boardState.removeField}
           onUpdateView={boardState.updateView}
           currentUserId={currentUserId}
-          groupId={groupId}
+          boardId={boardId}
           provider={provider}
         />
       )}
@@ -314,7 +312,7 @@ function BoardViewContent({
           onUpdateRow={boardState.updateRow}
           onDelete={boardState.deleteRow}
           onUpdateField={boardState.updateField}
-          groupId={groupId}
+          boardId={boardId}
         />
       )}
     </>

--- a/apps/web/src/features/boards/components/CardComments.tsx
+++ b/apps/web/src/features/boards/components/CardComments.tsx
@@ -244,7 +244,6 @@ const CommentItem = memo(function CommentItem({
 
 interface CardCommentsProps {
   cardId: string;
-  groupId?: string;
   currentUserId: string;
   currentUserName: string;
   currentUserAvatarRobotId: number;
@@ -252,7 +251,6 @@ interface CardCommentsProps {
 
 export const CardComments = memo(function CardComments({
   cardId,
-  groupId,
   currentUserId,
   currentUserName,
   currentUserAvatarRobotId,
@@ -339,7 +337,7 @@ export const CardComments = memo(function CardComments({
 
   const updateMentionState = useCallback(() => {
     const textarea = textareaRef.current;
-    if (!textarea || !groupId) {
+    if (!textarea || !boardId) {
       setMentionQuery(null);
       return;
     }
@@ -357,7 +355,7 @@ export const CardComments = memo(function CardComments({
     } else {
       setMentionQuery(null);
     }
-  }, [groupId]);
+  }, [boardId]);
 
   const handleMentionSelect = useCallback(
     (user: MentionUser) => {
@@ -538,7 +536,7 @@ export const CardComments = memo(function CardComments({
             placeholder={
               replyToId
                 ? 'Antwort schreiben...'
-                : groupId
+                : boardId
                   ? 'Kommentar schreiben... (@erwähnen)'
                   : 'Kommentar schreiben...'
             }
@@ -559,7 +557,7 @@ export const CardComments = memo(function CardComments({
         </div>
 
         <UserMentionPopover
-          groupId={groupId}
+          boardId={boardId}
           query={mentionQuery ?? ''}
           visible={mentionQuery !== null}
           anchorRect={mentionAnchor}

--- a/apps/web/src/features/boards/components/CardDetailPanel.tsx
+++ b/apps/web/src/features/boards/components/CardDetailPanel.tsx
@@ -115,7 +115,7 @@ interface CardDetailPanelProps {
   onUpdateRow: (rowId: string, updates: Partial<Row>) => void;
   onDelete: (rowId: string) => void;
   onUpdateField: (fieldId: string, updates: Partial<Field>) => void;
-  groupId?: string;
+  boardId?: string;
   currentUserId?: string;
   currentUserName?: string;
   currentUserAvatarRobotId?: number;
@@ -132,7 +132,7 @@ export const CardDetailPanel = memo(function CardDetailPanel({
   onUpdateRow,
   onDelete,
   onUpdateField,
-  groupId,
+  boardId,
   currentUserId = '',
   currentUserName = '',
   currentUserAvatarRobotId = 1,
@@ -445,8 +445,8 @@ export const CardDetailPanel = memo(function CardDetailPanel({
               </div>
             </div>
 
-            {/* Assignee — only shown when a group is linked */}
-            {groupId && (
+            {/* Assignee — available whenever the card has a board context */}
+            {boardId && (
               <div className="flex flex-row">
                 <p className="w-24 shrink-0 text-sm font-medium text-grey-500 dark:text-grey-100 pt-1.5">
                   <FiUser className="inline mr-1.5" size={13} />
@@ -470,7 +470,7 @@ export const CardDetailPanel = memo(function CardDetailPanel({
                       </button>
                     </div>
                   )}
-                  <MemberPicker groupId={groupId} onSelect={handleAssigneeChange}>
+                  <MemberPicker boardId={boardId} onSelect={handleAssigneeChange}>
                     <button className="flex items-center gap-1.5 text-xs text-grey-400 dark:text-grey-300 hover:text-primary-600 bg-transparent border-none cursor-pointer transition-colors py-2 sm:py-0">
                       <FiPlus size={12} />
                       {assignee ? 'Ändern' : 'Person zuweisen'}
@@ -580,7 +580,6 @@ export const CardDetailPanel = memo(function CardDetailPanel({
           {row && (
             <CardComments
               cardId={row.id}
-              groupId={groupId}
               currentUserId={currentUserId}
               currentUserName={currentUserName}
               currentUserAvatarRobotId={currentUserAvatarRobotId}

--- a/apps/web/src/features/boards/components/MemberPicker.tsx
+++ b/apps/web/src/features/boards/components/MemberPicker.tsx
@@ -1,41 +1,22 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import { getRobotAvatarPath } from '@gruenerator/shared/avatar';
 import { Popover, PopoverContent, PopoverTrigger } from '@gruenerator/ui';
-import { useState, useEffect, useMemo, type ReactNode } from 'react';
+import { useState, useMemo, type ReactNode } from 'react';
 import { FiSearch, FiUserX } from 'react-icons/fi';
 
-import type { CardAssignee } from '../types';
-
-interface Member {
-  user_id: string;
-  display_name: string | null;
-  first_name: string | null;
-  avatar_robot_id: number;
-}
+import { type AssignableMember, useAssignableMembers } from '../hooks/useAssignableMembers';
+import { type CardAssignee } from '../types';
 
 interface MemberPickerProps {
-  groupId: string;
+  boardId: string;
   onSelect: (assignee: CardAssignee | null) => void;
   children: ReactNode;
 }
 
-export function MemberPicker({ groupId, onSelect, children }: MemberPickerProps) {
+export function MemberPicker({ boardId, onSelect, children }: MemberPickerProps) {
   const [open, setOpen] = useState(false);
-  const [members, setMembers] = useState<Member[]>([]);
-  const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
 
-  useEffect(() => {
-    if (!open || !groupId) return;
-    setLoading(true);
-    fetch(`/api/auth/groups/${groupId}/members`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => {
-        if (Array.isArray(data)) setMembers(data);
-      })
-      .catch(() => setMembers([]))
-      .finally(() => setLoading(false));
-  }, [open, groupId]);
+  const { data: members = [], isLoading } = useAssignableMembers(open ? boardId : undefined);
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase();
@@ -45,7 +26,7 @@ export function MemberPicker({ groupId, onSelect, children }: MemberPickerProps)
     });
   }, [members, search]);
 
-  const handleSelect = (member: Member | null) => {
+  const handleSelect = (member: AssignableMember | null) => {
     if (member) {
       onSelect({
         id: member.user_id,
@@ -83,8 +64,8 @@ export function MemberPicker({ groupId, onSelect, children }: MemberPickerProps)
             <FiUserX size={14} className="shrink-0" />
             <span>Niemand</span>
           </button>
-          {loading && <p className="px-3 py-4 text-xs text-grey-400 text-center">Laden...</p>}
-          {!loading &&
+          {isLoading && <p className="px-3 py-4 text-xs text-grey-400 text-center">Laden...</p>}
+          {!isLoading &&
             filtered.map((member) => (
               <button
                 key={member.user_id}

--- a/apps/web/src/features/boards/components/PlannerKanban.tsx
+++ b/apps/web/src/features/boards/components/PlannerKanban.tsx
@@ -147,7 +147,7 @@ interface PlannerKanbanProps {
   removeField: (fieldId: string) => void;
   onUpdateView?: (viewId: string, updates: Partial<BoardView>) => void;
   currentUserId: string;
-  groupId?: string;
+  boardId?: string;
   provider?: HocuspocusProvider | null;
 }
 
@@ -163,7 +163,7 @@ export function PlannerKanban({
   updateField,
   onUpdateView,
   currentUserId,
-  groupId,
+  boardId,
   provider,
 }: PlannerKanbanProps) {
   const { userName, userAvatarRobotId } = useAuthStore(
@@ -466,7 +466,7 @@ export function PlannerKanban({
         onUpdateRow={updateRow}
         onDelete={deleteRow}
         onUpdateField={updateField}
-        groupId={groupId}
+        boardId={boardId}
         currentUserId={currentUserId}
         currentUserName={userName}
         currentUserAvatarRobotId={userAvatarRobotId}

--- a/apps/web/src/features/boards/components/UserMentionPopover.tsx
+++ b/apps/web/src/features/boards/components/UserMentionPopover.tsx
@@ -1,12 +1,7 @@
 import { getRobotAvatarPath } from '@gruenerator/shared/avatar';
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef } from 'react';
 
-interface Member {
-  user_id: string;
-  display_name: string | null;
-  first_name: string | null;
-  avatar_robot_id: number;
-}
+import { useAssignableMembers } from '../hooks/useAssignableMembers';
 
 export interface MentionUser {
   userId: string;
@@ -15,7 +10,7 @@ export interface MentionUser {
 }
 
 interface UserMentionPopoverProps {
-  groupId: string | undefined;
+  boardId: string | undefined;
   query: string;
   visible: boolean;
   anchorRect: { x: number; y: number } | null;
@@ -27,26 +22,16 @@ interface UserMentionPopoverProps {
 const MAX_RESULTS = 5;
 
 export const UserMentionPopover = memo(function UserMentionPopover({
-  groupId,
+  boardId,
   query,
   visible,
   anchorRect,
   onSelect,
-  onDismiss,
   selectedIndex,
 }: UserMentionPopoverProps) {
-  const [members, setMembers] = useState<Member[]>([]);
   const listRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!groupId) return;
-    fetch(`/api/auth/groups/${groupId}/members`, { credentials: 'include' })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => {
-        if (Array.isArray(data)) setMembers(data);
-      })
-      .catch(() => setMembers([]));
-  }, [groupId]);
+  const { data: members = [] } = useAssignableMembers(visible ? boardId : undefined);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();

--- a/apps/web/src/features/boards/hooks/useAssignableMembers.ts
+++ b/apps/web/src/features/boards/hooks/useAssignableMembers.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+
+import apiClient from '../../../components/utils/apiClient';
+
+export interface AssignableMember {
+  user_id: string;
+  source: 'owner' | 'direct' | 'group';
+  first_name: string | null;
+  display_name: string | null;
+  avatar_robot_id: number;
+}
+
+export function useAssignableMembers(boardId: string | undefined) {
+  return useQuery<AssignableMember[]>({
+    queryKey: ['boards', boardId, 'assignable-members'],
+    queryFn: async () => {
+      const res = await apiClient.get<AssignableMember[]>(`/boards/${boardId}/assignable-members`);
+      return res.data;
+    },
+    enabled: !!boardId,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/src/features/boards/hooks/useBoardSharing.ts
+++ b/apps/web/src/features/boards/hooks/useBoardSharing.ts
@@ -76,6 +76,9 @@ export const useBoardSharing = (boardId: string) => {
     void queryClient.invalidateQueries({ queryKey: permKey });
     void queryClient.invalidateQueries({ queryKey: shareKey });
     void queryClient.invalidateQueries({ queryKey: groupsKey });
+    void queryClient.invalidateQueries({
+      queryKey: ['boards', boardId, 'assignable-members'],
+    });
   };
 
   const setShareMode = useMutation({


### PR DESCRIPTION
## Summary

When a user shared a board with a group, those group's members couldn't be selected as "Zuständig" (responsible person) on a card, and couldn't be `@`-mentioned in comments. Two underlying causes:

1. **First-group-only**: `BoardPage` passed `boardGroups[0]?.group_id` downstream, so boards shared with multiple groups only exposed the first group's members.
2. **Requester-membership gate**: the picker hit `/api/auth/groups/:groupId/members`, which requires the *requester* to be a member of the group. A board owner who shared with a group they didn't belong to got 403 and saw an empty picker.

Boards have no owning group — sharing is a set of `group_content_shares` rows. Tying the pickers to a single `groupId` was architecturally wrong.

## Fix

- **New `GET /api/boards/:id/assignable-members`** returns the union of board owner + users in `permissions` JSONB + active members of every group the board is shared with, deduplicated via `DISTINCT ON` with source-priority (`owner` > `direct` > `group`). Defensive regex on `jsonb_object_keys` skips non-UUID keys so the `::uuid` cast can never raise.
- **Refactored `checkBoardAccess`** into `apps/api/routes/boards/boardAccess.ts` (first commit, pure refactor — mirrors `docs/documentAccess.ts`). Reused for the new endpoint.
- **New `useAssignableMembers` hook** centralises the query with key `['boards', boardId, 'assignable-members']`.
- **`MemberPicker` and `UserMentionPopover`** both consume the hook; the raw `fetch`+`useState/useEffect` blocks and local `Member` interfaces are gone.
- **`CardComments`** now derives `boardId` from `useParams` instead of taking it as a prop — removes the `groupId` drill-down through `CardDetailPanel` / `PlannerKanban` / `BoardPage` / `BoardViewContent`.
- **Zuständig gate** changed from `{groupId && ...}` to `{boardId && ...}` so direct-share-only boards also expose the field.
- **`useBoardSharing.invalidateAll`** now also invalidates the assignable-members query, so newly added shares populate the pickers immediately.

## Test plan

- [ ] Board owner who is NOT in the shared group can open a card and see that group's members in the Zuständig picker (core bug scenario).
- [ ] Board shared with groups A + B — members of both appear together in the picker and in the `@`-mention popover.
- [ ] Direct-share-only board (no group share) now shows the Zuständig field too.
- [ ] After adding a new group share, the picker reflects the new members without a hard reload.
- [ ] Owner / direct-share user / shared-group member all get 200; non-member gets 403.
- [ ] `pnpm typecheck` (api + web) — already green locally.
- [ ] End-to-end manual test: A creates a board, shares with G (A not in G), B is in G → A assigns B → B sees the assignment.