### PR TITLE
feat(web): rename /desk to /workplace and update sidebar labels

### DIFF
--- a/apps/api/routes/auth/appLogin.ts
+++ b/apps/api/routes/auth/appLogin.ts
@@ -125,7 +125,7 @@ router.get('/login', loginLimiter, async (req: AuthRequest, res: Response): Prom
       await storeAppLoginState(stateNonce, { redirectTo });
     }
 
-    const callbackURL = redirectTo ? `/api/auth/app-callback?state=${stateNonce}` : '/desk';
+    const callbackURL = redirectTo ? `/api/auth/app-callback?state=${stateNonce}` : '/workplace';
 
     log.info(
       '[AppLogin] Initiating OAuth: source=%s, providerId=%s, callbackURL=%s, redirectTo=%s',

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -175,7 +175,7 @@ function App() {
               {/* Legacy redirect: /generator/:slug -> /gruenerator/:slug */}
               <Route path="/generator/:slug" element={<LegacyGeneratorRedirect />} />
 
-              {/* Guest-only: redirect authenticated users to /desk */}
+              {/* Guest-only: redirect authenticated users to /workplace */}
               <Route element={<GuestRoute />}>
                 {routes.guest.map(({ path, layoutMode }) => (
                   <Route

--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -48,7 +48,7 @@ export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuI
   items.startseite = {
     id: 'startseite',
     path: '/',
-    title: 'Startseite',
+    title: 'Workplace',
     description: 'Erstellen, Dokumente & Medien',
     icon: getIcon('navigation', 'home'),
   };
@@ -56,7 +56,7 @@ export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuI
   items.docs = {
     id: 'docs',
     path: '/docs',
-    title: 'Dokumente',
+    title: 'Dokumente und Boards',
     description: 'Dokumente & Präsentationen',
     icon: getIcon('navigation', 'docs'),
     activePaths: ['/docs'],

--- a/apps/web/src/components/routing/GuestRoute.tsx
+++ b/apps/web/src/components/routing/GuestRoute.tsx
@@ -9,7 +9,7 @@ const GuestRoute = () => {
   // Don't redirect during logout — store may momentarily show authenticated from stale cache
   if (isLoggingOut) return <Outlet />;
 
-  return isAuthenticated ? <Navigate to="/desk" replace /> : <Outlet />;
+  return isAuthenticated ? <Navigate to="/workplace" replace /> : <Outlet />;
 };
 
 export default GuestRoute;

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -79,9 +79,11 @@ const ImageStudioKiTypeRedirect = lazy(() =>
 const ImaginePage = lazy(() => import('../features/image-studio/ImaginePage'));
 
 // Statische Importe in dynamische umwandeln
-const TexteRedirectToDeskComponent: FC<Record<string, unknown>> = () =>
-  createElement(Navigate, { to: '/desk', replace: true });
-const TexteRedirectToDesk = lazy(() => Promise.resolve({ default: TexteRedirectToDeskComponent }));
+const TexteRedirectToWorkplaceComponent: FC<Record<string, unknown>> = () =>
+  createElement(Navigate, { to: '/workplace', replace: true });
+const TexteRedirectToWorkplace = lazy(() =>
+  Promise.resolve({ default: TexteRedirectToWorkplaceComponent })
+);
 const VorlagenGallery = lazy(() => import('../components/common/Gallery'));
 const AdminDashboardPage = lazy(() => import('../features/admin/AdminDashboardPage'));
 const GrueneApiTestPage = lazy(() => import('../features/admin/GrueneApiTestPage'));
@@ -151,7 +153,7 @@ const TransferPage = lazy(() => import('../features/transfer/TransferPage'));
 const BriefingPage = lazy(() => import('../features/briefing/BriefingPage'));
 const BriefingArchivePage = lazy(() => import('../features/briefing/BriefingArchivePage'));
 const BriefingArticlePage = lazy(() => import('../features/briefing/BriefingArticlePage'));
-const DeskPage = lazy(() => import('../features/workplace/WorkplacePage'));
+const WorkplacePage = lazy(() => import('../features/workplace/WorkplacePage'));
 const RecherchePage = lazy(() => import('../features/recherche/RecherchePage'));
 const GruppenPage = lazy(() => import('../features/groups/pages/GruppenPage'));
 const BoardsListRedirect = lazy(() => Promise.resolve({ default: createRedirect('/docs') }));
@@ -167,7 +169,7 @@ const DocsEditorPage = lazy(() => import('../features/docs/DocsEditorPage'));
  * Lazy loading für Grüneratoren Bundle
  */
 export const GrueneratorenBundle = {
-  Texte: TexteRedirectToDesk,
+  Texte: TexteRedirectToWorkplace,
   ImageStudio: ImageStudioPage,
   ImageGallery: ImageGallery,
   Search: Search,
@@ -187,14 +189,18 @@ export const GrueneratorenBundle = {
 
 // Route Konfigurationen
 const standardRoutes: RouteConfig[] = [
-  // Desktop app always shows DesktopHome dashboard; web redirects auth'd users to /desk
+  // Desktop app always shows DesktopHome dashboard; web redirects auth'd users to /workplace
   isDesktopApp()
     ? { path: '/', component: DesktopHome }
     : { path: '/', component: Startseite, auth: 'guest' as const, layoutMode: 'noChrome' as const },
   { path: '/startseite', component: Startseite, auth: 'guest', layoutMode: 'noChrome' as const },
   // Unified Text Generator route (wildcard for path-based tab navigation)
   { path: '/texte/*', component: GrueneratorenBundle.Texte, withForm: true },
-  { path: '/desk', component: DeskPage },
+  { path: '/workplace', component: WorkplacePage },
+  {
+    path: '/desk',
+    component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),
+  },
   { path: '/recherche', component: RecherchePage },
   { path: '/gruppen', component: GruppenPage },
   { path: '/gruppen/:groupId', component: GruppenPage },
@@ -307,11 +313,11 @@ const standardRoutes: RouteConfig[] = [
   // Redirects for removed pages
   {
     path: '/agent/:slug',
-    component: lazy(() => Promise.resolve({ default: createRedirect('/desk') })),
+    component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),
   },
   {
     path: '/prompt/:slug',
-    component: lazy(() => Promise.resolve({ default: createRedirect('/desk') })),
+    component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),
   },
   {
     path: '/ask',

--- a/apps/web/src/config/sidebarFavouritesConfig.ts
+++ b/apps/web/src/config/sidebarFavouritesConfig.ts
@@ -12,8 +12,8 @@ export interface FavouriteItemConfig {
 }
 
 const TOOL_ITEMS: FavouriteItemConfig[] = [
-  { id: 'docs', title: 'Docs', path: '/desk', icon: getIcon('navigation', 'docs')! },
-  { id: 'boards', title: 'Boards', path: '/desk', icon: getIcon('navigation', 'boards')! },
+  { id: 'docs', title: 'Docs', path: '/workplace', icon: getIcon('navigation', 'docs')! },
+  { id: 'boards', title: 'Boards', path: '/workplace', icon: getIcon('navigation', 'boards')! },
   { id: 'gruppen', title: 'Gruppen', path: '/gruppen', icon: getIcon('navigation', 'gruppen')! },
   { id: 'suche', title: 'Suche', path: '/suche', icon: getIcon('navigation', 'suche')! },
   {

--- a/apps/web/src/features/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/features/admin/AdminDashboardPage.tsx
@@ -74,7 +74,7 @@ const AdminDashboardPage = () => {
             </p>
           )}
           <Button variant="brand" size="brand" asChild>
-            <Link to="/desk">Zurück zum Schreibtisch</Link>
+            <Link to="/workplace">Zurück zum Workplace</Link>
           </Button>
         </div>
       </PageContainer>

--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -65,7 +65,7 @@ function BoardContent() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['boards'] });
-      void navigate('/desk');
+      void navigate('/workplace');
     },
   });
 

--- a/apps/web/src/features/boards/components/BoardDropdown.tsx
+++ b/apps/web/src/features/boards/components/BoardDropdown.tsx
@@ -94,7 +94,7 @@ export const BoardDropdown = memo(function BoardDropdown({
               onClick={() => {
                 onDelete();
                 setDeleteConfirmOpen(false);
-                void navigate('/desk');
+                void navigate('/workplace');
               }}
             >
               Löschen

--- a/apps/web/src/features/boards/components/BoardHeader.tsx
+++ b/apps/web/src/features/boards/components/BoardHeader.tsx
@@ -27,7 +27,7 @@ export function BoardHeader({ title, isConnected, isSynced, provider }: BoardHea
   return (
     <div className="flex items-center gap-sm sm:gap-md px-md sm:px-lg py-2.5 sm:py-3 border-b border-grey-200 bg-background dark:border-grey-700">
       <button
-        onClick={() => navigate('/desk')}
+        onClick={() => navigate('/workplace')}
         className="flex items-center gap-xs text-foreground hover:text-primary-600 transition-colors bg-transparent border-none cursor-pointer p-xs rounded-md hover:bg-grey-100 dark:hover:bg-grey-800"
         aria-label="Zurück zur Board-Liste"
       >

--- a/apps/web/src/features/boards/components/BoardInlineHeader.tsx
+++ b/apps/web/src/features/boards/components/BoardInlineHeader.tsx
@@ -47,7 +47,7 @@ export const BoardInlineHeader = memo(function BoardInlineHeader({
     >
       <div className={`flex items-center gap-sm ${compact ? '' : 'order-2 sm:order-1'}`}>
         <button
-          onClick={() => navigate('/desk')}
+          onClick={() => navigate('/workplace')}
           className="flex items-center text-grey-500 hover:text-foreground transition-colors bg-transparent border-none cursor-pointer p-1 rounded-md hover:bg-grey-100 dark:hover:bg-[#2a2a2a]"
           aria-label="Zurück zur Board-Liste"
         >

--- a/apps/web/src/utils/authRedirect.ts
+++ b/apps/web/src/utils/authRedirect.ts
@@ -66,7 +66,7 @@ interface LocationObject {
  */
 export const getIntendedRedirect = (
   location: LocationObject,
-  defaultRedirect = '/desk'
+  defaultRedirect = '/workplace'
 ): string => {
   // 1. Check URL query parameters (highest priority)
   const searchParams = new URLSearchParams(location.search);

--- a/packages/shared/src/auth/LoginProviderButtons.tsx
+++ b/packages/shared/src/auth/LoginProviderButtons.tsx
@@ -41,7 +41,7 @@ export function LoginProviders({
       if (result === false) return;
     }
 
-    const callbackURL = redirectTo || '/desk';
+    const callbackURL = redirectTo || '/workplace';
 
     if (onLogin) {
       onLogin(provider, callbackURL);


### PR DESCRIPTION
## Summary

- Renames the user-facing `/desk` route to `/workplace` (component file was already named `WorkplacePage`; this finishes the rename at the URL layer).
- Sidebar labels: `Startseite` → `Workplace`, `Dokumente` → `Dokumente und Boards`.
- Keeps `/desk` alive as a back-compat redirect to `/workplace` so existing bookmarks and in-flight mobile/desktop OAuth callbacks (which currently default to `/desk` in `apps/api/routes/auth/appLogin.ts`) continue to work.

## Files touched

- `apps/web/src/config/routes.ts` — primary route rename + redirect; also renames local `DeskPage` / `TexteRedirectToDesk` bindings to match.
- `apps/web/src/components/layout/Header/menuData.tsx` — sidebar titles only (id `startseite` and path `/` preserved so persisted favourites and the existing root-redirect chain keep working).
- `apps/web/src/components/routing/GuestRoute.tsx`, `apps/web/src/utils/authRedirect.ts`, `apps/web/src/App.tsx` — auth redirect targets / comment.
- `apps/web/src/config/sidebarFavouritesConfig.ts`, `apps/web/src/features/admin/AdminDashboardPage.tsx` — internal links + the "Schreibtisch" → "Workplace" label.
- `apps/web/src/features/boards/{BoardPage,components/BoardDropdown,components/BoardHeader,components/BoardInlineHeader}.tsx` — `navigate('/desk')` call sites.
- `apps/api/routes/auth/appLogin.ts`, `packages/shared/src/auth/LoginProviderButtons.tsx` — OAuth callback fallback URLs.

## Test plan

- [ ] Visit `/workplace` while authenticated → page renders (was `/desk`).
- [ ] Visit `/desk` directly → redirects to `/workplace` (back-compat).
- [ ] Sidebar shows "Workplace" and "Dokumente und Boards"; clicking each lands on the right page.
- [ ] Login flow (web + mobile) ends at `/workplace` rather than `/desk`.
- [ ] `/agent/:slug`, `/prompt/:slug`, and `/texte/*` still redirect (now to `/workplace`).
- [ ] Admin "Zurück zum Workplace" button on the access-denied screen navigates to `/workplace`.