### PR TITLE
feat(mobile): open shared group content + fix Hocuspocus bearer auth

### DIFF
--- a/apps/mobile/app/(focused)/gruppen/[id]/index.tsx
+++ b/apps/mobile/app/(focused)/gruppen/[id]/index.tsx
@@ -19,6 +19,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { GroupAvatar } from '../../../../components/workplace/GroupAvatar';
+import { GroupContentSection } from '../../../../components/workplace/GroupContentSection';
 import {
   useDeleteGroup,
   useDeleteGroupAvatar,
@@ -353,6 +354,8 @@ export default function GroupDetailScreen() {
             <Text style={styles.primaryButtonText}>Einladungslink teilen</Text>
           </Pressable>
         ) : null}
+
+        {id ? <GroupContentSection groupId={id} /> : null}
 
         <Section title="Mitglieder" theme={theme}>
           <Pressable

--- a/apps/mobile/app/(fullscreen)/web-viewer.tsx
+++ b/apps/mobile/app/(fullscreen)/web-viewer.tsx
@@ -1,0 +1,127 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, ActivityIndicator, useColorScheme } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { WebView } from 'react-native-webview';
+
+import { secureStorage } from '../../services/storage';
+import { colors, lightTheme, darkTheme } from '../../theme';
+
+const WEB_BASE = 'https://gruenerator.eu';
+
+export default function WebViewerScreen() {
+  const { path, title } = useLocalSearchParams<{ path?: string; title?: string }>();
+  const router = useRouter();
+  const colorScheme = useColorScheme();
+  const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const insets = useSafeAreaInsets();
+  const webViewRef = useRef<WebView>(null);
+  const [loading, setLoading] = useState(true);
+  const [authToken, setAuthToken] = useState<string | null>(null);
+  const [tokenReady, setTokenReady] = useState(false);
+
+  useMemo(() => {
+    void secureStorage.getToken().then((t) => {
+      setAuthToken(t);
+      setTokenReady(true);
+    });
+  }, []);
+
+  const handleClose = useCallback(() => {
+    router.back();
+  }, [router]);
+
+  const normalizedPath = useMemo(() => {
+    if (!path) return '/';
+    const decoded = decodeURIComponent(path);
+    if (decoded.startsWith('//') || !decoded.startsWith('/')) return '/';
+    return decoded;
+  }, [path]);
+
+  if (!path) {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.background }]}>
+        <Text style={{ color: theme.text }}>Kein Pfad angegeben.</Text>
+      </View>
+    );
+  }
+
+  const targetUrl = `${WEB_BASE}/api/auth/v2/web-handoff?redirect=${encodeURIComponent(normalizedPath)}`;
+  const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
+      <View
+        style={[styles.header, { paddingTop: insets.top + 8, borderBottomColor: theme.border }]}
+      >
+        <Pressable onPress={handleClose} hitSlop={12} style={styles.closeButton}>
+          <Ionicons name="close" size={24} color={theme.text} />
+        </Pressable>
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={1}>
+          {title || 'Web'}
+        </Text>
+        <View style={styles.closeButton} />
+      </View>
+
+      {!tokenReady ? (
+        <View style={styles.loading}>
+          <ActivityIndicator color={colors.primary[600]} />
+        </View>
+      ) : (
+        <>
+          <WebView
+            ref={webViewRef}
+            source={{ uri: targetUrl, ...(headers ? { headers } : {}) }}
+            sharedCookiesEnabled
+            thirdPartyCookiesEnabled
+            onLoadStart={() => setLoading(true)}
+            onLoadEnd={() => setLoading(false)}
+            style={styles.webview}
+            allowsBackForwardNavigationGestures
+            domStorageEnabled
+            javaScriptEnabled
+          />
+          {loading && (
+            <View style={styles.loadingOverlay} pointerEvents="none">
+              <ActivityIndicator color={colors.primary[600]} />
+            </View>
+          )}
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  closeButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: { fontSize: 16, fontWeight: '600' },
+  webview: { flex: 1 },
+  loading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  loadingOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255,255,255,0.01)',
+  },
+});

