### PR TITLE
feat(chat): model picker with streaming Qwen reasoning display

### DIFF
--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -8,6 +8,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 
 import { env } from '../../../config/env.js';
 import { isVisionCapable } from '../../../services/ai/modelDiscovery.js';
+import { regoloFetchWithThinkingDisabled } from '../../../services/ai/regoloThinkingFetch.js';
 
 import type { AgentConfig } from './types.js';
 import type { LanguageModel } from 'ai';
@@ -43,6 +44,9 @@ export const AVAILABLE_MODELS: Record<
     model: env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b',
     contextWindow: 32768,
   },
+  'gpt-oss-regolo': { provider: 'regolo', model: 'gpt-oss-120b', contextWindow: 32768 },
+  'gemma-regolo': { provider: 'regolo', model: 'gemma4-31b', contextWindow: 32768 },
+  'qwen-regolo': { provider: 'regolo', model: 'qwen3.5-122b', contextWindow: 32768 },
 };
 
 /**
@@ -119,6 +123,7 @@ function getRegoloProvider() {
       baseURL: 'https://api.regolo.ai/v1',
       apiKey,
       name: 'regolo',
+      fetch: regoloFetchWithThinkingDisabled,
     });
   }
   return regoloInstance;

--- a/apps/api/routes/chat/chatGraphController.ts
+++ b/apps/api/routes/chat/chatGraphController.ts
@@ -29,6 +29,7 @@ import {
 } from '../../agents/langgraph/ChatGraph/index.js';
 import { isKnownNotebook } from '../../config/notebookCollectionMap.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
+import { isRegoloReasoningModel } from '../../services/ai/regoloReasoningStream.js';
 import {
   getMem0Instance,
   normalizeCategory,
@@ -67,6 +68,7 @@ import {
   resolveModel,
   buildMessagesForAI,
   streamAndAccumulate,
+  streamAndAccumulateWithReasoning,
 } from './services/responseStreamingService.js';
 import { createSSEStream, getIntentMessage, PROGRESS_MESSAGES } from './services/sseHelpers.js';
 import { canAccessThread } from './services/threadAccessService.js';
@@ -624,9 +626,14 @@ router.post(
           defaultModel: finalState.agentConfig.defaultModel,
         }),
       };
-      const { model: aiModel } = resolveModel(agentConfigForResolve, modelId, {
+      const {
+        model: aiModel,
+        provider: resolvedProvider,
+        modelName: resolvedModelName,
+      } = resolveModel(agentConfigForResolve, modelId, {
         hasImages: imageAttachments.length > 0,
       });
+      const useReasoningStream = isRegoloReasoningModel(resolvedProvider, resolvedModelName);
 
       const prunedValidMessages = pruneMessages(
         validMessages as Parameters<typeof pruneMessages>[0]
@@ -650,13 +657,23 @@ router.post(
         requestId
       );
 
-      const fullText = await streamAndAccumulate({
-        model: aiModel,
-        messages: messagesForAI as Parameters<typeof streamAndAccumulate>[0]['messages'],
-        maxTokens: finalState.agentConfig.params.max_tokens,
-        temperature: finalState.agentConfig.params.temperature,
-        sse,
-      });
+      const fullText = useReasoningStream
+        ? await streamAndAccumulateWithReasoning({
+            modelName: resolvedModelName,
+            messages: messagesForAI as Parameters<typeof streamAndAccumulate>[0]['messages'],
+            // Reasoning models burn most tokens on <think>; ensure headroom
+            // for the actual answer that follows.
+            maxTokens: Math.max(finalState.agentConfig.params.max_tokens, 9000),
+            temperature: finalState.agentConfig.params.temperature,
+            sse,
+          })
+        : await streamAndAccumulate({
+            model: aiModel,
+            messages: messagesForAI as Parameters<typeof streamAndAccumulate>[0]['messages'],
+            maxTokens: finalState.agentConfig.params.max_tokens,
+            temperature: finalState.agentConfig.params.temperature,
+            sse,
+          });
 
       if (fullText === null) return; // stream errored, SSE already closed
 
@@ -898,22 +915,36 @@ router.post(
           defaultModel: finalState.agentConfig.defaultModel,
         }),
       };
-      const { model: aiModel } = resolveModel(agentConfigForResolve2, modelId, {
+      const {
+        model: aiModel,
+        provider: resolvedProvider2,
+        modelName: resolvedModelName2,
+      } = resolveModel(agentConfigForResolve2, modelId, {
         hasImages: resumeImageAttachments.length > 0,
       });
+      const useReasoningStream2 = isRegoloReasoningModel(resolvedProvider2, resolvedModelName2);
 
       const validMessages = requestContext.validMessages;
       const prunedValidMessages = pruneMessages(validMessages);
       const messagesForAI = buildMessagesForAI(systemMessage, prunedValidMessages);
 
-      const fullText = await streamAndAccumulate({
-        model: aiModel,
-        messages: messagesForAI,
-        maxTokens: finalState.agentConfig.params.max_tokens,
-        temperature: finalState.agentConfig.params.temperature,
-        sse,
-        logPrefix: '[ChatGraph:Resume]',
-      });
+      const fullText = useReasoningStream2
+        ? await streamAndAccumulateWithReasoning({
+            modelName: resolvedModelName2,
+            messages: messagesForAI as Parameters<typeof streamAndAccumulate>[0]['messages'],
+            maxTokens: Math.max(finalState.agentConfig.params.max_tokens, 9000),
+            temperature: finalState.agentConfig.params.temperature,
+            sse,
+            logPrefix: '[ChatGraph:Resume]',
+          })
+        : await streamAndAccumulate({
+            model: aiModel,
+            messages: messagesForAI,
+            maxTokens: finalState.agentConfig.params.max_tokens,
+            temperature: finalState.agentConfig.params.temperature,
+            sse,
+            logPrefix: '[ChatGraph:Resume]',
+          });
 
       if (fullText === null) return;
 

--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -15,6 +15,10 @@ import {
   getSystemCollectionConfig,
 } from '../../config/systemCollectionsConfig.js';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import {
+  isRegoloReasoningModel,
+  streamRegoloWithReasoning,
+} from '../../services/ai/regoloReasoningStream.js';
 import { notebookQAService } from '../../services/notebook/index.js';
 import { rerankNotebookResults } from '../../services/notebook/rerankNotebookResults.js';
 import {
@@ -249,7 +253,11 @@ export async function handleNotebookStream(
 
     // Determine AI provider and model (same resolution as chat — handles model ID → real name)
     const defaultAgentConfig = { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL };
-    const { model: aiModel, provider: resolvedProvider } = resolveModel(defaultAgentConfig, model);
+    const {
+      model: aiModel,
+      provider: resolvedProvider,
+      modelName: resolvedModelName,
+    } = resolveModel(defaultAgentConfig, model);
 
     if (!isProviderConfigured(resolvedProvider)) {
       sse.send('error', { error: `Provider "${resolvedProvider}" is not configured` });
@@ -273,13 +281,11 @@ export async function handleNotebookStream(
     const t2 = Date.now();
     log.debug(`⏱ Model setup: ${t2 - t1}ms`);
 
-    const result = streamText({
-      model: aiModel,
-      messages: aiMessages,
-      maxOutputTokens: isFast ? 3000 : 16000,
-      temperature: 0.2,
-      abortSignal: abortController.signal,
-    });
+    const useReasoningStream = isRegoloReasoningModel(resolvedProvider, resolvedModelName);
+    // Reasoning models spend most of their budget on the <think> block before
+    // emitting the answer. Triple the ceiling so there's room for both phases.
+    const baseMaxOutput = isFast ? 3000 : 16000;
+    const maxOutputTokens = useReasoningStream ? Math.max(baseMaxOutput, 9000) : baseMaxOutput;
 
     sse.send('response_start', { message: 'Generiere Antwort...' });
 
@@ -287,14 +293,43 @@ export async function handleNotebookStream(
     let firstChunkTime: number | undefined;
 
     try {
-      for await (const chunk of result.textStream) {
-        if (abortController.signal.aborted) break;
-        if (!firstChunkTime) {
-          firstChunkTime = Date.now();
-          log.debug(`⏱ First token latency: ${firstChunkTime - t2}ms`);
+      if (useReasoningStream) {
+        for await (const chunk of streamRegoloWithReasoning({
+          model: resolvedModelName,
+          messages: aiMessages,
+          maxTokens: maxOutputTokens,
+          temperature: 0.2,
+          signal: abortController.signal,
+        })) {
+          if (abortController.signal.aborted) break;
+          if (!firstChunkTime) {
+            firstChunkTime = Date.now();
+            log.debug(`⏱ First token latency: ${firstChunkTime - t2}ms`);
+          }
+          if (chunk.type === 'text') {
+            fullText += chunk.delta;
+            sse.send('text_delta', { text: chunk.delta });
+          } else {
+            sse.send('reasoning_delta', { text: chunk.delta });
+          }
         }
-        fullText += chunk;
-        sse.send('text_delta', { text: chunk });
+      } else {
+        const result = streamText({
+          model: aiModel,
+          messages: aiMessages,
+          maxOutputTokens,
+          temperature: 0.2,
+          abortSignal: abortController.signal,
+        });
+        for await (const chunk of result.textStream) {
+          if (abortController.signal.aborted) break;
+          if (!firstChunkTime) {
+            firstChunkTime = Date.now();
+            log.debug(`⏱ First token latency: ${firstChunkTime - t2}ms`);
+          }
+          fullText += chunk;
+          sse.send('text_delta', { text: chunk });
+        }
       }
     } catch (streamError: unknown) {
       if (abortController.signal.aborted) {

--- a/apps/api/routes/chat/services/responseStreamingService.ts
+++ b/apps/api/routes/chat/services/responseStreamingService.ts
@@ -9,6 +9,7 @@
 
 import { streamText, type ModelMessage, type LanguageModel } from 'ai';
 
+import { streamRegoloWithReasoning } from '../../../services/ai/regoloReasoningStream.js';
 import { createLogger } from '../../../utils/logger.js';
 import { getModel, getModelConfig, VISION_MODEL, isVisionCapable } from '../agents/providers.js';
 
@@ -106,6 +107,61 @@ export async function streamAndAccumulate(params: {
   } catch (streamError: unknown) {
     const errorMessage = streamError instanceof Error ? streamError.message : 'Unknown error';
     log.error(`${logPrefix} Stream error:`, errorMessage);
+    sse.send('error', { error: PROGRESS_MESSAGES.streamInterrupted });
+    sse.end();
+    return null;
+  }
+
+  return fullText;
+}
+
+/**
+ * Stream directly from Regolo using the custom reasoning-aware bridge.
+ * Emits `text_delta` for answer chunks and `reasoning_delta` for thinking
+ * chunks, so the frontend's Reasoning/ReasoningGroup UI can render both.
+ * Returns the accumulated answer text, or null on error.
+ */
+export async function streamAndAccumulateWithReasoning(params: {
+  modelName: string;
+  messages: Array<{ role: string; content: string | unknown[] }>;
+  maxTokens: number;
+  temperature: number;
+  sse: SSEWriter;
+  signal?: AbortSignal;
+  logPrefix?: string;
+}): Promise<string | null> {
+  const {
+    modelName,
+    messages,
+    maxTokens,
+    temperature,
+    sse,
+    signal,
+    logPrefix = '[ChatGraph]',
+  } = params;
+
+  let fullText = '';
+
+  try {
+    const streamParams: Parameters<typeof streamRegoloWithReasoning>[0] = {
+      model: modelName,
+      messages: messages as ModelMessage[],
+      maxTokens,
+      temperature,
+    };
+    if (signal) streamParams.signal = signal;
+
+    for await (const chunk of streamRegoloWithReasoning(streamParams)) {
+      if (chunk.type === 'text') {
+        fullText += chunk.delta;
+        sse.send('text_delta', { text: chunk.delta });
+      } else {
+        sse.send('reasoning_delta', { text: chunk.delta });
+      }
+    }
+  } catch (streamError: unknown) {
+    const errorMessage = streamError instanceof Error ? streamError.message : 'Unknown error';
+    log.error(`${logPrefix} Reasoning stream error:`, errorMessage);
     sse.send('error', { error: PROGRESS_MESSAGES.streamInterrupted });
     sse.end();
     return null;

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -32,6 +32,7 @@ export type SSEEventType =
   | 'response_start'
   | 'thinking_step'
   | 'text_delta'
+  | 'reasoning_delta'
   | 'interrupt'
   | 'document_indexed'
   | 'document_created'
@@ -114,6 +115,7 @@ export interface SSEEventPayloads {
   response_start: { message: string };
   thinking_step: ThinkingStepPayload;
   text_delta: { text: string };
+  reasoning_delta: { text: string };
   document_indexed: { documentId: string; title: string };
   document_created: { documentId: string; title: string; subtype: string; url: string };
   interrupt: {

--- a/apps/api/services/ai/__tests__/regoloReasoningStream.vitest.ts
+++ b/apps/api/services/ai/__tests__/regoloReasoningStream.vitest.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { isRegoloReasoningModel, streamRegoloWithReasoning } from '../regoloReasoningStream.js';
+
+describe('isRegoloReasoningModel', () => {
+  it('returns true for qwen3.5-122b on regolo', () => {
+    expect(isRegoloReasoningModel('regolo', 'qwen3.5-122b')).toBe(true);
+  });
+
+  it('returns true for gpt-oss-120b on regolo', () => {
+    expect(isRegoloReasoningModel('regolo', 'gpt-oss-120b')).toBe(true);
+  });
+
+  it('returns false for gemma4-31b (not a reasoning model)', () => {
+    expect(isRegoloReasoningModel('regolo', 'gemma4-31b')).toBe(false);
+  });
+
+  it('returns false for qwen on litellm (different provider)', () => {
+    expect(isRegoloReasoningModel('litellm', 'qwen3.5-122b')).toBe(false);
+  });
+});
+
+describe.skipIf(!process.env.REGOLO_API_KEY)('streamRegoloWithReasoning — live integration', () => {
+  it('yields both reasoning and text chunks from qwen3.5-122b', async () => {
+    const chunks: Array<{ type: 'text' | 'reasoning'; delta: string }> = [];
+
+    for await (const chunk of streamRegoloWithReasoning({
+      model: 'qwen3.5-122b',
+      messages: [
+        {
+          role: 'system',
+          content: 'Answer in at most 3 words. Do not explain.',
+        },
+        { role: 'user', content: 'Say only "Hallo"' },
+      ],
+      maxTokens: 2000,
+      temperature: 0,
+    })) {
+      chunks.push(chunk);
+      if (chunks.length > 500) break; // safety
+    }
+
+    const textChunks = chunks.filter((c) => c.type === 'text');
+    const reasoningChunks = chunks.filter((c) => c.type === 'reasoning');
+
+    expect(reasoningChunks.length).toBeGreaterThan(0);
+    expect(textChunks.length).toBeGreaterThan(0);
+
+    const fullText = textChunks.map((c) => c.delta).join('');
+    expect(fullText.toLowerCase()).toContain('hallo');
+  }, 30_000);
+
+  it('throws a useful error on unknown model', async () => {
+    const run = async (): Promise<void> => {
+      for await (const _chunk of streamRegoloWithReasoning({
+        model: 'this-model-does-not-exist',
+        messages: [{ role: 'user', content: 'x' }],
+        maxTokens: 10,
+        temperature: 0,
+      })) {
+        void _chunk;
+      }
+    };
+    await expect(run()).rejects.toThrow(/Regolo stream failed/);
+  }, 15_000);
+});

--- a/apps/api/services/ai/__tests__/regoloThinkingFetch.vitest.ts
+++ b/apps/api/services/ai/__tests__/regoloThinkingFetch.vitest.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { regoloFetchWithThinkingDisabled } from '../regoloThinkingFetch.js';
+
+describe('regoloFetchWithThinkingDisabled — body transformation', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => new Response('{}', { status: 200 })) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('injects chat_template_kwargs.enable_thinking=false into chat completion bodies', async () => {
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.5-122b',
+        messages: [{ role: 'user', content: 'Hallo' }],
+      }),
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.chat_template_kwargs).toEqual({ enable_thinking: false });
+    expect(sentBody.model).toBe('qwen3.5-122b');
+    expect(sentBody.messages).toHaveLength(1);
+  });
+
+  it('preserves existing chat_template_kwargs fields', async () => {
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'qwen3.5-122b',
+        messages: [{ role: 'user', content: 'x' }],
+        chat_template_kwargs: { some_other_flag: true },
+      }),
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.chat_template_kwargs).toEqual({
+      some_other_flag: true,
+      enable_thinking: false,
+    });
+  });
+
+  it('does not mutate the caller-supplied init object', async () => {
+    const init: RequestInit = {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'qwen3.5-122b',
+        messages: [{ role: 'user', content: 'Hallo' }],
+      }),
+    };
+    const originalBody = init.body;
+
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/chat/completions', init);
+
+    expect(init.body).toBe(originalBody);
+  });
+
+  it('passes non-chat endpoints (no messages field) through unchanged', async () => {
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/embeddings', {
+      method: 'POST',
+      body: JSON.stringify({ model: 'Qwen3-Embedding-8B', input: 'text' }),
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.chat_template_kwargs).toBeUndefined();
+  });
+
+  it('passes non-JSON bodies through unchanged', async () => {
+    const form = new FormData();
+    form.append('file', new Blob(['data']));
+
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/audio/transcriptions', {
+      method: 'POST',
+      body: form,
+    });
+
+    const [, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((init as RequestInit).body).toBe(form);
+  });
+
+  it('passes GET requests (no body) through unchanged', async () => {
+    await regoloFetchWithThinkingDisabled('https://api.regolo.ai/v1/models', { method: 'GET' });
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe.skipIf(!process.env.REGOLO_API_KEY)(
+  'regoloFetchWithThinkingDisabled — live Regolo integration',
+  () => {
+    const apiKey = process.env.REGOLO_API_KEY!;
+
+    async function callQwen(body: Record<string, unknown>): Promise<{
+      content: string | null;
+      reasoning: string | null;
+      finish: string | undefined;
+    }> {
+      const res = await fetch('https://api.regolo.ai/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const json = (await res.json()) as {
+        choices?: Array<{
+          message?: { content?: string | null; reasoning_content?: string | null };
+          finish_reason?: string;
+        }>;
+      };
+      const msg = json.choices?.[0]?.message ?? {};
+      return {
+        content: msg.content ?? null,
+        reasoning: msg.reasoning_content ?? null,
+        finish: json.choices?.[0]?.finish_reason,
+      };
+    }
+
+    it('without wrapper: Qwen3.5-122b emits reasoning_content and empty content', async () => {
+      const { content, reasoning, finish } = await callQwen({
+        model: 'qwen3.5-122b',
+        messages: [{ role: 'user', content: 'Sag nur Hallo' }],
+        max_tokens: 150,
+      });
+
+      expect(reasoning ?? '').not.toBe('');
+      expect(content ?? '').toBe('');
+      expect(finish).toBe('length');
+    }, 30_000);
+
+    it('with chat_template_kwargs.enable_thinking=false: Qwen emits content directly', async () => {
+      const baseInit: RequestInit = {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: 'qwen3.5-122b',
+          messages: [{ role: 'user', content: 'Sag nur Hallo' }],
+          max_tokens: 150,
+        }),
+      };
+
+      const res = await regoloFetchWithThinkingDisabled(
+        'https://api.regolo.ai/v1/chat/completions',
+        baseInit
+      );
+      const json = (await res.json()) as {
+        choices?: Array<{
+          message?: { content?: string | null; reasoning_content?: string | null };
+          finish_reason?: string;
+        }>;
+      };
+      const msg = json.choices?.[0]?.message ?? {};
+
+      expect(msg.content ?? '').not.toBe('');
+      expect(msg.content?.toLowerCase()).toContain('hallo');
+      expect(json.choices?.[0]?.finish_reason).toBe('stop');
+    }, 30_000);
+  }
+);

