### PR TITLE
fix(auth): issue Better Auth session tokens on mobile login exchange

### DIFF
--- a/apps/api/config/authRegressions.vitest.ts
+++ b/apps/api/config/authRegressions.vitest.ts
@@ -36,6 +36,22 @@
  *      `apps/api/utils/betterAuthBridge.ts`. Helper ships with its own unit
  *      tests (`apps/api/utils/betterAuthBridge.vitest.ts`).
  *
+ *   4. Mobile custom-JWT rejected by requireAuth (branch
+ *      fix/mobile-better-auth-bearer). The legacy
+ *      `/auth/mobile/consume-login-code` Express route minted a custom HS256
+ *      JWT signed with SESSION_SECRET; that token was never recognised by
+ *      `auth.api.getSession({ headers })`, so every `/api/docs/*` (and any
+ *      other endpoint guarded by `requireAuth`) 401'd for mobile clients.
+ *      Symptom was `[DocsStore] Failed to fetch documents: AxiosError 401`
+ *      looping on the docs tab even though login itself succeeded. Fix:
+ *      move the exchange into the `mobileTokenExchange` Better Auth plugin's
+ *      new `/token-exchange-code` endpoint, which creates a real Better Auth
+ *      session via `internalAdapter.createSession(...)` and returns
+ *      `session.token`. Combined with the already-configured `bearer()`
+ *      plugin, mobile's `Authorization: Bearer <token>` flows through the
+ *      same code path as web's session cookie — no dual-auth logic in
+ *      `requireAuth`.
+ *
  * Run: `pnpm --filter @gruenerator/api test`
  */
 

--- a/apps/api/plugins/mobileTokenExchange.ts
+++ b/apps/api/plugins/mobileTokenExchange.ts
@@ -6,6 +6,14 @@ import { createLogger } from '../utils/logger.js';
 
 import type { BetterAuthPlugin } from 'better-auth';
 
