### PR TITLE
fix(scraper): restore date extraction for NEOS, brandenburg-archive; mark dissolved Thüringen Fraktion dormant

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -114,7 +114,7 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       ],
       contentSelectors: {
         title: ['h1', 'h2.headline', '.page-title', 'meta[property="og:title"]'],
-        date: ['time', '.date', '.publication-date'],
+        date: ['.mb-tiny', 'time', '.date', '.publication-date'],
         content: ['article', '.content-main', '.text-content', 'main'],
         categories: ['a[href*="/themen/"]', '.tags a'],
         author: ['.author', '.written-by'],

--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -53,6 +53,7 @@ export interface LandesverbandSource {
   qdrantCollection?: string; // Optional: custom collection name (default: landesverbaende_documents)
   maxAgeYears?: number; // Optional: max age of content in years (default: 10)
   notificationEmail?: string; // Optional: email to notify when new articles are indexed
+  dormant?: boolean; // Optional: when true, scrapeAllSources skips this source. Set for sources that no longer publish (e.g. dissolved Fraktionen). Direct scrapeSource(id) calls are unaffected.
 }
 
 export interface LandesverbaendeConfig {
@@ -492,6 +493,10 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       baseUrl: 'https://www.gruene-thl.de',
       cms: 'drupal',
       maxAgeYears: 12,
+      // Fraktion dissolved after the 2024-09-01 Landtag election (Greens fell below 5%
+      // and lost all seats). Site is being kept as an archive — last article 2024-09-17.
+      // Skip in scheduled scrapeAllSources runs to stop wasting cycles re-indexing dormant chunks.
+      dormant: true,
       contentPaths: [
         {
           type: 'presse',

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -485,10 +485,16 @@ export class LandesverbandScraper extends BaseScraper {
       sources = getSourcesByLandesverband(landesverband);
     }
 
+    const dormantSources = sources.filter((s) => s.dormant);
+    sources = sources.filter((s) => !s.dormant);
+
     console.log('\n╔═══════════════════════════════════════════════════════════╗');
     console.log('║       Landesverbaende Scraper - Full Crawl                ║');
     console.log('╚═══════════════════════════════════════════════════════════╝\n');
     this.log(`Sources to process: ${sources.length}`);
+    if (dormantSources.length > 0) {
+      this.log(`Dormant sources skipped: ${dormantSources.map((s) => s.id).join(', ')}`);
+    }
     if (sourceType) this.log(`Filter by type: ${sourceType}`);
     if (landesverband) this.log(`Filter by LV: ${landesverband}`);
     if (contentType) this.log(`Filter by content: ${contentType}`);

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/ContentExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/ContentExtractor.ts
@@ -54,6 +54,10 @@ export class ContentExtractor {
       }
     }
 
+    if (publishedAt) {
+      publishedAt = ContentExtractor.normalizeGermanDate(publishedAt);
+    }
+
     // Remove unwanted elements (after title/date extraction)
     $('script, style, noscript, iframe, nav, header, footer').remove();
     $('.navigation, .sidebar, .cookie-banner, .cookie-notice, .popup, .modal').remove();
@@ -119,6 +123,10 @@ export class ContentExtractor {
         publishedAt = el.attr('datetime') || el.text().trim();
         if (publishedAt) break;
       }
+    }
+
+    if (publishedAt) {
+      publishedAt = ContentExtractor.normalizeGermanDate(publishedAt);
     }
 
     // Remove unwanted elements (after title/date extraction)
@@ -236,21 +244,23 @@ export class ContentExtractor {
   static normalizeGermanDate(dateStr: string): string {
     const trimmed = dateStr.trim();
 
-    // DD.MM.YY (e.g., "19.02.26")
-    const shortMatch = trimmed.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2})$/);
-    if (shortMatch) {
-      const day = shortMatch[1].padStart(2, '0');
-      const month = shortMatch[2].padStart(2, '0');
-      const year = parseInt(shortMatch[3], 10) + 2000;
-      return `${year}-${month}-${day}`;
-    }
-
-    // DD.MM.YYYY (e.g., "19.02.2026")
-    const longMatch = trimmed.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})$/);
+    // DD.MM.YYYY (e.g., "19.02.2026"). Try the 4-digit year first so that
+    // "02.04.2026" doesn't get partially matched as DD.MM.YY ("02.04.20").
+    // The (?!\d) lookahead prevents capturing a 4-digit year as a 2-digit one.
+    const longMatch = trimmed.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})(?!\d)/);
     if (longMatch) {
       const day = longMatch[1].padStart(2, '0');
       const month = longMatch[2].padStart(2, '0');
       const year = longMatch[3];
+      return `${year}-${month}-${day}`;
+    }
+
+    // DD.MM.YY (e.g., "19.02.26")
+    const shortMatch = trimmed.match(/(\d{1,2})\.(\d{1,2})\.(\d{2})(?!\d)/);
+    if (shortMatch) {
+      const day = shortMatch[1].padStart(2, '0');
+      const month = shortMatch[2].padStart(2, '0');
+      const year = parseInt(shortMatch[3], 10) + 2000;
       return `${year}-${month}-${day}`;
     }
 