--- a/apps/api/services/ai/providers.ts
+++ b/apps/api/services/ai/providers.ts
@@ -13,6 +13,8 @@ import { createOpenAI } from '@ai-sdk/openai';
 
 import { env } from '../../config/env.js';
 
+import { regoloFetchWithThinkingDisabled } from './regoloThinkingFetch.js';
+
 import type { LanguageModel } from 'ai';
 
 // Provider name types
@@ -127,6 +129,7 @@ function getRegoloProvider(): ReturnType<typeof createOpenAI> {
       baseURL: REGOLO_BASE_URL,
       apiKey,
       name: 'regolo',
+      fetch: regoloFetchWithThinkingDisabled,
     });
   }
   return regoloInstance;

--- a/apps/api/services/ai/regoloReasoningStream.ts
+++ b/apps/api/services/ai/regoloReasoningStream.ts
@@ -1,0 +1,123 @@
+/**
+ * Custom Regolo streamer that parses both `content` and `reasoning_content`
+ * SSE deltas from the OpenAI-compatible chat completions endpoint.
+ *
+ * Why this exists: `@ai-sdk/openai@3.0.53` only bridges reasoning for the
+ * OpenAI *Responses* API (`response.reasoning_summary_text.delta`). Regolo's
+ * Qwen3 family uses Chat Completions with a vLLM-specific `reasoning_content`
+ * field, which the SDK silently drops. To surface the model's thinking to
+ * our UI (Reasoning/ReasoningGroup components), we bypass the AI SDK for
+ * reasoning-capable Regolo models and parse the raw SSE stream ourselves.
+ *
+ * The wrapper disables the chat-template `enable_thinking: false` workaround
+ * that we apply globally for non-reasoning consumers; here we explicitly want
+ * thinking ON.
+ */
+
+import { env } from '../../config/env.js';
+
+import type { ModelMessage } from 'ai';
+
+export interface ReasoningStreamChunk {
+  type: 'text' | 'reasoning';
+  delta: string;
+}
+
+export interface RegoloReasoningStreamParams {
+  model: string;
+  messages: ModelMessage[];
+  maxTokens: number;
+  temperature: number;
+  signal?: AbortSignal;
+}
+
+const REGOLO_ENDPOINT = 'https://api.regolo.ai/v1/chat/completions';
+
+/**
+ * Models on Regolo that emit `reasoning_content` by default (or when thinking
+ * is enabled). These are the cases where we want to surface reasoning to the
+ * frontend.
+ */
+const REGOLO_REASONING_MODELS = new Set(['qwen3.5-122b', 'qwen3.6-27b', 'gpt-oss-120b']);
+
+export function isRegoloReasoningModel(provider: string, model: string): boolean {
+  return provider === 'regolo' && REGOLO_REASONING_MODELS.has(model);
+}
+
+/**
+ * Stream a chat completion from Regolo, yielding both text and reasoning
+ * deltas as they arrive. Throws on non-2xx or aborted streams.
+ */
+export async function* streamRegoloWithReasoning(
+  params: RegoloReasoningStreamParams
+): AsyncGenerator<ReasoningStreamChunk, void, unknown> {
+  const apiKey = env.REGOLO_API_KEY;
+  if (!apiKey) {
+    throw new Error('REGOLO_API_KEY is not configured');
+  }
+
+  const response = await fetch(REGOLO_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: params.model,
+      messages: params.messages,
+      max_tokens: params.maxTokens,
+      temperature: params.temperature,
+      stream: true,
+      chat_template_kwargs: { enable_thinking: true },
+    }),
+    ...(params.signal && { signal: params.signal }),
+  });
+
+  if (!response.ok || !response.body) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Regolo stream failed: ${response.status} ${body.slice(0, 200)}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let lineBreak: number;
+      while ((lineBreak = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, lineBreak).trim();
+        buffer = buffer.slice(lineBreak + 1);
+        if (!line || !line.startsWith('data:')) continue;
+
+        const payload = line.slice(5).trim();
+        if (payload === '[DONE]') return;
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(payload);
+        } catch {
+          continue;
+        }
+
+        const delta = extractDelta(parsed);
+        if (delta.reasoning) yield { type: 'reasoning', delta: delta.reasoning };
+        if (delta.text) yield { type: 'text', delta: delta.text };
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function extractDelta(chunk: unknown): { text: string; reasoning: string } {
+  const choices = (chunk as { choices?: Array<{ delta?: Record<string, unknown> }> }).choices;
+  const delta = choices?.[0]?.delta ?? {};
+  const text = typeof delta.content === 'string' ? delta.content : '';
+  const reasoning = typeof delta.reasoning_content === 'string' ? delta.reasoning_content : '';
+  return { text, reasoning };
+}

