### PR TITLE
fix(auth): dedupe mobile OAuth callback handler to prevent surface remount

### DIFF
--- a/apps/mobile/app/auth/callback.tsx
+++ b/apps/mobile/app/auth/callback.tsx
@@ -1,3 +1,4 @@
+import { useAuthStore } from '@gruenerator/shared/stores';
 import { useLocalSearchParams, router } from 'expo-router';
 import { useEffect } from 'react';
 import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
@@ -8,36 +9,40 @@ import { colors } from '../../theme';
 
 export default function AuthCallback() {
   const { code } = useLocalSearchParams<{ code: string }>();
+  const user = useAuthStore((state) => state.user);
 
   useEffect(() => {
+    // Android delivers the OAuth callback URL to both the WebBrowser Custom
+    // Tab (which resolves openAuthSessionAsync in services/auth.ts) AND the
+    // Android Intent system (which mounts this screen). If the WebBrowser
+    // path won the race and already set `user`, this mount is redundant —
+    // navigate straight to tabs without re-processing the one-shot JWT.
+    if (user) {
+      router.replace('/(tabs)');
+      return;
+    }
+
+    // iOS cold-start fallback: ASWebAuthenticationSession doesn't fire
+    // Linking, and if the app was killed mid-flow we arrive here with a
+    // fresh `code` and no live WebBrowser session to process it. Since
+    // handleAuthCallback is idempotent by `code`, racing the WebBrowser
+    // path (Android) is harmless — both callers await one HTTP exchange.
     async function processCallback() {
       if (code) {
         try {
-          console.log('[AuthCallback] Processing code...');
-
-          // Ensure API client is initialized (may be called before AuthProvider)
           initializeApiClient();
           configureAuthStore();
-
           const result = await handleAuthCallback(code);
-          if (result.success) {
-            console.log('[AuthCallback] Login successful, redirecting to tabs');
-            router.replace('/(tabs)');
-          } else {
-            console.log('[AuthCallback] Login failed:', result.error);
-            router.replace('/(auth)/login');
-          }
-        } catch (error) {
-          console.error('[AuthCallback] Error:', error);
+          router.replace(result.success ? '/(tabs)' : '/(auth)/login');
+        } catch {
           router.replace('/(auth)/login');
         }
       } else {
-        console.log('[AuthCallback] No code provided, redirecting to login');
         router.replace('/(auth)/login');
       }
     }
     void processCallback();
-  }, [code]);
+  }, [code, user]);
 
   return (
     <View style={styles.container}>

--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -124,16 +124,40 @@ export async function login(source: AuthSource): Promise<{ success: boolean; err
   }
 }
 
+// On Android, an OAuth callback URL is delivered to BOTH the WebBrowser
+// Custom Tab (resolving openAuthSessionAsync's promise in login()) AND the
+// Android Intent system (which Expo Router routes to /auth/callback.tsx).
+// Without deduplication, the same one-shot JWT would be exchanged twice,
+// both writers would mutate useAuthStore, and two concurrent router.replace
+// calls would tear down the Fabric root. This cache ensures exactly one
+// HTTP exchange per code; every subsequent caller awaits the same promise.
+const inFlightExchanges = new Map<string, Promise<{ success: boolean; error?: string }>>();
+
 /**
- * Exchange login code for JWT and store credentials
+ * Exchange login code for JWT and store credentials.
+ *
+ * Idempotent by `code`: repeated calls with the same code await the first
+ * in-flight request instead of issuing a new one.
  */
 export async function handleAuthCallback(
+  code: string
+): Promise<{ success: boolean; error?: string }> {
+  const existing = inFlightExchanges.get(code);
+  if (existing) {
+    return existing;
+  }
+
+  const promise = exchangeCodeForTokens(code);
+  inFlightExchanges.set(code, promise);
+  return promise;
+}
+
+async function exchangeCodeForTokens(
   code: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const apiClient = getGlobalApiClient();
 
-    // Exchange code for JWT
     const response = await apiClient.post<ConsumeLoginCodeResponse>(
       API_ENDPOINTS.AUTH_MOBILE_CONSUME,
       { code }


### PR DESCRIPTION
## Summary
- **Bug**: after successful login the user landed on a blank screen with just a settings gear — the tabs layout rendered without its children. Regression surfaced the moment server-side auth started working (PR #655).
- **Root cause**: on Android the OAuth callback URL is delivered to **two** pathways that both call the code exchange and both navigate. The concurrent `router.replace('/(tabs)')` + double `useAuthStore` mutation tore down the Fabric surface; Fabric soft-faulted with \`reactInstance is null. Dropping work.\` and the tabs re-mounted against a half-settled root.
- **Fix**: idempotent \`handleAuthCallback(code)\` (in-flight \`Map\` cache) so the JWT only exchanges once, and \`/auth/callback.tsx\` short-circuits when \`useAuthStore.user\` is already set — so only one pathway navigates.

## Evidence from logcat

```
18.044  [DeepLink] Event URL: gruenerator://auth/callback?code=<JWT>
18.131  [AuthCallback] Processing code...          ← Expo Router path starts exchange
18.180  [Auth] Received login code, exchanging... ← WebBrowser promise path starts exchange
18.600  [Auth] Login successful for: moritz...    ← path #1 done
18.875  [Auth] Login successful for: moritz...    ← path #2 done
[...]
ReactHost: reactInstance is null. Dropping work. (×3)
Running \"main\" with rootTag:11  →  rootTag:21  →  rootTag:31  (full surface re-inits)
```

## Platform notes pinned in code comments
- **Android**: the callback URL goes to both WebBrowser Custom Tab *and* the Intent system (which mounts the callback screen). Both guards are required.
- **iOS**: \`ASWebAuthenticationSession\` doesn't fire \`Linking\`, so the callback screen never mounts during a normal OAuth flow. The code-processing branch remains as a cold-start fallback (app killed mid-OAuth, reopened via deep link).

## Dependency
Hidden by #655 until today — pre-fix, login never completed, so neither pathway ever reached the race. This PR becomes meaningful once #655 ships.

## Test plan
- [ ] Android device: tap \"Login with Grüne Österreich\" → authenticate → confirm tabs render with content (not blank gear).
- [ ] Check logcat: \`[Auth] Login successful for:\` should now fire exactly **once** per login; no \`reactInstance is null\` soft-exceptions; no \`Running main with rootTag:N\` re-inits post-login.
- [ ] iOS device (if available): verify login still completes via the WebBrowser promise path (callback screen won't mount during happy path).
- [ ] Cold-start edge case: kill the app mid-OAuth, reopen via the callback URL — the screen's iOS-fallback branch processes the code and lands on tabs.

## Risk
Low. Two files, both in the mobile app. No server changes. The \`Map\`-based cache is additive safety; existing code paths still work.