### PR TITLE
fix(boards): persist Expert*innen Modus across reloads

### DIFF
--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -7,6 +7,7 @@ import { DottedBackground } from '../../components/common/DottedBackground';
 import withAuthRequired from '../../components/common/LoginRequired/withAuthRequired';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import apiClient from '../../components/utils/apiClient';
+import useUserDefaults from '../../hooks/useUserDefaults';
 import { useAuthStore } from '../../stores/authStore';
 import { webAppDocsAdapter } from '../docs/docsAdapter';
 
@@ -39,7 +40,11 @@ function BoardContent() {
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
-  const [expertMode, setExpertMode] = useState(false);
+  const { get: getBoardsDefault, set: setBoardsDefault } = useUserDefaults<boolean>('boards');
+  const expertMode = getBoardsDefault('expertMode', false);
+  const handleExpertModeToggle = useCallback(() => {
+    void setBoardsDefault('expertMode', !expertMode);
+  }, [expertMode, setBoardsDefault]);
 
   const generatedStructure =
     (location.state as { generatedStructure?: BoardInitialStructure } | null)?.generatedStructure ??
@@ -123,7 +128,7 @@ function BoardContent() {
         provider={provider}
         onDelete={handleDelete}
         onArchiveToggle={handleArchiveToggle}
-        onExpertModeToggle={() => setExpertMode((prev) => !prev)}
+        onExpertModeToggle={handleExpertModeToggle}
         compact={isWhiteboard}
       />
       {isWhiteboard ? (


### PR DESCRIPTION
## Summary
- **Bug:** Expert*innen Modus in boards reset to off on every F5 reload (and on any navigation to a board), because it lived in component-local `useState` in `BoardPage.tsx`.
- **Fix:** Replaced the ephemeral state with the existing `useUserDefaults('boards')` hook. The toggle is now persisted per user in localStorage (synchronous first-paint) and PostgreSQL via `PATCH /auth/profile/user-defaults` (cross-device sync).
- **Scope:** Single file, single commit (`apps/web/src/features/boards/BoardPage.tsx`). No schema changes, no backend changes — `userDefaultsStore` already accepts arbitrary `(generator, key, value)` tuples.

## Test plan
- [ ] `pnpm dev:web`, open a board at `/boards/:id`
- [ ] Enable Expert*innenmodus via the board dropdown → `ViewSwitcher` + `ViewToolbar` appear
- [ ] Press F5 → Expert*innen Modus still on, advanced UI visible on first paint (no flicker)
- [ ] Navigate to a different board → Expert*innen Modus still on
- [ ] Toggle off → F5 → still off
- [ ] DevTools → Application → Local Storage → `user-defaults` contains `{ defaults: { boards: { expertMode: <bool> } } }`
- [ ] DevTools → Network on each toggle → `PATCH /auth/profile/user-defaults` with `{ generator: 'boards', key: 'expertMode', value: <bool> }` returns 2xx