--- a/apps/mobile/components/workplace/GroupContentSection.tsx
+++ b/apps/mobile/components/workplace/GroupContentSection.tsx
@@ -1,0 +1,263 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { memo, useCallback } from 'react';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator, useColorScheme } from 'react-native';
+
+import { useGroupContent, type GroupContentItem } from '../../hooks/useGroupContent';
+import {
+  colors,
+  spacing,
+  typography,
+  borderRadius,
+  lightTheme,
+  darkTheme,
+  type Theme,
+} from '../../theme';
+
+interface GroupContentSectionProps {
+  groupId: string;
+}
+
+interface SectionConfig {
+  key: keyof Pick<
+    ReturnType<typeof useGroupContent>['data'] & object,
+    'docs' | 'boards' | 'generators' | 'notebooks' | 'texts' | 'templates' | 'documents'
+  >;
+  label: string;
+  icon: keyof typeof Ionicons.glyphMap;
+}
+
+const SECTIONS: SectionConfig[] = [
+  { key: 'docs', label: 'Dokumente', icon: 'document-text-outline' },
+  { key: 'boards', label: 'Boards', icon: 'grid-outline' },
+  { key: 'generators', label: 'Grüneratoren', icon: 'sparkles-outline' },
+  { key: 'notebooks', label: 'Notizbücher', icon: 'book-outline' },
+  { key: 'texts', label: 'Texte', icon: 'reader-outline' },
+  { key: 'templates', label: 'Vorlagen', icon: 'albums-outline' },
+  { key: 'documents', label: 'Dateien', icon: 'folder-outline' },
+];
+
+export const GroupContentSection = memo(function GroupContentSection({
+  groupId,
+}: GroupContentSectionProps) {
+  const colorScheme = useColorScheme();
+  const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const router = useRouter();
+  const { data, isPending, isError, refetch } = useGroupContent(groupId);
+
+  const openItem = useCallback(
+    (item: GroupContentItem) => {
+      switch (item.kind) {
+        case 'doc':
+          router.push({ pathname: '/(fullscreen)/doc-editor', params: { id: item.id } });
+          return;
+        case 'board':
+          router.push({ pathname: '/(fullscreen)/board-viewer', params: { id: item.id } });
+          return;
+        case 'generator': {
+          const slugOrId = item.slug ?? item.id;
+          router.push({
+            pathname: '/(fullscreen)/web-viewer',
+            params: {
+              path: `/gruenerator/${slugOrId}`,
+              title: item.title,
+            },
+          });
+          return;
+        }
+        case 'notebook':
+          router.push({
+            pathname: '/(fullscreen)/web-viewer',
+            params: { path: `/notebook/${item.id}`, title: item.title },
+          });
+          return;
+        case 'text':
+          router.push({
+            pathname: '/(fullscreen)/web-viewer',
+            params: { path: `/texte/${item.id}`, title: item.title },
+          });
+          return;
+        case 'template':
+          router.push({
+            pathname: '/(fullscreen)/web-viewer',
+            params: {
+              path: `/datenbank/vorlagen?selected=${item.id}`,
+              title: item.title,
+            },
+          });
+          return;
+        case 'document':
+          router.push({
+            pathname: '/(fullscreen)/web-viewer',
+            params: { path: `/documents/${item.id}`, title: item.title },
+          });
+          return;
+      }
+    },
+    [router]
+  );
+
+  if (isPending) {
+    return (
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Inhalte</Text>
+        <View style={styles.loadingRow}>
+          <ActivityIndicator color={colors.primary[600]} />
+          <Text style={[styles.loadingText, { color: theme.textSecondary }]}>
+            Geteilte Inhalte werden geladen…
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Inhalte</Text>
+        <Pressable onPress={() => void refetch()} style={styles.errorRow}>
+          <Ionicons name="alert-circle-outline" size={18} color={colors.semantic.error} />
+          <Text style={[styles.errorText, { color: colors.semantic.error }]}>
+            Inhalte konnten nicht geladen werden. Erneut versuchen.
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!data || data.totalCount === 0) {
+    return (
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Inhalte</Text>
+        <View style={[styles.emptyRow, { borderColor: theme.cardBorder }]}>
+          <Ionicons name="folder-open-outline" size={22} color={theme.textSecondary} />
+          <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+            Noch keine Inhalte geteilt. Teile Dokumente, Boards oder Notizbücher auf dem Web.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      {SECTIONS.map((section) => {
+        const items = data[section.key];
+        if (items.length === 0) return null;
+        return (
+          <View key={section.key} style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>
+              {section.label} · {items.length}
+            </Text>
+            {items.map((item) => (
+              <ContentRow
+                key={`${section.key}-${item.id}`}
+                item={item}
+                icon={section.icon}
+                theme={theme}
+                onPress={() => openItem(item)}
+              />
+            ))}
+          </View>
+        );
+      })}
+    </View>
+  );
+});
+
+function ContentRow({
+  item,
+  icon,
+  theme,
+  onPress,
+}: {
+  item: GroupContentItem;
+  icon: keyof typeof Ionicons.glyphMap;
+  theme: Theme;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        {
+          backgroundColor: pressed ? theme.surface : theme.card,
+          borderColor: theme.cardBorder,
+        },
+      ]}
+    >
+      <View style={[styles.iconWrapper, { backgroundColor: colors.primary[600] + '18' }]}>
+        <Ionicons name={icon} size={20} color={colors.primary[600]} />
+      </View>
+      <View style={styles.rowBody}>
+        <Text style={[styles.rowTitle, { color: theme.text }]} numberOfLines={1}>
+          {item.title}
+        </Text>
+        {item.subtitle || item.sharedByName ? (
+          <Text style={[styles.rowSubtitle, { color: theme.textSecondary }]} numberOfLines={1}>
+            {[item.subtitle, item.sharedByName ? `geteilt von ${item.sharedByName}` : null]
+              .filter(Boolean)
+              .join(' · ')}
+          </Text>
+        ) : null}
+      </View>
+      <Ionicons name="chevron-forward" size={18} color={theme.textSecondary} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: spacing.large },
+  section: { gap: spacing.xsmall },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingHorizontal: spacing.xsmall,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.medium,
+    borderRadius: borderRadius.medium,
+    borderWidth: 1,
+    padding: spacing.medium,
+  },
+  iconWrapper: {
+    width: 38,
+    height: 38,
+    borderRadius: borderRadius.small,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowBody: { flex: 1, gap: 2 },
+  rowTitle: { ...typography.body, fontWeight: '600' },
+  rowSubtitle: { fontSize: 12 },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingVertical: spacing.medium,
+    paddingHorizontal: spacing.xsmall,
+  },
+  loadingText: { ...typography.bodySmall },
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingVertical: spacing.small,
+  },
+  errorText: { ...typography.bodySmall, flex: 1 },
+  emptyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    padding: spacing.medium,
+    borderRadius: borderRadius.medium,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+  },
+  emptyText: { ...typography.bodySmall, flex: 1 },
+});

