### PR TITLE
fix(monitor): surface silent fails in refresh and read paths

### DIFF
--- a/apps/api/services/monitor/MonitorService.ts
+++ b/apps/api/services/monitor/MonitorService.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
+import { toError } from '../../utils/errors/index.js';
 import { createLogger } from '../../utils/logger.js';
 import redisClient from '../../utils/redis/client.js';
 
@@ -169,45 +170,79 @@ export async function refreshMonitor(): Promise<MonitorSnapshot> {
   // Store articles in normalized table + snapshot aggregates
   await Promise.all([upsertArticles(allArticles), saveSnapshotAggregates(snapshot)]);
 
-  // Cache snapshot in Redis
+  // Cache snapshot in Redis. Non-fatal: DB still has canonical data, but a
+  // failure here means /monitor/latest pays the rebuild cost on every request.
   try {
     await redisClient.set(REDIS_SNAPSHOT_KEY, JSON.stringify(snapshot), { EX: REDIS_TTL_SECONDS });
   } catch (error) {
-    log.error(`Failed to cache snapshot in Redis: ${error}`);
+    log.error(`Failed to cache snapshot in Redis: ${toError(error).message}`);
   }
 
-  // Warm all caches in background (fire-and-forget)
+  const warmTasks: Array<{ name: string; run: () => Promise<unknown> }> = [];
+
   if (keywords.length > 0) {
     for (const locale of ['de', 'at'] as const) {
-      generateKeywordInsights(keywords, locale).catch((err) =>
-        log.warn(`Background keyword-insights warm (${locale}) failed: ${err}`)
-      );
+      warmTasks.push({
+        name: `keyword-insights:${locale}`,
+        run: () => generateKeywordInsights(keywords, locale),
+      });
     }
   }
 
   for (const locale of ['de', 'at'] as const) {
-    getStimmung(locale).catch((err) =>
-      log.warn(`Background stimmung warm (${locale}) failed: ${err}`)
-    );
+    warmTasks.push({ name: `stimmung:${locale}`, run: () => getStimmung(locale) });
   }
 
-  getPolls().catch((err) => log.warn(`Background polls warm failed: ${err}`));
+  warmTasks.push({ name: 'polls', run: () => getPolls() });
 
   for (const locale of ['de', 'at'] as const) {
-    Promise.all([getLatestSnapshot(locale), getStimmung(locale), getPolls()])
-      .then(([snap, stimmung, polls]) => {
-        if (snap) return generateMonitorBriefing(locale, snap, stimmung, polls?.average ?? {});
-      })
-      .catch((err) => log.warn(`Background briefing warm (${locale}) failed: ${err}`));
+    warmTasks.push({
+      name: `briefing:${locale}`,
+      run: async () => {
+        const [snap, stimmung, polls] = await Promise.all([
+          getLatestSnapshot(locale),
+          getStimmung(locale),
+          getPolls(),
+        ]);
+        if (!snap) throw new Error('no snapshot available');
+        return generateMonitorBriefing(locale, snap, stimmung, polls?.average ?? {});
+      },
+    });
   }
 
   for (const entity of WATCHER_ENTITIES) {
-    searchArticlesByKeywords(entity.keywords, entity.locale, 50, entity.excludePatterns)
-      .then((articles) => getEntitySummary(entity, articles, entity.locale))
-      .catch((err) =>
-        log.warn(`Background entity summary warm (${entity.id}/${entity.locale}) failed: ${err}`)
-      );
+    warmTasks.push({
+      name: `entity-summary:${entity.id}/${entity.locale}`,
+      run: async () => {
+        const articles = await searchArticlesByKeywords(
+          entity.keywords,
+          entity.locale,
+          50,
+          entity.excludePatterns
+        );
+        return getEntitySummary(entity, articles, entity.locale);
+      },
+    });
   }
+
+  // Run warmers in parallel, but don't block the refresh response. Aggregate
+  // failures into a single structured ERROR so a single watch on logs catches
+  // any background regression instead of 13 independent WARN lines.
+  void Promise.allSettled(warmTasks.map((t) => t.run())).then((results) => {
+    const failures = results
+      .map((r, i) => (r.status === 'rejected' ? { name: warmTasks[i].name, reason: r.reason } : null))
+      .filter((x): x is { name: string; reason: unknown } => x !== null);
+
+    if (failures.length === 0) {
+      log.info(`Background warm: ${warmTasks.length}/${warmTasks.length} succeeded`);
+      return;
+    }
+
+    const detail = failures.map((f) => `${f.name}: ${toError(f.reason).message}`).join('; ');
+    log.error(
+      `Background warm: ${failures.length}/${warmTasks.length} failed — ${detail}`
+    );
+  });
 
   const durationMs = Date.now() - startTime;
   log.info(
@@ -298,7 +333,8 @@ async function upsertArticles(articles: MonitorArticle[]): Promise<void> {
 
     log.info(`Upserted ${articles.length} articles into monitor_articles`);
   } catch (error) {
-    log.error(`Failed to upsert articles: ${error}`);
+    log.error(`Failed to upsert articles: ${toError(error).message}`);
+    throw error;
   }
 }
 
@@ -318,7 +354,8 @@ async function saveSnapshotAggregates(snapshot: MonitorSnapshot): Promise<void> 
       ]
     );
   } catch (error) {
-    log.error(`Failed to save snapshot: ${error}`);
+    log.error(`Failed to save snapshot: ${toError(error).message}`);
+    throw error;
   }
 }
 
