### PR TITLE
fix(scraper): revert Berlin /news/→/nachrichten/ rewrite — alias is unreliable

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -297,15 +297,17 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
           type: 'presse',
           path: '/nachrichten',
           listSelector: 'h2 a[href], h3 a[href]',
-          // Same TYPO3 pagination defect as berlin-lv-beschluesse: tx_xblog_pi1[pointer]
-          // is silently ignored upstream, so the listing only ever yields the rolling-10
-          // newest. Cross-checked against the news sub-sitemap (1000 entries) and found 2
-          // of the latest 5 articles missing from Qdrant — the rolling window doesn't keep
-          // up with publish cadence between hourly runs. Switch to typed sub-sitemap
-          // discovery; #normalizeUrl rewrites the canonical /news/ URLs back to the
-          // /nachrichten/ alias so URL-based dedup matches the 190 existing Qdrant points.
+          // TYPO3's tx_xblog_pi1[pointer] pagination is broken upstream (every page
+          // returns the same first ~10 items), so use the typed sub-sitemap. Filter on
+          // the canonical `/news/` prefix that gruene.berlin's TYPO3 SEO sitemap emits
+          // — do NOT rewrite to /nachrichten/. The /nachrichten/ alias only resolves
+          // for some articles; for older slugs TYPO3 silently routes /nachrichten/<slug>
+          // to the listing page with a "Uups, kein Eintrag vorhanden" notice (HTTP 200
+          // body, no redirect), and the scraper would then index the listing as if it
+          // were the article. /news/<slug>_<id> is the canonical TYPO3 URL and always
+          // resolves to the article page — it is what the sub-sitemap emits.
           sitemapUrls: ['https://gruene.berlin/sitemap.xml'],
-          sitemapFilter: '/nachrichten/',
+          sitemapFilter: '/news/',
         },
       ],
       contentSelectors: {

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -755,16 +755,6 @@ export class LandesverbandScraper extends BaseScraper {
       const parsed = new URL(absolute);
       parsed.hash = '';
       parsed.searchParams.delete('tmstv');
-
-      // gruene.berlin TYPO3 alias: the SEO sitemap emits canonical /news/<slug>_<id>
-      // URLs while the human-facing listing and existing Qdrant data both use
-      // /nachrichten/<slug>_<id>. Both routes resolve to the same article. Normalize
-      // sitemap-discovered URLs to the /nachrichten/ form so URL-based dedup matches
-      // already-indexed points instead of creating duplicates.
-      if (parsed.hostname === 'gruene.berlin' && parsed.pathname.startsWith('/news/')) {
-        parsed.pathname = '/nachrichten/' + parsed.pathname.slice('/news/'.length);
-      }
-
       const search = parsed.searchParams.toString();
       return parsed.origin + parsed.pathname + (search ? '?' + search : '');
     } catch {


### PR DESCRIPTION
## Summary

Hot-fix reverting the URL canonicalization from PR #674. That PR rewrote sitemap-discovered canonical \`/news/<slug>_<id>\` URLs to the user-facing \`/nachrichten/\` alias, on the assumption both routes resolve to the same article. **That assumption is wrong** for this TYPO3 install: \`/nachrichten/<slug>_<id>\` only resolves for some slugs. For older / dormant slugs TYPO3 silently serves the news listing page with a "Uups, kein Eintrag vorhanden" notice — HTTP 200, no redirect, just an unhelpful body.

The scraper indexed those listing pages as articles. Damage from the post-#674 manual sync run #1: **~282 berlin-lv-presse chunk_index=0 points** with \`title="Nachrichten"\` and chunk_text containing navigation menus + the "no entry found" notice + teaser links from the listing.

## Changes

1. **\`LandesverbandScraper.#normalizeUrl\`**: drop the \`/news/\` → \`/nachrichten/\` rewrite block. Sitemap URLs now pass through unchanged. Existing fragment / \`tmstv\` cache-buster stripping preserved.
2. **\`berlin-lv-presse\` config**: \`sitemapFilter\` from \`'/nachrichten/'\` to \`'/news/'\` to match what the TYPO3 SEO sub-sitemap actually emits.

Net effect:
- Future Berlin Presse articles store at \`/news/<slug>_<id>\` canonical URLs (always resolve).
- URL-keyed dedup will miss for articles that exist in Qdrant under both \`/nachrichten/\` (legacy from listing-page discovery) and \`/news/\` (new from sub-sitemap). Bounded duplicates possible — but those are real articles indexed twice with different URLs, far better than the current bogus listing-page captures.

## Cleanup

The 282 already-bogus entries need to be deleted from Qdrant separately. Filter: \`source_id=berlin-lv-presse AND title='Nachrichten'\`. Scope is bounded and the title-pattern match is unique to the bug — no real articles share that title.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] After merge, manually trigger \`gh workflow run content-sync.yml -f source=landesverbaende\` and confirm:
  - Berlin Presse new entries land at \`/news/<slug>_<id>\` URLs
  - No new entries with \`title="Nachrichten"\`
  - Articles previously bogus (e.g. _3794) are now indexed correctly under \`/news/\`