### PR TITLE
feat(auth): migrate /api/auth/status to ts-rest contract

### DIFF
--- a/apps/api/middleware/authMiddleware.ts
+++ b/apps/api/middleware/authMiddleware.ts
@@ -72,7 +72,7 @@ const DEV_BYPASS_USER: Express.User = {
  * the schema expects a number) throws ZodError at parse time instead of
  * cascading as `undefined` through the render tree.
  */
-function toBetterAuthUser(user: BetterAuthUser): UserProfile {
+export function toBetterAuthUser(user: BetterAuthUser): UserProfile {
   const nullStripped = Object.fromEntries(
     Object.entries(user).map(([k, v]) => [k, v === null ? undefined : v])
   );

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -8,6 +8,7 @@ import rateLimit from 'express-rate-limit';
 
 import authMiddleware from './middleware/authMiddleware.js';
 import antraegeRouter from './routes/antraege/index.js';
+import { mountAuthStatusContractRouter } from './routes/auth/authStatusContractRouter.js';
 import authInitRouter from './routes/auth/initController.js';
 import { mountAdminVorlagenContractRouter } from './routes/auth/templates/adminVorlagenContractRouter.js';
 import { mountUserProfileContractRouter } from './routes/auth/userProfileContractRouter.js';
@@ -273,6 +274,12 @@ export async function setupRoutes(app: Application): Promise<void> {
   // enforced per-handler via `checkIsAdmin` inside the contract).
   app.use('/api/auth/admin/vorlagen', requireAuth);
   mountAdminVorlagenContractRouter(app);
+  // ts-rest contract router for /api/auth/status — mounts BEFORE the legacy
+  // authRouter so the contract route matches first. NO requireAuth at the
+  // prefix: /status must respond to unauthed callers (returns
+  // { isAuthenticated: false, user: null }) so the frontend can decide
+  // whether to show the login screen.
+  mountAuthStatusContractRouter(app);
   app.use('/api/auth', authenticatedReadLimiter, authRouter);
   // ts-rest contract router for notebook collections — mounts BEFORE the
   // legacy router so contract-modeled routes match first. requireAuth is

--- a/apps/api/routes/auth/authCore.ts
+++ b/apps/api/routes/auth/authCore.ts
@@ -1,6 +1,7 @@
 /**
  * Core authentication routes
- * Handles status, logout, profile, locale, health, and error pages
+ * Handles logout, profile, locale, health, and error pages
+ * Status (/api/auth/status) is served by authStatusContractRouter
  * Login/callback handled by Better Auth at /api/auth/v2/*
  */
 
@@ -8,7 +9,7 @@ import { fromNodeHeaders } from 'better-auth/node';
 import { and, eq, like } from 'drizzle-orm';
 import express, { type Router, type Response } from 'express';
 
-import { auth, type BetterAuthUser } from '../../config/betterAuth.js';
+import { auth } from '../../config/betterAuth.js';
 import { env } from '../../config/env.js';
 import { ba_accounts } from '../../database/schema/auth.js';
 import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
@@ -16,7 +17,7 @@ import authMiddlewareModule from '../../middleware/authMiddleware.js';
 import * as chatMemory from '../../services/chat/ChatMemoryService.js';
 import { createLogger } from '../../utils/logger.js';
 
-import type { AuthRequest, AuthStatusResponse, LocaleUpdateBody } from './types.js';
+import type { AuthRequest, LocaleUpdateBody } from './types.js';
 
 const log = createLogger('authCore');
 const { requireAuth: ensureAuthenticated } = authMiddlewareModule;
@@ -37,40 +38,6 @@ router.get('/test', (_req: AuthRequest, res: Response): void => {
     message: 'Auth routes are working',
     timestamp: new Date().toISOString(),
   });
-});
-
-// ============================================================================
-// Status Route
-// ============================================================================
-
-router.get('/status', async (req: AuthRequest, res: Response): Promise<void> => {
-  try {
-    const session = await auth.api.getSession({
-      headers: fromNodeHeaders(req.headers),
-    });
-
-    if (session?.user) {
-      const user = session.user as BetterAuthUser & { locale?: string };
-      res.json({
-        isAuthenticated: true,
-        user: {
-          id: user.id,
-          email: user.email,
-          name: user.name,
-          image: user.image,
-          emailVerified: user.emailVerified,
-          createdAt: user.createdAt,
-          updatedAt: user.updatedAt,
-          ...(user.locale && { locale: user.locale }),
-        },
-      });
-      return;
-    }
-  } catch {
-    // Session check failed
-  }
-
-  res.json({ isAuthenticated: false, user: null } as AuthStatusResponse);
 });
 
 // ============================================================================

--- a/apps/api/routes/auth/authStatusContractRouter.ts
+++ b/apps/api/routes/auth/authStatusContractRouter.ts
@@ -1,0 +1,65 @@
+/**
+ * ts-rest contract router for the auth status endpoint.
+ *
+ *   GET /api/auth/status
+ *
+ * The status endpoint reports the current session and is intentionally
+ * NOT protected by `requireAuth` — it must respond gracefully for
+ * unauthenticated callers (with `isAuthenticated: false, user: null`),
+ * since the frontend uses it to decide whether to show the login screen.
+ *
+ * The contract enforces the response shape end-to-end. The handler returns
+ * the canonical `UserProfile` via `toBetterAuthUser()`, which is the single
+ * null-strip + Zod-parse boundary shared with the auth middleware. That
+ * removes the manual hand-pick step that previously dropped fields like
+ * `is_admin` and broke the admin gate on the frontend.
+ */
+
+import { authStatusContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+import { fromNodeHeaders } from 'better-auth/node';
+
+import { auth } from '../../config/betterAuth.js';
+import { toBetterAuthUser } from '../../middleware/authMiddleware.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { createLogger } from '../../utils/logger.js';
+
+import type { Application } from 'express';
+
+const log = createLogger('authStatusContractRouter');
+
+const s = initServer();
+
+export const authStatusContractRouter = s.router(authStatusContract, {
+  getStatus: async (args) => {
+    try {
+      const session = await auth.api.getSession({
+        headers: fromNodeHeaders(args.req.headers),
+      });
+      if (session?.user) {
+        return {
+          status: 200 as const,
+          body: { isAuthenticated: true, user: toBetterAuthUser(session.user) },
+        };
+      }
+    } catch (err) {
+      log.error('[authStatus.getStatus] session check failed: %s', (err as Error).message);
+    }
+    return { status: 200 as const, body: { isAuthenticated: false, user: null } };
+  },
+});
+
+/**
+ * Mount the ts-rest auth status contract router onto an Express app.
+ * Call from routes.ts BEFORE the legacy `app.use('/api/auth', authRouter)` so
+ * the contract route matches first; the legacy `/status` handler can then
+ * be removed.
+ *
+ * No `requireAuth` wrapper at the prefix — the endpoint must work for both
+ * authed and unauthed callers.
+ */
+export function mountAuthStatusContractRouter(app: Application): void {
+  createExpressEndpoints(authStatusContract, authStatusContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'authStatusContract'),
+  });
+}

