### PR TITLE
docs(newsletter): add April 2026 Work-Update + refresh March chat newsletter

### DIFF
--- a/documentation/docs/newsletter/2025-03-gruugo.md
+++ b/documentation/docs/newsletter/2025-03-gruugo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: 'März 2025: Kennst du schon Gruugo?'
 ---
 

--- a/documentation/docs/newsletter/2025-05-testlabor.md
+++ b/documentation/docs/newsletter/2025-05-testlabor.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: 'Mai 2025: Komm ins Testlabor!'
 ---
 

--- a/documentation/docs/newsletter/2025-10-reimagined.md
+++ b/documentation/docs/newsletter/2025-10-reimagined.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: 'Oktober 2025: Grünerator Reimagined'
 ---
 

--- a/documentation/docs/newsletter/2025-12-weihnachtszeit.md
+++ b/documentation/docs/newsletter/2025-12-weihnachtszeit.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: 'Dezember 2025: Grünerator zur Weihnachtszeit'
 ---
 

--- a/documentation/docs/newsletter/2026-01-jahr-der-daten.md
+++ b/documentation/docs/newsletter/2026-01-jahr-der-daten.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: 'Januar 2026: Jahr der Daten'
 ---
 

--- a/documentation/docs/newsletter/2026-03-ki-chat-launch.md
+++ b/documentation/docs/newsletter/2026-03-ki-chat-launch.md
@@ -1,65 +1,60 @@
 ---
-sidebar_position: 0
-title: 'März 2026: Wessen KI nutzt du?'
+sidebar_position: 1
+title: 'März 2026: Grünerator Chat'
 ---
 
-# Wessen KI nutzt du?
+# Grünerator Chat
 
 _Newsletter März 2026_
 
 ---
 
-Während du das hier liest, bombardieren die USA und Israel den Iran. KI-Systeme von Anthropic und OpenAI halfen dabei, die Ziele zu identifizieren. Die gleichen Unternehmen, deren Chatbots wir täglich nutzen.
+Während du das hier liest, befinden sich die USA und Israel mit dem Iran in einer militärischen Auseinandersetzung. Eigentlich ist das kein Grund für einen Grünerator-Newsletter. Doch es gibt etwas, worüber wir reden müssen: KI-Systeme, etwa Claude von Anthropic, halfen bei der Vorbereitung der Angriffe. Immer mehr Menschen wünschen sich daher Alternativen. Ich ziehe daher den Launch eines Features vor. Dazu später mehr.
 
-Das ist kein dystopischer Roman. Das ist diese Woche.
+## Hintergrund: Was ist passiert?
 
-## Was gerade passiert
+Das Pentagon — von der Trump-Regierung in „Department of War" umbenannt — hat Rahmenverträge mit KI-Anbietern wie Anthropic, OpenAI, Google und xAI geschlossen. Ziel: KI in Waffenentwicklung, Geheimdienstarbeit und Gefechtsführung einzusetzen. Als Anthropic sich weigerte, seine roten Linien gegen autonome Waffen und Massenüberwachung aufzugeben, drohte das Pentagon, das Unternehmen als „Lieferkettenrisiko" einzustufen — eine Kategorie, die sonst feindlichen Staaten vorbehalten ist. Und setzt dies nun um.
 
-Das Pentagon — von der Trump-Regierung in „Department of War" umbenannt — hat Rahmenverträge über bis zu 200 Millionen Dollar pro Anbieter mit Anthropic, OpenAI, Google und xAI geschlossen. Ziel: KI in Waffenentwicklung, Geheimdienstarbeit und Gefechtsführung einzusetzen. Als Anthropic sich weigerte, seine roten Linien gegen autonome Waffen und Massenüberwachung aufzugeben, drohte das Pentagon, das Unternehmen als „Lieferkettenrisiko" einzustufen — eine Kategorie, die sonst feindlichen Staaten vorbehalten ist.
+OpenAI – die Firma hinter ChatGPT – sprang ein. OpenAI-Chef Sam Altman unterschrieb einen Deal, der dem Militär Zugang zu OpenAIs Modellen auf geheimen Netzen gewährt. Die roten Linien? Stehen im Vertrag. Ob sie durchgesetzt werden? Offen. Altman bezeichnete das Abkommen später als überhastet. Da war das Kind aber schon in den Brunnen gefallen.
 
