### PR TITLE
refactor(mobile): retire legacy refresh-token flow

### DIFF
--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -5,47 +5,10 @@ import {
   apiRequest,
 } from '@gruenerator/shared/api';
 import { useAuthStore } from '@gruenerator/shared/stores';
-import axios from 'axios';
 
 import { secureStorage } from './storage';
 
-import type { User } from '@gruenerator/shared';
-
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://gruenerator.eu/api';
-
-let isRefreshing = false;
-
-async function tryRefreshToken(): Promise<boolean> {
-  if (isRefreshing) return false;
-  isRefreshing = true;
-  try {
-    const refreshToken = await secureStorage.getRefreshToken();
-    if (!refreshToken) return false;
-
-    interface RefreshResponse {
-      success: boolean;
-      access_token?: string;
-      user?: User;
-    }
-    const response = await axios.post<RefreshResponse>(`${API_BASE_URL}/auth/mobile/refresh`, {
-      refresh_token: refreshToken,
-    });
-
-    if (response.data.success && response.data.access_token) {
-      await secureStorage.setToken(response.data.access_token);
-      if (response.data.user) {
-        await secureStorage.setUser(JSON.stringify(response.data.user));
-        useAuthStore.getState().setAuthState({ user: response.data.user });
-      }
-      return true;
-    }
-    return false;
-  } catch {
-    return false;
-  } finally {
-    isRefreshing = false;
-  }
-}
 
 export function initializeApiClient(): void {
   const client = createApiClient({
@@ -54,14 +17,14 @@ export function initializeApiClient(): void {
     getAuthToken: async () => {
       return secureStorage.getToken();
     },
+    // Better Auth sessions auto-extend on each request via `updateAge`.
+    // A 401 means the session is actually gone (rotated, revoked, or
+    // expired past the rolling window), so there's nothing to refresh —
+    // wipe local state and let the UI route back to login.
     onUnauthorized: async (): Promise<boolean> => {
-      const refreshed = await tryRefreshToken();
-      if (!refreshed) {
-        await secureStorage.clearAll();
-        useAuthStore.getState().clearAuth();
-        return false;
-      }
-      return true;
+      await secureStorage.clearAll();
+      useAuthStore.getState().clearAuth();
+      return false;
     },
     timeout: 120000,
   });
@@ -86,8 +49,6 @@ export const API_ENDPOINTS = {
   // `bearer()` plugin recognises. Replaces the legacy HS256 mint at
   // `/auth/mobile/consume-login-code`.
   AUTH_TOKEN_EXCHANGE_CODE: '/auth/v2/token-exchange-code',
-  AUTH_MOBILE_CONSUME: '/auth/mobile/consume-login-code',
-  AUTH_MOBILE_REFRESH: '/auth/mobile/refresh',
   AUTH_MOBILE_STATUS: '/auth/mobile/status',
   AUTH_MOBILE_LOGOUT: '/auth/mobile/logout',
   AUTH_PROFILE: '/auth/profile',

--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -241,41 +241,6 @@ export async function logout(): Promise<void> {
   }
 }
 
-export async function refreshAccessToken(): Promise<string | null> {
-  try {
-    const refreshToken = await secureStorage.getRefreshToken();
-    if (!refreshToken) return null;
-
-    // Legacy refresh-token path — only hit by installs that still have an
-    // `app_refresh_tokens` row from before the move to Better Auth sessions.
-    // Better Auth sessions auto-extend via `updateAge`, so new installs never
-    // store a refresh_token and never reach this branch.
-    interface LegacyRefreshResponse {
-      success: boolean;
-      access_token?: string;
-      user?: User;
-    }
-    const apiClient = getGlobalApiClient();
-    const response = await apiClient.post<LegacyRefreshResponse>(
-      API_ENDPOINTS.AUTH_MOBILE_REFRESH,
-      { refresh_token: refreshToken }
-    );
-
-    if (response.data.success && response.data.access_token) {
-      await secureStorage.setToken(response.data.access_token);
-      if (response.data.user) {
-        await secureStorage.setUser(JSON.stringify(response.data.user));
-        useAuthStore.getState().setAuthState({ user: response.data.user });
-      }
-      return response.data.access_token;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
-}
-
 export async function getStoredToken(): Promise<string | null> {
   return secureStorage.getToken();
 }

--- a/apps/mobile/services/chatConfig.ts
+++ b/apps/mobile/services/chatConfig.ts
@@ -1,6 +1,5 @@
 import { useChatConfigStore, createChatApiClient, type ChatApiClient } from '@gruenerator/chat';
 
-import { refreshAccessToken } from './auth';
 import { secureStorage } from './storage';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://gruenerator.eu';
@@ -9,35 +8,19 @@ let cachedApiClient: ChatApiClient | null = null;
 
 async function mobileFetch(url: string, options?: RequestInit): Promise<Response> {
   const token = await secureStorage.getToken();
-
   const absoluteUrl = url.startsWith('http') ? url : `${API_BASE_URL}${url}`;
 
-  const response = await fetch(absoluteUrl, {
+  return fetch(absoluteUrl, {
     ...options,
     headers: {
       ...options?.headers,
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
   });
-
-  if (response.status === 401 && token) {
-    const newToken = await refreshAccessToken();
-    if (newToken) {
-      return fetch(absoluteUrl, {
-        ...options,
-        headers: {
-          ...options?.headers,
-          Authorization: `Bearer ${newToken}`,
-        },
-      });
-    }
-  }
-
-  return response;
 }
 
 function mobileOnUnauthorized(): void {
-  console.warn('[ChatConfig] Unauthorized — token refresh will be attempted on next request');
+  console.warn('[ChatConfig] Unauthorized — session gone, user will be routed to login');
 }
 
 export function configureMobileChat(): void {


### PR DESCRIPTION
## Summary

Follow-up to #657 and #658. Deletes the mobile refresh-token client infrastructure which became dead code after Better Auth session tokens replaced our custom HS256 JWTs.

Better Auth sessions auto-extend on each request via \`updateAge\`, so new installs never have a \`refresh_token\` to renew. The \`tryRefreshToken\` / \`refreshAccessToken\` pair still ran on every 401 but always read \`null\` from storage and returned false — a no-op round-trip. Net 91 lines removed.

### Removed

- \`tryRefreshToken\` + \`isRefreshing\` mutex (apps/mobile/services/api.ts)
- \`refreshAccessToken\` + \`LegacyRefreshResponse\` (apps/mobile/services/auth.ts)
- 401 re-fetch branch + orphan import (apps/mobile/services/chatConfig.ts)
- \`AUTH_MOBILE_CONSUME\` + \`AUTH_MOBILE_REFRESH\` endpoint constants

### Kept (intentional)

- \`secureStorage.getRefreshToken\` — still read by push-notification registration (broken for new installs; see follow-up)
- Server routes \`/auth/mobile/consume-login-code\` + \`/auth/mobile/refresh\` — still serve pre-#657 installs during the rollout window
- \`onUnauthorized\` handler — simplified to clearAuth-only, no retry

### Known follow-ups (not in this PR)

- Push notifications (\`registerPushToken\`) keys devices by refresh_token hash and silently bails on new installs — requires DB schema change to decouple
- Legacy server routes can be retired once pre-#657 installs rotate out

## Test plan

- [x] \`tsc --noEmit\` clean for apps/mobile
- [ ] Fresh install: login succeeds, app restart restores session without extra round-trip
- [ ] Chat tab: no 401 retry loops; on real expiry, user is routed to login cleanly