### PR TITLE
feat(chat): route Gemma via LiteLLM, add Qwen 3.6, deadline + fallback

### DIFF
--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -7,6 +7,7 @@ import { createMistral } from '@ai-sdk/mistral';
 import { createOpenAI } from '@ai-sdk/openai';
 
 import { env } from '../../../config/env.js';
+import { litellmFetchWithThinkingDisabled } from '../../../services/ai/litellmThinkingFetch.js';
 import { isVisionCapable } from '../../../services/ai/modelDiscovery.js';
 import { regoloFetchWithThinkingDisabled } from '../../../services/ai/regoloThinkingFetch.js';
 
@@ -29,33 +30,69 @@ export { isVisionCapable };
  * Maps user-facing model IDs to provider/model configurations.
  * contextWindow is in tokens — used by downstream context management to adapt budgets.
  */
-export const AVAILABLE_MODELS: Record<
-  string,
-  { provider: 'mistral' | 'litellm' | 'regolo'; model: string; contextWindow: number }
-> = {
+export interface ModelConfig {
+  provider: 'mistral' | 'litellm' | 'regolo';
+  model: string;
+  contextWindow: number;
+  /**
+   * User-facing model ID to fall back to when this model fails to produce
+   * output (first-token timeout, empty completion, or upstream HTTP error).
+   *
+   * Chinese-trained models (Qwen) intentionally have NO fallback. The user
+   * sees an explicit "Chinesisches Modell"-warning before selecting them
+   * (informed-consent boundary in chatStore.ts MODEL_OPTIONS); auto-routing
+   * either INTO or OUT OF Qwen would break that contract. Qwen failures must
+   * surface as errors so the user can choose to retry or switch manually.
+   */
+  fallback?: string;
+}
+
+export const AVAILABLE_MODELS: Record<string, ModelConfig> = {
   // 'mistral' is intentionally absent — it uses agent defaults (like 'auto')
   // Legacy IDs kept for backward compatibility (old stored client preferences)
   'mistral-large': { provider: 'mistral', model: 'mistral-large-latest', contextWindow: 128000 },
   'mistral-medium': { provider: 'mistral', model: 'mistral-medium-latest', contextWindow: 128000 },
   'pixtral-large': { provider: 'mistral', model: 'pixtral-large-latest', contextWindow: 128000 },
-  litellm: { provider: 'litellm', model: 'gpt-oss:120b', contextWindow: 16384 },
+  litellm: {
+    provider: 'litellm',
+    model: 'gpt-oss:120b',
+    contextWindow: 16384,
+    fallback: 'gpt-oss-regolo',
+  },
   regolo: {
     provider: 'regolo',
     model: env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b',
     contextWindow: 32768,
   },
-  'gpt-oss-regolo': { provider: 'regolo', model: 'gpt-oss-120b', contextWindow: 32768 },
-  'gemma-regolo': { provider: 'regolo', model: 'gemma4-31b', contextWindow: 32768 },
+  'gpt-oss-regolo': {
+    provider: 'regolo',
+    model: 'gpt-oss-120b',
+    contextWindow: 32768,
+    fallback: 'gemma-litellm',
+  },
+  // Chinese-trained models — no `fallback` field by design. See ModelConfig.
   'qwen-regolo': { provider: 'regolo', model: 'qwen3.5-122b', contextWindow: 32768 },
+  'qwen3.6-regolo': { provider: 'regolo', model: 'qwen3.6-27b', contextWindow: 32768 },
 };
+
+const GEMMA_LITELLM: ModelConfig = {
+  provider: 'litellm',
+  model: 'gpt-oss:120b',
+  contextWindow: 32768,
+  fallback: 'gpt-oss-regolo',
+};
+AVAILABLE_MODELS['gemma-litellm'] = GEMMA_LITELLM;
+// Legacy ID — old persisted client state may still send 'gemma-regolo'.
+// Aliased to the LiteLLM-served gemma so requests don't hit Regolo's broken
+// gemma4-31b endpoint. ChatStore migration upgrades the persisted ID on next
+// page load.
+AVAILABLE_MODELS['gemma-regolo'] = GEMMA_LITELLM;
 
 /**
  * Get model configuration by user-facing model ID.
  * Returns null if model ID is not recognized.
  */
-export function getModelConfig(
-  modelId: string
-): { provider: 'mistral' | 'litellm' | 'regolo'; model: string; contextWindow: number } | null {
+export function getModelConfig(modelId: string): ModelConfig | null {
   return AVAILABLE_MODELS[modelId] || null;
 }
 
@@ -108,6 +145,7 @@ function getLiteLLMProvider() {
       baseURL: `${baseURL}/v1`,
       apiKey: env.LITELLM_API_KEY || '',
       name: 'litellm',
+      fetch: litellmFetchWithThinkingDisabled,
     });
   }
   return litellmInstance;
@@ -169,9 +207,10 @@ export function getModel(provider: string, modelId: string): LanguageModel {
       return model;
     }
     case 'litellm': {
-      console.log(`[providers] Creating LiteLLM model with default: ${LITELLM_DEFAULT_MODEL}`);
+      const resolvedModel = modelId || LITELLM_DEFAULT_MODEL;
+      console.log(`[providers] Creating LiteLLM model: ${resolvedModel}`);
       const litellm = getLiteLLMProvider();
-      const model = litellm.chat(LITELLM_DEFAULT_MODEL);
+      const model = litellm.chat(resolvedModel);
       console.log(`[providers] LiteLLM model created successfully`);
       return model;
     }

--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -4,7 +4,7 @@
  * notebook controller and the public Gruen-O-Mat controller.
  */
 
