### PR TITLE
feat(scraper): sitemap-index recursion + Berlin Beschlüsse via typed sub-sitemap

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -30,6 +30,7 @@ export interface ContentPath {
   sitemapUrls?: string[]; // Optional: fetch URLs from sitemaps instead of pagination
   sitemapFilter?: string; // Optional: filter sitemap URLs (e.g., '/presse/')
   staticUrls?: string[]; // Optional: fixed list of URLs to scrape directly (bypasses pagination and sitemap)
+  disableOffPathFilter?: boolean; // Optional: when true, skip the post-discovery filter that requires URLs to share the listing-path prefix. Auto-applied when sitemapUrls is set, since sitemap URLs are already canonical and rarely match the human-facing listing path (e.g. TYPO3 sitemaps emit /news/ while listings live under /nachrichten/).
 }
 
 export interface ContentSelectors {

--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -326,10 +326,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
           type: 'beschluss',
           path: '/beschluesse',
           listSelector: 'h2 a[href], h3 a[href]',
-          paginationPattern: '?tx_xblog_pi1[pointer]={page}',
-          paginationOffset: -1,
-          paginationLinkSelector: '.pagination a',
-          maxPages: 27,
+          // TYPO3 silently ignores tx_xblog_pi1[pointer]: every page returns the
+          // same first ~10 entries, so pagination plateaus and beschluesse stagnate
+          // between LDKs. Discover via the typed sub-sitemap instead — sitemapindex
+          // recursion follows /sitemap.xml into ?sitemap=beschluesse&cHash=… (273
+          // entries, all canonical /beschluesse/<slug>_<id>).
+          sitemapUrls: ['https://gruene.berlin/sitemap.xml'],
+          sitemapFilter: '/beschluesse/',
         },
       ],
       contentSelectors: {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -316,7 +316,17 @@ export class LandesverbandScraper extends BaseScraper {
 
       // Filter: only keep links whose path starts with the content path being scraped.
       // Prevents cross-contamination (e.g., /beschluesse/ links picked up from /nachrichten sidebar).
-      if (contentPath.path && contentPath.path !== '/') {
+      //
+      // Bypass for sitemap-discovered URLs and any path that explicitly opts out:
+      // sitemap URLs are canonical and may not share the listing path's prefix
+      // (e.g. TYPO3 emits /news/<slug> in the sitemap while the listing is /nachrichten),
+      // and WordPress sites with root-permalinks publish at / regardless of the
+      // /category/X listing path used for discovery.
+      const skipOffPathFilter =
+        contentPath.disableOffPathFilter === true ||
+        (contentPath.sitemapUrls !== undefined && contentPath.sitemapUrls.length > 0);
+
+      if (!skipOffPathFilter && contentPath.path && contentPath.path !== '/') {
         const before = articleLinks.length;
         articleLinks = articleLinks.filter((url) => {
           try {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/LinkExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/LinkExtractor.ts
@@ -144,14 +144,17 @@ export class LinkExtractor {
   }
 
   /**
-   * Extract links from XML sitemaps
-   * Fetches multiple sitemaps and filters URLs
+   * Extract links from XML sitemaps. Handles both leaf sitemaps (<urlset>)
+   * and sitemap indexes (<sitemapindex>) by recursing one level into child
+   * sitemaps. TYPO3 SEO and WordPress core sitemaps both use this pattern.
    */
   async extractLinksFromSitemaps(
     sitemapUrls: string[],
     filter?: string,
-    log?: (msg: string) => void
+    log?: (msg: string) => void,
+    depth = 0
   ): Promise<string[]> {
+    const MAX_DEPTH = 2;
     const links = new Set<string>();
 
     for (const sitemapUrl of sitemapUrls) {
@@ -160,17 +163,41 @@ export class LinkExtractor {
         const xml = await response.text();
         const $ = cheerio.load(xml, { xmlMode: true });
 
+        // Sitemap index: collect child sitemap URLs and recurse.
+        const childSitemaps: string[] = [];
+        $('sitemap > loc').each((_, el) => {
+          const url = $(el).text().trim();
+          if (url) childSitemaps.push(url);
+        });
+
+        if (childSitemaps.length > 0) {
+          if (depth >= MAX_DEPTH) {
+            log?.(
+              `Sitemap ${sitemapUrl}: reached MAX_DEPTH=${MAX_DEPTH}, not recursing into ${childSitemaps.length} children`
+            );
+          } else {
+            log?.(`Sitemap index ${sitemapUrl}: recursing into ${childSitemaps.length} child sitemaps`);
+            const childLinks = await this.extractLinksFromSitemaps(
+              childSitemaps,
+              filter,
+              log,
+              depth + 1
+            );
+            for (const link of childLinks) links.add(link);
+          }
+        }
+
+        // Leaf sitemap: collect article URLs.
         $('url > loc').each((_, el) => {
           const url = $(el).text().trim();
           if (url) {
-            // Apply filter if specified
             if (filter && !url.includes(filter)) return;
             links.add(url);
           }
         });
 
         log?.(
-          `Sitemap ${sitemapUrl}: found ${links.size} URLs${filter ? ` (filtered by '${filter}')` : ''}`
+          `Sitemap ${sitemapUrl}: total ${links.size} URLs${filter ? ` (filtered by '${filter}')` : ''}`
         );
         await this.delay(300);
       } catch (error) {


### PR DESCRIPTION
## Summary

PR-β of the LV-content-restoration effort. Adds first-class support for sitemap-index discovery and migrates `berlin-lv-beschluesse` to use it. Three atomic commits.

### What's broken (background)

Qdrant inventory showed `berlin-lv-beschluesse` frozen at 2026-03-27 while the live site has fresh entries up to 2026-04-08 (LDK Wahlprogramm Kapitel 1-6, IDs 3763-3768). Investigation traced this to **TYPO3 silently ignoring `tx_xblog_pi1[pointer]={page}`** — every value of `pointer` returns the same first ~10 items, so the scraper sees only a rolling-10 window from the listing page. Beschluesse publish in clusters at Landesdelegiertenkonferenzen, so the window stagnates between LDKs.

The same upstream bug affects `berlin-lv-presse` but is hidden by higher publish cadence (rolling 10 always contains some new news). Spot-checked Qdrant vs sub-sitemap and found 2 of the latest 5 articles missing.

### Changes

1. **`feat(scraper): support sitemap-index recursion in LinkExtractor`**
   - `extractLinksFromSitemaps` detects `<sitemap><loc>` children and recurses depth+1 (capped at MAX_DEPTH=2). Leaf `<url><loc>` extraction unchanged. Cheerio `xmlMode` handles both schemas in one parse.
   - Unblocks any LV configured with a TYPO3 SEO or WordPress core sitemapindex URL — those previously returned zero links because the index XML doesn't contain `<url>` elements.

2. **`feat(scraper): bypass off-path filter for sitemap-discovered URLs`**
   - New `ContentPath.disableOffPathFilter?: boolean`.
   - `LandesverbandScraper.#scrapeContentPath` auto-applies the bypass when `sitemapUrls` is set; honors explicit flag otherwise.
   - Rationale: TYPO3 emits canonical `/news/<slug>` in sitemaps even when listings live at `/nachrichten`; WordPress root-permalink sites publish at `/<slug>` regardless of the `/category/X/` listing path. The off-path filter strips both. Sitemap URLs are pre-canonicalized so the filter offers no additional protection.

3. **`fix(config): migrate berlin-lv-beschluesse to TYPO3 sub-sitemap discovery`**
   - `sitemapUrls: ['https://gruene.berlin/sitemap.xml']`
   - `sitemapFilter: '/beschluesse/'`
   - cHash discovered fresh from the index each run (handles TYPO3 cache-key rotations automatically).
   - Coverage jumps from ~rolling-10 to 273 entries.

### Why this PR is small in scope

`berlin-lv-presse` migration deferred to a follow-up because it requires URL-canonicalization handling (sitemap returns `/news/<slug>_<id>`, existing Qdrant points use `/nachrichten/<slug>_<id>` aliases — naive migration would create duplicate documents). The Beschluesse sub-sitemap returns `/beschluesse/<slug>_<id>` URLs that match existing Qdrant data exactly, so no canonicalization needed.

### Out of scope (covered by follow-up PRs)

- **Follow-up to PR-β**: berlin-lv-presse migration with `/news/` ↔ `/nachrichten/` URL canonicalization.
- **PR-γ** (planned): WP REST API discovery mode + migrate sachsen-anhalt-lv (5 mo stale), mv-lv (7 wk), mv-fraktion (7 wk), thueringen-lv (10 wk).

## Test plan

- [x] `tsc --noEmit` clean
- [ ] After merge, manually trigger `gh workflow run content-sync.yml -f source=landesverbaende` and confirm:
  - LV scraper log shows `Sitemap index https://gruene.berlin/sitemap.xml: recursing into N child sitemaps`
  - berlin-lv-beschluesse stored count grows from 174 → ~273
  - Newest beschluesse from 2026-04-08 (chapters 3763-3768) appear in Qdrant