--- a/apps/api/services/ai/regoloThinkingFetch.ts
+++ b/apps/api/services/ai/regoloThinkingFetch.ts
@@ -1,0 +1,31 @@
+/**
+ * Regolo's Qwen3 family (qwen3.5-122b, qwen3.6-27b, …) defaults to thinking
+ * mode, emitting the final answer into a non-standard `reasoning_content`
+ * response field and leaving `content` null. The Vercel AI SDK only reads
+ * `content` from OpenAI-compat streams, so chat UIs see 0 chars.
+ *
+ * vLLM (Regolo's backend) exposes the chat-template flag
+ * `chat_template_kwargs.enable_thinking`. Setting it to `false` makes Qwen3
+ * skip the `<think>…</think>` block and stream the answer into `content` —
+ * restoring standard OpenAI behavior. Non-Qwen models ignore the flag.
+ *
+ * We apply this unconditionally to every chat completion request because
+ * (a) our current UI does not render `reasoning_content`, so thinking mode
+ * is invisible and wastes tokens, and (b) the flag is a safe no-op on the
+ * other Regolo-hosted models.
+ */
+export const regoloFetchWithThinkingDisabled: typeof fetch = async (input, init) => {
+  if (init?.body && typeof init.body === 'string') {
+    try {
+      const parsed = JSON.parse(init.body) as Record<string, unknown>;
+      if (parsed.model && parsed.messages) {
+        const existing = (parsed.chat_template_kwargs as Record<string, unknown> | undefined) ?? {};
+        parsed.chat_template_kwargs = { ...existing, enable_thinking: false };
+        init = { ...init, body: JSON.stringify(parsed) };
+      }
+    } catch {
+      // Non-JSON body (e.g. multipart upload), pass through unchanged
+    }
+  }
+  return fetch(input, init);
+};