### PR DESCRIPTION
## Summary

PR-α of a multi-PR effort to restore content sync across stale Landesverbände. Three independent, low-risk fixes uncovered while auditing per-LV freshness in Qdrant. Each fix is its own commit so they can be cherry-picked or reverted independently.

### What's broken (background)

A direct Qdrant inventory of `landesverbaende_documents` showed several LVs frozen at old `published_at` dates while their live sites publish daily. Three of those freezes are this PR's scope:

- **sachsen-anhalt-fraktion** — 743 articles, all `published_at = NULL`. Discovery works; date extraction fails because NEOS doesn't emit `<time>` / `meta article:published_time` and the existing selectors miss the actual `<div class="mb-tiny">DD.MM.YYYY</div>` marker. Even if the selector matched, NEOS extractor never called `normalizeGermanDate`, so the German format would land verbatim.
- **brandenburg-archive-presse / -beschluesse** — 75 / 3 articles with `published_at = "02.04.2026"` (literal German format). TYPO3 extractor *does* call `normalizeGermanDate`, but the `^...$` anchors only matched standalone dates; brandenburg-archive's date selectors return strings with surrounding context, so the regex misses and the string passes through.
- **thueringen-fraktion** — 2220 articles, last published 2024-09-17. Dates are correct; the source is genuinely dormant. The Fraktion was dissolved after the 2024-09-01 Landtag election when the Greens fell below 5%. Site stays online as an archive.

### Changes

1. **`fix(scraper): make German date normalization actually work`**
   - Loosen `normalizeGermanDate` regex to find DD.MM.YYYY anywhere in the input (with `(?!\d)` lookahead so a 4-digit year isn't partially captured).
   - Apply `normalizeGermanDate` in `extractContentNeos` and `extractContentWordPress` (TYPO3 already did).

2. **`fix(config): add .mb-tiny date selector for sachsen-anhalt-fraktion (NEOS)`**
   - Add `.mb-tiny` as the first date selector for that source.

3. **`feat(scraper): add dormant flag to skip dissolved sources`**
   - New `dormant?: boolean` on `LandesverbandSource`.
   - `scrapeAllSources` filters dormant sources and logs which IDs were skipped.
   - Direct `scrapeSource(id)` is unaffected (manual backfill still works).
   - Mark `thueringen-fraktion` dormant with a comment pointing at the political event.

### Out of scope (covered by follow-up PRs)

- **PR-β**: sitemapindex recursion in `LinkExtractor` + migrate Berlin LV to typed sub-sitemaps (fixes `berlin-lv-beschluesse` ~4 wk stale and increases coverage of `berlin-lv-presse` from rolling-10 → 1000 articles).
- **PR-γ**: WP REST API discovery mode + migrate `sachsen-anhalt-lv` (5 mo stale, Dec 2025 site relaunch broke permalinks), `mv-lv` (7 wk), `mv-fraktion` (7 wk), `thueringen-lv` (10 wk).
- Date-extractor backfill for the 743 NULL `sachsen-anhalt-fraktion` rows requires a `--force` re-scrape on that one source after this lands; URL-based dedup would otherwise skip them.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] After merge, manually trigger `gh workflow run content-sync.yml -f source=landesverbaende -f force=true` and confirm:
  - sachsen-anhalt-fraktion `published_at` populated as ISO
  - brandenburg-archive `published_at` reformatted to ISO
  - thueringen-fraktion appears under "Dormant sources skipped" in the log