### PR TITLE
fix(monitor): add migration for emotion_scores and top_nouns

### DIFF
--- a/apps/api/database/postgres/migrations/add_monitor_emotion_columns.sql
+++ b/apps/api/database/postgres/migrations/add_monitor_emotion_columns.sql
@@ -1,0 +1,6 @@
+-- Add NLP-derived columns to monitor_articles
+-- emotion_scores: per-article emotion intensities (angst, wut, hoffnung, ...)
+-- top_nouns: ranked nouns extracted by the NLP service for keyword aggregation
+ALTER TABLE monitor_articles
+  ADD COLUMN IF NOT EXISTS emotion_scores JSONB DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS top_nouns JSONB DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Why

`MonitorService.ts` writes and reads `emotion_scores` and `top_nouns` on `monitor_articles`, but those columns were never added by any migration. On fresh databases the three monitor endpoints fail:

- `GET /api/monitor/latest`
- `GET /api/monitor/briefing`
- `GET /api/monitor/keyword-insights`

with `column "emotion_scores" does not exist` / `column "top_nouns" does not exist`. Production was patched manually with the same DDL today; this commit lands the migration so new environments (and any rebuilt one) converge automatically.

## What

- `apps/api/database/postgres/migrations/add_monitor_emotion_columns.sql`
  - `emotion_scores JSONB DEFAULT '{}'::jsonb`
  - `top_nouns JSONB DEFAULT '[]'::jsonb`
  - Both `IF NOT EXISTS`, so prod (already patched) sees a no-op `NOTICE`.

Defaults are deliberate: existing queries use `WHERE emotion_scores != '{}'::jsonb` and `jsonb_array_length(a.top_nouns) > 0`, both of which would error on `NULL` and on a default-of-`'{}'` for the array column.

## Test plan

- [ ] Deploy to test env with empty DB → migration runner picks up the new file (`apps/api/database/services/PostgresService` runs everything in `migrations/` on startup).
- [ ] Verify `\d monitor_articles` shows both columns as `jsonb` with the expected defaults.
- [ ] Hit `/api/monitor/latest?locale=de` → no schema error in `api-1` logs (404 with `{"error": "No monitor data available yet"}` is expected until a refresh runs).
- [ ] Trigger a monitor refresh → endpoints return 200 with data.