### PR TITLE
fix: silence SSE drop noise + stop mutation limiter from rate-limiting GET polls

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -127,6 +127,11 @@ const standardMutationLimiter = isRateLimitDisabled
       max: 200,
       standardHeaders: true,
       legacyHeaders: false,
+      // Skip GETs so polling endpoints (e.g. /api/subtitler/export-progress/:token,
+      // fired every 2s during export) don't consume the mutation budget. The
+      // limiter's purpose is abuse-prevention on writes; reads are covered by
+      // authenticatedReadLimiter where it matters.
+      skip: (req) => req.method === 'GET',
       message: { error: 'Too many requests, please try again later.' },
     });
 

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -20,6 +20,8 @@ if (sentryDsn) {
       'NetworkError',
       'Failed to fetch',
       'Load failed', // Safari equivalent of "Failed to fetch"
+      'network error', // Chrome streaming-body drop (mid-SSE TCP close)
+      'Error in input stream', // Firefox streaming-body drop (mid-SSE TCP close)
       /Loading chunk [\d]+ failed/,
       'Importing a module script failed',
       'Failed to fetch dynamically imported module',

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -991,14 +991,26 @@ export function createGrueneratorModelAdapter(
 
       const streamOutcome: StreamOutcome = { interrupted: false, indexedDocumentIds: [] };
       const resolvedAgentId = effectiveAgentId || config.agentId;
-      yield* parseSSEStream(
-        response,
-        callbacks,
-        streamOutcome,
-        resolvedAgentId
-          ? { agentId: resolvedAgentId, agentMention: effectiveAgentMention }
-          : undefined
-      );
+      try {
+        yield* parseSSEStream(
+          response,
+          callbacks,
+          streamOutcome,
+          resolvedAgentId
+            ? { agentId: resolvedAgentId, agentMention: effectiveAgentMention }
+            : undefined
+        );
+      } catch (err) {
+        // Mid-stream connection drop (proxy timeout, mobile blip, worker recycle)
+        // surfaces as TypeError; treat it as a graceful end so it doesn't reach Sentry.
+        if (
+          err instanceof TypeError &&
+          /network error|failed to fetch|load failed|error in input stream/i.test(err.message)
+        ) {
+          return;
+        }
+        throw err;
+      }
 
       // Persist server-indexed document IDs to thread for follow-up messages
       if (streamOutcome.indexedDocumentIds.length > 0 && config.threadId) {


### PR DESCRIPTION
## Summary

Two production-Sentry incidents traced to root causes:

- **GRUENERATOR-8A (`HttpError 429`):** `standardMutationLimiter` (200 req / 15 min / IP) was applied to `/api/subtitler` *including the `GET /export-progress/:token` poll fired every 2s during export*. Heavy users behind NATed IPs exhausted the budget on routine polling, then hit 429 on their next mutating click (e.g. `POST /api/subtitler/generate-social`). Fixed by skipping GET on the limiter — matches its name and shifts read protection back to `authenticatedReadLimiter` where it belongs.
- **GRUENERATOR-8C / GRUENERATOR-6T (`TypeError: network error` / `Error in input stream`):** Mid-stream SSE drops on `/api/chat-graph/stream` (proxy timeout, mobile blip, worker recycle) surfaced as `TypeError` after the response was already HTTP 200. Sentry's `ignoreErrors` filter had Safari's `Load failed` and Firefox's capital-N `NetworkError`, but missed Chrome's lowercase `network error` and Firefox's `Error in input stream` (streaming-body variants). Plus `GrueneratorModelAdapter.run()` had no try/catch around `parseSSEStream`, so reader errors propagated as unhandled rejections.

## Changes

- `apps/api/routes.ts` — `standardMutationLimiter` now uses `skip: (req) => req.method === 'GET'`.
- `apps/web/src/index.tsx` — adds `'network error'` and `'Error in input stream'` to Sentry's `ignoreErrors`.
- `packages/chat/src/runtime/GrueneratorModelAdapter.ts` — wraps `yield* parseSSEStream(...)` in try/catch that swallows the four streaming-drop TypeError phrasings (Chrome / Firefox / Safari) while still propagating `AbortError` and any other error.

## Test plan

- [ ] Verify rate-limit fix: in dev with a low local `max`, hit `/api/subtitler/export-progress/:token` repeatedly via GET — counter no longer increments. POST to `/api/subtitler/generate-social` still counts.
- [ ] Verify Sentry filter: in dev, throw `new TypeError('network error')` / `new TypeError('Error in input stream')` from a component — no event reaches GlitchTip.
- [ ] Verify adapter try/catch: kill the API mid-stream during a chat — UI ends gracefully instead of showing an "Unerwarteter Fehler".
- [ ] Confirm GRUENERATOR-8A / 8C / 6T stop firing in production after deploy.

## Notes

- The 429 fix is the substantive bug; the Sentry filter additions are noise reduction. After deploy, future 429s should become rare and *informative* — if one shows up in Sentry it's a useful signal worth investigating, not background noise.