### PR TITLE
fix(boards): cast content_id to text in assignable-members query

### DIFF
--- a/apps/api/routes/boards/boardsController.ts
+++ b/apps/api/routes/boards/boardsController.ts
@@ -290,7 +290,7 @@ router.get('/:id/assignable-members', async (req: Request<{ id: string }>, res: 
              ON gm.group_id = gcs.group_id
             AND gm.is_active = TRUE
            WHERE gcs.content_type = 'collaborative_documents'
-             AND gcs.content_id = $1
+             AND gcs.content_id = $1::text
          )
          SELECT DISTINCT ON (a.user_id)
            a.user_id,


### PR DESCRIPTION
## Summary

Follow-up to #637. In production, the new `GET /api/boards/:id/assignable-members` endpoint crashes with:

```
error: operator does not exist: text = uuid
  hint: You might need to add explicit type casts.
```

## Root cause

Postgres infers parameter types per-query, not per-occurrence. The CTE's first branch uses `cd.id = $1` (where `cd.id` is `UUID`), so `$1` is inferred as `UUID` for the whole statement. The third branch then compares the `TEXT` column `gcs.content_id` to that `UUID`-typed `$1` → `42883`.

Typechecking didn't catch it — pg type inference only surfaces at query time against a real database. The existing `checkBoardAccess` query avoids this by using two distinct parameters (`$1` = userId, `$2` = boardId), so each param has a single inferred type.

## Fix

Force an explicit `::text` cast on the one site where `$1` is compared to a TEXT column:

```sql
AND gcs.content_id = $1::text
```

Single-line change. Matches the pattern already used elsewhere in `boardsController.ts` (e.g. `SELECT gcs.content_id::uuid` at line 73).

## Test plan

- [ ] Deploy to test env, hit `GET /api/boards/:id/assignable-members` on a shared board → returns 200 with members.
- [ ] Zuständig picker and `@`-mention popover populate for all shared-group members (the original #637 behavior).
- [ ] API logs no longer show `operator does not exist: text = uuid`.