### PR TITLE
feat(api): emit three sharepic variants per chat request

### DIFF
--- a/apps/api/routes/chat/services/intentExecutionService.ts
+++ b/apps/api/routes/chat/services/intentExecutionService.ts
@@ -17,11 +17,10 @@ import {
   buildCitations,
 } from '../../../agents/langgraph/ChatGraph/index.js';
 import { env } from '../../../config/env.js';
-import {
-  generateSharepicForChat,
-  type ExpressRequest as SharepicExpressRequest,
-} from '../../../services/chat/sharepicGenerationService.js';
+import { type ExpressRequest as SharepicExpressRequest } from '../../../services/chat/sharepicGenerationService.js';
 import { createLogger } from '../../../utils/logger.js';
+
+import { generateSharepicVariants } from './sharepicVariantHelpers.js';
 
 import { CONFIRM_ACTION_CONFIG } from './confirmActionService.js';
 import { extractTextContent } from './messageHelpers.js';
@@ -494,68 +493,36 @@ export async function executeIntentPipeline(opts: {
         }
       }
     } else if (currentIntent === 'sharepic') {
-      sse.send('image_start', { message: 'Erstelle Sharepic...' });
+      sse.send('image_start', { message: 'Erstelle Sharepic-Varianten...' });
       try {
-        const sharepicType = finalState.contentType || 'dreizeilen';
-        const message = finalState.messages?.[finalState.messages.length - 1]?.content || '';
-        const messageText = typeof message === 'string' ? message : '';
+        const lastMsg = finalState.messages?.[finalState.messages.length - 1];
+        const rawText = lastMsg ? extractTextContent(lastMsg.content) : '';
+        const messageText = rawText.replace(/@sharepic\b/gi, '').trim();
+        log.info(`[ChatGraph] Sharepic topic: "${messageText.slice(0, 100)}"`);
 
         if (!opts.req) throw new Error('Express request required for sharepic generation');
-        const result = await generateSharepicForChat(
-          opts.req as SharepicExpressRequest,
-          sharepicType,
-          {
-            text: messageText,
-            subject: messageText,
-            count: 1,
-          }
-        );
+        const variants = await generateSharepicVariants({
+          req: opts.req as SharepicExpressRequest,
+          text: messageText,
+        });
 
-        if (result.success) {
-          const { sharepic } = result.content;
-          const canvasTypeMap: Record<string, string> = {
-            info: 'info',
-            zitat_pure: 'zitat-pure',
-            zitat: 'zitat',
-            dreizeilen: 'dreizeilen',
-          };
-          const canvasType = canvasTypeMap[sharepic.type] || 'dreizeilen';
-
-          const initialProps: Record<string, unknown> = {};
-          if (sharepic.textData) {
-            if (sharepic.type === 'dreizeilen') {
-              initialProps.zeile1 = sharepic.textData.line1 || '';
-              initialProps.zeile2 = sharepic.textData.line2 || '';
-              initialProps.zeile3 = sharepic.textData.line3 || '';
-            } else if (sharepic.type === 'zitat_pure' || sharepic.type === 'zitat') {
-              initialProps.quote = sharepic.textData.quote || '';
-              initialProps.name = sharepic.textData.name || '';
-            } else if (sharepic.type === 'info') {
-              initialProps.headline = sharepic.textData.header || '';
-              initialProps.subtext = sharepic.textData.subheader || sharepic.textData.body || '';
-            }
-          }
-
+        if (variants.length === 0) {
           sse.send('sharepic_complete', {
-            message: 'Sharepic erstellt',
-            canvasType,
-            initialProps,
-            alternatives: (sharepic.alternatives as unknown[]) || [],
+            message: 'Sharepic-Erstellung fehlgeschlagen',
+            variants: [],
+            error: 'All variant generations failed',
           });
         } else {
           sse.send('sharepic_complete', {
-            message: 'Sharepic-Erstellung fehlgeschlagen',
-            canvasType: 'dreizeilen',
-            initialProps: {},
-            error: 'Generation failed',
+            message: `${variants.length} Sharepic-Varianten erstellt`,
+            variants,
           });
         }
       } catch (error) {
-        log.error('[ChatGraph] Sharepic generation failed:', error);
+        log.error('[ChatGraph] Sharepic variant generation failed:', error);
         sse.send('sharepic_complete', {
           message: 'Sharepic-Erstellung fehlgeschlagen',
-          canvasType: 'dreizeilen',
-          initialProps: {},
+          variants: [],
           error: error instanceof Error ? error.message : 'Unknown error',
         });
       }

--- a/apps/api/routes/chat/services/sharepicVariantHelpers.ts
+++ b/apps/api/routes/chat/services/sharepicVariantHelpers.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from 'crypto';
+
+import {
+  generateSharepicForChat,
+  type ExpressRequest as SharepicExpressRequest,
+} from '../../../services/chat/sharepicGenerationService.js';
+import { createLogger } from '../../../utils/logger.js';
+
+const log = createLogger('SharepicVariants');
+
+export const SHAREPIC_VARIANT_TYPES = ['dreizeilen', 'zitat', 'info'] as const;
+export type SharepicVariantType = (typeof SHAREPIC_VARIANT_TYPES)[number];
+
+export interface SharepicVariant {
+  id: string;
+  canvasType: string;
+  initialProps: Record<string, unknown>;
+  label?: string;
+}
+
+const CANVAS_TYPE_BY_SHAREPIC: Record<string, string> = {
+  dreizeilen: 'dreizeilen',
+  zitat: 'zitat-pure',
+  zitat_pure: 'zitat-pure',
+  info: 'info',
+};
+
+const VARIANT_LABEL_BY_CANVAS_TYPE: Record<string, string> = {
+  dreizeilen: 'Dreizeiler',
+  'zitat-pure': 'Zitat',
+  zitat: 'Zitat',
+  info: 'Info',
+};
+
+function mapSharepicTypeToCanvasType(sharepicType: string): string {
+  return CANVAS_TYPE_BY_SHAREPIC[sharepicType] ?? 'dreizeilen';
+}
+
+interface SharepicResponseShape {
+  type: string;
+  mainSlogan?: { line1?: string; line2?: string; line3?: string };
+  quote?: string;
+  name?: string;
+  header?: string;
+  subheader?: string;
+  body?: string;
+}
+
+function buildInitialPropsForType(sharepic: SharepicResponseShape, canvasType: string): Record<string, unknown> {
+  switch (canvasType) {
+    case 'dreizeilen': {
+      const slogan = sharepic.mainSlogan ?? {};
+      return {
+        line1: slogan.line1 ?? '',
+        line2: slogan.line2 ?? '',
+        line3: slogan.line3 ?? '',
+      };
+    }
+    case 'zitat-pure':
+    case 'zitat': {
+      return {
+        quote: sharepic.quote ?? '',
+        name: sharepic.name ?? '',
+      };
+    }
+    case 'info': {
+      return {
+        header: sharepic.header ?? '',
+        body: sharepic.body ?? sharepic.subheader ?? '',
+      };
+    }
+    default:
+      return {};
+  }
+}
+
+interface GenerateVariantsArgs {
+  req: SharepicExpressRequest;
+  text: string;
+}
+
+export async function generateSharepicVariants(args: GenerateVariantsArgs): Promise<SharepicVariant[]> {
+  const settled = await Promise.allSettled(
+    SHAREPIC_VARIANT_TYPES.map((type) =>
+      generateSharepicForChat(args.req, type, {
+        text: args.text,
+        subject: args.text,
+        count: 1,
+      })
+    )
+  );
+
+  const variants: SharepicVariant[] = [];
+  settled.forEach((result, idx) => {
+    const requestedType = SHAREPIC_VARIANT_TYPES[idx];
+    if (result.status !== 'fulfilled') {
+      log.warn(`[SharepicVariants] ${requestedType} variant rejected:`, result.reason);
+      return;
+    }
+    if (!result.value.success) {
+      log.warn(`[SharepicVariants] ${requestedType} variant unsuccessful`);
+      return;
+    }
+    const sharepic = result.value.content.sharepic as SharepicResponseShape;
+    const canvasType = mapSharepicTypeToCanvasType(sharepic.type ?? requestedType);
+    variants.push({
+      id: randomUUID(),
+      canvasType,
+      initialProps: buildInitialPropsForType(sharepic, canvasType),
+      label: VARIANT_LABEL_BY_CANVAS_TYPE[canvasType] ?? canvasType,
+    });
+  });
+
+  return variants;
+}

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -13,6 +13,7 @@ import type {
   ConfirmActionType,
   ChartData,
 } from '../../../agents/langgraph/ChatGraph/types.js';
+import type { SharepicVariant } from './sharepicVariantHelpers.js';
 import type { Response } from 'express';
 
 /**
@@ -113,12 +114,7 @@ export interface SSEEventPayloads {
   };
   sharepic_complete: {
     message: string;
-    variants: Array<{
-      id: string;
-      canvasType: string;
-      initialProps: Record<string, unknown>;
-      label?: string;
-    }>;
+    variants: SharepicVariant[];
     error?: string;
   };
   response_start: { message: string };


### PR DESCRIPTION
## Summary

- API now emits three sharepic layouts (`dreizeilen`, `zitat`, `info`) per chat request via a new `generateSharepicVariants` helper that runs them in parallel with `Promise.allSettled` (one type rejecting still ships the others).
- New `sharepicVariantHelpers.ts` owns the canonical `SharepicVariant` shape; `sseHelpers.ts` references it instead of an inline anonymous payload type.
- Strips the `@sharepic` mention from the topic before generation so the prompt isn't polluted with the trigger token.

## Why API-only

This PR is exclusively the producer-side migration — it fixes 3 pre-existing typecheck errors in `intentExecutionService.ts` (`'variants' does not exist on type {canvasType, initialProps, alternatives?}`) that were created when the SSE payload type was migrated ahead of the producer.

The runtime adapter on master (`packages/chat/src/runtime/GrueneratorModelAdapter.ts`) already accepts `variants[]` and falls back to legacy `canvasType`+`initialProps`, so this change is consumer-compatible. The chat-package variant rendering UI (new `SharepicVariantStack`/`SharepicVariantCard` components, `chatConfigStore` signature change, `apps/web` editor handoff) is a separate workstream that lands in a follow-up PR.

## Test plan

- [x] `pnpm --filter @gruenerator/api typecheck` clean (was failing with 3 errors on `'variants' does not exist`)
- [ ] Smoke: send `@sharepic <topic>` in chat — expect SSE `sharepic_complete` payload with `variants: SharepicVariant[]` of length 3, each with distinct `canvasType` (`dreizeilen` / `zitat-pure` / `info`)
- [ ] Graceful degradation: simulate one variant generation failing — expect the other two to still ship, with a warn log entry for the failed type