--- a/apps/mobile/components/chat/ChatSettingsSheet.tsx
+++ b/apps/mobile/components/chat/ChatSettingsSheet.tsx
@@ -189,6 +189,16 @@ export const ChatSettingsSheet = memo(function ChatSettingsSheet({ visible, onDi
                 >
                   {model.description}
                 </Text>
+                {model.warning && (
+                  <Text
+                    style={[
+                      styles.modelChipWarningText,
+                      { color: active ? colors.white : colors.warning },
+                    ]}
+                  >
+                    {model.warning}
+                  </Text>
+                )}
               </Pressable>
             );
           })}
@@ -278,5 +288,10 @@ const styles = StyleSheet.create({
   },
   modelChipDesc: {
     fontSize: 11,
+  },
+  modelChipWarningText: {
+    fontSize: 11,
+    lineHeight: 14,
+    marginTop: 2,
   },
 });

--- a/apps/mobile/components/chat/ComposerActionSheet.tsx
+++ b/apps/mobile/components/chat/ComposerActionSheet.tsx
@@ -131,6 +131,16 @@ export const ComposerActionSheet = memo(function ComposerActionSheet({
                 >
                   {model.description}
                 </Text>
+                {model.warning && (
+                  <Text
+                    style={[
+                      styles.modelChipWarningText,
+                      { color: active ? colors.white : colors.warning },
+                    ]}
+                  >
+                    {model.warning}
+                  </Text>
+                )}
               </Pressable>
             );
           })}
