### PR TITLE
fix(push): decouple device registration from refresh tokens

### DIFF
--- a/apps/api/database/postgres/migrations/create_app_push_devices.sql
+++ b/apps/api/database/postgres/migrations/create_app_push_devices.sql
@@ -1,0 +1,38 @@
+-- app_push_devices: decouples Expo push registration from auth tokens.
+--
+-- Before this migration, the push_token column lived on app_refresh_tokens,
+-- so a device's push identity was tied to its custom HS256 refresh token.
+-- After the move to Better Auth sessions (PR #657), new installs no longer
+-- have a refresh_token row, and registerPushToken() silently bailed. This
+-- table owns device registration independently of session identity.
+
+CREATE TABLE IF NOT EXISTS app_push_devices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  expo_push_token TEXT NOT NULL,
+  device_name TEXT,
+  device_type TEXT NOT NULL DEFAULT 'unknown',
+  last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT app_push_devices_user_token_unique UNIQUE (user_id, expo_push_token)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_push_devices_user ON app_push_devices (user_id);
+
+-- Backfill from legacy app_refresh_tokens.push_token so pre-#657 devices
+-- keep receiving notifications through the new service layer. Skip rows
+-- whose refresh token is revoked or expired — those sessions are already
+-- dead, and pushing to their devices would just fail at Expo.
+INSERT INTO app_push_devices (user_id, expo_push_token, device_name, device_type, last_seen_at, created_at)
+SELECT
+  user_id,
+  push_token,
+  device_name,
+  device_type,
+  COALESCE(last_used_at, push_token_updated_at, issued_at),
+  COALESCE(push_token_updated_at, issued_at)
+FROM app_refresh_tokens
+WHERE push_token IS NOT NULL
+  AND revoked_at IS NULL
+  AND expires_at > now()
+ON CONFLICT (user_id, expo_push_token) DO NOTHING;

--- a/apps/api/database/schema/system.ts
+++ b/apps/api/database/schema/system.ts
@@ -1,4 +1,14 @@
-import { bigint, boolean, pgTable, serial, text, timestamp, uuid, index } from 'drizzle-orm/pg-core';
+import {
+  bigint,
+  boolean,
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  unique,
+  uuid,
+  index,
+} from 'drizzle-orm/pg-core';
 
 export const wolkeSyncStatus = pgTable(
   'wolke_sync_status',
@@ -55,5 +65,22 @@ export const appRefreshTokens = pgTable(
     index('idx_app_refresh_tokens_user').on(t.userId),
     index('idx_app_refresh_tokens_hash').on(t.tokenHash),
     index('idx_app_refresh_tokens_expires').on(t.expiresAt),
+  ]
+);
+
+export const appPushDevices = pgTable(
+  'app_push_devices',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id').notNull(),
+    expoPushToken: text('expo_push_token').notNull(),
+    deviceName: text('device_name'),
+    deviceType: text('device_type').notNull().default('unknown'),
+    lastSeenAt: timestamp('last_seen_at', { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    unique('app_push_devices_user_token_unique').on(t.userId, t.expoPushToken),
+    index('idx_app_push_devices_user').on(t.userId),
   ]
 );

--- a/apps/api/routes/auth/mobileAuth.ts
+++ b/apps/api/routes/auth/mobileAuth.ts
@@ -13,10 +13,12 @@
 
 import { createHash, randomBytes } from 'crypto';
 
+import { fromNodeHeaders } from 'better-auth/node';
 import express, { type Response, type NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import { SignJWT, jwtVerify } from 'jose';
 
+import { auth } from '../../config/betterAuth.js';
 import { createLogger } from '../../utils/logger.js';
 import { storeBridgeCode, consumeBridgeCode } from '../../utils/redis/BridgeCodeStore.js';
 
@@ -606,55 +608,70 @@ router.delete('/mobile/sessions', async (req: AuthRequest, res: Response): Promi
 });
 
 /**
+ * Resolve the caller's userId from either a Better Auth session (new
+ * bearer tokens issued by `/token-exchange-code`) or a legacy HS256
+ * access JWT (pre-#657 installs still in rotation).
+ *
+ * Returns null if neither shape authenticates successfully.
+ */
+async function resolveUserId(req: AuthRequest): Promise<string | null> {
+  try {
+    const session = await auth.api.getSession({ headers: fromNodeHeaders(req.headers) });
+    if (session?.user?.id) return session.user.id;
+  } catch (err) {
+    log.debug('[MobileAuth] Better Auth session check failed', {
+      reason: (err as Error).message,
+    });
+  }
+
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith('Bearer ')) {
+    try {
+      const { payload } = await jwtVerify(authHeader.substring(7), JWT_SECRET, {
+        issuer: 'gruenerator-api',
+        audience: 'gruenerator-app',
+      });
+      if (payload.sub) return payload.sub as string;
+    } catch {
+      // fall through — 401
+    }
+  }
+
+  return null;
+}
+
+/**
  * POST /auth/mobile/register-push-token
  *
- * Register an Expo push token for the current device.
- * Requires both the Bearer access token and the refresh token to identify the device row.
+ * Upsert the caller's Expo push token into `app_push_devices`, keyed by
+ * (user_id, expo_push_token). Accepts either a Better Auth session or a
+ * legacy HS256 JWT so both rollout cohorts can register.
  */
 router.post(
   '/mobile/register-push-token',
   async (req: AuthRequest, res: Response): Promise<void> => {
     try {
-      const authHeader = req.headers.authorization;
-
-      if (!authHeader || !authHeader.startsWith('Bearer ')) {
-        res.status(401).json({ success: false, error: 'missing_token' });
+      const userId = await resolveUserId(req);
+      if (!userId) {
+        res.status(401).json({ success: false, error: 'unauthorized' });
         return;
       }
 
-      const token = authHeader.substring(7);
-      let payload;
-      try {
-        const result = await jwtVerify(token, JWT_SECRET, {
-          issuer: 'gruenerator-api',
-          audience: 'gruenerator-app',
-        });
-        payload = result.payload;
-      } catch {
-        res.status(401).json({ success: false, error: 'invalid_token' });
-        return;
-      }
+      const { expoPushToken, deviceName, deviceType } = (req.body as {
+        expoPushToken?: string;
+        deviceName?: string;
+        deviceType?: string;
+      }) ?? {};
 
-      if (!payload.sub) {
-        res.status(401).json({ success: false, error: 'invalid_token' });
-        return;
-      }
-
-      const { expoPushToken, refresh_token } = req.body as {
-        expoPushToken: string;
-        refresh_token: string;
-      };
-
-      if (!expoPushToken || !refresh_token) {
+      if (!expoPushToken) {
         res.status(400).json({
           success: false,
           error: 'missing_params',
-          message: 'expoPushToken and refresh_token are required',
+          message: 'expoPushToken is required',
         });
         return;
       }
 
-      // Validate Expo push token format
       if (
         !expoPushToken.startsWith('ExponentPushToken[') &&
         !expoPushToken.startsWith('ExpoPushToken[')
@@ -667,11 +684,25 @@ router.post(
         return;
       }
 
-      const userId = payload.sub as string;
-      const refreshTokenHash = hashToken(refresh_token);
+      const userAgent = req.headers['user-agent'] ?? '';
+      const uaLower = userAgent.toLowerCase();
+      const resolvedDeviceType =
+        deviceType ??
+        (uaLower.includes('android')
+          ? 'android'
+          : uaLower.includes('iphone')
+            ? 'ios'
+            : uaLower.includes('tauri')
+              ? 'desktop'
+              : 'unknown');
+
+      const resolvedDeviceName = deviceName ?? (userAgent ? userAgent.substring(0, 255) : null);
 
       const { registerPushToken } = await import('../../services/pushNotificationService.js');
-      await registerPushToken(userId, refreshTokenHash, expoPushToken);
+      await registerPushToken(userId, expoPushToken, {
+        ...(resolvedDeviceName ? { deviceName: resolvedDeviceName } : {}),
+        deviceType: resolvedDeviceType,
+      });
 
       log.info('[MobileAuth] Push token registered', { userId });
       res.json({ success: true });
@@ -685,37 +716,18 @@ router.post(
 /**
  * GET /auth/mobile/devices
  *
- * Get all active devices for the authenticated user.
+ * List the caller's push-capable devices.
  */
 router.get('/mobile/devices', async (req: AuthRequest, res: Response): Promise<void> => {
   try {
-    const authHeader = req.headers.authorization;
-
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      res.status(401).json({ success: false, error: 'missing_token' });
-      return;
-    }
-
-    const token = authHeader.substring(7);
-    let payload;
-    try {
-      const result = await jwtVerify(token, JWT_SECRET, {
-        issuer: 'gruenerator-api',
-        audience: 'gruenerator-app',
-      });
-      payload = result.payload;
-    } catch {
-      res.status(401).json({ success: false, error: 'invalid_token' });
-      return;
-    }
-
-    if (!payload.sub) {
-      res.status(401).json({ success: false, error: 'invalid_token' });
+    const userId = await resolveUserId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'unauthorized' });
       return;
     }
 
     const { getUserDevices } = await import('../../services/pushNotificationService.js');
-    const devices = await getUserDevices(payload.sub as string);
+    const devices = await getUserDevices(userId);
 
     res.json({ success: true, devices });
   } catch (error) {

--- a/apps/api/services/pushNotificationService.ts
+++ b/apps/api/services/pushNotificationService.ts
@@ -1,11 +1,15 @@
 /**
  * Push Notification Service
- * Sends Expo Push Notifications to mobile devices registered via app_refresh_tokens.
+ *
+ * Sends Expo Push Notifications to devices registered in app_push_devices.
+ * Device identity is keyed by (user_id, expo_push_token) — decoupled from
+ * auth tokens so that logout, session rotation, or the Better Auth
+ * migration don't silently un-register a device.
  */
 
-import { eq, and, isNotNull, isNull, gt, sql } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
 
-import { appRefreshTokens } from '../database/schema/index.js';
+import { appPushDevices } from '../database/schema/index.js';
 import { getDrizzleInstance } from '../database/services/DrizzleService.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -19,11 +23,6 @@ export interface PushPayload {
   data?: Record<string, unknown>;
 }
 
-type DeviceRow = Pick<
-  typeof appRefreshTokens.$inferSelect,
-  'id' | 'deviceName' | 'deviceType' | 'pushToken' | 'lastUsedAt'
->;
-
 interface ExpoPushResponse {
   data: Array<{
     id?: string;
@@ -33,67 +32,70 @@ interface ExpoPushResponse {
   }>;
 }
 
+export interface DeviceRegistrationInfo {
+  deviceName?: string;
+  deviceType?: string;
+}
+
 /**
- * Register or update an Expo push token for a device (identified by refresh token hash).
+ * Upsert an Expo push device for a user.
+ *
+ * The (user_id, expo_push_token) UNIQUE constraint means a repeat
+ * registration from the same device just refreshes `last_seen_at` and
+ * any device metadata instead of inserting a duplicate row.
  */
 export async function registerPushToken(
   userId: string,
-  refreshTokenHash: string,
-  expoPushToken: string
+  expoPushToken: string,
+  info: DeviceRegistrationInfo = {}
 ): Promise<void> {
   const db = getDrizzleInstance();
+  const now = new Date();
 
-  const result = await db
-    .update(appRefreshTokens)
-    .set({ pushToken: expoPushToken, pushTokenUpdatedAt: new Date() })
-    .where(
-      and(
-        eq(appRefreshTokens.tokenHash, refreshTokenHash),
-        eq(appRefreshTokens.userId, userId),
-        isNull(appRefreshTokens.revokedAt)
-      )
-    )
-    .returning({ id: appRefreshTokens.id });
-
-  if (result.length === 0) {
-    log.warn('[Push] No matching active refresh token found for push registration', { userId });
-    return;
-  }
-
-  log.info('[Push] Push token registered', { userId, deviceId: result[0].id });
-}
-
-/**
- * Get all devices with active push tokens for a user.
- */
-export async function getUserDevicesWithPush(userId: string): Promise<DeviceRow[]> {
-  const db = getDrizzleInstance();
-
-  const result = await db
-    .select({
-      id: appRefreshTokens.id,
-      deviceName: appRefreshTokens.deviceName,
-      deviceType: appRefreshTokens.deviceType,
-      pushToken: appRefreshTokens.pushToken,
-      lastUsedAt: appRefreshTokens.lastUsedAt,
+  await db
+    .insert(appPushDevices)
+    .values({
+      userId,
+      expoPushToken,
+      deviceName: info.deviceName ?? null,
+      deviceType: info.deviceType ?? 'unknown',
+      lastSeenAt: now,
     })
-    .from(appRefreshTokens)
-    .where(
-      and(
-        eq(appRefreshTokens.userId, userId),
-        isNotNull(appRefreshTokens.pushToken),
-        isNull(appRefreshTokens.revokedAt),
-        gt(appRefreshTokens.expiresAt, new Date())
-      )
-    )
-    .orderBy(appRefreshTokens.lastUsedAt);
+    .onConflictDoUpdate({
+      target: [appPushDevices.userId, appPushDevices.expoPushToken],
+      set: {
+        deviceName: info.deviceName ?? null,
+        deviceType: info.deviceType ?? 'unknown',
+        lastSeenAt: now,
+      },
+    });
 
-  return result;
+  log.info('[Push] Push device registered', { userId });
 }
 
-/**
- * Get all devices (with or without push tokens) for a user.
- */
+interface PushDeviceRow {
+  id: string;
+  deviceName: string | null;
+  deviceType: string;
+  expoPushToken: string;
+  lastSeenAt: Date;
+}
+
+async function getUserPushDevices(userId: string): Promise<PushDeviceRow[]> {
+  const db = getDrizzleInstance();
+  return db
+    .select({
+      id: appPushDevices.id,
+      deviceName: appPushDevices.deviceName,
+      deviceType: appPushDevices.deviceType,
+      expoPushToken: appPushDevices.expoPushToken,
+      lastSeenAt: appPushDevices.lastSeenAt,
+    })
+    .from(appPushDevices)
+    .where(eq(appPushDevices.userId, userId))
+    .orderBy(appPushDevices.lastSeenAt);
+}
+
 interface DeviceInfo {
   id: string;
   device_name: string | null;
@@ -102,33 +104,20 @@ interface DeviceInfo {
   last_used_at: string | null;
 }
 
+/**
+ * Device listing for `/auth/mobile/devices`. Every row in
+ * `app_push_devices` has a push token by definition, so `has_push_token`
+ * is always true — the field is kept in the response shape for
+ * backwards compatibility with existing mobile UIs.
+ */
 export async function getUserDevices(userId: string): Promise<DeviceInfo[]> {
-  const db = getDrizzleInstance();
-
-  const result = await db
-    .select({
-      id: appRefreshTokens.id,
-      device_name: appRefreshTokens.deviceName,
-      device_type: appRefreshTokens.deviceType,
-      has_push_token: sql<boolean>`(${appRefreshTokens.pushToken} IS NOT NULL)`,
-      last_used_at: appRefreshTokens.lastUsedAt,
-    })
-    .from(appRefreshTokens)
-    .where(
-      and(
-        eq(appRefreshTokens.userId, userId),
-        isNull(appRefreshTokens.revokedAt),
-        gt(appRefreshTokens.expiresAt, new Date())
-      )
-    )
-    .orderBy(appRefreshTokens.lastUsedAt);
-
-  return result.map((row) => ({
-    id: row.id,
-    device_name: row.device_name,
-    device_type: row.device_type,
-    has_push_token: row.has_push_token,
-    last_used_at: row.last_used_at ? row.last_used_at.toISOString() : null,
+  const devices = await getUserPushDevices(userId);
+  return devices.map((d) => ({
+    id: d.id,
+    device_name: d.deviceName,
+    device_type: d.deviceType,
+    has_push_token: true,
+    last_used_at: d.lastSeenAt.toISOString(),
   }));
 }
 
@@ -137,15 +126,15 @@ export async function getUserDevices(userId: string): Promise<DeviceInfo[]> {
  * Returns the number of devices the notification was sent to.
  */
 export async function sendPushToUser(userId: string, payload: PushPayload): Promise<number> {
-  const devices = await getUserDevicesWithPush(userId);
+  const devices = await getUserPushDevices(userId);
 
   if (devices.length === 0) {
-    log.info('[Push] No devices with push tokens for user', { userId });
+    log.info('[Push] No devices registered for user', { userId });
     return 0;
   }
 
   const messages = devices.map((device) => ({
-    to: device.pushToken,
+    to: device.expoPushToken,
     title: payload.title,
     body: payload.body,
     data: payload.data || {},
@@ -173,17 +162,17 @@ export async function sendPushToUser(userId: string, payload: PushPayload): Prom
 
     const result = (await response.json()) as ExpoPushResponse;
 
-    // Handle per-token errors (e.g. DeviceNotRegistered)
     let sentCount = 0;
     for (let i = 0; i < result.data.length; i++) {
       const ticket = result.data[i];
       if (ticket.status === 'ok') {
         sentCount++;
+        await touchLastSeen(devices[i].id);
       } else if (ticket.details?.error === 'DeviceNotRegistered') {
-        log.info('[Push] Device no longer registered, clearing push token', {
+        log.info('[Push] Device no longer registered, deleting row', {
           deviceId: devices[i].id,
         });
-        await clearPushToken(devices[i].id);
+        await deleteDevice(devices[i].id);
       } else {
         log.warn('[Push] Failed to send to device', {
           deviceId: devices[i].id,
@@ -201,10 +190,31 @@ export async function sendPushToUser(userId: string, payload: PushPayload): Prom
   }
 }
 
-async function clearPushToken(deviceId: string): Promise<void> {
+async function touchLastSeen(deviceId: string): Promise<void> {
   const db = getDrizzleInstance();
   await db
-    .update(appRefreshTokens)
-    .set({ pushToken: null, pushTokenUpdatedAt: new Date() })
-    .where(eq(appRefreshTokens.id, deviceId));
+    .update(appPushDevices)
+    .set({ lastSeenAt: sql`now()` })
+    .where(eq(appPushDevices.id, deviceId));
+}
+
+async function deleteDevice(deviceId: string): Promise<void> {
+  const db = getDrizzleInstance();
+  await db.delete(appPushDevices).where(eq(appPushDevices.id, deviceId));
+}
+
+/**
+ * Remove a user's registration for a single Expo token (e.g. explicit
+ * unregister on logout). No-op if the row is already gone.
+ */
+export async function unregisterPushToken(
+  userId: string,
+  expoPushToken: string
+): Promise<void> {
+  const db = getDrizzleInstance();
+  await db
+    .delete(appPushDevices)
+    .where(
+      and(eq(appPushDevices.userId, userId), eq(appPushDevices.expoPushToken, expoPushToken))
+    );
 }

--- a/apps/mobile/services/pushNotifications.ts
+++ b/apps/mobile/services/pushNotifications.ts
@@ -8,9 +8,7 @@ import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 
 import { getGlobalApiClient } from './api';
-import { secureStorage } from './storage';
 
-// Configure how notifications appear when the app is in the foreground
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
     shouldShowAlert: true,
@@ -22,13 +20,13 @@ Notifications.setNotificationHandler({
 });
 
 /**
- * Request notification permissions, get an Expo push token,
- * and register it with the backend.
- * Returns the token string or null if registration failed.
+ * Request notification permissions, get an Expo push token, and
+ * register it with the backend. The backend upserts into
+ * `app_push_devices` keyed by (user_id, expo_push_token); the caller is
+ * identified via the apiClient's Bearer interceptor.
  */
 export async function registerForPushNotifications(): Promise<string | null> {
   try {
-    // Android needs a notification channel
     if (Platform.OS === 'android') {
       await Notifications.setNotificationChannelAsync('default', {
         name: 'Standard',
@@ -63,17 +61,13 @@ export async function registerForPushNotifications(): Promise<string | null> {
 
     console.log('[Push] Expo push token:', expoPushToken);
 
-    // Send to backend along with the refresh token to identify the device row
-    const refreshToken = await secureStorage.getRefreshToken();
-    if (!refreshToken) {
-      console.warn('[Push] No refresh token available — skipping push registration');
-      return expoPushToken;
-    }
+    const deviceType =
+      Platform.OS === 'android' ? 'android' : Platform.OS === 'ios' ? 'ios' : 'unknown';
 
     const apiClient = getGlobalApiClient();
     await apiClient.post('/auth/mobile/register-push-token', {
       expoPushToken,
-      refresh_token: refreshToken,
+      deviceType,
     });
 
     console.log('[Push] Token registered with backend');


### PR DESCRIPTION
## Summary

Push notifications have been broken for every install post-#657. This PR fixes the root cause — device registration was entangled with auth token identity.

**Root cause.** The old pipeline keyed devices by \`app_refresh_tokens.token_hash\`. Better Auth installs don't have a refresh token in storage, so:
- Client: \`pushNotifications.ts\` bailed out at \`if (!refreshToken)\` and never registered
- Server: \`registerPushToken(userId, refreshTokenHash, ...)\` couldn't match a row to upsert

**Fix.** Split device identity out of the auth tokens table into a new \`app_push_devices\` table keyed by \`(user_id, expo_push_token)\`. Device rows own their own lifecycle; session rotation / logout / migration cannot silently un-register a device.

## Changes

### New table (migration)
\`create_app_push_devices.sql\` — backfills from \`app_refresh_tokens.push_token\` where the row is still active, so pre-#657 devices keep receiving notifications without re-registering.

### Service layer (\`pushNotificationService.ts\`)
- \`registerPushToken(userId, expoPushToken, info?)\` — upsert via ON CONFLICT (user_id, expo_push_token)
- \`sendPushToUser\` / \`getUserDevices\` query new table; DeviceNotRegistered tickets delete the row instead of clearing a column
- New \`unregisterPushToken\` exposed for future logout hygiene

### Route (\`/auth/mobile/register-push-token\`)
- \`resolveUserId()\` helper accepts both Better Auth sessions and legacy HS256 JWTs (both rollout cohorts can register)
- Body drops \`refresh_token\`; accepts optional \`deviceName\` / \`deviceType\`; falls back to User-Agent parsing

### Client (\`apps/mobile/services/pushNotifications.ts\`)
- Drops the \`secureStorage.getRefreshToken()\` coupling
- Auth flows through apiClient's Bearer interceptor

## Rollout

1. Merge this PR → migration runs on API startup → new table created + backfilled
2. Ship new mobile build → new installs register cleanly
3. Old installs keep working via the legacy JWT path in \`resolveUserId\`; their existing push tokens continue to fire from the backfilled rows

No breaking changes for old clients. The legacy \`app_refresh_tokens.push_token\` column is now write-dormant — a follow-up PR can drop it once telemetry confirms old installs have rotated out.

## Test plan

- [x] \`tsc --noEmit\` clean for apps/api + apps/mobile
- [x] \`pnpm --filter @gruenerator/api test\` — 802 passed, 0 broken
- [ ] Manual: fresh install → grant notifications → verify \`app_push_devices\` row appears
- [ ] Manual: \`curl\` \`sendPushToUser\` via a briefing trigger → verify the phone receives the notification