+// Matches the signing key used by `appLogin.ts` when it mints the short-lived
+// login-code after a successful OAuth callback. The code is passed through
+// the custom scheme (`gruenerator://auth/callback?code=…`) and exchanged
+// here for a Better Auth session token.
+const LOGIN_CODE_SECRET = new TextEncoder().encode(
+  env.SESSION_SECRET ?? 'fallback-secret-please-change'
+);
+
 const log = createLogger('mobileTokenExchange');
 
 interface KeycloakPayload {
@@ -111,6 +119,74 @@ export const mobileTokenExchange = () => {
           return ctx.json({
             token: session.token,
             user: userData,
+            expiresAt: session.expiresAt,
+          });
+        }
+      ),
+
+      // POST /token-exchange-code
+      //
+      // Exchanges the short-lived login-code JWT (minted in appLogin.ts after
+      // a browser-based OAuth callback) for a Better Auth session token. The
+      // mobile client stores the returned `token` in secure storage and sends
+      // it as `Authorization: Bearer <token>` on every request — the `bearer`
+      // plugin then teaches `auth.api.getSession({ headers })` to resolve it
+      // so our shared `requireAuth` middleware works unchanged for both web
+      // cookies and mobile Bearer tokens.
+      //
+      // Replaces the legacy `/auth/mobile/consume-login-code` Express route,
+      // which minted a custom HS256 JWT that Better Auth never recognised.
+      tokenExchangeCode: createAuthEndpoint(
+        '/token-exchange-code',
+        {
+          method: 'POST',
+          requireHeaders: false,
+        },
+        async (ctx) => {
+          const { code } = ctx.body as { code?: string };
+          if (!code) {
+            log.warn('[TokenExchangeCode] Request missing code');
+            throw new Error('code is required');
+          }
+
+          let payload: { sub?: string; token_use?: string };
+          try {
+            const verified = await jwtVerify<{ sub?: string; token_use?: string }>(
+              code,
+              LOGIN_CODE_SECRET,
+              {
+                issuer: 'gruenerator-auth',
+                audience: 'gruenerator-app-login-code',
+              }
+            );
+            payload = verified.payload;
+          } catch (err) {
+            log.warn('[TokenExchangeCode] Invalid or expired login code: %s', (err as Error).message);
+            throw new Error('Login code is invalid or expired');
+          }
+
+          if (payload.token_use !== 'app_login_code' || !payload.sub) {
+            log.warn('[TokenExchangeCode] Invalid token payload: %o', payload);
+            throw new Error('Invalid token payload');
+          }
+
+          const userId = payload.sub;
+          const existing = await ctx.context.internalAdapter.findUserById(userId);
+          if (!existing) {
+            log.error('[TokenExchangeCode] User not found for login code: id=%s', userId);
+            throw new Error('User account not found');
+          }
+
+          const session = await ctx.context.internalAdapter.createSession(userId, false);
+          log.info(
+            '[TokenExchangeCode] Session issued: user_id=%s, token_prefix=%s...',
+            userId,
+            session.token?.slice(0, 8) ?? 'NONE'
+          );
+
+          return ctx.json({
+            token: session.token,
+            user: existing,
             expiresAt: session.expiresAt,
           });
         }

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -81,6 +81,11 @@ export { getGlobalApiClient, apiRequest };
 export const API_ENDPOINTS = {
   // Auth
   AUTH_LOGIN: '/auth/login',
+  // Better Auth's `mobileTokenExchange` plugin endpoint — takes the login-code
+  // JWT from the OAuth callback and returns an opaque session token the
+  // `bearer()` plugin recognises. Replaces the legacy HS256 mint at
+  // `/auth/mobile/consume-login-code`.
+  AUTH_TOKEN_EXCHANGE_CODE: '/auth/v2/token-exchange-code',
   AUTH_MOBILE_CONSUME: '/auth/mobile/consume-login-code',
   AUTH_MOBILE_REFRESH: '/auth/mobile/refresh',
   AUTH_MOBILE_STATUS: '/auth/mobile/status',

--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -28,13 +28,14 @@ export const REDIRECT_URI = makeRedirectUri({
   path: 'auth/callback',
 });
 
-interface ConsumeLoginCodeResponse {
-  success: boolean;
-  access_token: string;
-  refresh_token: string;
+// Response shape from Better Auth's `mobileTokenExchange` plugin endpoint at
+// `/api/auth/v2/token-exchange-code`. The `token` field is an opaque Better
+// Auth session token that the `bearer()` plugin teaches `getSession` to
+// accept as a drop-in for the session cookie.
+interface TokenExchangeCodeResponse {
+  token: string;
   user: User;
-  expires_in: number;
-  token_type: string;
+  expiresAt: string;
 }
 
 /**
@@ -158,16 +159,18 @@ async function exchangeCodeForTokens(
   try {
     const apiClient = getGlobalApiClient();
 
-    const response = await apiClient.post<ConsumeLoginCodeResponse>(
-      API_ENDPOINTS.AUTH_MOBILE_CONSUME,
+    // Swap our custom JWT mint (legacy /auth/mobile/consume-login-code) for
+    // a real Better Auth session, issued via the mobileTokenExchange plugin.
+    // The resulting token works with the shared `requireAuth` middleware
+    // because it IS a Better Auth session token — the bearer() plugin teaches
+    // auth.api.getSession({ headers }) to accept it.
+    const response = await apiClient.post<TokenExchangeCodeResponse>(
+      API_ENDPOINTS.AUTH_TOKEN_EXCHANGE_CODE,
       { code }
     );
 
-    if (response.data.success && response.data.access_token && response.data.user) {
-      await secureStorage.setToken(response.data.access_token);
-      if (response.data.refresh_token) {
-        await secureStorage.setRefreshToken(response.data.refresh_token);
-      }
+    if (response.data.token && response.data.user) {
+      await secureStorage.setToken(response.data.token);
       await secureStorage.setUser(JSON.stringify(response.data.user));
 
       useAuthStore.getState().setAuthState({
@@ -243,8 +246,17 @@ export async function refreshAccessToken(): Promise<string | null> {
     const refreshToken = await secureStorage.getRefreshToken();
     if (!refreshToken) return null;
 
+    // Legacy refresh-token path — only hit by installs that still have an
+    // `app_refresh_tokens` row from before the move to Better Auth sessions.
+    // Better Auth sessions auto-extend via `updateAge`, so new installs never
+    // store a refresh_token and never reach this branch.
+    interface LegacyRefreshResponse {
+      success: boolean;
+      access_token?: string;
+      user?: User;
+    }
     const apiClient = getGlobalApiClient();
-    const response = await apiClient.post<ConsumeLoginCodeResponse>(
+    const response = await apiClient.post<LegacyRefreshResponse>(
       API_ENDPOINTS.AUTH_MOBILE_REFRESH,
       { refresh_token: refreshToken }
     );


### PR DESCRIPTION
## Summary

Mobile's custom HS256 JWT was never accepted by `auth.api.getSession({ headers })`, so every endpoint guarded by `requireAuth` (docs, boards, chat-graph, notifications) 401'd for mobile clients. Symptom was `[DocsStore] Failed to fetch documents: AxiosError 401` looping on the docs tab.

Fix: issue real Better Auth session tokens via a new `/token-exchange-code` endpoint on the existing `mobileTokenExchange` plugin. With `bearer()` already configured, `getSession` resolves mobile Bearer tokens through the **same** code path as web session cookies — no dual-auth surface in `requireAuth`.

## Changes

| File | Change |
|---|---|
| `apps/api/plugins/mobileTokenExchange.ts` | New `/token-exchange-code` endpoint. Verifies login-code JWT (from `appLogin.ts`), calls `internalAdapter.createSession`, returns `{ token, user, expiresAt }`. |
| `apps/mobile/services/api.ts` | Add `AUTH_TOKEN_EXCHANGE_CODE: '/auth/v2/token-exchange-code'` constant. |
| `apps/mobile/services/auth.ts` | `exchangeCodeForTokens` posts to the new endpoint and stores the opaque Better Auth session token. Drops the `refresh_token` write (Better Auth sessions auto-extend via `updateAge`). |
| `apps/api/config/authRegressions.vitest.ts` | Documented as Incident 4. |

## Evidence from pre-fix logcat

```
17:08:06  [DocsStore] Failed to fetch documents: AxiosError: Request failed with status code 401
17:08:06  [API-401] onUnauthorized fired, attempting token refresh
17:08:06  [API-refresh] success, new token prefix=eyJhbGciOiJIUzI1
17:08:06  [API-401] refresh succeeded, retrying original request
17:08:06  [DocsStore] Failed to fetch documents: AxiosError: Request failed with status code 401   ← retry also 401s
```

The retry 401s because the refreshed token was also a custom HS256 JWT that `requireAuth` doesn't know how to validate. After this PR, the token is a Better Auth session token that `bearer()` teaches `getSession` to accept.

## Expert-confirmed architectural direction

Consulted Better Auth support on whether mobile clients can share the web `auth.api.getSession` path via `Authorization: Bearer`. Answer:

> Yes, \`plugins: [bearer()]\` makes \`auth.api.getSession({ headers })\` look at \`Authorization: Bearer <token>\` in addition to cookies, so your \`requireAuth\` can stay unified.

`bearer()` and `mobileTokenExchange()` were already in our plugins array; what was missing was the login-code exchange path that actually returns a Better Auth session token.

## Left for a follow-up

- Delete legacy `/auth/mobile/consume-login-code`, `/mobile/refresh`, `/mobile/status`, `/mobile/logout` routes once installed APKs have rotated to the new flow.
- Drop `app_refresh_tokens` table and related columns.
- Remove `tryRefreshToken` + the single-flight mutex from `apps/mobile/services/api.ts` (dead after legacy routes are gone).

## Test plan

- [ ] Build APK from this branch, install, log in, navigate to the Docs tab.
- [ ] Expect zero `[API-401]` events after login; `[DocsStore] Failed to fetch documents` should not appear.
- [ ] `adb logcat | grep TokenExchangeCode` on the API host — should see `[TokenExchangeCode] Session issued: user_id=..., token_prefix=...`
- [ ] `curl -H "Authorization: Bearer <token>" https://gruenerator.eu/api/docs` — should return 200 with the docs list.
- [ ] Web login unaffected (cookies, not Bearer — same code path).

## Risk

Medium. Touches the auth boundary but the new endpoint uses Better Auth's own `internalAdapter.createSession` (same primitive as `signInWithEmail`, `mobileTokenExchange`'s Keycloak flow). Legacy routes untouched so deployed APKs keep working.