### PR TITLE
ci: serialize docker builds to fix `:latest` tag race

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -80,6 +80,13 @@ permissions:
   contents: read
   packages: write
 
+# Serialize builds per branch so concurrent merges can't race for the `:latest` tag.
+# `cancel-in-progress: false` queues runs — each commit still gets its immutable
+# `:sha-XXXXXXX` tag, and `:latest` always reflects merge order.
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/gruenerator


### PR DESCRIPTION
## Summary

Adds a `concurrency` block to `build-images.yml` so concurrent merges to master can't race for the `:latest` tag.

## What happened

PRs #682 and #683 merged within 10 seconds of each other on 2026-04-25. Both triggered "Build and Push Docker Images" runs. Both ran nearly in parallel, and both pushed `:latest` (because `metadata-action` adds `type=raw,value=latest,enable={{is_default_branch}}` to every master build).

GHA reports both runs as `success`, but the `docker push` HTTP PUTs to GHCR raced — and the **older** commit's build (`7923b0f8`, pre-notebook-startpage) finished its push **after** the newer one (`fcd5d8ef`, includes the notebook startpage). That left `:latest` permanently pointing at the older image.

PR #680 (workflow-only change) was excluded by the `paths:` filter, so the bug never got naturally repaired by a subsequent build.

Production was stuck on a pre-#682 image: `/notebooks/berlin` returned 200 with the SPA but the bundle had no `idOrSlug` route — confirmed via `grep -c idOrSlug` against the served bundle inside the running web container (returned `0`).

## The fix

```yaml
concurrency:
  group: build-images-${{ github.ref }}
  cancel-in-progress: false
```

- Builds on the same branch are queued instead of running in parallel.
- Push order matches merge order, so `:latest` always reflects the newest commit's build.
- `cancel-in-progress: false` (not `true`) keeps every commit's immutable `:sha-XXXXXXX` tag — important for precise rollbacks. The trade-off is slower throughput on rapid-fire merges, which is fine for this workflow.

## Why not pin digests instead?

A more rigorous fix would be to drop `:latest` entirely and pin `docker-compose.prod.yml` to immutable `:sha-XXX` tags managed by deploy automation. That's a larger change to the deploy flow (Salt, compose, environment vars). Concurrency block is a 7-line precise fix for the race itself; digest pinning is a separate, larger improvement.

## Test plan

- [x] YAML structure verified locally
- [ ] After merge: future master pushes serialize per the workflow log "Waiting on … to finish before starting"
- [ ] Two rapid-fire merges no longer overlap their `:latest` push windows