### PR TITLE
fix(chat): show user-created roles reliably — hydrate defaults, guard concurrent fetches, clear on logout

### DIFF
--- a/apps/web/src/hooks/useHydrateUserProfile.ts
+++ b/apps/web/src/hooks/useHydrateUserProfile.ts
@@ -7,9 +7,18 @@ import { useUserDefaultsStore } from '../stores/userDefaultsStore';
 export function useHydrateUserProfile() {
   const locale = useAuthStore((s) => s.locale);
   const getDefault = useUserDefaultsStore((s) => s.getDefault);
+  const hydrate = useUserDefaultsStore((s) => s.hydrate);
+  const isHydrated = useUserDefaultsStore((s) => s.isHydrated);
 
   useEffect(() => {
+    if (!isHydrated) {
+      void hydrate();
+    }
+  }, [isHydrated, hydrate]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
     const roles = getDefault<UserRole[]>('profile', 'roles') || [];
     useUserProfileStore.getState().hydrate({ roles, locale: locale || 'de-DE' });
-  }, [getDefault, locale]);
+  }, [getDefault, isHydrated, locale]);
 }

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -1,9 +1,12 @@
+import { useUserProfileStore } from '@gruenerator/chat';
 import { type UserProfile } from '@gruenerator/contracts';
 import { create } from 'zustand';
 
 import apiClient, { setLoggingOutFlag } from '../components/utils/apiClient';
 import { openDesktopLogin, type AuthSource } from '../utils/desktopAuth';
 import { isDesktopApp } from '../utils/platform';
+
+import { useUserDefaultsStore } from './userDefaultsStore';
 
 // =============================================================================
 // Type Definitions
@@ -288,6 +291,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     }
 
     // Legacy cleanup - no longer needed with new auth system
+
+    useUserDefaultsStore.getState().reset();
+    useUserProfileStore.getState().reset();
 
     // Reset store to default state
     set({

--- a/apps/web/src/stores/userDefaultsStore.ts
+++ b/apps/web/src/stores/userDefaultsStore.ts
@@ -48,7 +48,7 @@ export const useUserDefaultsStore = create<UserDefaultsStore>()(
        * Hydrate store from backend
        */
       hydrate: async () => {
-        if (get().isHydrated) return;
+        if (get().isHydrated || get().isLoading) return;
 
         set({ isLoading: true });
         try {

--- a/packages/chat/src/stores/userProfileStore.ts
+++ b/packages/chat/src/stores/userProfileStore.ts
@@ -19,15 +19,21 @@ interface UserProfileActions {
   setRoles: (roles: UserRole[]) => void;
   setLocale: (locale: string) => void;
   hydrate: (state: Partial<UserProfileState>) => void;
+  reset: () => void;
 }
 
 type UserProfileStore = UserProfileState & UserProfileActions;
 
-export const useUserProfileStore = create<UserProfileStore>()((set) => ({
+const INITIAL_STATE: UserProfileState = {
   roles: [],
   locale: 'de-DE',
+};
+
+export const useUserProfileStore = create<UserProfileStore>()((set) => ({
+  ...INITIAL_STATE,
 
   setRoles: (roles) => set({ roles }),
   setLocale: (locale) => set({ locale }),
   hydrate: (state) => set(state),
+  reset: () => set(INITIAL_STATE),
 }));


### PR DESCRIPTION
## Summary

User-created "Rollen" (roles) in profile settings did not show up in chat. The report was about the Workplace page, but the bug is shared: both \`/chat\` and \`/workplace\` are affected on cold sessions — the symptom is just more visible on Workplace because \`/chat\` often gets its data re-hydrated from localStorage after a previous profile visit.

## Root cause

Only one hook — \`useHydrateUserProfile\` — bridges \`userDefaultsStore\` (persisted profile data) into \`@gruenerator/chat\`'s \`userProfileStore\` (consumed by \`ChatOverview\` and \`ToolToggles\`). That hook:
- read roles on mount **without triggering** the server fetch (\`userDefaultsStore.hydrate()\`)
- did not react when hydration landed (deps were \`[getDefault, locale]\`, both stable)

Result: cold session → empty \`defaults\` map → roles empty → \`ChatOverview\` hides the role chips because \`roles.length === 0\`.

## Fixes in this PR

Three atomic commits, all in the same state-management area:

### 1. \`fix(workplace): hydrate user defaults before reading profile roles\` (\`fc75d470\`)
\`useHydrateUserProfile\` now triggers \`userDefaultsStore.hydrate()\` if not yet hydrated and re-syncs \`userProfileStore\` once \`isHydrated\` flips \`false → true\`. Split into two effects (trigger vs. react) to mirror the pattern in \`useUserDefaults\`.

### 2. \`fix(userDefaultsStore): guard hydrate against concurrent calls\` (\`cb5bfd17\`)
\`hydrate()\` only early-returned on \`isHydrated\`. When multiple components mount in parallel (common in the chat layout), both fired \`GET /auth/profile/user-defaults\` simultaneously. Gate on \`isLoading\` too so only the first caller reaches the network.

### 3. \`fix(auth): reset user defaults and profile stores on logout\` (\`c795c625\`)
\`clearAuth\` cleared \`AUTH_STORAGE_KEY\` and the React Query cache but left \`user-defaults\` (persisted) and \`userProfileStore\` (in-memory) untouched. On a shared device, user B would start with user A's \`profile.roles\` rehydrated from localStorage until the server fetch landed — a visible flash of another user's data. Added a \`reset()\` action on \`userProfileStore\` to parallel \`userDefaultsStore\` and called both from \`clearAuth\`.

## Test plan

- [ ] Log in with a user who has custom roles saved in profile
- [ ] Open a private window (fresh localStorage) → go straight to \`/workplace\` → roles chips appear
- [ ] Same, but straight to \`/chat\` → roles chips appear
- [ ] Create a new role in profile → navigate to \`/chat\` → new role appears without reload
- [ ] Log out → log in as a different user → no flash of previous user's roles on \`/chat\` or \`/workplace\`
- [ ] Open DevTools Network, hard-reload \`/workplace\` → only one \`GET /auth/profile/user-defaults\` request (no duplicate from thundering-herd)

## Files changed

- \`apps/web/src/hooks/useHydrateUserProfile.ts\` — trigger hydrate + react to \`isHydrated\`
- \`apps/web/src/stores/userDefaultsStore.ts\` — guard \`isLoading\`
- \`apps/web/src/stores/authStore.ts\` — reset both stores in \`clearAuth\`
- \`packages/chat/src/stores/userProfileStore.ts\` — add \`reset()\` action