### PR TITLE
fix(admin): gate admin queries on is_admin and log denials

### DIFF
--- a/apps/api/routes/auth/templates/adminTemplates.ts
+++ b/apps/api/routes/auth/templates/adminTemplates.ts
@@ -20,11 +20,19 @@ const rejectSchema = z.object({
 async function verifyAdmin(req: AuthRequest, res: Response): Promise<boolean> {
   const postgres = getPostgresInstance();
   const profile = await postgres.queryOne(
-    'SELECT is_admin FROM profiles WHERE id = $1',
+    'SELECT is_admin, email FROM profiles WHERE id = $1',
     [req.user!.id],
     { table: 'profiles' }
   );
   if (!profile?.is_admin) {
+    log.warn(
+      '[adminTemplates] admin check denied: session user_id=%s session_email=%s profile_found=%s profile_email=%s profile_is_admin=%s',
+      req.user!.id,
+      req.user?.email ?? '(none)',
+      profile ? 'yes' : 'no',
+      profile?.email ?? '(null)',
+      profile?.is_admin
+    );
     res.status(403).json({ success: false, message: 'Keine Admin-Berechtigung.' });
     return false;
   }

--- a/apps/api/routes/auth/templates/adminVorlagenContractRouter.ts
+++ b/apps/api/routes/auth/templates/adminVorlagenContractRouter.ts
@@ -23,12 +23,25 @@ import type { Application } from 'express';
 
 const log = createLogger('adminVorlagenContractRouter');
 
-async function checkIsAdmin(userId: string): Promise<boolean> {
+async function checkIsAdmin(userId: string, email?: string): Promise<boolean> {
   const postgres = getPostgresInstance();
-  const profile = await postgres.queryOne('SELECT is_admin FROM profiles WHERE id = $1', [userId], {
-    table: 'profiles',
-  });
-  return Boolean(profile?.is_admin);
+  const profile = await postgres.queryOne(
+    'SELECT is_admin, email FROM profiles WHERE id = $1',
+    [userId],
+    { table: 'profiles' }
+  );
+  const allowed = Boolean(profile?.is_admin);
+  if (!allowed) {
+    log.warn(
+      '[adminVorlagenContract] admin check denied: session user_id=%s session_email=%s profile_found=%s profile_email=%s profile_is_admin=%s',
+      userId,
+      email ?? '(none)',
+      profile ? 'yes' : 'no',
+      profile?.email ?? '(null)',
+      profile?.is_admin
+    );
+  }
+  return allowed;
 }
 
 const FORBIDDEN = {
@@ -41,8 +54,9 @@ const s = initServer();
 export const adminVorlagenContractRouter = s.router(adminVorlagenContract, {
   list: async (args) => {
     try {
-      const userId = getAuthedUser(args.req).id;
-      if (!(await checkIsAdmin(userId))) return FORBIDDEN;
+      const authedUser = getAuthedUser(args.req);
+      const userId = authedUser.id;
+      if (!(await checkIsAdmin(userId, authedUser.email))) return FORBIDDEN;
 
       const { status = 'pending_review', limit = '50', offset = '0' } = args.query;
       const postgres = getPostgresInstance();
@@ -73,8 +87,9 @@ export const adminVorlagenContractRouter = s.router(adminVorlagenContract, {
 
   getStats: async (args) => {
     try {
-      const userId = getAuthedUser(args.req).id;
-      if (!(await checkIsAdmin(userId))) return FORBIDDEN;
+      const authedUser = getAuthedUser(args.req);
+      const userId = authedUser.id;
+      if (!(await checkIsAdmin(userId, authedUser.email))) return FORBIDDEN;
 
       const postgres = getPostgresInstance();
       const result = await postgres.query(
@@ -105,8 +120,9 @@ export const adminVorlagenContractRouter = s.router(adminVorlagenContract, {
 
   approve: async (args) => {
     try {
-      const userId = getAuthedUser(args.req).id;
-      if (!(await checkIsAdmin(userId))) return FORBIDDEN;
+      const authedUser = getAuthedUser(args.req);
+      const userId = authedUser.id;
+      if (!(await checkIsAdmin(userId, authedUser.email))) return FORBIDDEN;
 
       const { id } = args.params;
       const postgres = getPostgresInstance();
@@ -155,8 +171,9 @@ export const adminVorlagenContractRouter = s.router(adminVorlagenContract, {
 
   reject: async (args) => {
     try {
-      const userId = getAuthedUser(args.req).id;
-      if (!(await checkIsAdmin(userId))) return FORBIDDEN;
+      const authedUser = getAuthedUser(args.req);
+      const userId = authedUser.id;
+      if (!(await checkIsAdmin(userId, authedUser.email))) return FORBIDDEN;
 
       const { id } = args.params;
       const reason = args.body.reason ?? null;

--- a/apps/web/src/features/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/features/admin/AdminDashboardPage.tsx
@@ -38,12 +38,13 @@ const TABS: { key: StatusTab; label: string }[] = [
 
 const AdminDashboardPage = () => {
   const user = useAuthStore((s) => s.user);
+  const isAdmin = user?.is_admin === true;
   const [activeTab, setActiveTab] = useState<StatusTab>('pending_review');
   const [rejectTarget, setRejectTarget] = useState<string | null>(null);
   const [rejectReason, setRejectReason] = useState('');
 
-  const { data: stats } = useVorlagenStats();
-  const { data: vorlagen, isLoading } = useAdminVorlagen(activeTab);
+  const { data: stats } = useVorlagenStats(isAdmin);
+  const { data: vorlagen, isLoading } = useAdminVorlagen(activeTab, isAdmin);
   const approveMutation = useApproveVorlage();
   const rejectMutation = useRejectVorlage();
 
@@ -56,7 +57,7 @@ const AdminDashboardPage = () => {
     );
   };
 
-  if (!user?.is_admin) {
+  if (!isAdmin) {
     return (
       <PageContainer maxWidth="md">
         <div className="flex flex-col items-center justify-center gap-md py-xl text-center">

--- a/apps/web/src/features/admin/hooks/useAdminVorlagen.ts
+++ b/apps/web/src/features/admin/hooks/useAdminVorlagen.ts
@@ -32,19 +32,21 @@ export interface VorlagenStats {
   rejected: number;
 }
 
-export function useAdminVorlagen(status = 'pending_review') {
+export function useAdminVorlagen(status = 'pending_review', enabled = true) {
   return useQuery<AdminVorlage[]>({
     queryKey: ['admin-vorlagen', status],
     queryFn: () => fetchAdminVorlagen(status) as Promise<AdminVorlage[]>,
     staleTime: 30_000,
+    enabled,
   });
 }
 
-export function useVorlagenStats() {
+export function useVorlagenStats(enabled = true) {
   return useQuery<VorlagenStats>({
     queryKey: ['admin-vorlagen-stats'],
     queryFn: () => fetchVorlagenStats() as Promise<VorlagenStats>,
     staleTime: 30_000,
+    enabled,
   });
 }
 


### PR DESCRIPTION
## Summary

- **Frontend**: gate `useAdminVorlagen` / `useVorlagenStats` with `enabled: user.is_admin === true` so non-admins no longer fire 403s on `/admin`. The "Kein Zugriff" page (added in #a9a90d7bd) replaced the previous redirect with an in-place render, but the `useQuery` hooks at the top of `AdminDashboardPage` kept firing before the early return — two console errors per visit.
- **Backend**: add a `warn` log on `checkIsAdmin` / `verifyAdmin` when admin access is denied. Previously the 403 path was silent, making it impossible to diagnose admin-flag mismatches from production logs. The log line includes session `user_id`, session `email`, profile lookup result, and the actual `profiles.is_admin` value — so a multi-IdP profile mismatch (where one of a user's linked Keycloak profiles has the flag and another doesn't) is one grep away.

No backend authorization behavior changes — `verifyAdmin` still queries postgres directly and returns 403 on a falsy `is_admin`. This is purely about removing UI noise for non-admins and making the rejection path observable for admins who unexpectedly hit it.

## Test plan

- [ ] As a non-admin user, visit `/admin` → "Kein Zugriff" page renders, no 403s in browser console, no admin-vorlagen network requests.
- [ ] As an admin user, visit `/admin` → tabs and stats load successfully, no 403s.
- [ ] As an admin whose session is bound to a non-admin profile, visit `/admin` → backend logs emit `[adminVorlagenContract] admin check denied: session user_id=… session_email=… profile_found=yes profile_email=… profile_is_admin=false`.
- [ ] `pnpm --filter @gruenerator/api typecheck` clean.
- [ ] `pnpm --filter @gruenerator/web typecheck` clean.