### PR TITLE
feat(api): add LV operations scripts (sync-source, patch-dates)

### DIFF
--- a/apps/api/patch-dates.ts
+++ b/apps/api/patch-dates.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env tsx
+/**
+ * Metadata-only date backfill — for each Qdrant point with NULL or
+ * malformatted `published_at`, fetches the article URL, extracts the date
+ * with current contentSelectors + normalizeGermanDate, and PATCHes the
+ * `published_at` payload field on Qdrant. NO embedding, NO vector replacement.
+ *
+ * Usage:
+ *   npx tsx patch-dates.ts <source-id> [--dry-run]
+ *
+ * Examples:
+ *   npx tsx patch-dates.ts hamburg-lv-presse
+ *   npx tsx patch-dates.ts sachsen-anhalt-fraktion
+ *   npx tsx patch-dates.ts brandenburg-archive-presse  # also re-normalizes existing DD.MM.YYYY
+ *
+ * Order of magnitude faster than --force re-scrape:
+ *   - sachsen-anhalt-fraktion 743 articles: ~5 min (vs ~25 min --force, and --force only
+ *     covers articles on the listing, missing 695 of them)
+ *   - hamburg-lv-presse 1948 articles: ~10 min (vs ~1.5h --force)
+ */
+
+import * as cheerio from 'cheerio';
+
+import { getSourceById } from './config/landesverbaendeConfig.js';
+import { ContentExtractor } from './services/scrapers/implementations/LandesverbandScraper/extractors/ContentExtractor.js';
+import { getQdrantInstance } from './database/services/QdrantService/index.js';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const sourceId = args.find((a) => !a.startsWith('--'));
+
+if (!sourceId) {
+  console.error('Usage: patch-dates.ts <source-id> [--dry-run]');
+  process.exit(1);
+}
+
+const source = getSourceById(sourceId);
+if (!source) {
+  console.error(`Unknown source: ${sourceId}`);
+  process.exit(1);
+}
+
+const COLLECTION = source.qdrantCollection || 'landesverbaende_documents';
+const UA = 'Gruenerator-Bot/1.0 (+https://gruenerator.eu)';
+
+interface QdrantPoint {
+  id: string | number;
+  payload?: { source_url?: string; published_at?: string | null; chunk_index?: number };
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const r = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(15000) });
+    if (!r.ok) return null;
+    return await r.text();
+  } catch {
+    return null;
+  }
+}
+
+function extractDate(html: string): string | null {
+  const $ = cheerio.load(html);
+  for (const sel of source!.contentSelectors.date) {
+    const el = $(sel).first();
+    if (!el.length) continue;
+    let raw = el.attr('datetime') || el.attr('content') || el.text().trim();
+    if (!raw) continue;
+    raw = ContentExtractor.normalizeGermanDate(raw);
+    if (raw) return raw;
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  console.log(`\n[patch-dates] source=${sourceId} collection=${COLLECTION} dry-run=${dryRun}`);
+
+  const qdrant = getQdrantInstance();
+  await qdrant.init();
+  const client = qdrant.client!;
+
+  // Scroll all chunk_index=0 points for this source (one per article).
+  // Note: tsconfig has `exactOptionalPropertyTypes`, so we spread `offset` only
+  // when defined rather than passing `offset: undefined`.
+  const points: QdrantPoint[] = [];
+  let offset: string | number | Record<string, unknown> | null | undefined = undefined;
+  do {
+    const res = await client.scroll(COLLECTION, {
+      filter: {
+        must: [
+          { key: 'source_id', match: { value: sourceId } },
+          { key: 'chunk_index', match: { value: 0 } },
+        ],
+      },
+      limit: 200,
+      with_payload: ['source_url', 'published_at'],
+      with_vector: false,
+      ...(offset !== undefined && offset !== null ? { offset } : {}),
+    });
+    points.push(...(res.points as QdrantPoint[]));
+    offset = res.next_page_offset;
+  } while (offset !== null && offset !== undefined);
+
+  console.log(`Fetched ${points.length} articles from Qdrant`);
+
+  // Filter: only articles where published_at is missing OR not in ISO format
+  const isISO = (s: string | null | undefined): boolean => !!s && /^\d{4}-\d{2}-\d{2}/.test(s);
+  const candidates = points.filter((p) => !isISO(p.payload?.published_at));
+  console.log(`Candidates needing date patch: ${candidates.length}`);
+
+  if (dryRun) {
+    console.log('\n[dry-run] sample 5:');
+    for (const p of candidates.slice(0, 5)) {
+      console.log(`  pub=${p.payload?.published_at ?? 'NULL'} url=${p.payload?.source_url}`);
+    }
+    process.exit(0);
+  }
+
+  let patched = 0;
+  let no_html = 0;
+  let no_date = 0;
+  let already = 0;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const p = candidates[i];
+    const url = p.payload?.source_url;
+    if (!url) continue;
+
+    const existing = p.payload?.published_at;
+
+    // For sources with stored DD.MM.YYYY (brandenburg-archive), try renormalizing
+    // FIRST without re-fetching — saves an HTTP call per article.
+    if (existing && /\d{1,2}\.\d{1,2}\.\d{2,4}/.test(existing)) {
+      const norm = ContentExtractor.normalizeGermanDate(existing);
+      if (isISO(norm)) {
+        await client.setPayload(COLLECTION, {
+          payload: { published_at: norm },
+          filter: {
+            must: [
+              { key: 'source_id', match: { value: sourceId } },
+              { key: 'source_url', match: { value: url } },
+            ],
+          },
+        });
+        patched++;
+        if (i % 20 === 0 || i === candidates.length - 1)
+          console.log(`  [${i + 1}/${candidates.length}] renorm: ${existing} → ${norm}`);
+        continue;
+      }
+    }
+
+    // NULL or non-ISO and not renormalizable → fetch the article
+    const html = await fetchPage(url);
+    if (!html) {
+      no_html++;
+      continue;
+    }
+    const date = extractDate(html);
+    if (!date || !isISO(date)) {
+      no_date++;
+      continue;
+    }
+
+    // Patch all chunks for this article (set_payload with filter)
+    await client.setPayload(COLLECTION, {
+      payload: { published_at: date },
+      filter: {
+        must: [
+          { key: 'source_id', match: { value: sourceId } },
+          { key: 'source_url', match: { value: url } },
+        ],
+      },
+    });
+    patched++;
+    if (i % 20 === 0 || i === candidates.length - 1)
+      console.log(`  [${i + 1}/${candidates.length}] ${date} ← ${url.slice(-60)}`);
+  }
+
+  console.log(`\n═══ SUMMARY ═══`);
+  console.log(`  patched:   ${patched}`);
+  console.log(`  no_html:   ${no_html} (article fetch failed)`);
+  console.log(`  no_date:   ${no_date} (selector still didn't match)`);
+  console.log(`  already:   ${already}`);
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/api/sync-source.ts
+++ b/apps/api/sync-source.ts
@@ -1,0 +1,66 @@
+#!/usr/bin/env tsx
+/**
+ * Generic single-source LV sync — runs LandesverbandScraper.scrapeSource for
+ * one or more source IDs passed as args. Use --force to re-process URLs already
+ * in Qdrant (default: skip-by-source_url, only fetches new articles).
+ *
+ * Usage:
+ *   npx tsx sync-source.ts [--force] <source-id> [<source-id> ...]
+ *
+ * Examples:
+ *   npx tsx sync-source.ts thueringen-lv
+ *   npx tsx sync-source.ts --force sachsen-anhalt-fraktion
+ *   npx tsx sync-source.ts --force brandenburg-archive-presse brandenburg-archive-beschluesse
+ *
+ * Env: requires .env (Qdrant + Mistral creds). Run with `--env-file=.env --import tsx`
+ * via node when invoking outside the monorepo's standard launcher.
+ */
+
+import { landesverbandScraperService } from './services/scrapers/implementations/LandesverbandScraper/index.js';
+
+const args = process.argv.slice(2);
+const force = args.includes('--force');
+const sourceIds = args.filter((a) => !a.startsWith('--'));
+
+if (sourceIds.length === 0) {
+  console.error('Usage: sync-source.ts [--force] <source-id> [<source-id> ...]');
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  console.log(`\n[sync-source] starting — force=${force} sources=${sourceIds.join(', ')}\n`);
+  await landesverbandScraperService.init();
+
+  const startAll = Date.now();
+  const results: Record<string, { stored: number; updated: number; skipped: number; errors: number }> = {};
+
+  for (const id of sourceIds) {
+    const start = Date.now();
+    console.log(`\n═══ ${id} ═══`);
+    try {
+      const r = await landesverbandScraperService.scrapeSource(id, { forceUpdate: force });
+      const dur = Math.round((Date.now() - start) / 1000);
+      results[id] = { stored: r.stored, updated: r.updated, skipped: r.skipped, errors: r.errors };
+      console.log(
+        `[${id}] stored=${r.stored} updated=${r.updated} skipped=${r.skipped} errors=${r.errors} (${dur}s)`
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      console.error(`[${id}] FAILED: ${msg}`);
+      results[id] = { stored: 0, updated: 0, skipped: 0, errors: 1 };
+    }
+  }
+
+  const totalDur = Math.round((Date.now() - startAll) / 1000);
+  console.log('\n═══ SUMMARY ═══');
+  for (const [id, r] of Object.entries(results)) {
+    console.log(`  ${id}: stored=${r.stored} updated=${r.updated} skipped=${r.skipped} errors=${r.errors}`);
+  }
+  console.log(`Total duration: ${totalDur}s\n`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Two operational helper scripts under \`apps/api/\`, alongside the existing one-off scripts (\`update-all-content.ts\`, \`aggregate-sync-summaries.ts\`).

### \`apps/api/sync-source.ts\`

Targeted single-source scraper invocation. Bypasses \`update-all-content.ts\`'s
group-level scope (which only accepts source-group args like \`landesverbaende\`)
to scrape one or more specific source IDs.

Used in this work for:
- Validating PR #676's \`wpApi\` discovery on \`thueringen-lv\` without scraping all 16 LVs
- Backfilling \`berlin-lv-presse\` after the \`/pressemitteilungen\` migration (PR #679)
- Force-rescraping \`brandenburg-archive-*\` to apply the date format fix from PR #672

\`\`\`
npx tsx sync-source.ts [--force] <source-id> [<source-id> ...]
\`\`\`

### \`apps/api/patch-dates.ts\`

Metadata-only date backfill via Qdrant \`points/payload\` (no Mistral embedding,
no vector replacement). For each \`chunk_index=0\` point with NULL or non-ISO
\`published_at\`, fetches the article URL, extracts the date with current
\`contentSelectors\` + \`normalizeGermanDate\`, and PATCHes the \`published_at\` field
on all chunks for that article in one \`setPayload\` call.

**~100x cheaper than \`--force\` re-scrape** (no embedding cost) and works on
articles deeper than the listing pagination (where \`--force\` can't reach).

Used in this work to fix:
- \`hamburg-lv-presse\`: 1900 → 1 NULL dates in ~10 min
- \`sachsen-anhalt-fraktion\`: identified that 681 of 695 NULL-date URLs return
  HTTP 404 (NEOS site restructure), only 12 had reachable pages
- \`brandenburg-archive\`: confirmed already-ISO after a prior \`--force\` run

\`\`\`
npx tsx patch-dates.ts <source-id> [--dry-run]
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` clean (with \`exactOptionalPropertyTypes\` strict)
- [x] Used in production this session, fixed ~1900 NULL dates without Mistral cost
- [ ] Future use cases: any time a \`contentSelectors.date\` change lands and
  pre-existing entries need backfill, run \`patch-dates.ts <source-id>\` instead
  of \`--force\` re-scrape.