### PR TITLE
fix(content-sync): scope hourly cron to LVs and identify blocked sources in logs

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -272,7 +272,7 @@ jobs:
         id: sync
         continue-on-error: true
         run: |
-          ARGS="--source ${{ inputs.source }}"
+          ARGS="--source ${{ inputs.source || 'landesverbaende' }}"
           if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
           echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -286,7 +286,9 @@ export class LandesverbandScraper extends BaseScraper {
           await this.delay(this.crawlDelay);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          console.error(`[Landesverband] ✗ PDF error: ${errorMessage}`);
+          console.error(
+            `[Landesverband] ✗ PDF error in ${source.id} (${pdf.url}): ${errorMessage}`
+          );
           result.errors++;
         }
       }
@@ -406,7 +408,7 @@ export class LandesverbandScraper extends BaseScraper {
           await this.delay(this.crawlDelay);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-          console.error(`[Landesverband] ✗ Error: ${errorMessage}`);
+          console.error(`[Landesverband] ✗ Error in ${source.id} (${url}): ${errorMessage}`);
           result.errors++;
         }
       }


### PR DESCRIPTION
## Summary

Two small, low-risk fixes uncovered while investigating stale Landesverband notebook content. The hourly content-sync job has been silently skipping its intended scope and masking per-LV failures.

### Changes

1. **`ci(content-sync)`** — Hourly cron passed `--source ${{ inputs.source }}` to `update-all-content.ts`, but `inputs.source` is only populated on `workflow_dispatch`. On schedule events it was empty, so the script ran *every* scraper hourly (KommunalWiki, Bundestag, SocialMedia, LV) instead of just landesverbaende. Setup job's matrix output was effectively ignored. Default to `landesverbaende` when unset.

2. **`fix(scraper)`** — Per-article error logs in `LandesverbandScraper` printed `[Landesverband] ✗ Error: HTTP 403` with no source attribution. With `LV_CONCURRENCY=4`, four states' logs interleave on stdout, so the consistent 4× HTTP 403 errors per run can't be traced to specific LVs. Include `source.id` and the failing URL in both HTML and PDF catch blocks.

### Why

In production, the workflow reports "✅ success" every hour but several Landesverbände have not received any new content for weeks (Mecklenburg-Vorpommern's freshest article in our DB is from 23.02.2026; Berlin's is ~4 weeks old). The "success" hides:
- 4 of 16 LVs throwing HTTP 403 on every run (continue-on-error: true + per-LV try/catch swallow these)
- Hourly schedule running everything instead of just LVs (CI cost waste)

After this lands, the next hourly run will print lines like `[Landesverband] ✗ Error in gruene-mv (https://...): HTTP 403` so we can identify the blocked LVs and remediate (likely via UA rotation or sitemap-mode for those sources). Separate follow-up issues to come for the deeper fixes.

### Out of scope (separate follow-ups)

- BundestagScraper Fachtexte reports "12 stored" every single hour — possible dedup bug
- `update-all-content.ts` should exit non-zero when per-source errors > 0 so green check actually means green
- Berlin TYPO3 pagination (`?tx_xblog_pi1[pointer]=N`) returns identical content for all page values — pagination effectively broken

## Test plan

- [ ] Workflow YAML lints OK (GH Actions parses on push)
- [ ] After merge, next hourly run identifies the 4 blocked LVs by id in the logs
- [ ] CI run time drops from ~21 min back toward LV-only duration