@@ -199,5 +209,10 @@ const styles = StyleSheet.create({
   },
   modelChipDesc: {
     fontSize: 11,
+  },
+  modelChipWarningText: {
+    fontSize: 11,
+    lineHeight: 14,
+    marginTop: 2,
   },
 });

--- a/packages/chat/components.json
+++ b/packages/chat/components.json
@@ -18,6 +18,7 @@
     "hooks": "@/hooks"
   },
   "registries": {
-    "@tool-ui": "https://www.tool-ui.com/r/{name}.json"
+    "@tool-ui": "https://www.tool-ui.com/r/{name}.json",
+    "@assistant-ui": "https://r.assistant-ui.com/{name}.json"
   }
 }

--- a/packages/chat/src/components/ToolToggles.tsx
+++ b/packages/chat/src/components/ToolToggles.tsx
@@ -27,10 +27,9 @@ import {
   ResponsiveMenuItem,
   ResponsiveMenuToggle,
 } from '@gruenerator/ui';
-import { cn, composerToolbarButtonClass } from '../lib/utils';
-import { MODEL_ICONS } from '../lib/modelIcons';
+import { composerToolbarButtonClass } from '../lib/utils';
 import { useShallow } from 'zustand/shallow';
-import { useAgentStore, MODEL_OPTIONS, type ThreadMode, type ToolKey } from '../stores/chatStore';
+import { useAgentStore, type ThreadMode, type ToolKey } from '../stores/chatStore';
 import { useUserProfileStore } from '../stores/userProfileStore';
 import { notebookMentionables } from '../lib/mentionables';
 import { ShareThreadDialog } from './thread/ShareThreadDialog';
