### PR TITLE
chore(env): document iconify URL and add service to local composes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,7 @@ VITE_VERIFY_PASSWORD=
 VITE_APP_ENV=production
 VITE_MAINTENANCE_MODE=false
 VITE_DOCS_URL=                 # Grünerator Docs URL (defaults to docs.{current hostname})
+VITE_ICONIFY_API_URL=          # Self-hosted Iconify API for canvas editor icon search (e.g. https://iconify.gruenerator.eu)
 
 # Apify (optional — for social media scraping in briefing agents)
 APIFY_TOKEN=apfy_api_YOUR_APIFY_TOKEN  # Get from https://console.apify.com/account/integrations

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -142,6 +142,22 @@ services:
     labels:
       - 'com.gruenerator.service=doku'
 
+  iconify:
+    image: ghcr.io/netzbegruenung/gruenerator-iconify:${TAG:-latest}
+    restart: unless-stopped
+    environment:
+      - PORT=3100
+    networks:
+      - gruenerator
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3100/collections']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    labels:
+      - 'com.gruenerator.service=iconify'
+
   nginx:
     image: nginx:alpine
     restart: unless-stopped

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -122,6 +122,20 @@ services:
     networks:
       - gruenerator
 
+  iconify:
+    image: ghcr.io/netzbegruenung/gruenerator-iconify:${TAG:-latest}
+    restart: unless-stopped
+    environment:
+      - PORT=3100
+    networks:
+      - gruenerator
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '--spider', 'http://localhost:3100/collections']
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
   nginx:
     image: nginx:alpine
     restart: unless-stopped


### PR DESCRIPTION
## Why

Iconify lives in production (`https://iconify.gruenerator.eu`) — it's wired up in Salt's deployed `docker-compose.yml.j2`, has its own subdomain + Let's Encrypt cert, and the canvas editor consumes it via `VITE_ICONIFY_API_URL`. But the repo's compose files and `.env.example` never picked up the change, so:

- New contributors copying `.env.example` → `.env` don't know about `VITE_ICONIFY_API_URL`, so canvas editor icon search silently no-ops locally (`getIconifyApiUrl()` falls back to `''`).
- Anyone running the repo's `docker-compose.{prod,test}.yml` for a local prod-like stack doesn't get the iconify container, so even with the env var set the URL points at a non-existent service.

This PR closes the dev-experience gap by mirroring Salt's iconify configuration into the repo. No prod-deploy impact — Salt's compose remains authoritative and unchanged.

## Changes

- **`.env.example`**: add `VITE_ICONIFY_API_URL` next to other VITE build vars, with an example pointing at the prod URL.
- **`docker-compose.prod.yml`**: add `iconify` service block (`ghcr.io/netzbegruenung/gruenerator-iconify`, port 3100, healthcheck on `/collections`) between `doku` and `nginx` — same ordering as Salt's compose.
- **`docker-compose.test.yml`**: same iconify service block (minus the `com.gruenerator.service` label, matching test compose conventions).

Single-quoted YAML throughout to match the repo's existing Prettier style (Salt uses double quotes; converted on port).

## Test plan

- [ ] `docker compose -f docker-compose.prod.yml config` parses without error
- [ ] `docker compose -f docker-compose.test.yml config` parses without error
- [ ] Local `docker compose -f docker-compose.prod.yml up -d iconify` reaches healthy state
- [ ] `curl http://localhost:8080/...` (via the local nginx routing) returns icon collections, OR `docker compose exec iconify wget -qO- http://localhost:3100/collections` returns JSON