-OpenAI sprang ein. Sam Altman unterschrieb einen Deal, der dem Militär Zugang zu OpenAIs Modellen auf geheimen Netzen gewährt. Die roten Linien? Stehen im Vertrag. Ob sie durchgesetzt werden? Offen.
+Und dann nutzten die USA KI-Systeme (ironischerweise von Anthropic) für den Angriff auf den Iran. Für was genau, dafür gibt es in US-Medien Vermutungen.
 
-Und dann nutzte die CIA amerikanische KI-Systeme, um Irans obersten Führer zu lokalisieren. Israel schlug zu.
+Hunderte Mitarbeitende bei Google DeepMind und OpenAI haben in offenen Briefen dieselben roten Linien wie Anthropic gefordert: Nein zu Massenüberwachung, Nein zu autonomen Waffen ohne menschliche Kontrolle.
 
-## Warum uns das betrifft
+## Darf ich vorstellen? Chat!
 
-Jedes Mal, wenn wir ChatGPT oder Claude nutzen, fließt Geld an Unternehmen, die gleichzeitig Militärtechnologie liefern. Das heißt nicht, dass diese Tools schlecht sind. Aber es heißt, dass wir eine Wahl haben.
-
-Hunderte Mitarbeitende bei Google DeepMind und OpenAI haben in offenen Briefen dieselben roten Linien wie Anthropic gefordert: Nein zu Massenüberwachung, Nein zu autonomen Waffen ohne menschliche Kontrolle. Sie schrieben: „We will not be divided." Das verdient Respekt. Aber es ändert nichts daran, wohin das Geld fließt.
-
-Als Grüne stehen wir für Frieden, europäische Souveränität und verantwortungsvolle Technologie. Wenn wir das ernst meinen, müssen wir auch bei KI konsequent sein.
-
-## Grünerator Chat ist da
-
-Deshalb veröffentlichen wir heute den Grünerator Chat. Ein vollständiger KI-Chat — vergleichbar mit ChatGPT oder Claude — aber ausschließlich auf europäischen Servern, ohne militärische Verträge, ohne Überwachung, ohne dass deine Daten zum Training verwendet werden.
+Deshalb veröffentliche ich heute den Grünerator Chat. Ein vollständiger KI-Chat — vergleichbar mit ChatGPT oder Claude — aber ausschließlich auf unseren europäischen Servern, ohne militärische Verträge, ohne Überwachung, ohne dass deine Daten zum Training verwendet werden.
 
 Was kann der Chat?
 
-- **12 spezialisierte Assistenten** für Anträge, Pressemitteilungen, Social Media, Reden und mehr — tippe `/` im Eingabefeld
-- **Grüne Quellen durchsuchen** mit `@`: Grundsatzprogramm, Bundestagsfraktion, Landesverbände, KommunalWiki, Böll-Stiftung und mehr
-- **Websuche** für aktuelle Nachrichten und Fakten
-- **Bildgenerierung** direkt im Chat
-- **Dateien hochladen** — PDFs und Bilder als Kontext nutzen
-- **Quellenangaben** mit Zitaten, die du nachprüfen kannst
+- **Spezialisierte Assistenten** für Anträge, Pressemitteilungen, Social Media, Reden und mehr — tippe dafür `/` im Eingabefeld. In der Regel erkennt der Grünerator diese aber automatisch.
+- **Grüne Quellen durchsuchen:** Landesverbände, die ein Notebook gekauft haben, können mit `@` (z.B. `@Thueringen`) direkt mit ihren Dokumenten chatten und damit z.B. Bürger\*innenanfragen beantworten.
+- **Websuche** für aktuelle Nachrichten und Fakten.
+- **Dateien hochladen** — PDFs und Bilder als Kontext nutzen (experimentell).
+- **Quellenangaben** mit Zitaten, die du nachprüfen kannst.
 