--- a/packages/contracts/src/contracts/authStatusContract.ts
+++ b/packages/contracts/src/contracts/authStatusContract.ts
@@ -1,0 +1,32 @@
+/**
+ * ts-rest contract for the auth status endpoint.
+ *
+ *   GET /api/auth/status
+ *
+ * Reports current session: { isAuthenticated, user } where user is the full
+ * canonical UserProfile or null. Always returns 200 — the unauthenticated
+ * branch is part of the contract, not an error.
+ */
+import { initContract } from '@ts-rest/core';
+
+import { authStatusResponseSchema } from '../schemas/authStatus.js';
+
+const c = initContract();
+
+export const authStatusContract = c.router(
+  {
+    /**
+     * GET /api/auth/status
+     * Returns the current session state.
+     */
+    getStatus: {
+      method: 'GET',
+      path: '/api/auth/status',
+      responses: {
+        200: authStatusResponseSchema,
+      },
+      summary: 'Get current auth/session status',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -25,3 +25,4 @@ export { transferContract } from './transferContract.js';
 export { unsplashContract } from './unsplashContract.js';
 export { notificationsContract } from './notificationsContract.js';
 export { adminVorlagenContract } from './adminVorlagenContract.js';
+export { authStatusContract } from './authStatusContract.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -36,6 +36,7 @@ export {
   unsplashContract,
   notificationsContract,
   adminVorlagenContract,
+  authStatusContract,
 } from './contracts/index.js';
 
 // ── Schemas (Zod) ───────────────────────────────────────────────────────────
@@ -62,3 +63,4 @@ export * from './schemas/transfer.js';
 export * from './schemas/unsplash.js';
 export * from './schemas/notifications.js';
 export * from './schemas/adminVorlagen.js';
+export * from './schemas/authStatus.js';

--- a/packages/contracts/src/schemas/authStatus.ts
+++ b/packages/contracts/src/schemas/authStatus.ts
@@ -1,0 +1,20 @@
+/**
+ * Zod schemas for the /api/auth/status endpoint.
+ *
+ * The status endpoint reports the current session: either authenticated (with
+ * the full UserProfile) or unauthenticated (user = null). Both branches return
+ * 200, so a single response schema covers the surface.
+ *
+ * Reuses `userProfileSchema` from userProfile.ts so the contract is the single
+ * source of truth for the canonical UserProfile shape end-to-end.
+ */
+import { z } from 'zod';
+
+import { userProfileSchema } from './userProfile.js';
+
+export const authStatusResponseSchema = z.object({
+  isAuthenticated: z.boolean(),
+  user: userProfileSchema.nullable(),
+});
+
+export type AuthStatusResponseSchema = z.infer<typeof authStatusResponseSchema>;

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -27,6 +27,7 @@ import {
   transferContract,
   notificationsContract,
   adminVorlagenContract,
+  authStatusContract,
 } from '@gruenerator/contracts';
 import { initClient } from '@ts-rest/core';
 
@@ -131,6 +132,7 @@ const _wordpressClient = () => initClient(wordpressContract, CLIENT_OPTS);
 const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
 const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
+const _authStatusClient = () => initClient(authStatusContract, CLIENT_OPTS);
 
 export interface ContractsClient {
   threads: ReturnType<typeof _threadsClient>;
@@ -143,6 +145,7 @@ export interface ContractsClient {
   transfer: ReturnType<typeof _transferClient>;
   notifications: ReturnType<typeof _notificationsClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
+  authStatus: ReturnType<typeof _authStatusClient>;
 }
 
 // ── Lazy singleton ────────────────────────────────────────────────────────────
@@ -172,6 +175,7 @@ export function getContractsClient(): ContractsClient {
     transfer: _transferClient(),
     notifications: _notificationsClient(),
     adminVorlagen: _adminVorlagenClient(),
+    authStatus: _authStatusClient(),
   };
 
   return _client;


### PR DESCRIPTION
## Summary

- Fixes admin gate ("Kein Zugriff") visible to admin users — root cause was `/api/auth/status` hand-picking 8 fields from the Better Auth user object and dropping `is_admin` (and ~30 other `UserProfile` fields) from the response. The frontend's `useAuthStore.user.is_admin` was therefore always `undefined`.
- Migrates the endpoint to a ts-rest contract so the response shape is enforced end-to-end (server handler must return the canonical `UserProfile` or 200/null) — making this regression class impossible to reintroduce.
- Reuses `toBetterAuthUser()` (the existing null-strip + Zod-parse boundary in `authMiddleware.ts`) instead of a fresh hand-pick — single source of truth for the wire shape.

## Why TypeScript missed the original bug

`is_admin` is `z.boolean().optional()` in `userProfileSchema` (it's `is_admin?: boolean` in TS). Even with a typed `Response<AuthStatusResponse>`, omitting an optional field is legal — so TS could not catch the missing field. The contract fixes this structurally: the handler returns `toBetterAuthUser(session.user)` (full UserProfile) or `null`, with no hand-pick step in between.

## Files

- `packages/contracts/src/{schemas,contracts}/authStatus*.ts` — new schema + contract; `authStatusResponseSchema` reuses `userProfileSchema.nullable()`
- `apps/api/routes/auth/authStatusContractRouter.ts` — server handler; mounted in `routes.ts` BEFORE the legacy `authRouter` so the contract route matches first
- `apps/api/routes/auth/authCore.ts` — legacy `/status` handler removed
- `apps/api/middleware/authMiddleware.ts` — `toBetterAuthUser` exported for reuse
- `packages/shared/src/api/contractsClient.ts` — `authStatus` added to typed `ContractsClient`

## Test plan

- [ ] `pnpm --filter @gruenerator/api typecheck` passes (auth-status changes only — pre-existing `intentExecutionService.ts` `variants` errors are out of scope)
- [ ] `curl http://localhost:3001/api/auth/status` (no cookie) returns `{ "isAuthenticated": false, "user": null }` with HTTP 200
- [ ] Logged in via browser: `/api/auth/status` payload includes `is_admin: true` for admin users
- [ ] AdminDashboardPage no longer shows "Kein Zugriff" for admins; vorlagen review UI loads