### PR TITLE
fix(groups): show create button on empty groups page

### DIFF
--- a/apps/web/src/features/groups/pages/GruppenPage.tsx
+++ b/apps/web/src/features/groups/pages/GruppenPage.tsx
@@ -1,4 +1,4 @@
-import { StatusBanner } from '@gruenerator/ui';
+import { SectionHeader, StatusBanner } from '@gruenerator/ui';
 import { useState, useCallback, useRef } from 'react';
 import { HiUserGroup } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -85,18 +85,31 @@ const GruppenPage = () => {
           onErrorMessage={showError}
         />
       ) : (
-        <ToolGrid
-          tools={(userGroups || []).map(
-            (g): ToolEntry => ({
-              id: g.id,
-              title: g.name,
-              description: 'Gruppe',
-              path: `/gruppen/${g.id}`,
-              icon: HiUserGroup,
-            })
+        <>
+          <SectionHeader
+            title="Deine Gruppen"
+            onCreate={handleCreateNew}
+            createLabel={isCreatingGroup ? 'Wird erstellt...' : 'Neue Gruppe erstellen'}
+          />
+          {userGroups && userGroups.length === 0 ? (
+            <p className="text-sm text-grey-500 dark:text-grey-400 py-lg text-center">
+              Noch keine Gruppen vorhanden. Erstelle deine erste Gruppe über das Plus-Symbol.
+            </p>
+          ) : (
+            <ToolGrid
+              tools={(userGroups || []).map(
+                (g): ToolEntry => ({
+                  id: g.id,
+                  title: g.name,
+                  description: 'Gruppe',
+                  path: `/gruppen/${g.id}`,
+                  icon: HiUserGroup,
+                })
+              )}
+              columns={2}
+            />
           )}
-          columns={2}
-        />
+        </>
       )}
 
       <GroupsCreateSection


### PR DESCRIPTION
## Summary

- The Gruppen list page (`apps/web/src/features/groups/pages/GruppenPage.tsx`) mounted `<GroupsCreateSection>` but had no UI trigger to open it — when `userGroups` was empty, `ToolGrid` rendered nothing, making the "create group" feature unreachable on a fresh account.
- Added a persistent `<SectionHeader>` with an `onCreate` callback above the grid, so the "+" button is always visible regardless of list length.
- Added an empty-state message ("Noch keine Gruppen vorhanden. Erstelle deine erste Gruppe über das Plus-Symbol.") for when the user has zero groups.

The existing `handleCreateNew` / `GroupsCreateSection` dialog plumbing already worked — it was just missing a caller. Mirrors the pattern already used by `apps/web/src/features/workplace/components/GroupsSection.tsx`.

## Test plan

- [ ] Log in as a user with **zero** groups → navigate to `/gruppen` → verify the "Deine Gruppen" section header with "+" button is visible and the empty-state message is shown.
- [ ] Click the "+" button → verify the create-group dialog opens.
- [ ] Submit a new group name → verify success banner appears and page navigates to the new group's detail view.
- [ ] Log in as a user with **existing** groups → verify the "+" button is still visible in the section header and clicking it opens the dialog.
- [ ] Verify the empty-state message only appears when `userGroups.length === 0`.