### PR TITLE
fix(docs): keep selection visible when mobile keyboard overlaps document

### DIFF
--- a/apps/web/src/components/common/DocsEditorModal.tsx
+++ b/apps/web/src/components/common/DocsEditorModal.tsx
@@ -77,7 +77,7 @@ const DocsEditorContent = ({
         connectionStatus={connectionStatus}
         onBack={onClose}
       />
-      <div className="flex-1 overflow-y-auto px-6 pt-4 pb-8 bg-grey-100 dark:bg-grey-900 max-[768px]:px-3 max-[768px]:pt-2 max-[768px]:pb-6">
+      <div className="flex-1 overflow-y-auto px-6 pt-4 pb-8 bg-grey-100 dark:bg-grey-900 max-[768px]:px-3 max-[768px]:pt-2 max-[768px]:pb-[calc(1.5rem+var(--mobile-keyboard-offset,0px))]">
         {!isReady ? (
           <div className="flex items-center justify-center h-[200px] text-grey-500 text-sm">
             Verbinde mit Server...

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -565,7 +565,7 @@ function EditorContent() {
       )}
 
       <div className="flex-1 flex flex-row overflow-hidden max-md:flex-col">
-        <main className="flex-1 min-w-0 overflow-y-auto py-4 px-6 bg-grey-100 dark:bg-grey-900 max-sm:px-0 max-sm:pt-0 max-sm:bg-background dark:max-sm:bg-background">
+        <main className="flex-1 min-w-0 overflow-y-auto py-4 px-6 bg-grey-100 dark:bg-grey-900 max-sm:px-0 max-sm:pt-0 max-sm:pb-[var(--mobile-keyboard-offset,0px)] max-sm:bg-background dark:max-sm:bg-background">
           <MemoizedBlockNoteEditor
             documentId={id!}
             initialContent={initialContent}

--- a/apps/web/src/features/texte/components/InlineEditor.tsx
+++ b/apps/web/src/features/texte/components/InlineEditor.tsx
@@ -137,7 +137,7 @@ const InlineEditorContent = memo(({ editorState, onBack, docsApiClient }: Inline
         editable
         rightActions={rightActions}
       />
-      <div className="flex-1 overflow-y-auto px-md py-lg bg-grey-50 dark:bg-grey-900">
+      <div className="flex-1 overflow-y-auto px-md py-lg bg-grey-50 dark:bg-grey-900 max-sm:pb-[var(--mobile-keyboard-offset,0px)]">
         <div className="max-w-[780px] mx-auto w-full">
           {!isReady ? (
             <div className="flex items-center justify-center h-[200px] text-grey-500 text-sm">

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -144,17 +144,25 @@ const BlockNoteEditorInner = ({
   const scrollSelectionIntoView = useCallback(() => {
     const sel = window.getSelection();
     if (!sel || sel.rangeCount === 0) return;
+
+    const anchorNode = sel.anchorNode;
+    const anchorEl =
+      anchorNode?.nodeType === Node.ELEMENT_NODE
+        ? (anchorNode as Element)
+        : anchorNode?.parentElement ?? null;
+    const blockEl = anchorEl?.closest('[data-id], .bn-block-content') ?? anchorEl;
+    if (!blockEl) return;
+
     const rect = sel.getRangeAt(0).getBoundingClientRect();
     const vp = window.visualViewport;
-    if (!vp) return;
     const toolbarHeight =
       wrapperRef.current?.querySelector('.bn-formatting-toolbar')?.getBoundingClientRect().height ||
       44;
-    const visibleBottom = vp.offsetTop + vp.height - toolbarHeight;
-    if (rect.bottom > visibleBottom) {
-      window.scrollBy({ top: rect.bottom - visibleBottom + 16, behavior: 'smooth' });
-    } else if (rect.top < vp.offsetTop) {
-      window.scrollBy({ top: rect.top - vp.offsetTop - 16, behavior: 'smooth' });
+    const visibleBottom = vp ? vp.offsetTop + vp.height - toolbarHeight : window.innerHeight;
+    const visibleTop = vp?.offsetTop ?? 0;
+
+    if (rect.bottom > visibleBottom || rect.top < visibleTop) {
+      blockEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
   }, []);
 

--- a/packages/docs/src/hooks/useMobileKeyboardOffset.ts
+++ b/packages/docs/src/hooks/useMobileKeyboardOffset.ts
@@ -9,9 +9,10 @@ interface MobileKeyboardOffsetOptions {
 }
 
 /**
- * Sets CSS custom property `--mobile-keyboard-offset` on the referenced element
- * to reflect the virtual keyboard height. Uses VirtualKeyboard API (Chrome/Edge)
- * with VisualViewport fallback (Safari/Firefox).
+ * Sets CSS custom property `--mobile-keyboard-offset` on both the referenced
+ * element AND `:root` so ancestors/siblings can add bottom padding to their
+ * scroll containers. Uses VirtualKeyboard API (Chrome/Edge) with VisualViewport
+ * fallback (Safari/Firefox).
  */
 export function useMobileKeyboardOffset<T extends HTMLElement>(
   ref: RefObject<T | null>,
@@ -27,12 +28,17 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(
     let debounceTimer: ReturnType<typeof setTimeout>;
 
     const setOffset = (px: number) => {
-      ref.current?.style.setProperty('--mobile-keyboard-offset', px > 0 ? `${px}px` : '0px');
+      const value = px > 0 ? `${px}px` : '0px';
+      ref.current?.style.setProperty('--mobile-keyboard-offset', value);
+      document.documentElement.style.setProperty('--mobile-keyboard-offset', value);
       if (callbackRef.current) {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(() => callbackRef.current?.(), 100);
       }
     };
+
+    const clearRootVar = () =>
+      document.documentElement.style.removeProperty('--mobile-keyboard-offset');
 
     // Prefer VirtualKeyboard API (Chrome/Edge 94+)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,6 +50,7 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(
       return () => {
         vk.removeEventListener('geometrychange', onGeometryChange);
         clearTimeout(debounceTimer);
+        clearRootVar();
       };
     }
 
@@ -81,6 +88,7 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(
       document.removeEventListener('focusin', onFocusIn);
       document.removeEventListener('focusout', onFocusOut);
       clearTimeout(debounceTimer);
+      clearRootVar();
     };
   }, [isTouchDevice, ref]);
 }


### PR DESCRIPTION
## Summary

On mobile, selecting text near the bottom of a document left the selection hidden behind the on-screen keyboard and the formatting toolbar. Fixes that by making the existing keyboard-offset infrastructure reach the scroll container and using a more reliable scroll primitive.

- **Root-scoped CSS variable**: `useMobileKeyboardOffset` now publishes `--mobile-keyboard-offset` on `:root` (in addition to the editor wrapper). Ancestors/siblings of the editor — in particular the `<main>` scroll container — can now react to the keyboard height.
- **Scroll the right container**: `BlockNoteEditor.scrollSelectionIntoView` previously called `window.scrollBy`, but the document scrolls inside a nested `<main className="overflow-y-auto">`, not the window — so the helper did nothing. Replaced with `Element.scrollIntoView({ block: 'center' })` on the selection's closest block, which walks up all scrollable ancestors and respects `visualViewport`.
- **Scroll runway**: Added `pb-[var(--mobile-keyboard-offset,0px)]` (mobile only) to the three editor scroll containers — `DocsEditorPage`, `InlineEditor`, `DocsEditorModal` — so the bottom-most line has empty space to scroll into above the keyboard.

## Test plan

- [ ] Open a long document on mobile (`/docs/<id>`), tap near the bottom, drag selection handles onto the last line — selection should scroll into the visible area above keyboard + formatting toolbar.
- [ ] Verify behavior in iOS Safari (VisualViewport fallback) and Chrome Android (VirtualKeyboard API path).
- [ ] Rotate portrait ↔ landscape while keyboard is open — no layout jump, selection stays visible.
- [ ] Desktop / non-touch: no regression; padding resolves to `0px`.
- [ ] `InlineEditor` and `DocsEditorModal` surfaces exhibit the same behavior.