### PR TITLE
fix(scraper): migrate berlin-lv-presse to sub-sitemap with /news/ → /nachrichten/ alias canonicalization

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -290,10 +290,15 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
           type: 'presse',
           path: '/nachrichten',
           listSelector: 'h2 a[href], h3 a[href]',
-          paginationPattern: '?tx_xblog_pi1[pointer]={page}',
-          paginationOffset: -1,
-          paginationLinkSelector: '.pagination a',
-          maxPages: 62,
+          // Same TYPO3 pagination defect as berlin-lv-beschluesse: tx_xblog_pi1[pointer]
+          // is silently ignored upstream, so the listing only ever yields the rolling-10
+          // newest. Cross-checked against the news sub-sitemap (1000 entries) and found 2
+          // of the latest 5 articles missing from Qdrant — the rolling window doesn't keep
+          // up with publish cadence between hourly runs. Switch to typed sub-sitemap
+          // discovery; #normalizeUrl rewrites the canonical /news/ URLs back to the
+          // /nachrichten/ alias so URL-based dedup matches the 190 existing Qdrant points.
+          sitemapUrls: ['https://gruene.berlin/sitemap.xml'],
+          sitemapFilter: '/nachrichten/',
         },
       ],
       contentSelectors: {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -742,6 +742,16 @@ export class LandesverbandScraper extends BaseScraper {
       const parsed = new URL(absolute);
       parsed.hash = '';
       parsed.searchParams.delete('tmstv');
+
+      // gruene.berlin TYPO3 alias: the SEO sitemap emits canonical /news/<slug>_<id>
+      // URLs while the human-facing listing and existing Qdrant data both use
+      // /nachrichten/<slug>_<id>. Both routes resolve to the same article. Normalize
+      // sitemap-discovered URLs to the /nachrichten/ form so URL-based dedup matches
+      // already-indexed points instead of creating duplicates.
+      if (parsed.hostname === 'gruene.berlin' && parsed.pathname.startsWith('/news/')) {
+        parsed.pathname = '/nachrichten/' + parsed.pathname.slice('/news/'.length);
+      }
+
       const search = parsed.searchParams.toString();
       return parsed.origin + parsed.pathname + (search ? '?' + search : '');
     } catch {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/LinkExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/LinkExtractor.ts
@@ -187,13 +187,16 @@ export class LinkExtractor {
           }
         }
 
-        // Leaf sitemap: collect article URLs.
+        // Leaf sitemap: collect article URLs. Pipe through normalizeUrl so any
+        // injected canonicalization (e.g. TYPO3 alias rewrites in the parent
+        // scraper) applies before dedup and filter, and so the resulting URLs
+        // match what would be discovered via HTML listings.
         $('url > loc').each((_, el) => {
-          const url = $(el).text().trim();
-          if (url) {
-            if (filter && !url.includes(filter)) return;
-            links.add(url);
-          }
+          const rawUrl = $(el).text().trim();
+          if (!rawUrl) return;
+          const url = this.normalizeUrl(rawUrl, '') ?? rawUrl;
+          if (filter && !url.includes(filter)) return;
+          links.add(url);
         });
 
         log?.(


### PR DESCRIPTION
## Summary

Follow-up to PR #673. Migrates `berlin-lv-presse` to typed sub-sitemap discovery and adds the URL canonicalization needed to avoid duplicate Qdrant documents.

### Why

Cross-checking Qdrant against the live Berlin sub-sitemap revealed `berlin-lv-presse` is **not as fresh as it looked**: `MAX(published_at) = 2026-04-23` masks coverage gaps deeper in the rolling window:

| Rank | Live `<lastmod>` | Qdrant `published_at` | Status |
|---|---|---|---|
| 1 | 2026-04-23 `csd-auftakt_3802` | 2026-04-23 | ✓ |
| 2 | 2026-04-21 `berliner-gruene_3801` | 2026-04-21 | ✓ |
| 3 | 2026-04-19 `kandidierenden_3796` | 2026-04-16 | ⚠️ wrong date |
| 4 | 2026-04-16 `2-jahre-cannabisgesetz_3797` | — | ✗ missing |
| 5 | 2026-04-13 `kultur-kandidatinnen_3794` | — | ✗ missing |

Same root cause as PR #673's berlin-lv-beschluesse fix: TYPO3 silently ignores `tx_xblog_pi1[pointer]={page}`, so the scraper sees only the rolling 10 newest from the listing. Presse's higher publish cadence usually papers over this, but slips when articles publish in clusters.

### Why this needs a separate PR (not folded into #673)

The Beschluesse sub-sitemap returns canonical `/beschluesse/<slug>_<id>` URLs that match existing Qdrant data exactly — clean migration. The news sub-sitemap returns canonical `/news/<slug>_<id>` URLs while existing Qdrant data uses the `/nachrichten/<slug>_<id>` alias for the same articles. Naive migration would create 190 duplicate documents.

### Changes

1. **`feat(scraper): canonicalize sitemap URLs through normalizeUrl`**
   - `extractLinksFromSitemaps` pipes each `<url><loc>` through the injected `normalizeUrl` before dedup and filter (was bypassing it entirely).
   - `LandesverbandScraper.#normalizeUrl` rewrites `gruene.berlin/news/<…>` → `gruene.berlin/nachrichten/<…>` so sitemap-discovered URLs match existing Qdrant data.

2. **`fix(config): migrate berlin-lv-presse to TYPO3 sub-sitemap discovery`**
   - `sitemapUrls: ['https://gruene.berlin/sitemap.xml']`
   - `sitemapFilter: '/nachrichten/'` (operates on the post-canonicalization URL, so this is the canonical alias)
   - cHash for the news sub-sitemap is discovered fresh from the index each run.

### Coverage impact

Before: rolling 10 most recent items from listing, with gaps when cadence > 10/period.
After: full 1000 entries from sub-sitemap, no rolling-window edge cases.

### Test plan

- [x] `tsc --noEmit` clean
- [ ] After merge:
  - `gh workflow run content-sync.yml -f source=landesverbaende` and verify in run logs:
    - `Sitemap index https://gruene.berlin/sitemap.xml: recursing into N child sitemaps`
    - berlin-lv-presse new docs > 0 (the previously-missing 2026-04-16 and 2026-04-13 articles, plus any that fell out of the rolling window)
    - berlin-lv-presse Qdrant point count grows past 190 without the count doubling (which would indicate duplicates)
- [ ] Spot-check `published_at` for Qdrant entries matches the live sitemap `<lastmod>` for the rank-3-and-below articles