@@ -330,8 +367,8 @@ export async function getLatestSnapshot(locale?: MonitorLocale): Promise<Monitor
     try {
       const cached = await redisClient.get(REDIS_SNAPSHOT_KEY);
       if (cached) return JSON.parse(cached) as MonitorSnapshot;
-    } catch {
-      // Fall through
+    } catch (error) {
+      log.warn(`Redis snapshot read failed, falling back to DB: ${toError(error).message}`);
     }
   }
 
@@ -367,8 +404,8 @@ export async function getLatestSnapshot(locale?: MonitorLocale): Promise<Monitor
         if (loc === 'de') snapshot.articlesByLocale.de = cnt;
         if (loc === 'at') snapshot.articlesByLocale.at = cnt;
       }
-    } catch {
-      // Non-critical
+    } catch (error) {
+      log.warn(`Failed to load locale article counts: ${toError(error).message}`);
     }
 
     if (locale) {
@@ -397,13 +434,13 @@ export async function getLatestSnapshot(locale?: MonitorLocale): Promise<Monitor
       await redisClient.set(REDIS_SNAPSHOT_KEY, JSON.stringify(snapshot), {
         EX: REDIS_TTL_SECONDS,
       });
-    } catch {
-      // Ignore
+    } catch (error) {
+      log.warn(`Failed to repopulate Redis snapshot cache: ${toError(error).message}`);
     }
 
     return snapshot;
   } catch (error) {
-    log.error(`Failed to fetch snapshot: ${error}`);
+    log.error(`Failed to fetch snapshot: ${toError(error).message}`);
     return null;
   }
 }
@@ -425,8 +462,8 @@ export async function getStimmung(locale?: MonitorLocale): Promise<StimmungResul
   try {
     const cached = await redisClient.get(stimmungCacheKey);
     if (cached) return JSON.parse(cached) as StimmungResult;
-  } catch {
-    // Fall through to DB
+  } catch (error) {
+    log.warn(`Redis stimmung read failed, falling back to DB: ${toError(error).message}`);
   }
 
   try {
@@ -539,13 +576,13 @@ export async function getStimmung(locale?: MonitorLocale): Promise<StimmungResul
 
     try {
       await redisClient.set(stimmungCacheKey, JSON.stringify(result), { EX: REDIS_TTL_SECONDS });
-    } catch {
-      // Non-critical
+    } catch (error) {
+      log.warn(`Failed to cache stimmung in Redis: ${toError(error).message}`);
     }
 
     return result;
   } catch (error) {
-    log.error(`Failed to get stimmung: ${error}`);
+    log.error(`Failed to get stimmung: ${toError(error).message}`);
     return { overall: {}, byTopic: [], bySource: [], byKeyword: [], dominantEmotion: null };
   }
 }


### PR DESCRIPTION
## Why

The monitor module had three classes of silent failure that made it impossible to tell from logs whether a refresh actually worked:

1. **Critical writes logged-and-swallowed.** \`upsertArticles\` and \`saveSnapshotAggregates\` caught DB errors, logged them, and returned normally — so \`refreshMonitor()\` would continue, the HTTP handler would respond \`{ success: true }\`, and the user would think the refresh worked while nothing got persisted. (This is exactly how today's prod incident hid for so long: every refresh was 'succeeding' while every \`INSERT\` was failing on the missing \`emotion_scores\` column.)
2. **13 fire-and-forget warm tasks each had their own \`.catch(log.warn)\`.** A Mistral outage or a single broken briefing path produced 13 independent WARN lines scattered through the log; nothing aggregated them, so unless someone tailed the right grep, partial degradation was invisible.
3. **Three empty \`catch {}\` blocks** around Redis reads/writes in \`getLatestSnapshot\` and \`getStimmung\` masked actual Redis errors as 'cache miss', making Redis-side problems indistinguishable from a normal cold cache.

## What

Single-file change in \`apps/api/services/monitor/MonitorService.ts\` (+71/-34):

- **Critical writes re-throw.** \`upsertArticles\` and \`saveSnapshotAggregates\` now \`throw error\` after logging. \`refreshMonitor()\` propagates, and the route returns 500 — which is correct for 'refresh that didn't persist'.
- **Background warm uses \`Promise.allSettled\` with a single structured summary.** Tasks are now collected as \`{ name, run }\` descriptors. Result: one log line per refresh — \`INFO 13/13 succeeded\` or \`ERROR 4/13 failed — briefing:de: …; entity-summary:scholz/de: …\`. Future warmers join the same aggregator automatically; no more 'forgot to add a .catch' regressions.
- **Empty Redis catches replaced with \`log.warn\`** that includes the actual error message via \`toError\`. The fall-through behaviour is preserved (Redis hiccups still don't fail the request) but they're observable now.
- All error stringification routed through \`toError()\` for consistency with the rest of the API.

## Test plan

- [x] Typecheck passes (\`tsc --noEmit --project apps/api/tsconfig.json\` → 0 errors).
- [ ] Trigger a successful refresh on test → expect single \`INFO Background warm: N/N succeeded\` line per refresh.
- [ ] Simulate a downstream failure (e.g. revoke Mistral key in test) → expect single \`ERROR Background warm: K/N failed — <task>: <reason>; …\` line.
- [ ] Force a DB write failure (e.g. lock the table) → expect refresh to return 500 instead of \`{ success: true }\`.
- [ ] Stop Redis → expect \`/monitor/latest\` to still serve via DB rebuild, with WARN log lines naming the read/write that failed.

## Out of scope

- Adding a scheduler (separate concern; flagged in earlier conversation).
- Switching warm to blocking (would 3× the user's perceived refresh latency; the right tradeoff is non-blocking but observable).
- Cleanup of unbounded \`monitor_articles\` growth (separate cron PR).