### PR TITLE
fix(notebook): stabilize citation rendering during streaming

### DIFF
--- a/packages/chat/src/components/message-parts/CitationMarkdownText.tsx
+++ b/packages/chat/src/components/message-parts/CitationMarkdownText.tsx
@@ -19,7 +19,6 @@ function CitationMarkdownTextImpl() {
       remarkPlugins={remarkPlugins}
       components={components}
       preprocess={escapeCitationMarkers}
-      smooth
     />
   );
 }

--- a/packages/chat/src/context/CitationContext.tsx
+++ b/packages/chat/src/context/CitationContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useContext } from 'react';
+import { createContext, useCallback, useContext, useMemo } from 'react';
 import type { Citation } from '../hooks/useChatGraphStream';
 import { useChatConfigStore } from '../stores/chatConfigStore';
 
@@ -22,11 +22,8 @@ export function CitationProvider({
   fetchFullText?: FetchFullTextFn;
   children: React.ReactNode;
 }) {
-  return (
-    <CitationContext.Provider value={{ citations, fetchFullText }}>
-      {children}
-    </CitationContext.Provider>
-  );
+  const value = useMemo(() => ({ citations, fetchFullText }), [citations, fetchFullText]);
+  return <CitationContext.Provider value={value}>{children}</CitationContext.Provider>;
 }
 
 export function useCitations(): Citation[] {

--- a/packages/chat/src/lib/citationMarkdownComponents.tsx
+++ b/packages/chat/src/lib/citationMarkdownComponents.tsx
@@ -4,7 +4,7 @@ import { processChildren } from './citationProcessing';
 import type { Citation } from '../hooks/useChatGraphStream';
 
 export function makeCitationComponents(citationMap: Map<number, Citation>) {
-  const withCitations = (children: ReactNode) => processChildren(children, citationMap);
+  const withCitations = (children: ReactNode) => processChildren(children, citationMap, true);
 
   return memoizeMarkdownComponents({
     a: ({ children, href }: { children?: ReactNode; href?: string }) => (

--- a/packages/chat/src/lib/citationProcessing.ts
+++ b/packages/chat/src/lib/citationProcessing.ts
@@ -3,54 +3,63 @@ import { CitationBadge } from '../components/message-parts/CitationPopover';
 import type { Citation } from '../hooks/useChatGraphStream';
 
 const CITATION_REGEX = /\[(\d+)\]/g;
+const MAX_CITATION_ID = 999;
 
 export function processTextWithCitations(
   text: string,
-  citationMap: Map<number, Citation>
+  citationMap: Map<number, Citation>,
+  allowPlaceholders = false
 ): ReactNode[] {
-  if (citationMap.size === 0) return [text];
-
   const parts: ReactNode[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
+  let replacedAny = false;
 
   CITATION_REGEX.lastIndex = 0;
   while ((match = CITATION_REGEX.exec(text)) !== null) {
     const citationId = parseInt(match[1], 10);
     const citation = citationMap.get(citationId);
 
+    // Reserve the same inline box during streaming so the final text→badge
+    // swap at completion does not reflow paragraph line wrapping.
+    const shouldRenderBadge =
+      citation !== undefined ||
+      (allowPlaceholders && citationId >= 1 && citationId <= MAX_CITATION_ID);
+
+    if (!shouldRenderBadge) continue;
+
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
 
-    if (citation) {
-      parts.push(
-        createElement(CitationBadge, {
-          key: `cite-${match.index}`,
-          citationId,
-          citation,
-        })
-      );
-    }
+    parts.push(
+      createElement(CitationBadge, {
+        key: `cite-${match.index}`,
+        citationId,
+        citation,
+      })
+    );
     lastIndex = match.index + match[0].length;
+    replacedAny = true;
   }
+
+  if (!replacedAny) return [text];
 
   if (lastIndex < text.length) {
     parts.push(text.slice(lastIndex));
   }
 
-  return parts.length > 0 ? parts : [text];
+  return parts;
 }
 
 export function processChildren(
   children: ReactNode,
-  citationMap: Map<number, Citation>
+  citationMap: Map<number, Citation>,
+  allowPlaceholders = false
 ): ReactNode {
-  if (citationMap.size === 0) return children;
-
   return Children.map(children, (child) => {
     if (typeof child === 'string') {
-      const parts = processTextWithCitations(child, citationMap);
+      const parts = processTextWithCitations(child, citationMap, allowPlaceholders);
       if (parts.length === 1 && parts[0] === child) return child;
       return createElement(Fragment, null, ...parts);
     }
@@ -61,7 +70,7 @@ export function processChildren(
           ...child,
           props: {
             ...props,
-            children: processChildren(props.children as ReactNode, citationMap),
+            children: processChildren(props.children as ReactNode, citationMap, allowPlaceholders),
           },
         };
       }

--- a/packages/chat/src/lib/citationUtils.ts
+++ b/packages/chat/src/lib/citationUtils.ts
@@ -1,5 +1,10 @@
 import type { Citation as ChatCitation } from '../hooks/useChatGraphStream';
 
+// Stable empty-citations singleton. Returning a fresh `[]` on every call breaks
+// downstream memoization in React (citationMap / components identity churn),
+// which causes MarkdownTextPrimitive to remount and restart smooth animations.
+const EMPTY_CITATIONS: ChatCitation[] = [];
+
 /**
  * Maps raw snake_case notebook citations (unknown[]) to the standardized ChatCitation format.
  * Also used as a backward-compat fallback for old stored messages that lack pre-mapped citations.
@@ -27,12 +32,12 @@ export function mapRawCitationsToChat(raw: unknown[]): ChatCitation[] {
  * Priority: citations (pre-mapped ChatCitation[]) → rawCitations (mapped on-the-fly) → chatCitations (deprecated)
  */
 export function resolveCitations(meta: Record<string, unknown> | undefined): ChatCitation[] {
-  if (!meta) return [];
+  if (!meta) return EMPTY_CITATIONS;
   const citations = meta.citations as ChatCitation[] | undefined;
   if (citations && citations.length > 0) return citations;
   const rawCitations = meta.rawCitations as unknown[] | undefined;
   if (rawCitations && rawCitations.length > 0) return mapRawCitationsToChat(rawCitations);
   const chatCitations = meta.chatCitations as ChatCitation[] | undefined;
   if (chatCitations && chatCitations.length > 0) return chatCitations;
-  return [];
+  return EMPTY_CITATIONS;
 }

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -337,13 +337,16 @@ export function createNotebookModelAdapter(
 
         completionCitations = mapToChatCitations(rawCitationsAccum);
         console.debug(
-          '[Notebook] Completion: %d rawCitations, %d citations, answer length: %d',
+          '[Notebook] Completion: %d rawCitations, %d citations, answer length: %d streamed vs %d final',
           rawCitationsAccum.length,
           completionCitations.length,
+          accumulatedText.length,
           completionData.answer.length
         );
         currentProgress = { stage: 'complete', message: '' };
-        accumulatedText = completionData.answer;
+        // Keep the streamed deltas as the source of truth. Overwriting with
+        // completionData.answer can reflow the final frame if the backend
+        // canonicalizes whitespace/markers between streaming and completion.
 
         yield buildResult();
 
@@ -356,7 +359,7 @@ export function createNotebookModelAdapter(
           linkConfig: linkConfigAccum,
           question,
           resultId: resultIdAccum,
-          answerText: completionData.answer,
+          answerText: accumulatedText,
           progress: { stage: 'complete', message: '' },
           ...(sourcesByCollectionAccum && { sourcesByCollection: sourcesByCollectionAccum }),
         };

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -344,9 +344,12 @@ export function createNotebookModelAdapter(
           completionData.answer.length
         );
         currentProgress = { stage: 'complete', message: '' };
-        // Keep the streamed deltas as the source of truth. Overwriting with
-        // completionData.answer can reflow the final frame if the backend
-        // canonicalizes whitespace/markers between streaming and completion.
+        // Swap in the backend's canonical answer so citation IDs in the text
+        // match completionCitations. The LLM emits raw IDs during streaming
+        // (e.g. [23], [19], [24]) that the backend renumbers to dense
+        // sequential IDs at completion — without this swap, markers point to
+        // the wrong sources or fall off the map entirely.
+        accumulatedText = completionData.answer;
 
         yield buildResult();
 
@@ -359,7 +362,7 @@ export function createNotebookModelAdapter(
           linkConfig: linkConfigAccum,
           question,
           resultId: resultIdAccum,
-          answerText: accumulatedText,
+          answerText: completionData.answer,
           progress: { stage: 'complete', message: '' },
           ...(sourcesByCollectionAccum && { sourcesByCollection: sourcesByCollectionAccum }),
         };


### PR DESCRIPTION
## Summary
- Stop citation rendering from visibly jumping as SSE deltas arrive: `EMPTY_CITATIONS` singleton, memoized `CitationProvider` value, drop `smooth` on notebook markdown, always render placeholder badges during streaming with identical box metrics.
- Guard `[year]` markers (`citationId <= 999`) and restore unknown markers as literal text (fixes a pre-existing silent-drop bug).
- Swap to backend-canonical `completionData.answer` at completion so dense citation IDs (`[cite:1]..[cite:9]`) align with the source map — prior fix kept raw streamed IDs, which left `[23]/[19]/[24]` style markers pointing at wrong sources or falling off the map entirely.

Cherry-picked from test-branch (\`c014deaa\`, \`0d4825d1\`).

## Test plan
- [ ] Open a notebook, ask a long-form question, confirm rendered text no longer collapses mid-stream.
- [ ] Click citation badges in the final answer — each should open the correct source.
- [ ] Verify \`[year]\` markers (e.g. \`[2024]\`) still render as literal text, not as citation badges.