### PR TITLE
fix(config): Berlin Presse via /pressemitteilungen listing, drop news sub-sitemap

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -294,20 +294,27 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       maxAgeYears: 5,
       contentPaths: [
         {
+          // Scrape the dedicated /pressemitteilungen listing instead of /nachrichten
+          // or the news sub-sitemap. The news sub-sitemap aggregates ALL Berlin LV
+          // posts (press releases + AG-Sitzung announcements + LAG meetings + events),
+          // and articles indexed from there polluted Berlin Presse with non-press
+          // content. /pressemitteilungen is TYPO3's category-filtered listing route
+          // and only contains real press releases.
+          //
+          // Pagination on /pressemitteilungen actually works (unlike /nachrichten,
+          // where tx_xblog_pi1[pointer] is silently ignored) — pages 1, 2, 3 ... 57
+          // each return distinct article IDs, and the next-page links carry
+          // per-page cHash signatures. Use paginationLinkSelector so the extractor
+          // follows next-links from HTML rather than constructing URLs (which
+          // wouldn't carry the required cHash). paginationPattern stays as fallback
+          // for the rare case the link-following can't find a "next" anchor.
           type: 'presse',
-          path: '/nachrichten',
+          path: '/pressemitteilungen',
           listSelector: 'h2 a[href], h3 a[href]',
-          // TYPO3's tx_xblog_pi1[pointer] pagination is broken upstream (every page
-          // returns the same first ~10 items), so use the typed sub-sitemap. Filter on
-          // the canonical `/news/` prefix that gruene.berlin's TYPO3 SEO sitemap emits
-          // — do NOT rewrite to /nachrichten/. The /nachrichten/ alias only resolves
-          // for some articles; for older slugs TYPO3 silently routes /nachrichten/<slug>
-          // to the listing page with a "Uups, kein Eintrag vorhanden" notice (HTTP 200
-          // body, no redirect), and the scraper would then index the listing as if it
-          // were the article. /news/<slug>_<id> is the canonical TYPO3 URL and always
-          // resolves to the article page — it is what the sub-sitemap emits.
-          sitemapUrls: ['https://gruene.berlin/sitemap.xml'],
-          sitemapFilter: '/news/',
+          paginationLinkSelector: '.pagination a',
+          paginationPattern: '?tx_xblog_pi1[pointer]={page}',
+          paginationOffset: -1,
+          maxPages: 60,
         },
       ],
       contentSelectors: {


### PR DESCRIPTION
## Summary

Switches \`berlin-lv-presse\` from the news sub-sitemap (PR #673/#674/#677) to the
dedicated \`/pressemitteilungen\` listing.

## Why

The news sub-sitemap aggregates ALL Berlin LV posts: press releases, AG-Sitzung
announcements, LAG meetings, and online events. Audit of top 50 articles by
\`published_at\` found 7 of 50 (~14%) had logic problems:

- 3 entries with chunk_text containing the listing-page boilerplate (\"Listenansicht
  Zurück Nachrichten Termine Beschlüsse...\"). TYPO3's \`/nachrichten/<slug>\` alias
  silently 404s for some slugs and serves the listing page; the title comes through
  via \`og:title\` so my title-pattern cleanup missed these.
- 8 articles total (across all 227 stored) with AG-Sitzung in the title.
- 8 with LAG (Landesarbeitsgemeinschaft).
- 1 Termin invitation, 2 Online-Veranstaltungen.

## Changes

\`/pressemitteilungen\` is TYPO3's category-filtered route — only real press releases.

Verified pagination works there (unlike \`/nachrichten\`):
- pages 1, 2, 3, 57 each return distinct article IDs (3802/3801/... → 3636/3637/... → 3570/... → 2422)
- next-page links carry per-page \`cHash\` signatures

Use \`paginationLinkSelector\` mode so the extractor follows next-page anchors from
HTML rather than constructing pagination URLs (which can't include the required
cHash). \`paginationPattern\` stays as a fallback.

\`listSelector\` and \`contentSelectors\` unchanged — only the discovery path changes.
The off-path filter naturally drops legacy \`/nachrichten/\` teaser URLs from the
listing page since they don't share the \`/pressemitteilungen\` prefix.

Going forward, scrapes index articles at \`/pressemitteilungen/<slug>_<id>\` canonical
URLs. Existing legacy \`/nachrichten/\` and \`/news/\` entries in Qdrant get purged in a
companion clean-slate operation so URL-based dedup works against a single form.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] After merge, manual sync produces clean berlin-lv-presse with all URLs starting \`/pressemitteilungen/\`
- [ ] Top 50 audit returns 0 logic issues