### PR TITLE
feat(shared,web): inline-editable canvas title in top bar

### DIFF
--- a/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
+++ b/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
@@ -1,6 +1,6 @@
 import { useCanvasCollaboration, MasterCanvasEditor } from '@gruenerator/canvas-editor';
-import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DottedBackground } from '../../components/common/DottedBackground';
@@ -15,6 +15,8 @@ import { CanvasPageHeader } from './components/CanvasPageHeader';
 interface CanvasDocument {
   id: string;
   title: string;
+  created_by: string;
+  permissions: Record<string, { level: string }> | null;
   template_type: string;
   base_template_id: string | null;
   thumbnail_url: string | null;
@@ -29,6 +31,8 @@ function CollabCanvasStudioContent() {
   const config = useCollaborationConfig();
   const [shareOpen, setShareOpen] = useState(false);
 
+  const queryClient = useQueryClient();
+
   const { data: canvas, isLoading } = useQuery<CanvasDocument>({
     queryKey: ['canvas', id],
     queryFn: async () => {
@@ -37,6 +41,36 @@ function CollabCanvasStudioContent() {
     },
     enabled: !!id,
   });
+
+  const canEdit = useMemo(() => {
+    if (!canvas || !user) return false;
+    const uid = String(user.id);
+    if (canvas.created_by === uid) return true;
+    const perm = canvas.permissions?.[uid];
+    return perm ? ['owner', 'editor'].includes(perm.level) : false;
+  }, [canvas, user]);
+
+  const handleTitleChange = useCallback(
+    async (newTitle: string) => {
+      if (!id) return;
+      const key = ['canvas', id];
+      const previous = queryClient.getQueryData<CanvasDocument>(key);
+      queryClient.setQueryData<CanvasDocument>(key, (old) =>
+        old ? { ...old, title: newTitle } : old
+      );
+      try {
+        await apiClient.patch(`/canvas/${id}`, { title: newTitle });
+      } catch (err) {
+        console.error('[canvas-rename] PATCH failed, reverting', err);
+        queryClient.setQueryData(key, previous);
+      }
+    },
+    [id, queryClient]
+  );
+
+  useEffect(() => {
+    if (canvas?.title) document.title = canvas.title;
+  }, [canvas?.title]);
 
   const collaborationUser = useMemo(
     () =>
@@ -82,6 +116,8 @@ function CollabCanvasStudioContent() {
       <CanvasPageHeader
         canvasId={canvas.id}
         title={canvas.title}
+        editable={canEdit}
+        onTitleChange={handleTitleChange}
         provider={collab.provider}
         isConnected={collab.isConnected}
         isSynced={collab.isSynced}

--- a/apps/web/src/features/image-studio/components/CanvasPageHeader.tsx
+++ b/apps/web/src/features/image-studio/components/CanvasPageHeader.tsx
@@ -1,4 +1,5 @@
 import { PresenceAvatars, useCollaborators } from '@gruenerator/collab';
+import { EditableTitle } from '@gruenerator/shared/components/EditableTitle';
 import { Button } from '@gruenerator/ui';
 import { HiShare } from 'react-icons/hi';
 
@@ -9,6 +10,8 @@ import type { HocuspocusProvider } from '@hocuspocus/provider';
 interface CanvasPageHeaderProps {
   canvasId: string;
   title: string;
+  editable?: boolean;
+  onTitleChange?: (newTitle: string) => void;
   provider: HocuspocusProvider | null;
   isConnected: boolean;
   isSynced: boolean;
@@ -20,6 +23,8 @@ interface CanvasPageHeaderProps {
 export function CanvasPageHeader({
   canvasId,
   title,
+  editable = false,
+  onTitleChange,
   provider,
   isConnected,
   isSynced,
@@ -37,7 +42,16 @@ export function CanvasPageHeader({
   return (
     <div className="z-10 flex items-center justify-between gap-sm px-md py-sm border-b border-grey-200 dark:border-grey-700 bg-background">
       <div className="flex items-center gap-sm min-w-0">
-        <span className="text-sm font-medium text-foreground-heading truncate">{title}</span>
+        <EditableTitle
+          as="span"
+          title={title}
+          editable={editable}
+          onTitleChange={onTitleChange}
+          className="text-sm font-medium text-foreground-heading truncate"
+          editableClassName="cursor-pointer rounded px-1 -mx-1 hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
+          inputClassName="text-sm font-medium text-foreground-heading bg-transparent border border-secondary-400 dark:border-secondary-600 rounded px-1 -mx-1 outline-none w-64 max-w-full"
+          ariaLabel="Canvas-Titel bearbeiten"
+        />
         <span className="text-[10px] text-grey-400 px-1.5 py-0.5 rounded border border-grey-200 dark:border-grey-700">
           {statusLabel}
         </span>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -108,6 +108,12 @@
       "import": "./dist/components/EditorTopBar/index.js",
       "default": "./dist/components/EditorTopBar/index.js"
     },
+    "./components/EditableTitle": {
+      "development": "./src/components/EditableTitle/index.ts",
+      "types": "./src/components/EditableTitle/index.ts",
+      "import": "./dist/components/EditableTitle/index.js",
+      "default": "./dist/components/EditableTitle/index.js"
+    },
     "./groups": {
       "development": "./src/groups/index.ts",
       "types": "./src/groups/index.ts",

--- a/packages/shared/src/components/EditableTitle/EditableTitle.tsx
+++ b/packages/shared/src/components/EditableTitle/EditableTitle.tsx
@@ -1,0 +1,111 @@
+import { type ElementType, useCallback, useEffect, useRef, useState } from 'react';
+
+interface EditableTitleProps {
+  title: string;
+  editable?: boolean;
+  onTitleChange?: (newTitle: string) => void;
+  className?: string;
+  inputClassName?: string;
+  editableClassName?: string;
+  ariaLabel?: string;
+  placeholder?: string;
+  as?: 'h1' | 'h2' | 'h3' | 'span' | 'div';
+}
+
+export const EditableTitle = ({
+  title,
+  editable = false,
+  onTitleChange,
+  className,
+  inputClassName,
+  editableClassName,
+  ariaLabel = 'Titel bearbeiten',
+  placeholder = 'Unbenannt',
+  as = 'h1',
+}: EditableTitleProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const committedRef = useRef(false);
+
+  useEffect(() => {
+    setEditValue(title);
+  }, [title]);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const commitEdit = useCallback(() => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    setIsEditing(false);
+    const trimmed = editValue.trim();
+    const newTitle = trimmed || placeholder;
+    const currentTitle = title || placeholder;
+    if (newTitle !== currentTitle) {
+      console.log('[title-rename] commitEdit: "%s" → "%s"', currentTitle, newTitle);
+      onTitleChange?.(newTitle);
+    }
+  }, [editValue, title, onTitleChange, placeholder]);
+
+  const cancelEdit = useCallback(() => {
+    setEditValue(title);
+    setIsEditing(false);
+  }, [title]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        commitEdit();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        cancelEdit();
+      }
+    },
+    [commitEdit, cancelEdit]
+  );
+
+  const canEditTitle = editable && !!onTitleChange;
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        className={inputClassName}
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onBlur={commitEdit}
+        onKeyDown={handleKeyDown}
+        aria-label={ariaLabel}
+      />
+    );
+  }
+
+  const Tag: ElementType = as;
+  const idleClassName =
+    canEditTitle && editableClassName
+      ? `${className ?? ''} ${editableClassName}`.trim()
+      : className;
+
+  return (
+    <Tag
+      className={idleClassName}
+      onClick={
+        canEditTitle
+          ? () => {
+              committedRef.current = false;
+              setIsEditing(true);
+            }
+          : undefined
+      }
+      title={canEditTitle ? 'Klicken zum Umbenennen' : undefined}
+    >
+      {title || placeholder}
+    </Tag>
+  );
+};

--- a/packages/shared/src/components/EditableTitle/index.ts
+++ b/packages/shared/src/components/EditableTitle/index.ts
@@ -1,0 +1,1 @@
+export { EditableTitle } from './EditableTitle';

--- a/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
+++ b/packages/shared/src/components/EditorTopBar/EditorTopBar.tsx
@@ -1,4 +1,6 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode } from 'react';
+
+import { EditableTitle } from '../EditableTitle';
 
 import './EditorTopBar.css';
 
@@ -19,57 +21,6 @@ export const EditorTopBar = ({
   onTitleChange,
   editable = false,
 }: EditorTopBarProps) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState(title || '');
-  const inputRef = useRef<HTMLInputElement>(null);
-  const committedRef = useRef(false);
-
-  useEffect(() => {
-    setEditValue(title || '');
-  }, [title]);
-
-  useEffect(() => {
-    if (isEditing) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [isEditing]);
-
-  const commitEdit = useCallback(() => {
-    if (committedRef.current) return;
-    committedRef.current = true;
-    setIsEditing(false);
-    const trimmed = editValue.trim();
-    const newTitle = trimmed || 'Unbenannt';
-    const currentTitle = title || 'Unbenannt';
-    if (newTitle !== currentTitle) {
-      console.log('[docs-rename] EditorTopBar commitEdit: "%s" → "%s"', currentTitle, newTitle);
-      onTitleChange?.(newTitle);
-    } else {
-      console.log('[docs-rename] EditorTopBar commitEdit: no change (both "%s")', currentTitle);
-    }
-  }, [editValue, title, onTitleChange]);
-
-  const cancelEdit = useCallback(() => {
-    setEditValue(title || '');
-    setIsEditing(false);
-  }, [title]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        commitEdit();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        cancelEdit();
-      }
-    },
-    [commitEdit, cancelEdit]
-  );
-
-  const canEditTitle = editable && !!onTitleChange;
-
   return (
     <header className="editor-topbar">
       <div className="editor-topbar__left">
@@ -93,32 +44,16 @@ export const EditorTopBar = ({
         {title != null && (
           <>
             <span className="glass-divider editor-topbar__divider" />
-            {isEditing ? (
-              <input
-                ref={inputRef}
-                className="editor-topbar__title-input"
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onBlur={commitEdit}
-                onKeyDown={handleKeyDown}
-                aria-label="Dokumenttitel bearbeiten"
-              />
-            ) : (
-              <h1
-                className={`editor-topbar__title${canEditTitle ? ' editor-topbar__title--editable' : ''}`}
-                onClick={
-                  canEditTitle
-                    ? () => {
-                        committedRef.current = false;
-                        setIsEditing(true);
-                      }
-                    : undefined
-                }
-                title={canEditTitle ? 'Klicken zum Umbenennen' : undefined}
-              >
-                {title || 'Unbenannt'}
-              </h1>
-            )}
+            <EditableTitle
+              title={title}
+              editable={editable}
+              onTitleChange={onTitleChange}
+              className="editor-topbar__title"
+              editableClassName="editor-topbar__title--editable"
+              inputClassName="editor-topbar__title-input"
+              ariaLabel="Dokumenttitel bearbeiten"
+              as="h1"
+            />
           </>
         )}
         {connectionStatus && (


### PR DESCRIPTION
## Summary
- Adds inline title editing to the canvas editor's top bar — click the title, press Enter to commit, Escape to cancel, blur to commit. Matches the UX docs already has.
- Extracts a shared `<EditableTitle>` primitive into `@gruenerator/shared` so docs (via `EditorTopBar`) and canvas reuse one state machine — including the `committedRef` guard that prevents blur from double-firing after Enter, and the `Unbenannt` trim-fallback.
- Wires `CollabCanvasStudioPage` with a permission-gated optimistic mutation (`PATCH /canvas/:id`) that uses previous-snapshot revert (avoids the closure-revert latent bug present in the docs handler), plus a `useEffect` that keeps `document.title` in sync without fighting `withAuthRequired`.

No backend changes required — `PATCH /canvas/:id` already accepted `title` and `GET /canvas/:id` already returned `created_by`/`permissions` (just not declared on the frontend type).

## Test plan
- [ ] Open a canvas you own → click title → input focuses + selects all
- [ ] Type new title, press Enter → title commits, browser tab updates, share button stays in place
- [ ] Reload page → new title persists
- [ ] Click title, press Escape → reverts
- [ ] Click title, blur → commits
- [ ] Click title, clear it, blur → commits as `Unbenannt`
- [ ] Open same canvas in a 2nd browser → rename in one, refresh the other → new title appears
- [ ] Open as a user with `viewer` permission → no edit affordance; direct `PATCH` returns 403
- [ ] Block `/canvas/:id` PATCH in DevTools → rename optimistically applies, then reverts on failure
- [ ] Regression: open `/docs/<id>` → title editing still works (Enter/Escape/blur, `Unbenannt` fallback)
- [ ] Regression: texte inline editor + DocsEditorModal still rename correctly
- [ ] Mobile (<640px): canvas title still tappable, share button not pushed off-screen