### PR TITLE
fix(doku): add @docusaurus/faster dependency

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.0",
+    "@docusaurus/faster": "^3.10.0",
     "@docusaurus/preset-classic": "^3.10.0",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.1.1",


### PR DESCRIPTION
## Summary

`docusaurus.config.ts` sets `future: { v4: true }`, which in Docusaurus 3.10+ transitively enables `experimental_faster`. That flag requires `@docusaurus/faster` to be installed as a dependency — otherwise `docusaurus build` aborts with `ERR_MODULE_NOT_FOUND` from `@docusaurus/bundler/lib/importFaster.js`.

The `build-doku` job has been failing on every master push since the **April 2026 Work-Update** merge (PR #696, 2026-04-26 11:54 UTC). Net effect: every newsletter / docs page added in that PR and after is on master but not deployed to `doku.gruenerator.eu`.

This PR pins `@docusaurus/faster` to `^3.10.0` to match the rest of the Docusaurus packages.

## Test plan

- [ ] `build-doku` job in **Build and Push Docker Images** turns green on this branch
- [ ] After merge, confirm new newsletter pages appear on `doku.gruenerator.eu`