--- a/apps/mobile/hooks/useGroupContent.ts
+++ b/apps/mobile/hooks/useGroupContent.ts
@@ -1,0 +1,222 @@
+import { getGlobalApiClient } from '@gruenerator/shared/api';
+import { useQuery } from '@tanstack/react-query';
+
+export type GroupContentKind =
+  | 'doc'
+  | 'board'
+  | 'generator'
+  | 'notebook'
+  | 'text'
+  | 'template'
+  | 'document';
+
+interface CollabDocRow {
+  id: string;
+  title: string | null;
+  document_subtype: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface GeneratorRow {
+  id: string;
+  name: string;
+  title: string | null;
+  description: string | null;
+  slug?: string;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface NotebookRow {
+  id: string;
+  name: string;
+  description: string | null;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface TextRow {
+  id: string;
+  title: string | null;
+  document_type: string | null;
+  word_count?: number;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface TemplateRow {
+  id: string;
+  title: string;
+  description: string | null;
+  external_url?: string;
+  thumbnail_url?: string | null;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface DocumentRow {
+  id: string;
+  title: string | null;
+  filename: string;
+  file_size: number;
+  status: string;
+  updated_at: string;
+  shared_at?: string;
+  shared_by_name?: string;
+}
+
+interface ContentApiResponse {
+  success: boolean;
+  content: {
+    collaborative_documents?: CollabDocRow[];
+    generators?: GeneratorRow[];
+    notebooks?: NotebookRow[];
+    texts?: TextRow[];
+    templates?: TemplateRow[];
+    documents?: DocumentRow[];
+  };
+}
+
+export interface GroupContentItem {
+  id: string;
+  kind: GroupContentKind;
+  title: string;
+  subtitle?: string;
+  updatedAt: string;
+  sharedAt?: string;
+  sharedByName?: string;
+  slug?: string;
+}
+
+export interface GroupedContent {
+  docs: GroupContentItem[];
+  boards: GroupContentItem[];
+  generators: GroupContentItem[];
+  notebooks: GroupContentItem[];
+  texts: GroupContentItem[];
+  templates: GroupContentItem[];
+  documents: GroupContentItem[];
+  totalCount: number;
+}
+
+function emptyGroupedContent(): GroupedContent {
+  return {
+    docs: [],
+    boards: [],
+    generators: [],
+    notebooks: [],
+    texts: [],
+    templates: [],
+    documents: [],
+    totalCount: 0,
+  };
+}
+
+export function useGroupContent(groupId: string | null | undefined) {
+  return useQuery({
+    queryKey: ['groupContent', groupId],
+    queryFn: async (): Promise<GroupedContent> => {
+      const res = await getGlobalApiClient().get<ContentApiResponse>(
+        `/auth/groups/${groupId}/content`
+      );
+      const raw = res.data.content ?? {};
+      const grouped = emptyGroupedContent();
+
+      (raw.collaborative_documents ?? []).forEach((row) => {
+        const isBoard = row.document_subtype === 'boards';
+        const item: GroupContentItem = {
+          id: row.id,
+          kind: isBoard ? 'board' : 'doc',
+          title: row.title?.trim() || (isBoard ? 'Unbenanntes Board' : 'Unbenanntes Dokument'),
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+        };
+        if (isBoard) grouped.boards.push(item);
+        else grouped.docs.push(item);
+      });
+
+      (raw.generators ?? []).forEach((row) => {
+        grouped.generators.push({
+          id: row.id,
+          kind: 'generator',
+          title: row.title?.trim() || row.name || 'Grünerator',
+          ...(row.description ? { subtitle: row.description } : {}),
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+          ...(row.slug ? { slug: row.slug } : {}),
+        });
+      });
+
+      (raw.notebooks ?? []).forEach((row) => {
+        grouped.notebooks.push({
+          id: row.id,
+          kind: 'notebook',
+          title: row.name || 'Notizbuch',
+          ...(row.description ? { subtitle: row.description } : {}),
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+        });
+      });
+
+      (raw.texts ?? []).forEach((row) => {
+        grouped.texts.push({
+          id: row.id,
+          kind: 'text',
+          title: row.title?.trim() || 'Unbenannter Text',
+          ...(row.word_count ? { subtitle: `${row.word_count} Wörter` } : {}),
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+        });
+      });
+
+      (raw.templates ?? []).forEach((row) => {
+        grouped.templates.push({
+          id: row.id,
+          kind: 'template',
+          title: row.title || 'Vorlage',
+          ...(row.description ? { subtitle: row.description } : {}),
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+        });
+      });
+
+      (raw.documents ?? []).forEach((row) => {
+        grouped.documents.push({
+          id: row.id,
+          kind: 'document',
+          title: row.title?.trim() || row.filename || 'Datei',
+          subtitle: row.filename,
+          updatedAt: row.updated_at,
+          ...(row.shared_at ? { sharedAt: row.shared_at } : {}),
+          ...(row.shared_by_name ? { sharedByName: row.shared_by_name } : {}),
+        });
+      });
+
+      grouped.totalCount =
+        grouped.docs.length +
+        grouped.boards.length +
+        grouped.generators.length +
+        grouped.notebooks.length +
+        grouped.texts.length +
+        grouped.templates.length +
+        grouped.documents.length;
+
+      return grouped;
+    },
+    enabled: !!groupId,
+    staleTime: 30_000,
+  });
+}

--- a/services/hocuspocus/src/auth.ts
+++ b/services/hocuspocus/src/auth.ts
@@ -418,14 +418,53 @@ export class AuthService {
       }
 
       const userId = payload.sub as string;
-      log.debug(`[Auth-Token] Token validated for user: ${userId}`);
-
+      log.debug(`[Auth-Token] HS256 token validated for user: ${userId}`);
       return this.checkRoomAccess(documentName, userId);
+    } catch (jwtError) {
+      const err = jwtError instanceof Error ? jwtError : new Error(String(jwtError));
+      log.debug(
+        `[Auth-Token] HS256 JWT invalid (${err.message}); falling back to Better Auth bearer lookup`
+      );
+    }
+
+    return this.authenticateByBearer(token, documentName);
+  }
+
+  private async authenticateByBearer(
+    token: string,
+    documentName: string
+  ): Promise<AuthenticationResult> {
+    const apiBase = process.env.API_INTERNAL_URL || 'http://api:3001';
+    let userId: string;
+
+    try {
+      const response = await fetch(`${apiBase}/api/auth/v2/get-session`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      if (!response.ok) {
+        log.warn(`[Auth-Bearer] API session check returned ${response.status}`);
+        return { authenticated: false, reason: 'Invalid or expired token' };
+      }
+
+      const data = (await response.json()) as {
+        session?: { userId?: string };
+        user?: { id?: string };
+      };
+      userId = data.session?.userId || data.user?.id || '';
+
+      if (!userId) {
+        log.warn(`[Auth-Bearer] API returned session but no user ID`);
+        return { authenticated: false, reason: 'Invalid or expired token' };
+      }
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
-      log.warn(`[Auth-Token] JWT validation failed: ${err.message}`);
-      return { authenticated: false, reason: 'Invalid or expired token' };
+      log.error(`[Auth-Bearer] API session check failed: ${err.message}`);
+      return { authenticated: false, reason: 'Session verification failed' };
     }
+
+    log.debug(`[Auth-Bearer] User ${userId} authenticated via Better Auth bearer token`);
+    return this.checkRoomAccess(documentName, userId);
   }
 
   private async authenticateByCookie(


### PR DESCRIPTION
## Summary

- **Mobile group detail** now surfaces everything that's been shared into a group (docs, boards, grüneratoren, notebooks, texts, templates, uploaded files) and opens each kind in the right place — native BlockNote for docs, existing native WebView for boards, a new generic `/web-viewer` route for everything else.
- **Generic `web-viewer` fullscreen route** reuses the existing bearer→cookie bridge at `/api/auth/v2/web-handoff` so users aren't asked to re-login when we fall back to the web SPA.
- **Hocuspocus bearer auth fallback** teaches the collab server's `authenticateByToken` to recognise Better Auth bearer tokens by calling `/api/auth/v2/get-session` with `Authorization: Bearer`. Previously the token path only accepted a custom HS256 JWT that nothing in the codebase actually mints, so mobile doc connections were hitting guest auth and getting "permission-denied" when opening a doc shared via a group.

## Why

Tapping "Beispielgedicht" (a group-shared doc) from the mobile group detail was navigating correctly into the native doc-editor, but the editor immediately showed a red *"Auth FAILED: permission-denied"* banner. Root cause was a mismatch between what mobile sends (Better Auth bearer) and what Hocuspocus's token path expects (custom HS256 JWT). Group-share permission resolution via `group_content_shares` continues to flow through `checkRoomAccess` unchanged — the fix only widens which tokens are accepted at auth time.

## Test plan

- [ ] Build + deploy Hocuspocus service with the new auth.ts
- [ ] From the mobile app, open a group that has shared content → content sections appear (Dokumente · N, Boards · N, …) between the share button and Mitglieder
- [ ] Tap a shared doc → opens in native editor, syncs without the red "Auth FAILED" banner
- [ ] Tap a shared board → opens via existing board-viewer
- [ ] Tap a shared grünerator / notebook / text / template → opens in the new generic web-viewer with seamless auth handoff (no re-login prompt)
- [ ] Open a group with no shared content → empty dashed card shows the placeholder text
- [ ] Non-admin group member opens a shared doc with `group_perms.write === false` → doc loads read-only