### PR TITLE
fix(docs): scan @blocknote/shadcn for Tailwind classes

### DIFF
--- a/apps/web/src/assets/styles/index.css
+++ b/apps/web/src/assets/styles/index.css
@@ -70,6 +70,12 @@
 @source "../../../../../packages/collab/src/**/*.{js,ts,jsx,tsx}";
 @source "../../../../../packages/canvas-editor/src/**/*.{js,ts,jsx,tsx}";
 
+/* BlockNote ships shadcn components with raw Tailwind classes (e.g. w-[300px] on
+   the FloatingComposer card). They aren't precompiled into @blocknote/shadcn/style.css,
+   so Tailwind needs to scan the bundled output to emit them. Without this, the
+   comment composer collapses to its content width. */
+@source "../../../../../node_modules/@blocknote/shadcn/dist/**/*.{js,cjs,mjs}";
+
 /* ── CSS-only tooltip (zero JS, zero re-renders) ── */
 @layer components {
   .css-tooltip {


### PR DESCRIPTION
## Summary
- Adds an `@source` directive in `apps/web/src/assets/styles/index.css` for `node_modules/@blocknote/shadcn/dist/`, so Tailwind v4 emits the utility classes BlockNote ships in its shadcn components (notably `w-[300px]`).
- Fixes the broken comment composer in the docs editor: when you select text and click "Comment", the floating popup collapsed to ~min-content width, making the placeholder wrap one character per line and the Save button overflow.

## Root cause
BlockNote's shadcn `Card` (used by `FloatingComposer`) hardcodes `w-[300px]` as its only width source. Our Tailwind `@source` globs covered our own workspace packages but never `node_modules`, so the class was never generated. The threads sidebar wasn't affected because its portal mounts inside a parent that already has explicit width — the Card stretches to fill regardless. Only the free-floating popover (a flex container with no width set) actually relied on the missing class.

## Test plan
- [ ] Open a document at `/docs/<id>`.
- [ ] Select text in the editor and click the Comment button in the formatting toolbar.
- [ ] Verify the popup renders at 300px wide with the placeholder on a single line and the Save button properly inside the card.
- [ ] Open the comments sidebar and verify thread cards still look correct (unchanged behavior).