### PR TITLE
fix(mobile): unbreak OAuth login loop

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -65,7 +65,7 @@ function RootLayout() {
     return null;
   }
 
-  const isInAuthFlow = segments[0] === '(auth)';
+  const isInAuthFlow = segments[0] === '(auth)' || segments[0] === 'auth';
 
   if (!user && !isInAuthFlow) {
     return <Redirect href="/(auth)/login" />;

--- a/apps/mobile/app/auth/callback.tsx
+++ b/apps/mobile/app/auth/callback.tsx
@@ -1,53 +1,40 @@
 import { useAuthStore } from '@gruenerator/shared/stores';
-import { useLocalSearchParams, router } from 'expo-router';
-import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Redirect, useLocalSearchParams } from 'expo-router';
 import { View, ActivityIndicator, Text, StyleSheet } from 'react-native';
 
 import { initializeApiClient } from '../../services/api';
-import { handleAuthCallback, configureAuthStore } from '../../services/auth';
+import { configureAuthStore, handleAuthCallback } from '../../services/auth';
 import { colors } from '../../theme';
 
 export default function AuthCallback() {
   const { code } = useLocalSearchParams<{ code: string }>();
   const user = useAuthStore((state) => state.user);
 
-  useEffect(() => {
-    // Android delivers the OAuth callback URL to both the WebBrowser Custom
-    // Tab (which resolves openAuthSessionAsync in services/auth.ts) AND the
-    // Android Intent system (which mounts this screen). If the WebBrowser
-    // path won the race and already set `user`, this mount is redundant —
-    // navigate straight to tabs without re-processing the one-shot JWT.
-    if (user) {
-      router.replace('/(tabs)');
-      return;
-    }
+  const { data, isError } = useQuery({
+    queryKey: ['auth-callback', code],
+    queryFn: async () => {
+      initializeApiClient();
+      configureAuthStore();
+      return handleAuthCallback(code!);
+    },
+    enabled: !!code && !user,
+    retry: false,
+    gcTime: 0,
+    staleTime: Infinity,
+  });
 
-    // iOS cold-start fallback: ASWebAuthenticationSession doesn't fire
-    // Linking, and if the app was killed mid-flow we arrive here with a
-    // fresh `code` and no live WebBrowser session to process it. Since
-    // handleAuthCallback is idempotent by `code`, racing the WebBrowser
-    // path (Android) is harmless — both callers await one HTTP exchange.
-    async function processCallback() {
-      if (code) {
-        try {
-          initializeApiClient();
-          configureAuthStore();
-          const result = await handleAuthCallback(code);
-          router.replace(result.success ? '/(tabs)' : '/(auth)/login');
-        } catch {
-          router.replace('/(auth)/login');
-        }
-      } else {
-        router.replace('/(auth)/login');
-      }
-    }
-    void processCallback();
-  }, [code, user]);
+  if (user || data?.success) {
+    return <Redirect href="/(tabs)" />;
+  }
+  if (!code || isError || (data && !data.success)) {
+    return <Redirect href="/(auth)/login" />;
+  }
 
   return (
     <View style={styles.container}>
       <ActivityIndicator size="large" color={colors.white} />
-      <Text style={styles.text}>Anmeldung wird abgeschlossen...</Text>
+      <Text style={styles.text}>Anmeldung wird abgeschlossen…</Text>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
Fixes the mobile login loop where — after successful Keycloak authentication — the server generates a login code but the app unmounts the callback screen before it can exchange the code, then keeps showing the login screen.

## Root cause
The OAuth deep link `gruenerator://auth/callback` lives at `apps/mobile/app/auth/callback.tsx`, **outside** the `(auth)` route group (the `redirect_uri` must be the literal `/auth/callback` path; Expo Router strips paren-wrapped group segments from URLs).

`_layout.tsx:68` only recognized the paren form:

```ts
const isInAuthFlow = segments[0] === '(auth)';
```

So when the deep link arrived and `user` was still null (the one-shot JWT code hadn't been exchanged yet), the root layout fired `<Redirect href="/(auth)/login" />` **before the callback subtree mounted**. The code was wasted and the user kept landing on `/(auth)/login`.

Observed log sequence:
```
[AppLogin] Initiating OAuth ...
[Auth] account-updated ... provider=keycloak-gruene-at
[Auth] session-created ...
[appLogin] [AppCallback] Login code generated, redirecting to app
  ← server done — mobile app never exchanges the code
```

## Changes

### 1. `fix(mobile): treat /auth/callback as part of auth flow`
One-line fix in `_layout.tsx`:
```diff
- const isInAuthFlow = segments[0] === '(auth)';
+ const isInAuthFlow = segments[0] === '(auth)' || segments[0] === 'auth';
```

### 2. `refactor(mobile): declarative auth callback with useQuery + Redirect`
Replaces the `useEffect` + imperative `router.replace(...)` pattern with `useQuery` keyed by the one-shot code, resolving navigation via `<Redirect>`.

Why: navigation decisions happen *during render* instead of post-commit, so the root layout's routing and the callback's routing agree on the same frame. Matches the CLAUDE.md "no unnecessary useEffect" rule — this is data fetching, which is what useQuery is for. Also eliminates the one-frame flicker where the callback first rendered the spinner, then effect ran, then imperative navigation tore everything down.

- `gcTime: 0` keeps one-shot JWTs out of the query cache (no replay risk on remount)
- `staleTime: Infinity` + `retry: false` — single-try, no backoff on a JWT that expires in 60s
- `enabled: !!code && !user` — query only runs when there's actually work to do

The `inFlightExchanges` map in `services/auth.ts` is retained — it dedupes across *different* callers (the `login()` flow and the deep-link handler both call `handleAuthCallback(code)` concurrently on Android), which query-scoped dedup can't cover.

## Test plan
- [ ] Fresh mobile install → tap "Anmelden (Grüne Österreich)" → complete Keycloak → land on tabs (not login loop)
- [ ] Kill app during OAuth → restart → complete flow → land on tabs
- [ ] Airplane mode during code exchange → lands on login screen with error state (not stuck on spinner forever)
- [ ] Verify typecheck passes for `@gruenerator/mobile`

## Not addressed here
The "first-try hang" is separate and appears to be a UX issue: on first OAuth attempt the user hasn't yet signed into Keycloak, the Custom Tab stays open waiting for credentials, and if the user backgrounds or gives up there's no signal back to the app. Second-try SSO is instant. Worth a follow-up but out of scope.