@@ -60,7 +59,6 @@ interface ToolTogglesProps {
 export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: ToolTogglesProps) {
   const {
     enabledTools,
-    selectedModel,
     currentThreadId: threadId,
     threadMode,
     selectedNotebookId,
@@ -68,7 +66,6 @@ export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: 
   } = useAgentStore(
     useShallow((s) => ({
       enabledTools: s.enabledTools,
-      selectedModel: s.selectedModel,
       currentThreadId: s.currentThreadId,
       threadMode: s.threadMode,
       selectedNotebookId: s.selectedNotebookId,
@@ -76,7 +73,6 @@ export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: 
     }))
   );
   const toggleTool = useAgentStore((s) => s.toggleTool);
-  const setSelectedModel = useAgentStore((s) => s.setSelectedModel);
   const setThreadMode = useAgentStore((s) => s.setThreadMode);
   const setSelectedNotebook = useAgentStore((s) => s.setSelectedNotebook);
   const [shareOpen, setShareOpen] = useState(false);
@@ -86,8 +82,6 @@ export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: 
   const hasCustomPrompt = !!customSystemPrompt;
   const hasRoles = roles.length > 0;
 
-  const current = MODEL_OPTIONS.find((m) => m.id === selectedModel) ?? MODEL_OPTIONS[0];
-  const CurrentIcon = MODEL_ICONS[current.icon];
   const ActiveModeIcon =
     threadMode === 'eigener'
       ? Settings
@@ -213,32 +207,6 @@ export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: 
         </DropdownMenuSubContent>
       </DropdownMenuSub>
 
-      {/* Model picker hidden — fixed to LiteLLM for generation, Regolo for agent nodes */}
-      {false && (
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <CurrentIcon className="h-3.5 w-3.5" />
-            Modell
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            <DropdownMenuRadioGroup
-              value={selectedModel}
-              onValueChange={(v) => setSelectedModel(v as typeof selectedModel)}
-            >
-              {MODEL_OPTIONS.map((model) => {
-                const Icon = MODEL_ICONS[model.icon];
-                return (
-                  <DropdownMenuRadioItem key={model.id} value={model.id}>
-                    <Icon className="h-3.5 w-3.5" />
-                    {model.name}
-                  </DropdownMenuRadioItem>
-                );
-              })}
-            </DropdownMenuRadioGroup>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      )}
-
       {threadId && (
         <>
           <DropdownMenuSeparator />
@@ -313,22 +281,6 @@ export const ToolToggles = memo(function ToolToggles({ onNavigate, firstName }: 
             onCheckedChange={() => toggleTool(key)}
           />
         ))}
-      </ResponsiveMenuSection>
-
-      <ResponsiveMenuSection title="Modell">
-        {MODEL_OPTIONS.map((model) => {
-          const Icon = MODEL_ICONS[model.icon];
-          return (
-            <ResponsiveMenuItem
-              key={model.id}
-              icon={<Icon />}
-              active={selectedModel === model.id}
-              onClick={() => setSelectedModel(model.id as typeof selectedModel)}
-            >
-              {model.name}
-            </ResponsiveMenuItem>
-          );
-        })}
       </ResponsiveMenuSection>
 
       {threadId && (

--- a/packages/chat/src/components/assistant-ui/reasoning.tsx
+++ b/packages/chat/src/components/assistant-ui/reasoning.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@gruenerator/ui';
+import type {
+  ReasoningMessagePartComponent,
+  ReasoningGroupComponent,
+} from '@assistant-ui/core/react';
+
+export const Reasoning: ReasoningMessagePartComponent = ({ text }) => (
+  <div className="whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground-muted">
+    {text}
+  </div>
+);
+
+export const ReasoningGroup: ReasoningGroupComponent = ({ children }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="my-2 overflow-hidden rounded-lg border border-border/60 bg-muted/30">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-xs font-medium text-foreground-muted transition-colors hover:bg-muted/50 hover:text-foreground"
+        aria-expanded={open}
+      >
+        <span>Gedanken</span>
+        <ChevronDown
+          className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-180')}
+          aria-hidden="true"
+        />
+      </button>
+      {open && <div className="px-3 pb-3 pt-1">{children}</div>}
+    </div>
+  );
+};

--- a/packages/chat/src/components/thread/AssistantMessage.tsx
+++ b/packages/chat/src/components/thread/AssistantMessage.tsx
@@ -6,6 +6,7 @@ import { useAgentStore } from '../../stores/chatStore';
 import { agentsList, getDefaultAgent } from '../../lib/agents';
 import { ChatIcon } from '../icons';
 import { CitationMarkdownText } from '../message-parts/CitationMarkdownText';
+import { Reasoning, ReasoningGroup } from '../assistant-ui/reasoning';
 import { ProgressIndicator } from '../message-parts/ProgressIndicator';
 import { ProgressTracker } from '../tool-ui/progress-tracker/ProgressTracker';
 import { SkillBadge } from '../message-parts/SkillBadge';
@@ -29,7 +30,7 @@ function AssistantMessageTextPart() {
   );
 }
 
-const partComponents = { Text: AssistantMessageTextPart };
+const partComponents = { Text: AssistantMessageTextPart, Reasoning, ReasoningGroup };
 
 export const AssistantMessage = memo(function AssistantMessage() {
   const message = useMessage();

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -14,6 +14,7 @@ import { computeMentionInsertion } from '../../lib/mentionInsertion';
 import { FileMentionPopover } from './FileMentionPopover';
 import { CollabDocMentionPopover, type CollabDocSelection } from './CollabDocMentionPopover';
 import { PlusMenu } from './PlusMenu';
+import { ModelPicker } from './ModelPicker';
 import { getCaretCoords } from '../../lib/caretPosition';
 import { registerDocumentSlug } from '../../lib/documentMentionables';
 import type { Mentionable } from '../../lib/mentionables';
@@ -380,7 +381,10 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
             {showToolToggles && <ToolToggles onNavigate={onNavigate} firstName={firstName} />}
             {toolbarExtra}
           </div>
-          <ComposerButtons isRunning={isRunning} />
+          <div className="flex items-center gap-0.5">
+            <ModelPicker />
+            <ComposerButtons isRunning={isRunning} />
+          </div>
         </div>
       </ComposerPrimitive.Root>
       <p className="mt-1 hidden text-center text-xs text-foreground-muted sm:block">{disclaimer}</p>

--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { memo, useState } from 'react';
+import { AlertTriangle, ChevronDown } from 'lucide-react';
+import {
+  cn,
+  DropdownMenuItem,
+  ResponsiveMenu,
+  ResponsiveMenuSection,
+  ResponsiveMenuItem,
+} from '@gruenerator/ui';
+import { useShallow } from 'zustand/shallow';
+
+import { MODEL_ICONS } from '../../lib/modelIcons';
+import { composerToolbarButtonClass } from '../../lib/utils';
+import { MODEL_OPTIONS, useAgentStore, type ModelId } from '../../stores/chatStore';
+
+export const ModelPicker = memo(function ModelPicker() {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const { selectedModel, setSelectedModel } = useAgentStore(
+    useShallow((s) => ({
+      selectedModel: s.selectedModel,
+      setSelectedModel: s.setSelectedModel,
+    }))
+  );
+
+  const current = MODEL_OPTIONS.find((m) => m.id === selectedModel) ?? MODEL_OPTIONS[0];
+  const CurrentIcon = MODEL_ICONS[current.icon];
+
+  const handleSelect = (id: string) => {
+    setSelectedModel(id as ModelId);
+    setMenuOpen(false);
+  };
+
+  const desktopContent = (
+    <>
+      {MODEL_OPTIONS.map((model) => {
+        const Icon = MODEL_ICONS[model.icon];
+        const isActive = selectedModel === model.id;
+        return (
+          <DropdownMenuItem
+            key={model.id}
+            onSelect={() => setSelectedModel(model.id)}
+            className={cn(
+              'flex-col items-stretch gap-1 py-2',
+              isActive &&
+                'bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-400'
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="text-sm font-medium leading-tight">{model.name}</span>
+            </div>
+            <span
+              className={cn(
+                'text-[11px] leading-snug',
+                isActive ? 'text-primary-700/80 dark:text-primary-400/80' : 'text-foreground-muted'
+              )}
+            >
+              {model.description}
+            </span>
+            {model.warning && (
+              <span className="text-[11px] leading-snug text-amber-600 dark:text-amber-500">
+                {model.warning}
+              </span>
+            )}
+          </DropdownMenuItem>
+        );
+      })}
+    </>
+  );
+
+  const mobileContent = (
+    <ResponsiveMenuSection title="Modell">
+      {MODEL_OPTIONS.map((model) => {
+        const Icon = MODEL_ICONS[model.icon];
+        return (
+          <ResponsiveMenuItem
+            key={model.id}
+            active={selectedModel === model.id}
+            onClick={() => handleSelect(model.id)}
+          >
+            <div className="flex w-full flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Icon className="h-4 w-4 shrink-0" />
+                <span className="font-medium">{model.name}</span>
+              </div>
+              <span className="text-[11px] leading-snug text-foreground-muted">
+                {model.description}
+              </span>
+              {model.warning && (
+                <span className="text-[11px] leading-snug text-amber-600 dark:text-amber-500">
+                  {model.warning}
+                </span>
+              )}
+            </div>
+          </ResponsiveMenuItem>
+        );
+      })}
+    </ResponsiveMenuSection>
+  );
+
+  return (
+    <ResponsiveMenu
+      open={menuOpen}
+      onOpenChange={setMenuOpen}
+      sheetTitle="Modell wählen"
+      dropdownAlign="end"
+      dropdownClassName="min-w-[22rem] max-w-[90vw]"
+      trigger={
+        <button
+          type="button"
+          className={composerToolbarButtonClass}
+          aria-label={
+            current.warning ? `Modell wählen – ${current.name} (Warnhinweis)` : 'Modell wählen'
+          }
+        >
+          <CurrentIcon className="h-4 w-4" />
+          <span className="hidden sm:inline">{current.name}</span>
+          {current.warning && (
+            <AlertTriangle
+              className="h-3.5 w-3.5 text-amber-600 dark:text-amber-500"
+              aria-hidden="true"
+            />
+          )}
+          <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+        </button>
+      }
+      desktopContent={desktopContent}
+      mobileContent={mobileContent}
+    />
+  );
+});

--- a/packages/chat/src/lib/modelIcons.ts
+++ b/packages/chat/src/lib/modelIcons.ts
@@ -1,12 +1,10 @@
-import { Server, Sparkles } from 'lucide-react';
+import { Brain, Server, Sparkles, Zap } from 'lucide-react';
 
 import type { ModelOption } from '../stores/chatStore';
 
-/**
- * Icon components for each model option, keyed by the `icon` field on ModelOption.
- * Shared between ToolToggles and NotebookComposer.
- */
 export const MODEL_ICONS: Record<ModelOption['icon'], typeof Sparkles> = {
   sparkles: Sparkles,
   server: Server,
+  zap: Zap,
+  brain: Brain,
 };

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -95,6 +95,7 @@ async function* parseSSEStream(
   let buffer = '';
   const currentEvent = { type: '' };
   let accumulatedText = '';
+  let accumulatedReasoning = '';
   let currentProgress: ChatProgress = {
     stage: 'classifying',
     message: 'Analysiere Anfrage...',
@@ -163,9 +164,18 @@ async function* parseSSEStream(
   const YIELD_INTERVAL = 50; // ms — max 20 yields/sec, matches NotebookModelAdapter
 
   function buildResult(): ChatModelRunResult {
-    const content: Array<{ type: 'text'; text: string } | ToolCallPart | SourcePart> = [];
+    const content: Array<
+      | { type: 'text'; text: string }
+      | { type: 'reasoning'; text: string }
+      | ToolCallPart
+      | SourcePart
+    > = [];
 
     const groupId = activeToolCall ? activeToolCall.toolCallId : allToolCalls[0]?.toolCallId;
+
+    if (accumulatedReasoning) {
+      content.push({ type: 'reasoning' as const, text: accumulatedReasoning });
+    }
 
     for (const tc of allToolCalls) {
       content.push(tc);
@@ -475,6 +485,16 @@ async function* parseSSEStream(
         case 'text_delta': {
           const delta = (data as { text: string }).text;
           accumulatedText += delta;
+          const now = performance.now();
+          if (now - lastYieldTime >= YIELD_INTERVAL) {
+            lastYieldTime = now;
+            yield buildResult();
+          }
+          break;
+        }
+
+        case 'reasoning_delta': {
+          accumulatedReasoning += (data as { text: string }).text;
           const now = performance.now();
           if (now - lastYieldTime >= YIELD_INTERVAL) {
             lastYieldTime = now;

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -5,6 +5,7 @@ import type {
 } from '@assistant-ui/react';
 import { type ChatProgress, type Citation as ChatCitation } from '../hooks/useChatGraphStream';
 import { parseSSELine } from '../lib/sseParser';
+import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore } from '../stores/chatConfigStore';
 
 function normalizeCiteMarkers(text: string): string {
@@ -126,6 +127,8 @@ export function createNotebookModelAdapter(
         (config.collectionIds && config.collectionIds.length > 1) ||
         (!config.collectionId && config.collectionIds && config.collectionIds.length === 1);
 
+      const selectedModel = useAgentStore.getState().selectedModel;
+
       const payload = {
         messages: [{ role: 'user', content: question }],
         ...(isMulti
@@ -136,6 +139,7 @@ export function createNotebookModelAdapter(
         ...(config.mode && { mode: config.mode }),
         ...(config.documentIds?.length && { documentIds: config.documentIds }),
         ...(config.threadId && { threadId: config.threadId }),
+        model: selectedModel,
         ...config.extraParams,
       };
 
@@ -174,6 +178,7 @@ export function createNotebookModelAdapter(
       let buffer = '';
       const currentEvent = { type: '' };
       let accumulatedText = '';
+      let accumulatedReasoning = '';
       let completionData: StreamCompletionData | null = null;
       let currentProgress: ChatProgress | undefined;
       let firstDeltaReceived = false;
@@ -202,8 +207,15 @@ export function createNotebookModelAdapter(
         custom.question = question;
         custom.answerText = accumulatedText;
 
+        const parts: Array<{ type: 'text'; text: string } | { type: 'reasoning'; text: string }> =
+          [];
+        if (accumulatedReasoning) {
+          parts.push({ type: 'reasoning' as const, text: accumulatedReasoning });
+        }
+        parts.push({ type: 'text' as const, text: normalizeCiteMarkers(accumulatedText) });
+
         return {
-          content: [{ type: 'text' as const, text: normalizeCiteMarkers(accumulatedText) }],
+          content: parts,
           metadata: { custom },
         };
       }
@@ -271,6 +283,17 @@ export function createNotebookModelAdapter(
                   break;
                 }
 
+                const now = performance.now();
+                if (now - lastYieldTime >= YIELD_INTERVAL) {
+                  lastYieldTime = now;
+                  yield buildResult();
+                }
+                break;
+              }
+
+              case 'reasoning_delta': {
+                accumulatedReasoning += (data as { text: string }).text;
+                currentProgress = { stage: 'generating', message: '' };
                 const now = performance.now();
                 if (now - lastYieldTime >= YIELD_INTERVAL) {
                   lastYieldTime = now;

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -28,9 +28,9 @@ interface TriggerCompactionResponse {
   compactionState: CompactionState;
 }
 
-export type Provider = 'mistral' | 'litellm';
+export type Provider = 'mistral' | 'litellm' | 'regolo';
 
-export type ModelId = 'mistral' | 'litellm';
+export type ModelId = 'gpt-oss-regolo' | 'litellm' | 'gemma-regolo' | 'qwen-regolo';
 
 export type ToolKey = 'search' | 'web' | 'examples' | 'research';
 
@@ -43,25 +43,44 @@ export interface ModelOption {
   description: string;
   model: string;
   provider: Provider;
-  icon: 'sparkles' | 'server';
+  icon: 'sparkles' | 'server' | 'zap' | 'brain';
+  warning?: string;
 }
 
 export const MODEL_OPTIONS: ModelOption[] = [
   {
-    id: 'mistral',
-    name: 'Mistral',
-    description: 'EU-gehostet',
-    model: 'mistral',
-    provider: 'mistral',
+    id: 'gemma-regolo',
+    name: 'Gemma 4',
+    description: 'Leichtgewichtig, antwortet schnell',
+    model: 'gemma4-31b',
+    provider: 'regolo',
+    icon: 'zap',
+  },
+  {
+    id: 'gpt-oss-regolo',
+    name: 'GPT-OSS',
+    description: 'Offenes Modell über Regolo',
+    model: 'gpt-oss-120b',
+    provider: 'regolo',
     icon: 'sparkles',
   },
   {
     id: 'litellm',
-    name: 'GPT-OSS',
-    description: 'Selbst gehostet',
+    name: 'Verdigado',
+    description: 'Selbst gehostet bei Verdigado',
     model: 'gpt-oss:120b',
     provider: 'litellm',
     icon: 'server',
+  },
+  {
+    id: 'qwen-regolo',
+    name: 'Qwen 120B',
+    description: 'Groß & vielseitig, für komplexe Aufgaben',
+    model: 'qwen3.5-122b',
+    provider: 'regolo',
+    icon: 'brain',
+    warning:
+      'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.',
   },
 ];
 
@@ -155,8 +174,8 @@ export const useAgentStore = create<AgentState>()(
   persist(
     (set) => ({
       selectedAgentId: null,
-      selectedProvider: 'mistral',
-      selectedModel: 'mistral',
+      selectedProvider: 'regolo',
+      selectedModel: 'gemma-regolo',
       currentThreadId: null,
       enabledTools: { ...DEFAULT_ENABLED_TOOLS },
       selectedNotebookId: 'gruenerator-notebook',
@@ -339,7 +358,7 @@ export const useAgentStore = create<AgentState>()(
           removeItem: (key: string) => mem.delete(key),
         };
       }),
-      version: 4,
+      version: 5,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -359,6 +378,19 @@ export const useAgentStore = create<AgentState>()(
         if (version < 3) {
           state.threadMode = state.threadMode || 'chat';
           state.searchMode = state.searchMode || 'web';
+        }
+        if (version < 5) {
+          const validIds = new Set(['gpt-oss-regolo', 'litellm', 'gemma-regolo', 'qwen-regolo']);
+          if (!validIds.has(state.selectedModel as string)) {
+            state.selectedModel = 'gemma-regolo';
+          }
+          const providerByModel: Record<string, string> = {
+            'gpt-oss-regolo': 'regolo',
+            litellm: 'litellm',
+            'gemma-regolo': 'regolo',
+            'qwen-regolo': 'regolo',
+          };
+          state.selectedProvider = providerByModel[state.selectedModel as string] ?? 'regolo';
         }
         return state;
       },


### PR DESCRIPTION
## Summary

Adds a standalone model dropdown to the chat composer (next to Send, Gemini-style) with four selectable backends. Fully wires the user's choice through to the backend; for Qwen (a thinking-by-default model), the model's reasoning stream is surfaced in a collapsible panel above the answer — a separate new SSE event type, part type, and component.

### Models available in the picker

| Name | Backend | Notes |
|---|---|---|
| **Gemma 4** (default) | Regolo · `gemma4-31b` | Fast, lightweight |
| **GPT-OSS** | Regolo · `gpt-oss-120b` | Open model via Regolo |
| **Verdigado** | LiteLLM · `gpt-oss:120b` | Self-hosted at Verdigado |
| **Qwen 120B** | Regolo · `qwen3.5-122b` | Heavier, reasoning-capable, carries a warning about Chinese state regulation/censorship |

## Notable pieces

- **`AVAILABLE_MODELS`** extended with three Regolo entries; existing `resolveModel()` plumbing picks up user choice end-to-end (chat-graph + notebook streams, initial + resume).
- **Notebook adapter bug fix**: `NotebookModelAdapter` was dropping the user's model selection before sending the request. Now includes `model: selectedModel` in the payload.
- **Qwen thinking disable** (`regoloThinkingFetch.ts`): vLLM-specific `chat_template_kwargs.enable_thinking=false` injected into every Regolo chat completion via the provider's `fetch` wrapper. Without it Qwen3 routes all output into a non-standard `reasoning_content` field the AI SDK doesn't read — streams 0 chars. This fix keeps intermediate nodes (classifier, quality gate) fast while allowing the reasoning-specific path below to opt back into thinking.
- **Custom Regolo SSE bridge** (`regoloReasoningStream.ts`): `@ai-sdk/openai@3.0.53` only bridges reasoning for OpenAI's Responses API, not Chat Completions. For Regolo's Qwen we parse the raw SSE stream ourselves and yield both `content` and `reasoning_content` deltas. Emitted as `text_delta` + new `reasoning_delta` SSE events.
- **`Reasoning` / `ReasoningGroup` components** (`reasoning.tsx`, minimal local implementation following Assistant UI's typed contract — the CLI install of `@assistant-ui/reasoning` had a corrupted npx cache). Registered in `AssistantMessage.tsx`'s `partComponents`. Collapsed by default; click to expand.
- **Adapters construct reasoning parts**: both `NotebookModelAdapter` and `GrueneratorModelAdapter` accumulate `reasoning_delta` into a dedicated buffer and prepend a `{type:'reasoning'}` part before the text part in `buildResult()`.
- **Token headroom for reasoning**: `Math.max(base, 9000)` applied when `isRegoloReasoningModel(...)` is true, so Qwen has budget for both its `<think>` block and the final answer.
- **Mobile parity**: Qwen warning text renders on the mobile composer/settings sheets too, reading from the same shared store.

## Tests

- `regoloThinkingFetch.vitest.ts` — 6 unit tests (body transformation, non-mutation, non-JSON pass-through) + 2 live integration tests (real Regolo API, empirically verifying the fix).
- `regoloReasoningStream.vitest.ts` — 4 unit tests for the model-matching helper + 2 live integration tests (both `reasoning` and `text` chunks arrive; unknown model → useful error).

Live tests auto-skip when `REGOLO_API_KEY` is absent.

## Test plan

- [ ] `pnpm --filter @gruenerator/api test` — both new vitest files pass (unit always; integration with key)
- [ ] `npx tsc --noEmit --project packages/chat/tsconfig.json` — clean
- [ ] `npx tsc --noEmit --project apps/api/tsconfig.json` — clean
- [ ] `pnpm dev:web` + `pnpm dev:backend`: open `/chat`, verify picker appears next to Send, selection persists across reload, Qwen logs show `provider=regolo, modelId=qwen3.5-122b` and stream reasoning + text chunks (not 0 chars)
- [ ] Open the "Gedanken" collapsible panel while Qwen is streaming — reasoning text should render live
- [ ] Mobile viewport: picker shows in bottom sheet with same selections; Qwen warning visible

## Out of scope / follow-ups

- Shimmer animation on the reasoning trigger (`tw-shimmer` or similar) — was on the list but deferred while npx cache corruption was blocking installs
- Per-query thinking toggle — right now Qwen is implicitly thinking whenever selected; we may want a UI control for "tiefes Denken" later
- Migration from duplicate `apps/api/services/ai/providers.ts` ↔ `apps/api/routes/chat/agents/providers.ts` (both have their own Regolo singleton; both patched in this PR, but they should converge to one source of truth)