### PR TITLE
refactor(notebook): drop Kategorien and Quellen stat cards

### DIFF
--- a/apps/web/src/features/notebook/components/StatisticsSection.tsx
+++ b/apps/web/src/features/notebook/components/StatisticsSection.tsx
@@ -99,8 +99,8 @@ function TopicDistribution({ data, sampleSize }: { data: TopicCount[]; sampleSiz
 function Loading() {
   return (
     <div className="flex flex-col gap-lg">
-      <div className="grid gap-sm grid-cols-4 max-md:grid-cols-2">
-        {Array.from({ length: 4 }).map((_, i) => (
+      <div className="grid gap-sm grid-cols-2">
+        {Array.from({ length: 2 }).map((_, i) => (
           <div key={i} className={cardClass}>
             <Skeleton className="h-3 w-16" />
             <Skeleton className="h-6 w-12" />
@@ -145,10 +145,8 @@ export function StatisticsSection({
         <Loading />
       ) : (
         <div className="flex flex-col gap-lg">
-          <div className="grid gap-sm grid-cols-4 max-md:grid-cols-2">
+          <div className="grid gap-sm grid-cols-2">
             <StatCard label="Dokumente" value={stats.totalDocuments.toLocaleString('de-DE')} />
-            <StatCard label="Kategorien" value={stats.categoryDistribution.length} />
-            <StatCard label="Quellen" value={stats.sourceDistribution.length} />
             <StatCard label="Zeitraum" value={formatDateRange(stats.dateRange)} />
           </div>
 


### PR DESCRIPTION
## Summary
- Remove the **Kategorien** and **Quellen** cards from the notebook startpage `StatisticsSection`, keeping only **Dokumente** and **Zeitraum**.
- Collapse the stats grid from `grid-cols-4 max-md:grid-cols-2` to `grid-cols-2` so the remaining two cards fill the row at every breakpoint.
- Shrink the matching skeleton placeholder count from 4 to 2 to keep the loading state visually aligned with the live state.

## Test plan
- [ ] Open a notebook startpage with documents and confirm only **Dokumente** and **Zeitraum** appear in the stat row.
- [ ] Verify the two cards span the row evenly on desktop and mobile widths.
- [ ] Refresh while loading and confirm the skeleton shows two placeholders (no four-card flash).