-Der Chat erkennt automatisch, ob du in Parteiprogrammen recherchieren, im Web suchen oder einen Text erstellen willst. Alles in einer Oberfläche, die du von ChatGPT kennst — nur grüner.
+Alles in einer Oberfläche, die du von ChatGPT kennst — nur grüner. Aber Achtung: Das Chat-Feature ist in der Beta-Phase. Es kann zu Fehlern kommen. Zudem braucht die UI hier und da noch Feinschliff. Bitte sichere wichtige Texte außerhalb des Grünerators, etwa indem du sie als Docx herunterlädst.
+
+Ich habe mich dazu entschieden, den Launch vorzuziehen, um ihn anhand deines Feedbacks zu verbessern. Bitte gib Feedback und berichte Fehler, die du findest. Ich will den Chat schnellstmöglich zu einer echten Alternative ausbauen.
+
+:::tip Im Chat besprechen
+Eines meiner Lieblings-Features ist etwas versteckt: Grünerierst du dir einen neuen Text mit den bekannten Grüneratoren, kannst du auf die drei Punkte klicken und dann „Im Chat besprechen" auswählen. Dann gibt dir der Grünerator Chat direkt Feedback zu deinem Text und ihr könnt ihn gemeinsam bearbeiten.
+:::
 
 Eine ausführliche Anleitung mit allen Assistenten, Quellen und Werkzeugen findest du in der [Chat-Dokumentation](../gruenerieren/ki-chat).
 
-## Europäisch. Ohne Kompromisse.
+## Bug-Fixes und mehr
 
-Der Grünerator nutzt Mistral AI aus Frankreich als Hauptanbieter. Alle Daten werden auf Servern der Netzbegrünung in Deutschland gespeichert. Keine US-Server, kein Patriot Act, keine militärische Doppelnutzung. Mit jeder Grünerierung stärkst du die europäische Unabhängigkeit — gerade jetzt wichtiger denn je.
+Neben neuen Features wurde eine Reihe von Fehlern behoben:
 
-## Was du tun kannst
+- Fehler, die das Erstellen von Accounts unmöglich machten oder nach dem Login wieder das Login-Fenster zeigten.
+- Reels wurden teils merkwürdig gedreht.
+- Grünerierte Texte wurden unabsichtlich gespeichert und wiederverwendet. Dadurch wurden neue Texte teils sehr komisch.
 
-**Nutze den Chat.** Gehe auf [gruenerator.eu/chat](https://gruenerator.eu/chat) und probiere es aus. Tippe `/antrag @grundsatz` und dein Thema — und erlebe, was grüne KI kann.
+Zudem ist der Grünerator auf einen neuen Server umgezogen. Die Erstellung von Reels ist jetzt ca. doppelt so schnell und fühlt sich richtig gut an. Außerdem werden Texte nun gestreamt und erscheinen je nach Modell fast sofort. Probier es gerne aus!
 
-**Teile diesen Newsletter.** Leite ihn an deinen Orts- oder Kreisverband weiter. Je mehr Grüne europäische KI nutzen, desto stärker wird unsere digitale Unabhängigkeit.
+Bei Fragen oder Problemen wende dich gerne jederzeit an den Support-Chat (Deutschland) oder an das Helpdesk (Österreich). Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband versenden. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
 
-**Bleib informiert.** Die Lage entwickelt sich schnell. Wir werden in den kommenden Wochen weitere Updates zum Chat und neuen Quellen veröffentlichen.
-
-Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) für diesen Newsletter anmelden.
-
-Viel Spaß beim Grünerieren — jetzt erst recht.
+Viel Spaß beim Grünerieren!
 
 _Moritz_

