### PR TITLE
fix(boards): always render robot avatar instead of letter fallback

### DIFF
--- a/apps/web/src/features/boards/components/PresenceAvatars.tsx
+++ b/apps/web/src/features/boards/components/PresenceAvatars.tsx
@@ -23,11 +23,7 @@ export const PresenceAvatars = memo(function PresenceAvatars({
           style={{ backgroundColor: user.color }}
           title={user.name}
         >
-          {user.avatarRobotId ? (
-            <img src={getRobotAvatarPath(user.avatarRobotId)} alt="" className="w-full h-full" />
-          ) : (
-            user.name.charAt(0).toUpperCase()
-          )}
+          <img src={getRobotAvatarPath(user.avatarRobotId ?? 1)} alt="" className="w-full h-full" />
         </div>
       ))}
       {collaborators.length > MAX_VISIBLE && (

--- a/packages/collab/src/hooks/useCollaboration.ts
+++ b/packages/collab/src/hooks/useCollaboration.ts
@@ -76,7 +76,7 @@ export const useCollaboration = ({
       id: u.id,
       name: u.display_name || u.email || 'Anonymous',
       color: generateUserColor(),
-      ...(u.avatar_robot_id ? { avatarRobotId: u.avatar_robot_id } : {}),
+      avatarRobotId: u.avatar_robot_id ?? 1,
     };
   }, [isGuest]);
 


### PR DESCRIPTION
## Summary
- **Bug:** On board pages, the presence bar occasionally renders a collaborator as a capital letter (e.g. "M") instead of their robot avatar.
- **Root cause A (receive side):** `PresenceAvatars.tsx` uses `user.avatarRobotId ? <img> : letter`. If awareness state ever arrives without an `avatarRobotId` (stale client, legacy cached profile, guest), it falls through to the letter — breaking the uniform "always robots" convention used by every other board avatar renderer (`MemberPicker`, `CardContent`, `CardDetailPanel`, `CardComments`, `UserMentionPopover`).
- **Root cause B (broadcast side):** `packages/collab/src/hooks/useCollaboration.ts` broadcasts `avatarRobotId` via conditional spread, so a sender whose `avatar_robot_id` is 0/null (e.g. stale localStorage from before the Zod schema added `.default(1)`) transmits an awareness state with **no** avatar at all — forcing every peer into the letter fallback.

## Fix
- `PresenceAvatars` now always renders `<img src={getRobotAvatarPath(user.avatarRobotId ?? 1)} />` — matches the rest of the boards codebase.
- `useCollaboration` now broadcasts `avatarRobotId: u.avatar_robot_id ?? 1` unconditionally for authenticated users, so peers always receive a renderable robot id.

Two files, +2/-6 lines.

## Test plan
- [ ] `pnpm dev:web`, open a board
- [ ] In another browser (different account), open the same board → confirm the collaborator shows as a robot avatar in the top-right presence bar, never a letter
- [ ] Clear `localStorage.gruenerator_auth_state` to simulate a stale profile without `avatar_robot_id`, hard reload → still shows robot #1 instead of a letter
- [ ] Existing robot-avatar selection (profile settings) still shows the chosen robot (1-9) for users who have one set