-import { streamText, type ModelMessage } from 'ai';
+import { type ModelMessage } from 'ai';
 
 import {
   buildConcisePromptGrundsatz,
@@ -15,10 +15,7 @@ import {
   getSystemCollectionConfig,
 } from '../../config/systemCollectionsConfig.js';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
-import {
-  isRegoloReasoningModel,
-  streamRegoloWithReasoning,
-} from '../../services/ai/regoloReasoningStream.js';
+import { isRegoloReasoningModel } from '../../services/ai/regoloReasoningStream.js';
 import { notebookQAService } from '../../services/notebook/index.js';
 import { rerankNotebookResults } from '../../services/notebook/rerankNotebookResults.js';
 import {
@@ -30,7 +27,11 @@ import { createLogger } from '../../utils/logger.js';
 import { containsPromptLeakage } from '../gruenomat/topicGuard.js';
 
 import { isProviderConfigured } from './agents/providers.js';
-import { resolveModel } from './services/responseStreamingService.js';
+import {
+  resolveModel,
+  streamForResolution,
+  streamWithFallback,
+} from './services/responseStreamingService.js';
 import { SSEWriter } from './services/sseHelpers.js';
 
 import type { SearchContext } from '../../services/notebook/types.js';
@@ -253,14 +254,10 @@ export async function handleNotebookStream(
 
     // Determine AI provider and model (same resolution as chat — handles model ID → real name)
     const defaultAgentConfig = { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL };
-    const {
-      model: aiModel,
-      provider: resolvedProvider,
-      modelName: resolvedModelName,
-    } = resolveModel(defaultAgentConfig, model);
+    const primaryResolution = resolveModel(defaultAgentConfig, model);
 
-    if (!isProviderConfigured(resolvedProvider)) {
-      sse.send('error', { error: `Provider "${resolvedProvider}" is not configured` });
+    if (!isProviderConfigured(primaryResolution.provider)) {
+      sse.send('error', { error: `Provider "${primaryResolution.provider}" is not configured` });
       sse.end();
       return null;
     }
@@ -281,127 +278,42 @@ export async function handleNotebookStream(
     const t2 = Date.now();
     log.debug(`⏱ Model setup: ${t2 - t1}ms`);
 
-    const useReasoningStream = isRegoloReasoningModel(resolvedProvider, resolvedModelName);
-    // Reasoning models spend most of their budget on the <think> block before
-    // emitting the answer. Triple the ceiling so there's room for both phases.
+    // Reasoning models need extra room for the <think> block before content.
     const baseMaxOutput = isFast ? 3000 : 16000;
-    const maxOutputTokens = useReasoningStream ? Math.max(baseMaxOutput, 9000) : baseMaxOutput;
 
     sse.send('response_start', { message: 'Generiere Antwort...' });
 
-    let fullText = '';
-    let firstChunkTime: number | undefined;
-
-    try {
-      if (useReasoningStream) {
-        for await (const chunk of streamRegoloWithReasoning({
-          model: resolvedModelName,
+    const fullText = await streamWithFallback({
+      primary: primaryResolution,
+      sse,
+      logPrefix: '[Notebook]',
+      buildStream: async (resolution) => {
+        const isReasoning = isRegoloReasoningModel(resolution.provider, resolution.modelName);
+        return streamForResolution({
+          resolution,
           messages: aiMessages,
-          maxTokens: maxOutputTokens,
+          maxTokens: isReasoning ? Math.max(baseMaxOutput, 9000) : baseMaxOutput,
           temperature: 0.2,
+          sse,
           signal: abortController.signal,
-        })) {
-          if (abortController.signal.aborted) break;
-          if (!firstChunkTime) {
-            firstChunkTime = Date.now();
-            log.debug(`⏱ First token latency: ${firstChunkTime - t2}ms`);
-          }
-          if (chunk.type === 'text') {
-            fullText += chunk.delta;
-            sse.send('text_delta', { text: chunk.delta });
-          } else {
-            sse.send('reasoning_delta', { text: chunk.delta });
-          }
-        }
-      } else {
-        const result = streamText({
-          model: aiModel,
-          messages: aiMessages,
-          maxOutputTokens,
-          temperature: 0.2,
-          abortSignal: abortController.signal,
+          logPrefix: '[Notebook]',
         });
-        for await (const chunk of result.textStream) {
-          if (abortController.signal.aborted) break;
-          if (!firstChunkTime) {
-            firstChunkTime = Date.now();
-            log.debug(`⏱ First token latency: ${firstChunkTime - t2}ms`);
-          }
-          fullText += chunk;
-          sse.send('text_delta', { text: chunk });
-        }
-      }
-    } catch (streamError: unknown) {
-      if (abortController.signal.aborted) {
-        log.debug('Notebook stream aborted by client disconnect');
-        log.debug(`⏱ Total (aborted): ${Date.now() - t0}ms, ${fullText.length} chars`);
-        sse.end();
-        return null;
-      }
-      const streamErrMsg = streamError instanceof Error ? streamError.message : String(streamError);
-      const t4err = Date.now();
-      log.warn('Stream error (accumulated %d chars): %s', fullText.length, streamErrMsg);
-      log.debug(
-        `⏱ Streaming (error): ${t4err - (firstChunkTime || t2)}ms, ${fullText.length} chars`
-      );
+      },
+    });
 
-      if (fullText.length > 0) {
-        try {
-          const { renumberedDraft, newReferencesMap } = renumberCitationsInOrder(
-            fullText,
-            searchContext.referencesMap
-          );
-          const { cleanDraft, citations, sources } = validateAndInjectCitations(
-            renumberedDraft,
-            newReferencesMap
-          );
-          const allSources = searchContext.sortedResults
-            .filter((_, i) => !citations.some((c) => c.index === String(i + 1)))
-            .slice(0, 10);
+    if (fullText === null) {
+      log.debug(`⏱ Total (stream failed): ${Date.now() - t0}ms`);
+      return null;
+    }
 
-          let sourcesByCollection: SourcesByCollection | undefined;
-          if (searchContext.isMulti && searchContext.effectiveCollectionIds) {
-            const collectionsConfig: { [collectionId: string]: CollectionConfig } = {};
-            for (const id of searchContext.effectiveCollectionIds) {
-              const config = SYSTEM_COLLECTIONS[id];
-              if (config) collectionsConfig[id] = { name: config.name };
-            }
-            sourcesByCollection = groupSourcesByCollection(
-              citations,
-              searchContext.sortedResults,
-              collectionsConfig
-            );
-          }
-
-          sse.send('completion', {
-            answer: cleanDraft,
-            citations,
-            sources,
-            allSources,
-            ...(sourcesByCollection && { sourcesByCollection }),
-            metadata: {
-              isMulti: searchContext.isMulti,
-              collectionName: searchContext.collectionName,
-              effectiveCollectionIds: searchContext.effectiveCollectionIds,
-              totalResults: searchContext.sortedResults.length,
-              citationsCount: citations.length,
-              partial: true,
-            },
-          });
-        } catch (citationError: unknown) {
-          log.error('Failed to process partial citations:', citationError);
-          sse.send('error', { error: streamErrMsg || 'Stream interrupted' });
-        }
-      } else {
-        sse.send('error', { error: streamErrMsg || 'Stream interrupted' });
-      }
-      log.debug(`⏱ Total (error path): ${Date.now() - t0}ms`);
+    if (abortController.signal.aborted) {
+      log.debug('Notebook stream aborted by client disconnect');
       sse.end();
       return null;
     }
 
     const t4 = Date.now();
-    log.debug(`⏱ Streaming: ${t4 - (firstChunkTime || t2)}ms, ${fullText.length} chars`);
+    log.debug(`⏱ Streaming: ${t4 - t2}ms, ${fullText.length} chars`);
 
     // Layer 5: Output leakage detection — check if the LLM leaked system prompt fragments
     if (options.systemPromptOverride && containsPromptLeakage(fullText)) {
@@ -466,7 +378,7 @@ export async function handleNotebookStream(
 
     const t6 = Date.now();
     log.debug(
-      `⏱ Total: ${t6 - t0}ms [${isFast ? 'fast' : 'deep'}] (search=${t1 - t0}, setup=${t2 - t1}, ttft=${(firstChunkTime || t2) - t2}, stream=${t4 - (firstChunkTime || t2)}, cite=${t5 - t4})`
+      `⏱ Total: ${t6 - t0}ms [${isFast ? 'fast' : 'deep'}] (search=${t1 - t0}, setup=${t2 - t1}, stream=${t4 - t2}, cite=${t5 - t4})`
     );
     sse.end();
 

--- a/apps/api/routes/chat/services/responseStreamingService.ts
+++ b/apps/api/routes/chat/services/responseStreamingService.ts
@@ -4,26 +4,46 @@
  * Handles AI model resolution and text streaming:
  * - Model selection (user override vs agent default)
  * - Building the final messages array for AI
- * - Streaming text via SSE with error handling
+ * - Streaming text via SSE with first-token deadline + cross-provider fallback
  */
 
 import { streamText, type ModelMessage, type LanguageModel } from 'ai';
 
-import { streamRegoloWithReasoning } from '../../../services/ai/regoloReasoningStream.js';
+import {
+  isRegoloReasoningModel,
+  streamRegoloWithReasoning,
+} from '../../../services/ai/regoloReasoningStream.js';
 import { createLogger } from '../../../utils/logger.js';
-import { getModel, getModelConfig, VISION_MODEL, isVisionCapable } from '../agents/providers.js';
+import {
+  getModel,
+  getModelConfig,
+  AVAILABLE_MODELS,
+  VISION_MODEL,
+  isVisionCapable,
+  type ModelConfig,
+} from '../agents/providers.js';
 
 import { sanitizeContentPartsForModel, stripEmptyAssistantMessages } from './messageHelpers.js';
-import { PROGRESS_MESSAGES } from './sseHelpers.js';
-
-import type { SSEWriter } from './sseHelpers.js';
+import { PROGRESS_MESSAGES, type FallbackReason, type SSEWriter } from './sseHelpers.js';
 
 const log = createLogger('ResponseStreaming');
+
+/**
+ * How long to wait for the first content token before declaring the upstream
+ * model dead and triggering fallback. Set generously enough to accommodate
+ * gemma's reasoning preamble on LiteLLM (~10s observed), with headroom for
+ * production load.
+ */
+const FIRST_TOKEN_DEADLINE_MS = 20_000;
 
 interface ModelResolution {
   model: LanguageModel;
   provider: string;
   modelName: string;
+  /** User-facing model ID (key in AVAILABLE_MODELS), if set by the user. */
+  modelId?: string;
+  /** Resolved config from AVAILABLE_MODELS, if applicable. */
+  config?: ModelConfig;
 }
 
 /**
@@ -36,12 +56,16 @@ export function resolveModel(
 ): ModelResolution {
   let modelProvider = agentConfig.provider;
   let modelName = agentConfig.model;
+  let resolvedConfig: ModelConfig | undefined;
+  let resolvedId: string | undefined;
 
   if (modelId && modelId !== 'mistral' && modelId !== 'auto') {
     const userModelConfig = getModelConfig(modelId);
     if (userModelConfig) {
       modelProvider = userModelConfig.provider;
       modelName = userModelConfig.model;
+      resolvedConfig = userModelConfig;
+      resolvedId = modelId;
       log.info(`[ChatGraph] Using user-selected model: ${modelId} → ${modelProvider}/${modelName}`);
     } else {
       log.warn(`[ChatGraph] Unknown model ID "${modelId}", using agent default`);
@@ -54,13 +78,18 @@ export function resolveModel(
     );
     modelProvider = VISION_MODEL.provider;
     modelName = VISION_MODEL.model;
+    resolvedConfig = undefined;
+    resolvedId = undefined;
   }
 
-  return {
+  const result: ModelResolution = {
     model: getModel(modelProvider, modelName),
     provider: modelProvider,
     modelName,
   };
+  if (resolvedId) result.modelId = resolvedId;
+  if (resolvedConfig) result.config = resolvedConfig;
+  return result;
 }
 
 /**
@@ -75,38 +104,129 @@ export function buildMessagesForAI(
   return sanitizeContentPartsForModel(stripEmptyAssistantMessages(messages as ModelMessage[]));
 }
 
+class FirstTokenTimeoutError extends Error {
+  readonly kind: FallbackReason = 'first_token_timeout';
+  constructor() {
+    super(`No content token received within ${FIRST_TOKEN_DEADLINE_MS}ms`);
+    this.name = 'FirstTokenTimeoutError';
+  }
+}
+
+class EmptyCompletionError extends Error {
+  readonly kind: FallbackReason = 'empty_completion';
+  constructor() {
+    super('Stream completed with empty content');
+    this.name = 'EmptyCompletionError';
+  }
+}
+
 /**
- * Stream text from the AI model and accumulate the full response.
- * Sends text_delta SSE events for each chunk.
- * Returns the accumulated full text, or null if stream errored.
+ * Sentinel error thrown when the primary model fails to produce output AND
+ * no text_delta has been emitted yet. Caller catches this to trigger fallback.
  */
-export async function streamAndAccumulate(params: {
+export type StreamFailure = FirstTokenTimeoutError | EmptyCompletionError;
+
+export function isStreamFailure(err: unknown): err is StreamFailure {
+  return err instanceof FirstTokenTimeoutError || err instanceof EmptyCompletionError;
+}
+
+/**
+ * Set up a one-shot first-token deadline. Returns the deadline promise (which
+ * rejects with FirstTokenTimeoutError after FIRST_TOKEN_DEADLINE_MS), an
+ * abort signal that fires at the same time, and a clear() to disarm both
+ * once the first real text chunk arrives.
+ */
+function createFirstTokenDeadline(): {
+  deadline: Promise<never>;
+  signal: AbortSignal;
+  clear: () => void;
+} {
+  const controller = new AbortController();
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      controller.abort();
+      reject(new FirstTokenTimeoutError());
+    }, FIRST_TOKEN_DEADLINE_MS);
+  });
+  // Suppress unhandled-rejection if cleared before resolution.
+  deadline.catch(() => {});
+  return {
+    deadline,
+    signal: controller.signal,
+    clear: () => {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    },
+  };
+}
+
+async function streamAndAccumulateOrThrow(params: {
   model: LanguageModel;
   messages: Array<{ role: string; content: string | unknown[] }>;
   maxTokens: number;
   temperature: number;
   sse: SSEWriter;
+  signal?: AbortSignal;
   logPrefix?: string;
 }): Promise<string | null> {
-  const { model, messages, maxTokens, temperature, sse, logPrefix = '[ChatGraph]' } = params;
+  const {
+    model,
+    messages,
+    maxTokens,
+    temperature,
+    sse,
+    signal,
+    logPrefix = '[ChatGraph]',
+  } = params;
+
+  const { deadline, signal: deadlineSignal, clear } = createFirstTokenDeadline();
+  const composed = signal ? AbortSignal.any([signal, deadlineSignal]) : deadlineSignal;
 
   const result = streamText({
     model,
     messages: messages as ModelMessage[],
     maxOutputTokens: maxTokens,
     temperature,
+    abortSignal: composed,
   });
 
+  const iterator = result.textStream[Symbol.asyncIterator]();
   let fullText = '';
 
+  // Single shared deadline across all initial-probe iterations. Some providers
+  // emit empty initial chunks before content; we keep racing against the SAME
+  // timeout (not a fresh one each time) until either content arrives or the
+  // deadline fires.
   try {
-    for await (const chunk of result.textStream) {
-      fullText += chunk;
-      sse.send('text_delta', { text: chunk });
+    while (true) {
+      const next = await Promise.race([iterator.next(), deadline]);
+      if (next.done) throw new EmptyCompletionError();
+      if (next.value.length > 0) {
+        clear();
+        fullText += next.value;
+        sse.send('text_delta', { text: next.value });
+        break;
+      }
+    }
+  } catch (err) {
+    clear();
+    throw err;
+  }
+
+  // Past the first real chunk: no more deadline races, just drain.
+  try {
+    while (true) {
+      const { done, value } = await iterator.next();
+      if (done) break;
+      fullText += value;
+      sse.send('text_delta', { text: value });
     }
   } catch (streamError: unknown) {
     const errorMessage = streamError instanceof Error ? streamError.message : 'Unknown error';
-    log.error(`${logPrefix} Stream error:`, errorMessage);
+    log.error(
+      `${logPrefix} Stream error after first token (${fullText.length} chars):`,
+      errorMessage
+    );
     sse.send('error', { error: PROGRESS_MESSAGES.streamInterrupted });
     sse.end();
     return null;
@@ -116,12 +236,10 @@ export async function streamAndAccumulate(params: {
 }
 
 /**
- * Stream directly from Regolo using the custom reasoning-aware bridge.
- * Emits `text_delta` for answer chunks and `reasoning_delta` for thinking
- * chunks, so the frontend's Reasoning/ReasoningGroup UI can render both.
- * Returns the accumulated answer text, or null on error.
+ * Internal: same as streamAndAccumulateOrThrow but for the Regolo
+ * reasoning-aware path. Throws StreamFailure on first-token failure.
  */
-export async function streamAndAccumulateWithReasoning(params: {
+async function streamAndAccumulateWithReasoningOrThrow(params: {
   modelName: string;
   messages: Array<{ role: string; content: string | unknown[] }>;
   maxTokens: number;
@@ -140,32 +258,201 @@ export async function streamAndAccumulateWithReasoning(params: {
     logPrefix = '[ChatGraph]',
   } = params;
 
+  const { deadline, signal: deadlineSignal, clear } = createFirstTokenDeadline();
+  const composed = signal ? AbortSignal.any([signal, deadlineSignal]) : deadlineSignal;
+
+  const streamParams: Parameters<typeof streamRegoloWithReasoning>[0] = {
+    model: modelName,
+    messages: messages as ModelMessage[],
+    maxTokens,
+    temperature,
+    signal: composed,
+  };
+
+  const iterator = streamRegoloWithReasoning(streamParams)[Symbol.asyncIterator]();
   let fullText = '';
 
+  // Phase 1 — race against the deadline until the first TEXT chunk. Reasoning
+  // chunks pass through as reasoning_delta but don't satisfy the deadline:
+  // a model that only ever emits reasoning is functionally hung.
   try {
-    const streamParams: Parameters<typeof streamRegoloWithReasoning>[0] = {
-      model: modelName,
-      messages: messages as ModelMessage[],
-      maxTokens,
-      temperature,
-    };
-    if (signal) streamParams.signal = signal;
-
-    for await (const chunk of streamRegoloWithReasoning(streamParams)) {
+    while (true) {
+      const next = await Promise.race([iterator.next(), deadline]);
+      if (next.done) throw new EmptyCompletionError();
+      const chunk = next.value;
       if (chunk.type === 'text') {
+        clear();
         fullText += chunk.delta;
         sse.send('text_delta', { text: chunk.delta });
+        break;
+      }
+      sse.send('reasoning_delta', { text: chunk.delta });
+    }
+  } catch (err) {
+    clear();
+    throw err;
+  }
+
+  // Phase 2 — first text chunk is in. Drain without deadline.
+  try {
+    while (true) {
+      const { done, value } = await iterator.next();
+      if (done) break;
+      if (value.type === 'text') {
+        fullText += value.delta;
+        sse.send('text_delta', { text: value.delta });
       } else {
-        sse.send('reasoning_delta', { text: chunk.delta });
+        sse.send('reasoning_delta', { text: value.delta });
       }
     }
   } catch (streamError: unknown) {
     const errorMessage = streamError instanceof Error ? streamError.message : 'Unknown error';
-    log.error(`${logPrefix} Reasoning stream error:`, errorMessage);
+    log.error(`${logPrefix} Reasoning stream error after first token:`, errorMessage);
     sse.send('error', { error: PROGRESS_MESSAGES.streamInterrupted });
     sse.end();
     return null;
   }
 
   return fullText;
+}
+
+const GENERIC_GENERATION_ERROR =
+  'Antwort konnte nicht generiert werden. Bitte später erneut versuchen.';
+
+function failStream(sse: SSEWriter): null {
+  sse.send('error', { error: GENERIC_GENERATION_ERROR });
+  sse.end();
+  return null;
+}
+
+function wrapWithCompatCatch<P extends { sse: SSEWriter; logPrefix?: string }>(
+  impl: (params: P) => Promise<string | null>,
+  label: string
+): (params: P) => Promise<string | null> {
+  return async (params) => {
+    try {
+      return await impl(params);
+    } catch (err) {
+      if (isStreamFailure(err)) {
+        log.warn(`${params.logPrefix ?? '[ChatGraph]'} ${label}: ${err.kind} — ${err.message}`);
+        return failStream(params.sse);
+      }
+      throw err;
+    }
+  };
+}
+
+export const streamAndAccumulate = wrapWithCompatCatch(streamAndAccumulateOrThrow, 'Stream failed');
+export const streamAndAccumulateWithReasoning = wrapWithCompatCatch(
+  streamAndAccumulateWithReasoningOrThrow,
+  'Reasoning stream failed'
+);
+
+/**
+ * Stream from a primary model with single-step fallback to its configured
+ * sibling on first-token failure. Models without a `fallback` field (Qwen)
+ * skip the fallback — the "Chinese-only-when-selected" firewall: never auto-
+ * route INTO Qwen, never silently auto-route OUT of Qwen.
+ *
+ * Note: AVAILABLE_MODELS contains intentional bidirectional fallback pairs
+ * (gemma-litellm ↔ gpt-oss-regolo). This is safe because dispatch is
+ * single-step — the fallback's own buildStream is invoked directly, not via
+ * a recursive streamWithFallback. Do not refactor to recurse.
+ */
+export async function streamWithFallback(params: {
+  primary: ModelResolution;
+  buildStream: (resolution: ModelResolution) => Promise<string | null>;
+  sse: SSEWriter;
+  logPrefix?: string;
+}): Promise<string | null> {
+  const { primary, buildStream, sse, logPrefix = '[ChatGraph]' } = params;
+  const primaryLabel = primary.modelId ?? primary.modelName;
+
+  try {
+    return await buildStream(primary);
+  } catch (err) {
+    if (!isStreamFailure(err)) throw err;
+
+    const fallbackId = primary.config?.fallback;
+    if (!fallbackId) {
+      log.warn(`${logPrefix} ${primaryLabel} failed (${err.kind}) — no fallback configured`);
+      return failStream(sse);
+    }
+
+    const fallbackConfig = AVAILABLE_MODELS[fallbackId];
+    if (!fallbackConfig) {
+      log.error(`${logPrefix} Fallback ID "${fallbackId}" missing from AVAILABLE_MODELS`);
+      return failStream(sse);
+    }
+
+    log.warn(`${logPrefix} ${primaryLabel} failed (${err.kind}) → falling back to ${fallbackId}`);
+
+    // Client receives only IDs. Display names are resolved client-side from
+    // MODEL_OPTIONS (see packages/chat/src/stores/chatStore.ts) — keeps the
+    // server out of the i18n/branding business and avoids a duplicated map.
+    sse.send('fallback', {
+      from: { id: primaryLabel, name: primaryLabel },
+      to: { id: fallbackId, name: fallbackId },
+      reason: err.kind,
+    });
+
+    const fallbackResolution: ModelResolution = {
+      model: getModel(fallbackConfig.provider, fallbackConfig.model),
+      provider: fallbackConfig.provider,
+      modelName: fallbackConfig.model,
+      modelId: fallbackId,
+      config: fallbackConfig,
+    };
+
+    try {
+      return await buildStream(fallbackResolution);
+    } catch (fallbackErr) {
+      if (isStreamFailure(fallbackErr)) {
+        log.error(`${logPrefix} Fallback ${fallbackId} also failed (${fallbackErr.kind})`);
+        return failStream(sse);
+      }
+      throw fallbackErr;
+    }
+  }
+}
+
+/**
+ * Dispatch entry point paired with streamWithFallback. Routes Regolo
+ * reasoning models through the reasoning-aware streamer; everything else
+ * through the standard AI SDK path.
+ */
+export async function streamForResolution(params: {
+  resolution: ModelResolution;
+  messages: Array<{ role: string; content: string | unknown[] }>;
+  maxTokens: number;
+  temperature: number;
+  sse: SSEWriter;
+  signal?: AbortSignal;
+  logPrefix?: string;
+}): Promise<string | null> {
+  const { resolution, messages, maxTokens, temperature, sse, signal, logPrefix } = params;
+
+  if (isRegoloReasoningModel(resolution.provider, resolution.modelName)) {
+    const args: Parameters<typeof streamAndAccumulateWithReasoningOrThrow>[0] = {
+      modelName: resolution.modelName,
+      messages,
+      maxTokens,
+      temperature,
+      sse,
+    };
+    if (signal) args.signal = signal;
+    if (logPrefix) args.logPrefix = logPrefix;
+    return streamAndAccumulateWithReasoningOrThrow(args);
+  }
+
+  const args: Parameters<typeof streamAndAccumulateOrThrow>[0] = {
+    model: resolution.model,
+    messages,
+    maxTokens,
+    temperature,
+    sse,
+  };
+  if (signal) args.signal = signal;
+  if (logPrefix) args.logPrefix = logPrefix;
+  return streamAndAccumulateOrThrow(args);
 }

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -33,6 +33,7 @@ export type SSEEventType =
   | 'thinking_step'
   | 'text_delta'
   | 'reasoning_delta'
+  | 'fallback'
   | 'interrupt'
   | 'document_indexed'
   | 'document_created'
@@ -42,6 +43,11 @@ export type SSEEventType =
   | 'completion'
   | 'done'
   | 'error';
+
+/**
+ * Reasons a primary model can fail in a way that triggers fallback.
+ */
+export type FallbackReason = 'first_token_timeout' | 'empty_completion' | 'upstream_error';
 
 /**
  * Search result structure sent to the client.
@@ -107,15 +113,23 @@ export interface SSEEventPayloads {
   };
   sharepic_complete: {
     message: string;
-    canvasType: string;
-    initialProps: Record<string, unknown>;
-    alternatives?: unknown[];
+    variants: Array<{
+      id: string;
+      canvasType: string;
+      initialProps: Record<string, unknown>;
+      label?: string;
+    }>;
     error?: string;
   };
   response_start: { message: string };
   thinking_step: ThinkingStepPayload;
   text_delta: { text: string };
   reasoning_delta: { text: string };
+  fallback: {
+    from: { id: string; name: string };
+    to: { id: string; name: string };
+    reason: FallbackReason;
+  };
   document_indexed: { documentId: string; title: string };
   document_created: { documentId: string; title: string; subtype: string; url: string };
   interrupt: {

--- a/apps/api/services/ai/litellmThinkingFetch.ts
+++ b/apps/api/services/ai/litellmThinkingFetch.ts
@@ -1,0 +1,26 @@
+/**
+ * LiteLLM (Ollama-backed) at Verdigado serves gemma4 models which default to
+ * thinking mode: the OpenAI-compat layer streams long `reasoning` deltas with
+ * empty `content` until the budget runs out. The Vercel AI SDK only reads
+ * `delta.content`, so chat UIs see 0 chars before `finish_reason: length`.
+ *
+ * Ollama exposes a top-level `think` parameter on chat completions. Setting it
+ * to `false` makes gemma4 emit content directly into `content` (after a brief
+ * upstream reasoning preamble that the SDK silently drops). Models that don't
+ * support thinking ignore the flag, so it's a safe no-op elsewhere on the
+ * proxy.
+ */
+export const litellmFetchWithThinkingDisabled: typeof fetch = async (input, init) => {
+  if (init?.body && typeof init.body === 'string') {
+    try {
+      const parsed = JSON.parse(init.body) as Record<string, unknown>;
+      if (parsed.model && parsed.messages) {
+        parsed.think = false;
+        init = { ...init, body: JSON.stringify(parsed) };
+      }
+    } catch {
+      // Non-JSON body, pass through unchanged
+    }
+  }
+  return fetch(input, init);
+};

--- a/packages/chat/src/hooks/useChatGraphStream.ts
+++ b/packages/chat/src/hooks/useChatGraphStream.ts
@@ -31,10 +31,15 @@ export type SearchIntent =
   | 'summary'
   | 'direct';
 
-export interface SharepicData {
+export interface SharepicVariant {
+  id: string;
   canvasType: string;
   initialProps: Record<string, unknown>;
-  alternatives?: unknown[];
+  label?: string;
+}
+
+export interface SharepicData {
+  variants: SharepicVariant[];
 }
 
 export interface GeneratedImage {
@@ -58,6 +63,17 @@ export interface MemoryContextInfo {
   memoryCount: number;
   memories: Array<{ content: string; category: string | null }>;
   isPersona: boolean;
+}
+
+/**
+ * Server-side model fallback notification. Logged in the browser console for
+ * debugging, NOT surfaced in the UI — the response continues seamlessly from
+ * the user's perspective.
+ */
+export interface FallbackInfo {
+  from: { id: string; name: string };
+  to: { id: string; name: string };
+  reason: 'first_token_timeout' | 'empty_completion' | 'upstream_error';
 }
 
 export interface ChatProgress {
@@ -403,6 +419,15 @@ export function useChatGraphStream(
                 const { text } = data as { text: string };
                 accumulatedText += text;
                 setStreamingText(accumulatedText);
+                break;
+              }
+
+              case 'fallback': {
+                // Log-only — no user-visible UI. Response continues silently.
+                const fallbackInfo = data as FallbackInfo;
+                console.warn(
+                  `[useChatGraphStream] Fallback: ${fallbackInfo.from.id} → ${fallbackInfo.to.id} (${fallbackInfo.reason})`
+                );
                 break;
               }
 

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -11,6 +11,7 @@ import type {
   GeneratedImage,
   ChatProgress,
   Citation,
+  FallbackInfo,
   SearchResult,
   StreamMetadata,
   ProgressStep,
@@ -409,27 +410,38 @@ async function* parseSSEStream(
         }
 
         case 'sharepic_complete': {
-          const {
-            message,
-            canvasType,
-            initialProps,
-            alternatives,
-            error: sharepicError,
-          } = data as {
+          const payload = data as {
             message: string;
-            canvasType: string;
-            initialProps: Record<string, unknown>;
+            variants?: import('../hooks/useChatGraphStream').SharepicVariant[];
+            canvasType?: string;
+            initialProps?: Record<string, unknown>;
             alternatives?: unknown[];
             error?: string;
           };
-          if (!sharepicError && canvasType && initialProps) {
-            receivedSharepicData = { canvasType, initialProps, alternatives };
+          if (!payload.error) {
+            if (payload.variants && payload.variants.length > 0) {
+              receivedSharepicData = { variants: payload.variants };
+            } else if (payload.canvasType && payload.initialProps) {
+              const legacyId =
+                typeof crypto !== 'undefined' && 'randomUUID' in crypto
+                  ? crypto.randomUUID()
+                  : `legacy-${Date.now()}`;
+              receivedSharepicData = {
+                variants: [
+                  {
+                    id: legacyId,
+                    canvasType: payload.canvasType,
+                    initialProps: payload.initialProps,
+                  },
+                ],
+              };
+            }
           }
-          transitionStep(sharepicError ? 'error' : 'generating');
+          transitionStep(payload.error ? 'error' : 'generating');
           currentProgress = {
             ...currentProgress,
-            stage: sharepicError ? 'error' : 'generating',
-            message,
+            stage: payload.error ? 'error' : 'generating',
+            message: payload.message,
           };
           yield buildResult();
           break;
@@ -500,6 +512,15 @@ async function* parseSSEStream(
             lastYieldTime = now;
             yield buildResult();
           }
+          break;
+        }
+
+        case 'fallback': {
+          // Server switched models silently — log only, no UI.
+          const info = data as FallbackInfo;
+          console.warn(
+            `[GrueneratorModelAdapter] Model fallback: ${info.from.id} → ${info.to.id} (${info.reason})`
+          );
           break;
         }
 

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -3,8 +3,13 @@ import type {
   ChatModelRunOptions,
   ChatModelRunResult,
 } from '@assistant-ui/react';
-import { type ChatProgress, type Citation as ChatCitation } from '../hooks/useChatGraphStream';
+import {
+  type ChatProgress,
+  type Citation as ChatCitation,
+  type FallbackInfo,
+} from '../hooks/useChatGraphStream';
 import { parseSSELine } from '../lib/sseParser';
+import { chatLog, chatLogRate } from '../lib/chatDebug';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore } from '../stores/chatConfigStore';
 
@@ -278,6 +283,9 @@ export function createNotebookModelAdapter(
                   console.debug(
                     `[Notebook] ⏱ First token: ${Math.round(performance.now() - c0)}ms`
                   );
+                  chatLog('adapter', 'first-delta', {
+                    sinceRequest: Math.round(performance.now() - c0),
+                  });
                   lastYieldTime = performance.now();
                   yield buildResult();
                   break;
@@ -287,6 +295,19 @@ export function createNotebookModelAdapter(
                 if (now - lastYieldTime >= YIELD_INTERVAL) {
                   lastYieldTime = now;
                   yield buildResult();
+                  // Throttled per-yield tick (one log per 500ms regardless of
+                  // 50ms yield cadence) so we can correlate adapter rhythm
+                  // with viewport content/reflow events.
+                  chatLogRate(
+                    'adapter',
+                    'yield',
+                    {
+                      len: accumulatedText.length,
+                      cites: (accumulatedText.match(/\[(\d+)\]/g) ?? []).length,
+                    },
+                    'notebook:yield',
+                    500
+                  );
                 }
                 break;
               }
@@ -299,6 +320,15 @@ export function createNotebookModelAdapter(
                   lastYieldTime = now;
                   yield buildResult();
                 }
+                break;
+              }
+
+              case 'fallback': {
+                // Server switched models silently — log only, no UI.
+                const info = data as FallbackInfo;
+                console.warn(
+                  `[Notebook] Model fallback: ${info.from.id} → ${info.to.id} (${info.reason})`
+                );
                 break;
               }
 
@@ -367,6 +397,31 @@ export function createNotebookModelAdapter(
           completionData.answer.length
         );
         currentProgress = { stage: 'complete', message: '' };
+
+        // Diagnose the streamed→final text swap. If the canonical answer
+        // differs in length, citation marker count, or citation IDs, the
+        // entire message reflows on the very last yield — a leading suspect
+        // for the "jumps" the user reports.
+        const streamedText = accumulatedText;
+        const finalText = completionData.answer;
+        const streamCites = streamedText.match(/\[(\d+)\]/g) ?? [];
+        const finalCites = finalText.match(/\[(\d+)\]/g) ?? [];
+        chatLog('adapter', 'final-swap', {
+          streamedLen: streamedText.length,
+          finalLen: finalText.length,
+          deltaLen: finalText.length - streamedText.length,
+          streamedCites: streamCites.length,
+          finalCites: finalCites.length,
+          identical: streamedText === finalText,
+          // Sample of the FIRST citation marker that differs between streamed
+          // and final — if you see this, the LLM emitted IDs that the backend
+          // renumbered, and badge widths shift on swap.
+          firstCiteDiff:
+            streamCites.find((m, i) => finalCites[i] !== m) !== undefined
+              ? { streamed: streamCites.slice(0, 5), final: finalCites.slice(0, 5) }
+              : null,
+        });
+
         // Swap in the backend's canonical answer so citation IDs in the text
         // match completionCitations. The LLM emits raw IDs during streaming
         // (e.g. [23], [19], [24]) that the backend renumbers to dense

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -30,7 +30,12 @@ interface TriggerCompactionResponse {
 
 export type Provider = 'mistral' | 'litellm' | 'regolo';
 
-export type ModelId = 'gpt-oss-regolo' | 'litellm' | 'gemma-regolo' | 'qwen-regolo';
+export type ModelId =
+  | 'gpt-oss-regolo'
+  | 'litellm'
+  | 'gemma-litellm'
+  | 'qwen-regolo'
+  | 'qwen3.6-regolo';
 
 export type ToolKey = 'search' | 'web' | 'examples' | 'research';
 
@@ -47,13 +52,16 @@ export interface ModelOption {
   warning?: string;
 }
 
+const QWEN_WARNING =
+  'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.';
+
 export const MODEL_OPTIONS: ModelOption[] = [
   {
-    id: 'gemma-regolo',
+    id: 'gemma-litellm',
     name: 'Gemma 4',
     description: 'Leichtgewichtig, antwortet schnell',
-    model: 'gemma4-31b',
-    provider: 'regolo',
+    model: 'gpt-oss:120b',
+    provider: 'litellm',
     icon: 'zap',
   },
   {
@@ -79,8 +87,16 @@ export const MODEL_OPTIONS: ModelOption[] = [
     model: 'qwen3.5-122b',
     provider: 'regolo',
     icon: 'brain',
-    warning:
-      'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.',
+    warning: QWEN_WARNING,
+  },
+  {
+    id: 'qwen3.6-regolo',
+    name: 'Qwen 3.6 27B',
+    description: 'Kompaktes Reasoning-Modell, denkt sichtbar mit',
+    model: 'qwen3.6-27b',
+    provider: 'regolo',
+    icon: 'brain',
+    warning: QWEN_WARNING,
   },
 ];
 
@@ -174,8 +190,8 @@ export const useAgentStore = create<AgentState>()(
   persist(
     (set) => ({
       selectedAgentId: null,
-      selectedProvider: 'regolo',
-      selectedModel: 'gemma-regolo',
+      selectedProvider: 'litellm',
+      selectedModel: 'gemma-litellm',
       currentThreadId: null,
       enabledTools: { ...DEFAULT_ENABLED_TOOLS },
       selectedNotebookId: 'gruenerator-notebook',
@@ -358,7 +374,7 @@ export const useAgentStore = create<AgentState>()(
           removeItem: (key: string) => mem.delete(key),
         };
       }),
-      version: 5,
+      version: 6,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -382,15 +398,35 @@ export const useAgentStore = create<AgentState>()(
         if (version < 5) {
           const validIds = new Set(['gpt-oss-regolo', 'litellm', 'gemma-regolo', 'qwen-regolo']);
           if (!validIds.has(state.selectedModel as string)) {
-            state.selectedModel = 'gemma-regolo';
+            // Default to current valid ID; v6 below remaps any legacy
+            // 'gemma-regolo' that survives this point.
+            state.selectedModel = 'gemma-litellm';
+          }
+        }
+        if (version < 6) {
+          // Regolo's gemma4-31b endpoint hangs upstream; route Gemma through
+          // LiteLLM (which serves the same gemma4 family) instead.
+          if (state.selectedModel === 'gemma-regolo') {
+            state.selectedModel = 'gemma-litellm';
+          }
+          const validIds = new Set([
+            'gpt-oss-regolo',
+            'litellm',
+            'gemma-litellm',
+            'qwen-regolo',
+            'qwen3.6-regolo',
+          ]);
+          if (!validIds.has(state.selectedModel as string)) {
+            state.selectedModel = 'gemma-litellm';
           }
           const providerByModel: Record<string, string> = {
             'gpt-oss-regolo': 'regolo',
             litellm: 'litellm',
-            'gemma-regolo': 'regolo',
+            'gemma-litellm': 'litellm',
             'qwen-regolo': 'regolo',
+            'qwen3.6-regolo': 'regolo',
           };
-          state.selectedProvider = providerByModel[state.selectedModel as string] ?? 'regolo';
+          state.selectedProvider = providerByModel[state.selectedModel as string] ?? 'litellm';
         }
         return state;
       },


### PR DESCRIPTION
## Summary

Regolo's `gemma4-31b` endpoint hangs upstream — every notebook chat with the default Gemma model spun forever because the AI SDK has no built-in first-token deadline. This PR fixes the immediate hang, adds resilience for similar future outages, and adds Qwen 3.6 27B as a new selectable model.

### What changes for users
- **Gemma 4** still appears as a model option but now routes through LiteLLM (Verdigado-hosted gemma4) instead of Regolo. No UI change; old `gemma-regolo` selections are migrated to `gemma-litellm` on next page load.
- **Qwen 3.6 27B** is a new selectable model. Reasoning streamer wires up automatically (already in `REGOLO_REASONING_MODELS`).
- If a model fails to produce a first content token within 20s, the server silently falls back to a sibling on the other provider. **No user-visible UI** for fallbacks — just a log line in the browser console (per request from product).

### Chinese-only-when-selected firewall
**This is the load-bearing constraint of this PR.** Qwen entries in `AVAILABLE_MODELS` intentionally have NO `fallback` field. The firewall works both directions:
- Never auto-route INTO Qwen (would violate informed-consent boundary — users see the explicit \"Chinesisches Modell – unterliegt staatlicher Zensur\" warning before opting in)
- Never silently auto-route OUT of Qwen (the user picked Qwen for a reason; substituting hides the failure)

Encoded in code, not just docs: `streamWithFallback` early-returns when `primary.config?.fallback` is undefined. Reviewers can verify the firewall by reading `AVAILABLE_MODELS` — Qwen entries omit the field, comment block at \`ModelConfig.fallback\` explains why.

### Pre-existing bug fixed
\`getModel('litellm', modelId)\` ignored the modelId argument and always used \`LITELLM_DEFAULT_MODEL\`. Latent footgun — masked today because both LiteLLM-mapped IDs (\`litellm\`, \`gemma-litellm\`) want the same physical model. Adding any second LiteLLM-served model would have silently routed to the wrong one. One-line fix included.

### Implementation highlights
- New \`litellmFetchWithThinkingDisabled\` (sibling to \`regoloFetchWithThinkingDisabled\`) injects Ollama's top-level \`think: false\` so gemma streams content into \`delta.content\` instead of burning the entire token budget on \`reasoning\`.
- 20s first-token deadline guards against silent upstream hangs. Single shared deadline across initial probes (was accidentally giving 40s grace via per-call setTimeout).
- Reasoning streamer split into Phase-1 (race vs deadline until first text chunk) + Phase-2 (drain without race) — eliminates per-chunk Promise.race microtask hops after first content arrives.
- Native \`AbortSignal.any()\` (Node 20.3+) replaces a hand-rolled \`composeAbortSignals\` helper.
- \`streamAndAccumulate\` / \`streamAndAccumulateWithReasoning\` keep their old null-on-failure shape for existing chat router callers via a shared \`wrapWithCompatCatch\` factory; they get the deadline + empty-completion safety nets for free.

### Out of scope (flagged for follow-up)
- **Vision pipeline** also uses broken Regolo gemma (\`providers.ts:20\` — \`VISION_MODEL = { provider: 'regolo', model: 'gemma4-31b' }\`). Same outage hits image analysis; same fallback policy could apply. Separate PR.
- **Worker pool / monitor / voice paths** also call \`getModel()\` but are non-streaming, so failure shape differs. Bigger refactor.

## Test plan

- [ ] **Manual: Berlin notebook chat with Gemma 4 (default) returns an answer.** Pre-PR: spins forever. Post-PR: gemma streams via LiteLLM (~10s reasoning preamble swallowed by AI SDK, then content streams).
- [ ] **Manual: Pick Qwen 3.6 27B in the model picker** — answer streams with visible reasoning chunks via the existing reasoning UI.
- [ ] **Manual: Pick Qwen 120B and ask a question** — works as before; if Regolo Qwen happens to be down, error message says \"Antwort konnte nicht generiert werden\" (no silent fallback to non-Chinese model).
- [ ] **Manual: With browser DevTools open, force Regolo to fail** (block \`api.regolo.ai\` in Network panel) and pick GPT-OSS — server falls back to LiteLLM gemma; no UI banner; \`[Notebook] Model fallback: gpt-oss-regolo → gemma-litellm (first_token_timeout)\` appears in console.
- [ ] **Persistence**: load app with stale localStorage \`selectedModel: 'gemma-regolo'\` — chatStore migration v6 upgrades to \`gemma-litellm\` automatically.
- [ ] **Regression**: existing chat routes (\`chatGraphContractRouter\`, \`chatGraphController\`, \`searchGraphController\`) still work — they use the backward-compatible \`streamAndAccumulate\` wrapper; behavior unchanged plus the new 20s deadline as bonus safety.
- [ ] \`pnpm --filter @gruenerator/api typecheck\`
- [ ] \`pnpm --filter @gruenerator/chat typecheck\`
- [ ] \`pnpm --filter @gruenerator/api test\` (specifically \`responseStreaming\` if any tests exist)

## Notes

- A duplicate of this commit exists on \`feat/notebook-startpage-tabs-and-stats\` (PR #693) because it was committed there first before being moved to its own branch. When this PR merges, the duplicate becomes a no-op for #693's rebase.
- This change introduces no new tests — the streaming layer is hard to unit-test against a real LLM. Worth adding mocked vitests for \`streamWithFallback\` (4 cases: success, primary-timeout-fallback-success, both-fail, no-fallback-configured) as a follow-up.