--- a/documentation/docs/newsletter/2026-04-work-update.md
+++ b/documentation/docs/newsletter/2026-04-work-update.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 0
+title: 'April 2026: Das große Work-Update'
+---
+
+# Das große Work-Update
+
+_Newsletter April 2026_
+
+---
+
+Wir müssen alle mehr arbeiten, heißt es. Wie es selten heißt: Wir müssen effizienter arbeiten. Aber warum eigentlich nicht? Mit einem KI-assistierten Arbeitsplatz können wir schneller und effizienter werden, ohne den Menschen zu ersetzen. Dafür veröffentliche ich heute das Work-Update. Der neue Grünerator Workplace ist präzise für Vorstandsarbeit, Kreis- und Landesgeschäftsstellen sowie kleine Abgeordnetenbüros erstellt worden. Ich habe versucht, die Workflows beim Erstellen von Pressemitteilungen, Social-Media-Posts und Anträgen so gut es geht nachzuempfinden.
+
+## Grünerator Docs – Grünes Google Docs
+
+Ich muss zugeben: Ich bin großer Fan von Google Docs. Die Einfachheit, gemeinsam mit anderen an Dokumenten zu arbeiten, fand ich immer großartig. Aber für Parteizwecke ein Google-Programm zu verwenden? Schwierig.
+
+Dafür veröffentliche ich endlich ein Feature, an dem ich schon länger arbeite: Grünerator Docs. Grünerator Docs ist ein KI-assistierter Dokumenteneditor, der ähnlich funktioniert wie Notion oder WordPress. Das Design ist clean und arbeitsfokussiert. Ihr könnt verschiedene Dokumententypen erstellen, von abhakbaren To-Do-Listen über Terminpläne bis hin zu Anträgen und Pressemitteilungen.
+
+Diese können anschließend geteilt werden, entweder nur für Parteimitglieder (hinter Login) oder öffentlich. Das Teilen von Dokumenten war relativ kompliziert zu programmieren; sollten hier Fehler auftreten, meldet euch gern! Docs basiert auf einer Open-Source-Software, die unter anderem von der deutschen und französischen Regierung getragen wird. Grünerator und Europa – das passt einfach.
+
+## Grünerator Boards – Grünes Trello
+
+Womit ich nie so wirklich warm wurde, sind Trello-Boards. Da sie jedoch sehr beliebt sind, habe ich mir überlegt, wie man sie intelligent in den Grünerator integrieren kann.
+
+Herausgekommen sind die neuen Grünerator Boards. Sie funktionieren exakt wie jene Trello-Boards, sehen dabei jedoch großartig aus und können mit der Grünerator-KI erstellt werden. In den Boards können neben Kommentaren auch Dokumente aus Grünerator Docs zugeordnet werden. Außerdem arbeiten die Boards kollaborativ – dazu gleich mehr.
+
+## Gruppen und kollaboratives Arbeiten
+
+Erstmals ermöglicht der Grünerator nun gemeinsames Arbeiten. Dafür starte ich ein neues Feature: Gruppen. Diese funktionieren einladungsbasiert und dienen als zentraler Content-Hub für die Zusammenarbeit in eurer Geschäftsstelle, eurem Vorstand oder eurem Social-Media-Team. In Gruppen können Boards, Dokumente, Grüneratoren, Notebooks und Links geteilt sowie Boards und Dokumente gemeinsam bearbeitet werden. Aktuell können nur Admins Inhalte in Gruppen einpflegen – das ist zunächst so gewollt, ich passe es aber ggf. später an.
+
+Meiner Meinung nach kann dies ein echter Meilenstein für die gemeinsame, KI-assistierte Arbeit werden. Allerdings braucht es noch etwas Zeit, da kollaborative Features extrem schwer zu testen und zu debuggen sind. Dafür brauche ich jetzt deine Hilfe!
+
+:::tip Komm in die Grünerator-Testgruppe!
+Dort habe ich einige Dokumente und Boards hinterlegt, die du austesten kannst. Melde dich gern, wenn du dabei sein möchtest.
+:::
+
+## Neue und verbesserte Notebooks
+
+Ich arbeite daran, die Notebooks weiter zu verbessern. In manchen Notebooks kann nun direkt in den Quellen recherchiert werden, sodass Inhalte besser überprüft werden können: Wurde der gesamte Kontext beachtet? Hat der Grünerator etwas übersehen? Zudem wurden eine Reihe kleinerer Verbesserungen umgesetzt, wodurch die Notebooks nun ansprechender aussehen und schneller laden.
+
+Leider ist dadurch ein neuer Fehler aufgetreten, der insbesondere bei längeren Texten zu einem Flickern beim Laden führt. In seltenen Fällen kann es auch vorkommen, dass der Grünerator Zahlen falsch interpretiert.
+
+Aber: Mittlerweile sind über 10.000 Dokumente im Grünerator hinterlegt! Um diese aktuell zu halten, habe ich ein spezielles, noch experimentelles Tool entwickelt. Dieses durchsucht einmal pro Stunde automatisch die Websites der jeweiligen Landesverbände und fügt neue Texte in den Grünerator ein. Das Ziel ist, die Datenbank schnell zu erweitern – ohne zusätzlichen Personalaufwand. So bleibt der Grünerator selbst in Wahlkampfzeiten stets auf dem neuesten Stand.
+
+## Chats: Klimaneutral und mehr
+
+Ab sofort nutzen wir für den Grünerator-Chat und alle Notebooks ausschließlich Server mit erneuerbaren Energien und ohne Wasserkühlung. Dadurch sind alle Texte und Prozesse klimaneutral.
+
+Der Grünerator-Chat kann nun Boards und Dokumente erstellen und auslesen – das ist für mich der (zukünftige) Gamechanger. Ein möglicher Workflow könnte so aussehen:
+
+1. Person A erstellt mit dem Grünerator eine Pressemitteilung.
+2. Daraus wird ein Dokument generiert, das mithilfe der KI-Assistenz finalisiert wird.
+3. Das Dokument wird als Link oder über eine Gruppe an Person B weitergeleitet.
+4. Person B nutzt das Dokument (z. B. durch Zitieren mit `@docs` im Chat), um Social-Media-Posts zu erstellen, und fügt diese ins Dokument ein.
+5. Anschließend kann das Dokument mit einer Personengruppe C (z. B. einem Vorstand) geteilt werden, die Kommentare hinterlässt.
+
+All diese Funktionen befinden sich noch in einer sehr frühen Phase, und ich konnte viele Aspekte noch nicht ausführlich testen. Daher wird der komplette Workflow noch etwas Zeit benötigen. Aber genau so stelle ich mir die zukünftige Arbeit mit dem Grünerator vor.
+
+## Tools, Tools, Tools
+
+Auf der runderneuerten Startseite finden sich eine Reihe neuer, experimenteller Tools:
+
+- **Scanner:** Macht Texte digital lesbar – auch handgeschriebene! Wer Protokolle lieber auf Papier schreibt, kann sie mit dem Grünerator in bearbeitbaren Text umwandeln.
+- **Transkribierer:** Erstellt Protokolle aus aufgezeichneten Meetings – inklusive Sprecher\*innenerkennung, falls gewünscht.
+- **Grünerator Connect:** Verbindet den Grünerator mit ChatGPT, Claude, Le Chat, OpenWebUI & Co. und ermöglicht die Nutzung der Grünerator-Daten in eurer (Zweit-)liebsten Chat-App.
+- **Neue Websuche:** Jetzt als Perplexity-ähnlicher Chat verfügbar.
+
+## Lieber schlecht kopiert als gut selbst gemacht
+
+Dachte sich die FDP Bayern und hat den Grünerator, wie er früher war, kopiert und „Liberator" getauft. Mit denselben Textformen, denselben Überschriften, denselben Design-Elementen sowie einer teils falsch übernommenen Datenschutzerklärung. Heißt es nicht, die größte Ehre ist es, kopiert zu werden? Danke an Solveigh fürs Melden.
+
+Der Grünerator wurde zudem von der Bundestagsfraktion im Spiegel erwähnt.
+
+---
+
+Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung. Es können vermehrt Fehler auftreten. Hierbei brauche ich deine Unterstützung. Bei Fragen oder Problemen, insbesondere beim Login, wende dich gerne jederzeit an den Support-Chat (Deutschland) oder an das Helpdesk (Österreich). Du kannst diesen Newsletter gerne in deinem Orts- oder Kreisverband versenden. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_


### PR DESCRIPTION
## Summary
- Adds the April 2026 newsletter `Das große Work-Update` to the documentation archive (covers Workplace, Docs, Boards, Gruppen, notebook improvements, chat features, new Tools row, FDP-Liberator note).
- Rewrites the March 2026 chat-launch newsletter (`2026-03-ki-chat-launch.md`) so the doc archive matches the actually-sent email — replaces title `Wessen KI nutzt du?` with `Grünerator Chat`, restructures into Hintergrund / Chat / Bug-Fixes sections, adds the "Im Chat besprechen" tip and the bug-fix list.
- Bumps `sidebar_position` on the five older newsletters by +1 so the new April entry sits at the top of the archive.

## Test plan
- [ ] `pnpm --filter @gruenerator/documentation start` (or build) renders the Newsletter-Archiv with April 2026 first
- [ ] Both the new April entry and the refreshed March entry render markdown, admonitions (`:::tip`) and the relative link `../gruenerieren/ki-chat` correctly
- [ ] Sidebar order is: April 2026 → März 2026 → Januar 2026 → Dezember 2025 → Oktober 2025 → Mai 2025 → März 2025