### PR TITLE
ci(mobile): add Metro bundle check workflow

### DIFF
--- a/.github/workflows/mobile-bundle-check.yml
+++ b/.github/workflows/mobile-bundle-check.yml
@@ -1,0 +1,65 @@
+name: Mobile Bundle Check
+
+on:
+  push:
+    branches: [master, main]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - '.github/workflows/mobile-bundle-check.yml'
+  pull_request:
+    branches: [master, main]
+    paths:
+      - 'apps/mobile/**'
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - '.github/workflows/mobile-bundle-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bundle:
+    name: Metro bundle (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [android]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build canvas-editor CSS bundle
+        run: pnpm --filter @gruenerator/canvas-editor build:css
+
+      - name: Prebuild native project
+        working-directory: apps/mobile
+        run: pnpm exec expo prebuild --platform ${{ matrix.platform }} --no-install --clean
+
+      - name: Metro bundle
+        working-directory: apps/mobile
+        env:
+          SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+          EXPO_NO_TELEMETRY: '1'
+        run: pnpm exec expo export:embed --eager --platform ${{ matrix.platform }} --dev false


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/mobile-bundle-check.yml` that runs `expo export:embed --eager` on every push/PR touching mobile-relevant paths.
- Catches the three classes of regressions we just hit while shipping `v1.1.0 (22)` to Play Store internal:
  - **pnpm lockfile drift** — `pnpm install --frozen-lockfile` fails immediately (would have caught build `8caa929f`)
  - **`import.meta` / non-Hermes syntax in shared packages** — Metro parser throws (would have caught build `c52ead77`, PR #666)
  - **Missing workspace build artifacts** (e.g. canvas-editor `dist/*.css` needed by DOM components) — Metro resolver throws (would have caught build `25be321a`)

## Cost
- Runs on `ubuntu-latest` with 25 min timeout. Typical run: 5–10 min.
- Path-filtered: only triggers on `apps/mobile/**`, `packages/**`, `pnpm-lock.yaml`, `package.json`, or this workflow file. Backend-only changes don't pay this cost.
- Android only (Metro config is shared — iOS-specific bundle regressions are rare and macOS runners are ~10× cost).

## What it does not catch
- Gradle / native build errors (e.g. today's Sentry upload failure) — those need a real EAS build. Acceptable residual risk; Gradle issues are much rarer than JS bundle issues.
- Runtime errors — by design, this is purely a parse/resolve check.

## Test plan
- [ ] First PR run should complete in under 10 min
- [ ] Revert a known-good change (`git revert` of PR #666's first commit, for example) on a test PR → the workflow should fail with the same `import.meta` error as the failing EAS build