### PR TITLE
fix(auth): forward Better Auth Set-Cookie headers in mobile OAuth bridge

### DIFF
--- a/apps/api/config/authRegressions.vitest.ts
+++ b/apps/api/config/authRegressions.vitest.ts
@@ -22,6 +22,20 @@
  *      needs a live Postgres connection and is skipped gracefully when the
  *      DB is unreachable.
  *
+ *   3. Mobile OAuth Set-Cookie drop (branch fix/mobile-auth-cookie-forwarding).
+ *      `auth.api.signInWithOAuth2(...)` called without `asResponse: true`
+ *      silently drops Better Auth's state + PKCE cookies, so the Keycloak
+ *      round-trip comes back without `__Secure-ba.state`. Better Auth then
+ *      treats the callback as a `state_mismatch` replay and redirects to
+ *      `/?error=please_restart_the_process` — which the SPA renders as the
+ *      marketing homepage, so the Chrome Custom Tab never fires the custom
+ *      scheme and `WebBrowser.openAuthSessionAsync()` hangs forever. Fix
+ *      pattern: every programmatic `auth.api.*` call that mutates auth
+ *      state passes `asResponse: true` and then calls
+ *      `forwardBetterAuthCookies(res, response)` from
+ *      `apps/api/utils/betterAuthBridge.ts`. Helper ships with its own unit
+ *      tests (`apps/api/utils/betterAuthBridge.vitest.ts`).
+ *
  * Run: `pnpm --filter @gruenerator/api test`
  */
 

--- a/apps/api/routes/auth/appLogin.ts
+++ b/apps/api/routes/auth/appLogin.ts
@@ -32,6 +32,7 @@ import { SignJWT } from 'jose';
 
 import { auth } from '../../config/betterAuth.js';
 import { env } from '../../config/env.js';
+import { forwardBetterAuthCookies } from '../../utils/betterAuthBridge.js';
 import { createLogger } from '../../utils/logger.js';
 import { parseJSON } from '../../utils/parseJSON.js';
 import redisClient from '../../utils/redis/client.js';
@@ -133,14 +134,20 @@ router.get('/login', loginLimiter, async (req: AuthRequest, res: Response): Prom
       redirectTo ?? 'none'
     );
 
+    // asResponse + forwardBetterAuthCookies is mandatory. Without it, Better
+    // Auth's Set-Cookie headers (OAuth state, PKCE verifier) never reach the
+    // browser; the Keycloak callback then comes back cookie-less, Better
+    // Auth rejects the state as a replay, and the browser gets 302'd to
+    // `/?error=please_restart_the_process` — which renders as the marketing
+    // homepage and hangs `WebBrowser.openAuthSessionAsync()` forever.
     const response = await auth.api.signInWithOAuth2({
-      body: {
-        providerId,
-        callbackURL,
-      },
+      body: { providerId, callbackURL },
+      headers: fromNodeHeaders(req.headers),
+      asResponse: true,
     });
+    forwardBetterAuthCookies(res, response);
+    const { url } = (await response.json()) as { url?: string };
 
