### PR TITLE
fix(mem0): silence giant JSON-parse error dumps from gpt-oss hallucinations

### DIFF
--- a/apps/api/services/mem0/config.ts
+++ b/apps/api/services/mem0/config.ts
@@ -110,7 +110,9 @@ class LiteLLMAdapter {
     // GPT-OSS often outputs chain-of-thought reasoning before JSON,
     // sometimes with literal `...` ellipsis tokens in arrays.
     // extractLastJsonObject tries all JSON blocks last-to-first with ellipsis repair.
-    let parsed = extractJsonObject(raw);
+    // Pass silent:true so parse failures don't emit ERROR logs — failure is expected
+    // for this model; mem0ai gets a safe fallback below.
+    let parsed = extractJsonObject(raw, { silent: true });
 
     if (!parsed) {
       parsed = extractLastJsonObject(raw);
@@ -119,7 +121,17 @@ class LiteLLMAdapter {
       }
     }
 
-    const content = parsed ? JSON.stringify(parsed) : raw;
+    // On total parse failure, return a neutral shape containing BOTH keys mem0ai looks for:
+    //   facts: []  → mem0ai's fact-extraction path ends cleanly with zero memories
+    //   memory: [] → mem0ai's memory-action path ends cleanly with zero actions
+    // This prevents mem0ai's console.error dumps of the full raw LLM response.
+    const content = parsed ? JSON.stringify(parsed) : '{"facts": [], "memory": []}';
+
+    if (!parsed) {
+      log.warn(
+        `[LiteLLMAdapter] LLM returned non-JSON response (${raw.length} chars); using empty fallback`
+      );
+    }
 
     return { content };
   }

--- a/apps/api/utils/jsonParser.ts
+++ b/apps/api/utils/jsonParser.ts
@@ -151,9 +151,13 @@ export function extractLastJsonObject<T = Record<string, unknown>>(text: string)
  * - Prose wrapping the JSON
  * - Bare newlines in strings
  */
-export function extractJsonObject<T = Record<string, unknown>>(raw: unknown): T | null {
+export function extractJsonObject<T = Record<string, unknown>>(
+  raw: unknown,
+  options?: { silent?: boolean }
+): T | null {
   if (raw == null) return null;
 
+  const silent = options?.silent === true;
   let text = String(raw).trim();
 
   // Remove common Markdown code fences
@@ -196,17 +200,19 @@ export function extractJsonObject<T = Record<string, unknown>>(raw: unknown): T 
       const m = msg.match(/position\s+(\d+)/i);
       const pos = m ? parseInt(m[1], 10) : -1;
 
-      if (pos >= 0) {
-        const start = Math.max(0, pos - 60);
-        const end = Math.min(repaired.length, pos + 60);
-        log.error(
-          '[jsonParser] JSON parse error around position',
-          pos,
-          'context:',
-          repaired.slice(start, end)
-        );
-      } else {
-        log.error('[jsonParser] JSON parse error:', msg);
+      if (!silent) {
+        if (pos >= 0) {
+          const start = Math.max(0, pos - 60);
+          const end = Math.min(repaired.length, pos + 60);
+          log.error(
+            '[jsonParser] JSON parse error around position',
+            pos,
+            'context:',
+            repaired.slice(start, end)
+          );
+        } else {
+          log.error('[jsonParser] JSON parse error:', msg.slice(0, 300));
+        }
       }
       return null;
     }


### PR DESCRIPTION
## Summary

When `gpt-oss:120b` (used by Mem0 via LiteLLM) ignores the "respond with JSON only" instruction and returns a long markdown essay, our logs blow up with ~26k characters of hallucinated content per failed memory extraction. This PR silences that noise without changing any functional behaviour.

Two noise sources:
1. Our `LiteLLMAdapter` called `extractJsonObject()` on the raw response → `jsonParser.ts` logged `ERROR [jsonParser] JSON parse error:` with the full un-truncated parse error.
2. The adapter fell back to returning `raw`, so `mem0ai` itself hit `JSON.parse()` on the essay and emitted `console.error(...)` with the whole response (see `mem0ai/dist/oss/index.mjs:5107` and `:5146`).

## Changes

- **`apps/api/utils/jsonParser.ts`** — `extractJsonObject()` gains an optional `{ silent?: boolean }` option. Also truncates the fallback error message to 300 chars (previously un-bounded). Default behaviour is unchanged for every other caller; the Mem0 adapter is the only opt-in.
- **`apps/api/services/mem0/config.ts`** — `LiteLLMAdapter.invoke()` passes `silent: true` and, on total parse failure, returns a neutral `{"facts": [], "memory": []}` fallback. This JSON has both keys mem0ai's two internal paths look for (`FactRetrievalSchema.parse(...).facts` for extraction, `.memory || []` for action decisions) — so mem0ai never enters its `console.error` branches. One concise WARN is emitted instead.

## Functional impact

- **Zero behavioural change.** Mem0 already added zero memories on parse failure (caught by the `SyntaxError` handler in `Mem0Service.addMemories:133`). This PR just stops the logs from being screaming walls of LLM-hallucinated English productivity guides.
- **Not a fix for the root cause.** `gpt-oss:120b` is a weak JSON extractor; a follow-up could swap in Mistral-small for memory extraction. Out of scope here.

## Before/After

**Before:**
```
ERROR [jsonParser] [jsonParser] JSON parse error:
Failed to parse facts from LLM response: ## Goal
**Become a senior‑level software engineer...
[13,000 chars of essay]
SyntaxError: Unexpected token '#'...
```

**After:**
```
WARN  [Mem0Config] [LiteLLMAdapter] LLM returned non-JSON response (12847 chars); using empty fallback
[Mem0] Added 0 memories for user ...
```

## Test plan

- [x] `npx tsc --noEmit --project apps/api/tsconfig.json` → clean exit
- [x] Verified `extractJsonObject` has exactly one caller monorepo-wide (the one updated here), so the new optional parameter cannot break any other consumer
- [ ] Deploy to test env; confirm Mem0 extraction failures produce a single WARN line instead of the ~26k essay dump
- [ ] Verify real memory extractions still succeed when the LLM *does* return valid JSON (the happy path is unchanged — `parsed ? JSON.stringify(parsed) : fallback`)