### PR TITLE
fix(studio): preserve image on Imagine to Studio handoff

### DIFF
--- a/apps/web/src/features/image-studio/ImageStudioPage.tsx
+++ b/apps/web/src/features/image-studio/ImageStudioPage.tsx
@@ -21,6 +21,13 @@ interface TemplateLocationState {
   sharepicType?: string;
   templateCreator?: string;
 }
+
+interface ImagineHandoffLocationState {
+  imagineHandoff?: boolean;
+  generatedImage?: string | null;
+  prompt?: string;
+  variant?: string | null;
+}
 import Spinner from '../../components/common/Spinner';
 import Button from '../../components/common/SubmitButton';
 import ErrorBoundary from '../../components/ErrorBoundary';
@@ -90,6 +97,8 @@ const ImageStudioPageContent: React.FC = () => {
     loadGalleryEditData,
     loadEditSessionData,
     aiGeneratedContent,
+    setCurrentStep,
+    commitAiGeneration,
   } = useImageStudioStore();
 
   const { generateText, generateImage } = useImageGeneration();
@@ -201,6 +210,23 @@ const ImageStudioPageContent: React.FC = () => {
 
     void loadTemplateData();
   }, [location.state, loadGalleryEditData, urlType, updateFormData]);
+
+  // Handle Imagine → Studio handoff (image generated in workplace, opened in AI Editor)
+  useEffect(() => {
+    const state = location.state as ImagineHandoffLocationState | null;
+    if (!state?.imagineHandoff || !state.generatedImage) return;
+
+    setType(IMAGE_STUDIO_TYPES.AI_EDITOR);
+    updateFormData({
+      purePrompt: state.prompt ?? '',
+      variant: state.variant ?? null,
+      aiGeneratedContent: true,
+    });
+    commitAiGeneration(state.generatedImage, state.prompt ?? '');
+    setCurrentStep(FORM_STEPS.RESULT);
+
+    window.history.replaceState({}, document.title);
+  }, [location.state, setType, updateFormData, commitAiGeneration, setCurrentStep]);
 
   // Handle template cloning from URL query parameter
   useEffect(() => {

--- a/apps/web/src/features/image-studio/components/ImageStudioCategorySelector.tsx
+++ b/apps/web/src/features/image-studio/components/ImageStudioCategorySelector.tsx
@@ -6,7 +6,7 @@ import PageContainer from '../../../components/common/PageContainer';
 import { generateSharepicFromPrompt } from '../../../services/sharepicPromptService';
 import { useAuthStore } from '../../../stores/authStore';
 import useImageStudioStore from '../../../stores/imageStudioStore';
-import { useFeaturedVorlagen, type FeaturedVorlage } from '../hooks/useFeaturedVorlagen';
+// import { useFeaturedVorlagen, type FeaturedVorlage } from '../hooks/useFeaturedVorlagen';
 import { useRecentGalleryItems, type RecentGalleryItem } from '../hooks/useRecentGalleryItems';
 import { getSharepicRoute } from '../utils/sharepicRoutes';
 import { IMAGE_STUDIO_CATEGORIES } from '../utils/typeConfig';
@@ -52,12 +52,12 @@ const PreviewCard = ({
   </div>
 );
 
-function getTemplateThumbnailUrl(thumbnailUrl: string | null): string | null {
-  if (!thumbnailUrl) return null;
-  return thumbnailUrl.startsWith('http')
-    ? thumbnailUrl
-    : `${API_BASE_URL}/template-previews/${thumbnailUrl}`;
-}
+// function getTemplateThumbnailUrl(thumbnailUrl: string | null): string | null {
+//   if (!thumbnailUrl) return null;
+//   return thumbnailUrl.startsWith('http')
+//     ? thumbnailUrl
+//     : `${API_BASE_URL}/template-previews/${thumbnailUrl}`;
+// }
 
 const ImageStudioCategorySelector: React.FC = () => {
   const navigate = useNavigate();
@@ -79,7 +79,7 @@ const ImageStudioCategorySelector: React.FC = () => {
     useRecentGalleryItems(RECENT_GALLERY_OPTIONS);
   const showGallerySection = galleryLastFetch !== null && recentGalleryItems.length > 0;
 
-  const { data: featuredVorlagen = [] } = useFeaturedVorlagen(5);
+  // const { data: featuredVorlagen = [] } = useFeaturedVorlagen(5);
 
   const isAustrianUser = user?.locale === 'de-AT';
 
@@ -220,6 +220,7 @@ const ImageStudioCategorySelector: React.FC = () => {
         )}
       </section>
 
+      {/*
       <section className="mb-xl">
         <SectionHeader
           title="Vorlagen"
@@ -245,6 +246,7 @@ const ImageStudioCategorySelector: React.FC = () => {
           </CardGrid>
         )}
       </section>
+      */}
 
       <section className="mb-xl">
         <SectionHeader

--- a/apps/web/src/features/workplace/components/ImagineInner.tsx
+++ b/apps/web/src/features/workplace/components/ImagineInner.tsx
@@ -119,7 +119,20 @@ const ImagineInner: React.FC = memo(() => {
               <Download className="size-3.5" />
               Download
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => navigate('/studio')}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                navigate('/studio/ki/ai-editor', {
+                  state: {
+                    imagineHandoff: true,
+                    generatedImage,
+                    prompt: prompt.trim(),
+                    variant: modeState.variant ?? null,
+                  },
+                })
+              }
+            >
               <ExternalLink className="size-3.5" />
               Im Studio bearbeiten
             </Button>


### PR DESCRIPTION
## Summary

- Clicking **Im Studio bearbeiten** in the Imagine workplace widget no longer drops the generated image. The button now navigates to `/studio/ki/ai-editor` and passes the image, prompt, and variant via `location.state`.
- `ImageStudioPage` reads that handoff state, seeds the AI Editor's history via `commitAiGeneration`, and jumps straight to the RESULT step so the user can immediately download, re-prompt, or further edit the image.
- The **Vorlagen** section on `/studio` is commented out (along with its supporting `useFeaturedVorlagen` hook call and helper) so it can be cleanly re-enabled later.

## Implementation notes

- Reuses the existing `location.state` cross-route handoff pattern already used by gallery edit and template clone flows.
- Sets `aiGeneratedContent: true` to short-circuit the URL→state sync effect so the handoff state isn't overwritten.
- One-shot: `window.history.replaceState({}, document.title)` clears the handoff state after consumption, matching the existing pattern.

## Test plan

- [ ] Generate an image via the Imagine widget, click **Im Studio bearbeiten**, confirm you land on `/studio/ki/ai-editor` with the image visible in the RESULT step.
- [ ] Confirm undo is disabled (single history entry) and the prompt field is pre-populated.
- [ ] Refresh `/studio/ki/ai-editor` — the image should clear and the editor should reset to the INPUT step (handoff is one-shot, by design).
- [ ] Visit `/studio` — the **Vorlagen** section should be hidden; **Sharepics**, **Imagine**, and **Reel** sections still render.