### PR TITLE
fix(auth): route mobile session check through Better Auth get-session

### DIFF
--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -88,7 +88,6 @@ export const API_ENDPOINTS = {
   AUTH_TOKEN_EXCHANGE_CODE: '/auth/v2/token-exchange-code',
   AUTH_MOBILE_CONSUME: '/auth/mobile/consume-login-code',
   AUTH_MOBILE_REFRESH: '/auth/mobile/refresh',
-  AUTH_MOBILE_STATUS: '/auth/mobile/status',
   AUTH_MOBILE_LOGOUT: '/auth/mobile/logout',
   AUTH_PROFILE: '/auth/profile',
   AUTH_PROFILE_AVATAR: '/auth/profile/avatar',

--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -39,20 +39,6 @@ interface TokenExchangeCodeResponse {
 }
 
 /**
- * Response from auth status endpoint
- */
-interface AuthStatusResponse {
-  isAuthenticated: boolean;
-  user: User | null;
-  authMethod: string;
-  tokenInfo?: {
-    issuer: string;
-    audience: string;
-    expiresAt: number;
-  };
-}
-
-/**
  * Configure the auth store with mobile-specific API implementations
  */
 export function configureAuthStore(): void {
@@ -199,14 +185,18 @@ export async function checkAuthStatus(): Promise<boolean> {
       return false;
     }
 
-    // Verify token with backend
+    // Better Auth's native session endpoint — works with both cookies (web)
+    // and Bearer tokens (mobile, via the `bearer()` plugin). Replaces the
+    // legacy `/auth/mobile/status` route, which only validated our custom
+    // HS256 JWT and rejects the opaque Better Auth session tokens issued
+    // by `/token-exchange-code`.
     const apiClient = getGlobalApiClient();
-    const response = await apiClient.get<AuthStatusResponse>(API_ENDPOINTS.AUTH_MOBILE_STATUS);
+    const response = await apiClient.get<{ user?: User; session?: unknown } | null>(
+      '/auth/v2/get-session'
+    );
 
-    if (response.data.isAuthenticated && response.data.user) {
-      useAuthStore.getState().setAuthState({
-        user: response.data.user,
-      });
+    if (response.data && response.data.user) {
+      useAuthStore.getState().setAuthState({ user: response.data.user });
       return true;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #657. The mobile app was still probing `/auth/mobile/status` on launch, which only validates our legacy HS256 JWT. After the move to opaque Better Auth session tokens in #657, that route 401s on every restored session — the 401 interceptor then clears local auth state, producing a re-login loop on every app launch.

Swaps the call for Better Auth's native `/auth/v2/get-session`, which the `bearer()` plugin teaches to accept `Authorization: Bearer <token>` as a drop-in for the session cookie. Same code path as web.

Also drops the now-dead `AuthStatusResponse` interface and `AUTH_MOBILE_STATUS` endpoint constant.

## Test plan

- [x] Login with fresh install — no 401 loop observed after login succeeds
- [x] App relaunch with persisted token — `checkAuthStatus` returns user, session restored
- [ ] Verify docs tab no longer triggers re-login loop on cold start (user-facing regression)