-    const url = (response as { url?: string }).url;
     if (!url) {
       log.error(
         '[AppLogin] No URL returned from Better Auth signInWithOAuth2 (provider=%s, callbackURL=%s)',

--- a/apps/api/utils/betterAuthBridge.ts
+++ b/apps/api/utils/betterAuthBridge.ts
@@ -1,0 +1,35 @@
+/**
+ * Bridge between Express and Better Auth's programmatic `auth.api.*` surface.
+ *
+ * Better Auth's `auth.api.<method>(...)` calls run the same code path as the
+ * HTTP endpoints, which means they prepare Set-Cookie headers for state,
+ * session, PKCE verifier, etc. When invoked with the default body-only
+ * signature, those cookies are written onto a synthetic Response that we
+ * never see — the browser gets no cookies and any follow-up OAuth/state
+ * round-trip fails with `state_mismatch`.
+ *
+ * Canonical usage at every mutating call site:
+ *
+ *   const response = await auth.api.signInWithOAuth2({
+ *     body: { providerId, callbackURL },
+ *     headers: fromNodeHeaders(req.headers),
+ *     asResponse: true,                       // <- mandatory
+ *   });
+ *   forwardBetterAuthCookies(res, response); // <- mandatory
+ *   const { url } = (await response.json()) as { url?: string };
+ *
+ * Keeping this a thin utility (instead of a generic wrapper) preserves
+ * Better Auth's per-endpoint body types at the call site.
+ *
+ * Pinned incident: commit fix/mobile-auth-cookie-forwarding — mobile OAuth
+ * through `appLogin.ts` landed on the marketing homepage because
+ * `__Secure-ba.state` was never emitted by `GET /api/auth/login`.
+ */
+
+import type { Response as ExpressResponse } from 'express';
+
+export function forwardBetterAuthCookies(res: ExpressResponse, response: Response): void {
+  for (const cookie of response.headers.getSetCookie()) {
+    res.appendHeader('Set-Cookie', cookie);
+  }
+}

--- a/apps/api/utils/betterAuthBridge.vitest.ts
+++ b/apps/api/utils/betterAuthBridge.vitest.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { forwardBetterAuthCookies } from './betterAuthBridge.js';
+
+function makeFakeRes() {
+  const captured: Record<string, string[]> = {};
+  return {
+    captured,
+    appendHeader(name: string, value: string) {
+      const key = name.toLowerCase();
+      (captured[key] ||= []).push(value);
+    },
+  };
+}
+
+describe('forwardBetterAuthCookies', () => {
+  it('copies every Set-Cookie from a Better Auth Response onto the Express response', () => {
+    const fakeRes = makeFakeRes();
+    const headers = new Headers();
+    headers.append('set-cookie', '__Secure-ba.state=abc; Domain=.example.com; HttpOnly; Secure; SameSite=Lax');
+    headers.append('set-cookie', '__Secure-ba.pkce=def; HttpOnly; Secure');
+    const response = new Response(null, { status: 200, headers });
+
+    forwardBetterAuthCookies(fakeRes as unknown as import('express').Response, response);
+
+    expect(fakeRes.captured['set-cookie']).toHaveLength(2);
+    expect(fakeRes.captured['set-cookie'][0]).toContain('__Secure-ba.state=abc');
+    expect(fakeRes.captured['set-cookie'][1]).toContain('__Secure-ba.pkce=def');
+  });
+
+  it('writes nothing when the Better Auth Response has no Set-Cookie headers', () => {
+    const fakeRes = makeFakeRes();
+    const response = new Response(null, { status: 200, headers: new Headers() });
+
+    forwardBetterAuthCookies(fakeRes as unknown as import('express').Response, response);
+
+    expect(fakeRes.captured['set-cookie']).toBeUndefined();
+  });
+
+  it('preserves the original cookie strings verbatim (no re-encoding of attributes)', () => {
+    const fakeRes = makeFakeRes();
+    const raw = '__Secure-ba.state=xyz; Max-Age=300; Domain=.gruenerator.eu; Path=/; SameSite=Lax; HttpOnly; Secure';
+    const headers = new Headers();
+    headers.append('set-cookie', raw);
+    const response = new Response(null, { status: 200, headers });
+
+    forwardBetterAuthCookies(fakeRes as unknown as import('express').Response, response);
+
+    expect(fakeRes.captured['set-cookie']).toEqual([raw]);
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug**: mobile OAuth landed on the gruenerator.eu marketing homepage instead of `gruenerator://auth/callback`; `WebBrowser.openAuthSessionAsync()` stayed pending forever.
- **Root cause**: `appLogin.ts` called `auth.api.signInWithOAuth2(...)` without `asResponse: true`. Better Auth prepared `__Secure-ba.state` (+ PKCE) cookies on a synthetic Response that we discarded, so the browser got no state cookie. After Keycloak, the callback hit `/api/auth/v2/oauth2/callback/...` cookie-less, Better Auth flagged `state_mismatch`, and the resulting 302 chain landed on `/?error=please_restart_the_process` — rendered by the SPA as the homepage. `[BA:warn] oauth state replay` in prod logs confirmed the failure mode.
- **Fix**: new `forwardBetterAuthCookies(res, response)` helper in `apps/api/utils/betterAuthBridge.ts`. The `/login` handler now passes `asResponse: true` and forwards cookies before redirecting. Pattern is documented as Incident 3 in `authRegressions.vitest.ts` so every future programmatic `auth.api.*` call that mutates state follows it.

## Evidence pinned in the comment
- Probes showed `POST /api/auth/v2/sign-in/social` sets `__Secure-ba.state`, while `GET /api/auth/login` does NOT — identical inputs, different surfaces.
- `curl /api/auth/v2/oauth2/callback/...?code=x&state=invalid` reproduces the exact redirect chain to `/?error=please_restart_the_process`.

## Test plan
- [ ] `pnpm --filter @gruenerator/api test` — new `betterAuthBridge.vitest.ts` suite passes (multi-cookie forwarding, empty-headers safety, verbatim attribute preservation).
- [ ] On staging or a local dev stack: `curl -i 'https://<host>/api/auth/login?source=gruene-oesterreich-login&redirectTo=gruenerator://auth/callback'` now returns a `Set-Cookie: __Secure-ba.state=...` header alongside the 302 to Keycloak.
- [ ] End-to-end mobile flow: tap "Login with Grüne Österreich" in `apps/mobile` → authenticate at Keycloak → browser closes → app resumes on `/(tabs)`.
- [ ] Confirm existing web login (`/api/auth/v2/sign-in/social` via the SPA) is unaffected — this PR only changes the custom mobile/desktop wrapper.

## Risk
Low. Surface area is `GET /api/auth/login` only. Behaviour change is strictly additive (cookies that should have been sent all along). No DB migrations, no config changes required.