### PR TITLE
fix(chat): prevent false-positive document/chart intent on bare keyword mentions

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
@@ -215,11 +215,22 @@ export function heuristicClassify(userContent: string): HeuristicResult {
     };
   }
 
-  // High confidence (0.90): Save as document requests
+  // High confidence (0.90): Save as document requests.
+  // Bare "als Dokument/Protokoll/Notiz/Checkliste" must be paired with an explicit
+  // save imperative — otherwise prose mentions like "Pressemitteilung über das Dokument"
+  // or "gilt als Protokoll" would falsely trigger document creation.
+  const saveImperative =
+    /\b(speicher|abspeicher|sicher|exportier|ableg|festhalt|merk)[etns]*\b/i;
+  const saveAsBarePattern = /\bals\s+(neues\s+)?(dokument|protokoll|notiz|checkliste)\b/i;
+  const docWithVerbPattern =
+    /\b(dokument|protokoll|notiz|checkliste)\s+(erstellen|speichern|anlegen|abspeichern|exportieren)\b/i;
+  const machDarausPattern =
+    /\bmach[etn]*\b.{0,15}\b(dokument|protokoll|notiz|checkliste)\s+daraus\b/i;
+
   if (
-    /\b(als\s+dokument|dokument\s+(erstellen|speichern|anlegen)|als\s+(protokoll|notiz|checkliste)|mach.{0,10}dokument\s+daraus)\b/i.test(
-      q
-    )
+    (saveAsBarePattern.test(q) && saveImperative.test(q)) ||
+    docWithVerbPattern.test(q) ||
+    machDarausPattern.test(q)
   ) {
     return {
       intent: 'save_as_doc',
@@ -255,10 +266,19 @@ export function heuristicClassify(userContent: string): HeuristicResult {
     };
   }
 
-  // High confidence (0.88): Chart/data visualization requests
-  const chartKeywords =
-    /\b(diagramm|balkendiagramm|kreisdiagramm|liniendiagramm|tortendiagramm|chart|graph\b.{0,10}erstell|visualisier.{0,15}(daten|statistik|chart|werte))\b/i;
-  if (chartKeywords.test(q)) {
+  // High confidence (0.88): Chart/data visualization requests.
+  // Bare chart-type nouns must be paired with a creation imperative — otherwise
+  // prose mentions like "Im Diagramm sehen wir..." or "Erkläre mir das Chart" trigger.
+  const chartTypeNoun =
+    /\b(diagramm|balkendiagramm|kreisdiagramm|liniendiagramm|tortendiagramm|chart|graph)\b/i;
+  const chartCreateImperative =
+    /\b(erstell|generier|mach|bau|baue|visualisier|zeig|zeichn|erzeug|stell)[etn]*\b/i;
+  const dataVisualizePattern = /\bvisualisier.{0,15}(daten|statistik|chart|werte|zahlen)\b/i;
+
+  if (
+    (chartTypeNoun.test(q) && chartCreateImperative.test(q)) ||
+    dataVisualizePattern.test(q)
+  ) {
     return {
       intent: 'chart',
       searchQuery: userContent,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.vitest.ts
@@ -9,6 +9,7 @@ import {
   extractFilters,
   heuristicExtractFilters,
   looksMultiTopic,
+  HEURISTIC_CONFIDENCE_THRESHOLD,
 } from './classifierNode.js';
 
 // ─── extractSearchTopic ───────────────────────────────────────────────────
@@ -407,6 +408,18 @@ describe('heuristicClassify: chart intent', () => {
     const result = heuristicClassify('Visualisiere die Statistik als Chart');
     expect(result.intent).toBe('chart');
   });
+
+  it('does not commit chart at high confidence on bare "Diagramm" mention', () => {
+    // Fuzzy match still returns chart at 0.65, but pipeline only commits ≥0.85.
+    // Below threshold the LLM gets consulted, which is the safe behavior.
+    const result = heuristicClassify('Im Diagramm der Auswertung sehen wir steigende Zahlen');
+    expect(result.confidence).toBeLessThan(HEURISTIC_CONFIDENCE_THRESHOLD);
+  });
+
+  it('does not commit chart at high confidence on questions about a chart', () => {
+    const result = heuristicClassify('Erkläre mir bitte das Chart auf Seite drei');
+    expect(result.confidence).toBeLessThan(HEURISTIC_CONFIDENCE_THRESHOLD);
+  });
 });
 
 // ─── save_as_doc: heuristic detects explicit phrasing ──────────────
@@ -418,6 +431,23 @@ describe('heuristicClassify: doc/board action intents', () => {
   it('detects explicit save_as_doc phrasing', () => {
     const result = heuristicClassify('Speichere das als Dokument');
     expect(result.intent).toBe('save_as_doc');
+  });
+
+  it('does not trigger save_as_doc on bare "Dokument" mention without save action', () => {
+    const result = heuristicClassify(
+      'Schreib eine Pressemitteilung über das Dokument der Arbeitsgruppe'
+    );
+    expect(result.intent).not.toBe('save_as_doc');
+  });
+
+  it('does not trigger save_as_doc on "als Protokoll" without save action', () => {
+    const result = heuristicClassify('Das Treffen gilt als Protokoll der Sitzung');
+    expect(result.intent).not.toBe('save_as_doc');
+  });
+
+  it('does not trigger save_as_doc on questions about a document', () => {
+    const result = heuristicClassify('Was steht im Dokument zur Klimapolitik?');
+    expect(result.intent).not.toBe('save_as_doc');
   });
 
   it('does not heuristic-detect modify_doc (requires LLM + @doc)', () => {

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierParsing.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierParsing.ts
@@ -221,31 +221,31 @@ export function parseClassifierResponse(
       searchQuery: null,
       reasoning: 'Fallback: image detected in response',
     };
-  if (intentFieldPattern('save_as_doc').test(content) || /\bdokument|speicher/i.test(content))
+  if (intentFieldPattern('save_as_doc').test(content))
     return {
       intent: 'save_as_doc',
       searchQuery: null,
       reasoning: 'Fallback: save_as_doc detected in response',
     };
-  if (intentFieldPattern('share_doc').test(content) || /\bteile\s+mit|freigeben/i.test(content))
+  if (intentFieldPattern('share_doc').test(content))
     return {
       intent: 'share_doc',
       searchQuery: null,
       reasoning: 'Fallback: share_doc detected in response',
     };
-  if (intentFieldPattern('chart').test(content) || /\bdiagramm|chart\b/i.test(content))
+  if (intentFieldPattern('chart').test(content))
     return {
       intent: 'chart',
       searchQuery: userContent,
       reasoning: 'Fallback: chart detected in response',
     };
-  if (intentFieldPattern('summary').test(content) || /\bzusammenfass/i.test(content))
+  if (intentFieldPattern('summary').test(content))
     return {
       intent: 'summary',
       searchQuery: null,
       reasoning: 'Fallback: summary detected in response',
     };
-  if (intentFieldPattern('direct').test(content) || /\bdirekt|kreativ/i.test(content))
+  if (intentFieldPattern('direct').test(content))
     return {
       intent: 'direct',
       searchQuery: null,


### PR DESCRIPTION
## Summary

The chat intent classifier was creating documents (and charts) when the bare words "Dokument"/"Protokoll"/"Diagramm" appeared anywhere in a user message — even in prose that had nothing to do with creating one. Example: *"Schreib eine Pressemitteilung über das Dokument der Arbeitsgruppe"* triggered `save_as_doc` because `als\s+dokument` (and friends) matched at high confidence (0.9), bypassing the LLM.

Two related bugs found and fixed:

1. **Heuristic fast-path** (`classifierHeuristics.ts`) — bare-noun patterns (`als dokument`, `als protokoll`, `diagramm`, `chart`, etc.) committed at confidence ≥ 0.85 with no requirement for a save/create verb. Now require an explicit imperative (e.g. `speicher|sicher|exportier|ableg|erstell|generier|mach|bau|visualisier|zeig`).

2. **LLM-response fallback parser** (`classifierParsing.ts`) — five rules OR'd a keyword regex against the LLM's full reasoning text, contradicting the file's own comment on lines 211–213:
   > *"Only match when the LLM actually tried to output the intent value, not when it mentions a word in reasoning."*
   
   Removed the offending OR-clauses for `save_as_doc`, `share_doc`, `chart`, `summary`, and `direct`. The `intentFieldPattern` regex (which matches `intent: "<x>"`) is sufficient.

## Out of scope (flagged for follow-up)

- **`summary` heuristic** — `\bzusammenfass` matches anywhere; almost always summary intent in practice but borderline.
- **`share_doc` heuristic** — `teil[e]?\s+(das\s+)?(mit|an)\s+` could over-match generic share phrasing.
- **Fuzzy matcher** — `INTENT_KEYWORDS` includes `diagramm`/`chart`, but it operates at confidence 0.65 (below the 0.85 commit threshold), so the LLM is consulted — self-limiting.

## Test plan

- [x] All 73 tests in `classifierNode.vitest.ts` pass (5 new regression tests added)
- [x] `classifierContext.vitest.ts` and `classifierForcedIntent.vitest.ts` still pass (33 tests)
- [ ] Manual chat smoke test: *"Schreib eine PM über das Dokument der AG"* should not auto-create a document
- [ ] Manual chat smoke test: *"Im Diagramm sehen wir steigende Zahlen — kommentiere das"* should not auto-create a chart
- [ ] Existing flows still work: *"Speichere das als Dokument"* → `save_as_doc`, *"Erstelle ein Balkendiagramm"* → `chart`