### PR TITLE
fix(profile): include is_admin in UserProfile mapper

### DIFF
--- a/apps/api/services/user/profileMapper.ts
+++ b/apps/api/services/user/profileMapper.ts
@@ -30,6 +30,7 @@ export function toUserProfile(row: ProfileSelectModel): UserProfile {
     ...(row.custom_prompt != null && { custom_prompt: row.custom_prompt }),
 
     // Feature flags — all have DB defaults so they are non-null
+    is_admin: row.is_admin,
     groups_enabled: row.groups_enabled,
     custom_generators: row.custom_generators,
     database_access: row.database_access,


### PR DESCRIPTION
## Summary
Follow-up to #650 — the UI change merged, but this mapper fix did not. Without it, `user.is_admin` is always `undefined` on the frontend, so **every signed-in user hits "Kein Zugriff"** on `/admin`, including real admins.

`toUserProfile()` in `apps/api/services/user/profileMapper.ts` is an allow-list mapper that rebuilds `UserProfile` field-by-field. `is_admin` was not in the list, so the DB value was silently dropped between the Drizzle read and the API response.

Backend admin routes (e.g. `adminVorlagenContractRouter.ts`) query `profiles.is_admin` directly and were unaffected — this bug is scoped to the client-side `user.is_admin` check.

## Diff
One-line addition to the "Feature flags" block of the mapper:
```ts
is_admin: row.is_admin,
```
The DB column is `boolean NOT NULL DEFAULT false`, same as the other feature flags already mapped, so no null handling is needed.

## Test plan
- [ ] Deploy and have an admin user (`profiles.is_admin = true`) log out/in to refresh their persisted session state.
- [ ] `/admin` loads the dashboard.
- [ ] A non-admin still sees the "Kein Zugriff" page.
- [ ] `adminVorlagenContractRouter` endpoints continue to function (regression).

## Why this didn't land in #650
I pushed this commit to the `feat/admin-forbidden-page` branch *after* #650 was merged, so GitHub never associated it with the PR. Lesson: check `gh pr view` before assuming follow-up pushes join an already-merged PR.