### PR TITLE
fix(admin): restore is_admin on session + show access-denied page

### DIFF
--- a/apps/web/src/features/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/features/admin/AdminDashboardPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   CardGrid,
   Dialog,
   DialogContent,
@@ -10,7 +11,8 @@ import {
   Skeleton,
 } from '@gruenerator/ui';
 import { useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { FaLock } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 
 import withAuthRequired from '../../components/common/LoginRequired/withAuthRequired';
 import PageContainer from '../../components/common/PageContainer';
@@ -55,7 +57,27 @@ const AdminDashboardPage = () => {
   };
 
   if (!user?.is_admin) {
-    return <Navigate to="/" replace />;
+    return (
+      <PageContainer maxWidth="md">
+        <div className="flex flex-col items-center justify-center gap-md py-xl text-center">
+          <FaLock aria-hidden className="text-5xl text-grey-400" />
+          <h1 className="text-3xl font-semibold">Kein Zugriff</h1>
+          <p className="text-grey-600 dark:text-grey-400">
+            Du hast keine Berechtigung, den Administrationsbereich zu öffnen. Bitte wende dich an
+            eine administrierende Person, falls du Zugriff benötigst.
+          </p>
+          {user?.email && (
+            <p className="text-sm text-grey-500">
+              Angemeldet als{' '}
+              <span className="font-medium text-grey-700 dark:text-grey-300">{user.email}</span>
+            </p>
+          )}
+          <Button variant="brand" size="brand" asChild>
+            <Link to="/desk">Zurück zum Schreibtisch</Link>
+          </Button>
+        </div>
+      </PageContainer>
+    );
   }
 
   const statCounts: Record<StatusTab, number> = {


### PR DESCRIPTION
## Summary
Two related fixes for the `/admin` route:

### 1. `fix(profile): include is_admin in UserProfile mapper` — the actual bug
`toUserProfile()` in `apps/api/services/user/profileMapper.ts` is an allow-list mapper that explicitly rebuilds `UserProfile` field-by-field. It was **silently dropping `is_admin`** between the DB read and the API response. Result: every user's `user.is_admin` on the frontend was `undefined`, so **real admins were locked out of `/admin` too**.

Backend admin routes (e.g. `adminVorlagenContractRouter.ts`) do their own `SELECT is_admin FROM profiles` and were unaffected, which is why this went unnoticed — only the client-side `user.is_admin` check was broken.

### 2. `fix(admin): show access-denied page for non-admins on /admin` — UX improvement
Previously the admin route silently redirected non-admins to `/`, which re-chained through `GuestRoute` to `/desk` — obscuring *why* the admin area was inaccessible. Now renders an inline "Kein Zugriff" state with a lock icon, the signed-in email (for wrong-account clarity), and a button back to `/desk`.

## Notes
- Several other columns (`deutschlandmodus`, `igel_modus`, `content_management`, `sites`, `website`, `ai_sharepic`, `groups`, `auth_source`, …) are *also* missing from the mapper. Left alone per the project's "don't bundle unrelated cleanup" rule — tracked as a follow-up.
- Client-side admin check is UX only; server-side enforcement lives on API endpoints and is unchanged.
- Genderstern avoided via neutral construction ("eine administrierende Person") per the project's gendern rules.
- No new CSS file — Tailwind + `@gruenerator/ui` primitives per project convention.

## Test plan
- [ ] Log in as an admin (`profiles.is_admin = true`) and visit `/admin` — dashboard renders.
- [ ] Log in as a non-admin and visit `/admin` — "Kein Zugriff" page renders with signed-in email visible.
- [ ] "Zurück zum Schreibtisch" button lands on `/desk`.
- [ ] Dark mode text/icon colors remain legible.
- [ ] Existing admin API endpoints continue to function (`adminVorlagenContractRouter`).