### PR TITLE
fix(chat): suppress Unauthorized unhandled rejection from optimistic init

### DIFF
--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -399,13 +399,19 @@ export function GrueneratorChatProvider({
     useChatConfigStore.getState().configure(config);
   }
 
-  // Safety net: suppress "Thread not found" unhandled rejections from @assistant-ui
-  // internals (generateTitle, initialize, rename) that we can't intercept via onClick
+  // Safety net: suppress unhandled rejections from @assistant-ui internals
+  // (generateTitle, initialize, rename) that we can't intercept via onClick.
+  // - "Thread not found": optimistic rollback after a delete
+  // - "Unauthorized": stale cached userId triggers eager initialize() before
+  //   useAuth clears the session, then the 401 surfaces after redirect.
+  //   onUnauthorized() in chatConfig has already fired the redirect.
   useEffect(() => {
     const handler = (event: PromiseRejectionEvent) => {
-      if (event.reason instanceof Error && event.reason.message === 'Thread not found') {
+      if (!(event.reason instanceof Error)) return;
+      const msg = event.reason.message;
+      if (msg === 'Thread not found' || msg === 'Unauthorized') {
         event.preventDefault();
-        console.warn('[ThreadList] Suppressed unhandled "Thread not found" rejection');
+        console.warn(`[ThreadList] Suppressed unhandled "${msg}" rejection`);
       }
     };
     window.addEventListener('unhandledrejection', handler);


### PR DESCRIPTION
## Summary

Stale cached `userId` in localStorage triggers eager `threadListAdapter.initialize()` on `/login` before `useAuth` clears the session. The resulting 401 from `POST /api/chat-service/threads` surfaces as an unhandled rejection captured by Sentry — even though `onUnauthorized()` in `chatConfig` already handles the redirect side effect.

This extends the existing `"Thread not found"` suppression in `GrueneratorChatProvider` to also drop `"Unauthorized"` rejections — same root-cause class (assistant-ui `optimisticUpdate` paths we can't intercept via `onClick`).

## Root cause

1. Zustand `authStore` rehydrates synchronously from `localStorage` (15-min TTL cache).
2. On `/login`, cached `userId` is non-empty even though the backend session is invalid.
3. The `if (!userId) return children` guard at `GrueneratorChatProvider.tsx:421` passes; runtime mounts.
4. assistant-ui's `optimisticUpdate.initialize` eagerly calls `threadListAdapter.initialize()`, which `POST`s `/api/chat-service/threads`.
5. Backend returns 401, `request()` in `ChatContext.tsx:33` calls `onUnauthorized()` then `throw new Error('Unauthorized')`.
6. The rejection is re-emitted asynchronously by assistant-ui's optimistic rollback, bypassing `history.load`'s try/catch — Sentry captures it.

The redirect side effect already happens before the throw, so suppressing the unhandled rejection is purely about Sentry noise.

GlitchTip issue: GRUENERATOR-46 (494 events).

## Test plan
- [ ] Verify normal chat thread creation still works for authenticated users
- [ ] Verify `"Thread not found"` suppression still works (delete a thread)
- [ ] Verify a 401 on `/login` no longer hits Sentry but `onUnauthorized` redirect still fires when the user is on a protected page