### PR TITLE
feat(scraper): WordPress REST API discovery mode + migrate 4 stale WP LVs

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -76,18 +76,21 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       cms: 'wordpress',
       contentPaths: [
         {
+          // Site relaunched in Dec 2025 and changed permalinks from
+          // /category/pressemitteilung/<slug>/ to /<slug>/. Pre-relaunch URLs
+          // matched the off-path filter; post-relaunch URLs don't, which is why
+          // Qdrant froze at 2025-12-03. Use WP REST API (cat 9) to bypass
+          // HTML-listing discovery entirely.
           type: 'presse',
           path: '/category/pressemitteilung/',
           listSelector: 'article a[href], .entry-title a, h2 a, h3 a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 50,
+          wpApi: { categoryId: 9 },
         },
         {
           type: 'beschluss',
           path: '/category/beschluesse/',
           listSelector: 'article a[href], .entry-title a, h2 a, h3 a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 20,
+          wpApi: { categoryId: 11 },
         },
       ],
       contentSelectors: {
@@ -138,11 +141,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       maxAgeYears: 5,
       contentPaths: [
         {
+          // Articles publish at /<slug>/ (root permalinks); /presse/ is a virtual
+          // category index. Off-path filter strips every article. Use WP REST API
+          // category 12 = "Pressemitteilungen" (259 posts) instead.
           type: 'presse',
           path: '/presse/',
           listSelector: 'article a[href], h3 a, .elementor-post__title a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 30,
+          wpApi: { categoryId: 12 },
         },
         {
           type: 'beschluss',
@@ -188,18 +193,19 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       maxAgeYears: 5,
       contentPaths: [
         {
+          // Same root-permalink pattern as mv-lv. WP cat 13 = "Pressemitteilung"
+          // (1038 posts — Fraktion publishes ~4× more than the state party).
           type: 'presse',
           path: '/presse/',
           listSelector: 'article a[href], h2 a, h3 a, .wp-block-heading a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 50,
+          wpApi: { categoryId: 13 },
         },
         {
+          // WP cat 4 = "Antrag" (135 posts).
           type: 'antrag',
           path: '/category/antrag/',
           listSelector: 'article a[href], h2 a, h3 a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 30,
+          wpApi: { categoryId: 4 },
         },
       ],
       contentSelectors: {
@@ -474,11 +480,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       maxAgeYears: 12,
       contentPaths: [
         {
+          // Articles at /<slug>/ (root permalinks); /category/service/pressemitteilungen/
+          // is a virtual category index. Off-path filter strips everything. WP cat 243
+          // = "Pressemitteilungen" (471 posts).
           type: 'presse',
           path: '/category/service/pressemitteilungen/',
           listSelector: 'article a[href], .entry-title a, h2 a, h3 a',
-          paginationPattern: '/page/{page}/',
-          maxPages: 50,
+          wpApi: { categoryId: 243 },
         },
       ],
       contentSelectors: {

--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -30,7 +30,8 @@ export interface ContentPath {
   sitemapUrls?: string[]; // Optional: fetch URLs from sitemaps instead of pagination
   sitemapFilter?: string; // Optional: filter sitemap URLs (e.g., '/presse/')
   staticUrls?: string[]; // Optional: fixed list of URLs to scrape directly (bypasses pagination and sitemap)
-  disableOffPathFilter?: boolean; // Optional: when true, skip the post-discovery filter that requires URLs to share the listing-path prefix. Auto-applied when sitemapUrls is set, since sitemap URLs are already canonical and rarely match the human-facing listing path (e.g. TYPO3 sitemaps emit /news/ while listings live under /nachrichten/).
+  disableOffPathFilter?: boolean; // Optional: when true, skip the post-discovery filter that requires URLs to share the listing-path prefix. Auto-applied when sitemapUrls or wpApi is set, since both yield canonical URLs that rarely match the human-facing listing path (e.g. TYPO3 sitemaps emit /news/ while listings live under /nachrichten/; WP root-permalinks publish at /<slug>/ regardless of the /category/X listing seed).
+  wpApi?: { categoryId: number; maxPages?: number }; // Optional: discover articles via WordPress REST API (/wp-json/wp/v2/posts?categories=…). Bypasses HTML-listing pagination entirely; required for WP sites with root-permalink structure where /category/X/ is a virtual index.
 }
 
 export interface ContentSelectors {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -34,6 +34,7 @@ import { BaseScraper } from '../../base/BaseScraper.js';
 import { ContentExtractor } from './extractors/ContentExtractor.js';
 import { DateExtractor } from './extractors/DateExtractor.js';
 import { LinkExtractor } from './extractors/LinkExtractor.js';
+import { WpApiExtractor } from './extractors/WpApiExtractor.js';
 import { SearchOperations } from './operations/SearchOperations.js';
 import { DocumentProcessor } from './processors/DocumentProcessor.js';
 
@@ -56,6 +57,7 @@ export class LandesverbandScraper extends BaseScraper {
   private searchOps!: SearchOperations;
   private documentProcessor!: DocumentProcessor;
   private linkExtractor!: LinkExtractor;
+  private wpApiExtractor!: WpApiExtractor;
 
   private crawlDelay: number;
   private batchSize: number;
@@ -103,6 +105,7 @@ export class LandesverbandScraper extends BaseScraper {
       this.#shouldExcludeUrl.bind(this),
       this.delay.bind(this)
     );
+    this.wpApiExtractor = new WpApiExtractor(this.#fetchUrl.bind(this), this.delay.bind(this));
 
     this.log('Service initialized');
   }
@@ -299,6 +302,15 @@ export class LandesverbandScraper extends BaseScraper {
       if (contentPath.staticUrls && contentPath.staticUrls.length > 0) {
         this.log(`Using ${contentPath.staticUrls.length} static URLs for ${contentPath.type}`);
         articleLinks = contentPath.staticUrls;
+      } else if (contentPath.wpApi) {
+        this.log(
+          `Using WordPress REST API discovery (category ${contentPath.wpApi.categoryId}) for ${contentPath.type}`
+        );
+        articleLinks = await this.wpApiExtractor.extractArticleLinks(
+          source,
+          contentPath,
+          this.log.bind(this)
+        );
       } else if (contentPath.sitemapUrls && contentPath.sitemapUrls.length > 0) {
         this.log(`Using sitemap extraction for ${contentPath.type}`);
         articleLinks = await this.linkExtractor.extractLinksFromSitemaps(
@@ -324,7 +336,8 @@ export class LandesverbandScraper extends BaseScraper {
       // /category/X listing path used for discovery.
       const skipOffPathFilter =
         contentPath.disableOffPathFilter === true ||
-        (contentPath.sitemapUrls !== undefined && contentPath.sitemapUrls.length > 0);
+        (contentPath.sitemapUrls !== undefined && contentPath.sitemapUrls.length > 0) ||
+        contentPath.wpApi !== undefined;
 
       if (!skipOffPathFilter && contentPath.path && contentPath.path !== '/') {
         const before = articleLinks.length;

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/WpApiExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/WpApiExtractor.ts
@@ -1,0 +1,84 @@
+/**
+ * WordPress REST API Extractor
+ *
+ * Discovers article URLs by querying a WordPress site's `/wp-json/wp/v2/posts`
+ * endpoint with a category filter. Lets the scraper bypass HTML-listing pagination
+ * entirely on WP sites where article URLs don't share the listing-path prefix
+ * (root-permalink sites where /category/X/ is a virtual index, not part of the
+ * article URL — see mv-lv, thueringen-lv, sachsen-anhalt-lv post-relaunch).
+ *
+ * Returns canonical article URLs only; the existing per-URL Qdrant skip and
+ * ContentExtractor pipeline still runs to fetch+parse each post page. This keeps
+ * the integration small but means N+1 HTTP fetches per content path. A future
+ * optimization can pipe `post.content.rendered` directly into DocumentProcessor.
+ */
+
+import type { LandesverbandSource, ContentPath } from '../../../../../config/landesverbaendeConfig.js';
+
+interface WpPost {
+  link: string;
+}
+
+export class WpApiExtractor {
+  constructor(
+    private fetchUrl: (url: string) => Promise<Response>,
+    private delay: (ms: number) => Promise<void>
+  ) {}
+
+  async extractArticleLinks(
+    source: LandesverbandSource,
+    contentPath: ContentPath,
+    log: (msg: string) => void
+  ): Promise<string[]> {
+    if (!contentPath.wpApi) return [];
+
+    const { categoryId, maxPages = 50 } = contentPath.wpApi;
+    const perPage = 100;
+    const links = new Set<string>();
+    let page = 1;
+
+    while (page <= maxPages) {
+      const url = `${source.baseUrl}/wp-json/wp/v2/posts?categories=${categoryId}&per_page=${perPage}&page=${page}&_fields=link`;
+      let response: Response;
+      try {
+        response = await this.fetchUrl(url);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        log(`[WP API] page ${page} fetch failed: ${msg}`);
+        break;
+      }
+
+      // WP returns HTTP 400 with code rest_post_invalid_page_number when paging
+      // past the last page. Treat that as a normal end-of-results.
+      if (response.status === 400) {
+        log(`[WP API] page ${page} beyond range, stopping`);
+        break;
+      }
+      if (!response.ok) {
+        log(`[WP API] page ${page} HTTP ${response.status}, stopping`);
+        break;
+      }
+
+      let posts: WpPost[];
+      try {
+        posts = (await response.json()) as WpPost[];
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        log(`[WP API] page ${page} JSON parse failed: ${msg}`);
+        break;
+      }
+      if (!Array.isArray(posts) || posts.length === 0) break;
+
+      for (const post of posts) {
+        if (post.link) links.add(post.link);
+      }
+      log(`[WP API] page ${page}: ${posts.length} posts (total: ${links.size})`);
+
+      if (posts.length < perPage) break;
+      page++;
+      await this.delay(300);
+    }
+
+    return Array.from(links);
+  }
+}


### PR DESCRIPTION
## Summary

PR-γ of the LV-content-restoration effort. Adds a new WordPress REST API discovery mode and migrates the four most-stale WP-based LVs to use it. Recovers ~2.2k articles of stale content across sources frozen between 4 weeks and 5 months.

### Why

Per-LV Qdrant inventory plus live-site probing identified four WordPress sources with the same root cause: **article URLs don't share the listing-path prefix the off-path filter expects**. WP themes that use root permalinks publish at `/<slug>/` while exposing `/category/X/` as a virtual taxonomy index. The HTML-listing scraper grabs the index page links, then the off-path filter strips every article because none start with `/category/X`.

| LV | Frozen since | Cause |
|---|---|---|
| `sachsen-anhalt-lv` | 2025-12-03 (5 mo) | Dec 2025 site relaunch moved permalinks from `/category/X/<slug>/` to `/<slug>/`. Pre-relaunch URLs matched, post-relaunch URLs don't. |
| `thueringen-lv` | 2026-02-12 (10 wk) | Always used root permalinks; `/category/service/pressemitteilungen/` is a virtual index. |
| `mv-lv` | 2026-03-02 (7.5 wk) | Same root-permalink pattern. |
| `mv-fraktion` | 2026-03-03 (7.5 wk) | Same root-permalink pattern, two content paths (`/presse/`, `/category/antrag/`). |

HTML scraping cannot recover them without per-site permalink-aware logic. The cleanest fix is to query the WP REST API for category-filtered posts directly.

### Changes

1. **`feat(scraper): add WordPress REST API discovery mode`**
   - New `WpApiExtractor` queries `GET /wp-json/wp/v2/posts?categories={id}&per_page=100&page={n}&_fields=link` with normal pagination handling (HTTP 400 `rest_post_invalid_page_number` = end-of-results, sub-100 page = last page).
   - New `wpApi: { categoryId: number; maxPages?: number }` field on `ContentPath`.
   - Wired into `LandesverbandScraper.#scrapeContentPath` dispatch chain: `staticUrls` > `wpApi` > `sitemapUrls` > pagination.
   - Off-path-filter bypass auto-applies when `wpApi` is set.
   - Discovery returns canonical article URLs only — existing per-URL Qdrant skip and `ContentExtractor` flow still runs to fetch+parse each post page. N+1 HTTP cost; future optimization can pipe `post.content.rendered` directly into `DocumentProcessor`.

2. **`fix(config): migrate 4 stale WP LVs to wpApi discovery`**
   - `sachsen-anhalt-lv`: presse cat 9 (286), beschluss cat 11 (77)
   - `mv-lv`: presse cat 12 (259). Beschluss path stays as `isPdfArchive: true` despite being broken (page now serves /download/ HTML wrappers, not raw PDFs — separate concern, deferred).
   - `mv-fraktion`: presse cat 13 (1038), antrag cat 4 (135)
   - `thueringen-lv`: presse cat 243 (471)
   - All 4 sites probed live: REST endpoints respond, category names match content-type semantics, latest post on each is yesterday's date.

### Out of scope (deferred)

- mv-lv `/parteitags-beschluesse/` PDF archive: HTML-page → PDF-link architecture redesign.
- Pipe `post.content.rendered` into `DocumentProcessor` directly to avoid the per-article re-fetch.
- Berlin Wahlprogramm sub-sitemap auto-discovery (still uses 7 hardcoded `staticUrls`).
- Bundestag Fachtexte "12 stored every hour" dedup loop.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] After merge, manually trigger `gh workflow run content-sync.yml -f source=landesverbaende` and confirm in run logs:
  - `Using WordPress REST API discovery (category 9) for presse` (or 11/12/13/4/243 for the others)
  - `[WP API] page 1: 100 posts (total: 100)` etc., one per content path
  - For each migrated LV, Qdrant `MAX(published_at)` jumps from frozen date to recent (within last week)
  - Total chunk count grows by ~2k+ across the 4 sources