### PR TITLE
chore(contracts): add eslint.config.js

### DIFF
--- a/packages/contracts/eslint.config.js
+++ b/packages/contracts/eslint.config.js
@@ -1,0 +1,18 @@
+import baseConfig from '@gruenerator/eslint-config/base';
+
+export default [
+  ...baseConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+        projectService: {
+          allowDefaultProject: ['eslint.config.js'],
+        },
+      },
+    },
+  },
+  {
+    ignores: ['dist/**'],
+  },
+];

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,6 +24,8 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@gruenerator/eslint-config": "workspace:*",
+    "eslint": "^9.39.4",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/contracts/src/contracts/unsplashContract.ts
+++ b/packages/contracts/src/contracts/unsplashContract.ts
@@ -11,7 +11,6 @@
  * Routes are public (no requireAuth).
  */
 import { initContract } from '@ts-rest/core';
-import { z } from 'zod';
 
 import {
   unsplashSearchQuerySchema,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1435,6 +1435,12 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@gruenerator/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -31063,9 +31069,7 @@ snapshots:
       metro-runtime: 0.83.6
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89':


### PR DESCRIPTION
## Summary
- Every other workspace package has an \`eslint.config.js\`; \`packages/contracts\` was missing one.
- \`packages/contracts/package.json\` already declared \`"lint": "eslint ."\` but the script failed with \`Cannot find package '@gruenerator/eslint-config'\` because the devDep was also missing.
- Dropped one pre-existing warning (unused \`z\` import in \`unsplashContract.ts\`) that the newly-working lint surfaced.

## Test plan
- [ ] \`pnpm --filter @gruenerator/contracts lint\` → clean.
- [ ] \`pnpm --filter @gruenerator/contracts typecheck\` → clean.