### PR TITLE
fix(doku): disable unused blog preset blocking MDX-3 build

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -58,21 +58,7 @@ const config: Config = {
           editUrl:
             'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
         },
-        blog: {
-          showReadingTime: true,
-          feedOptions: {
-            type: ['rss', 'atom'],
-            xslt: true,
-          },
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-          // Useful options to enforce blogging best practices
-          onInlineTags: 'warn',
-          onInlineAuthors: 'warn',
-          onUntruncatedBlogPosts: 'warn',
-        },
+        blog: false,
         theme: {
           customCss: './src/css/custom.css',
         },


### PR DESCRIPTION
## Summary

After PR #704 + #706 enabled Docusaurus Faster, the doku build now runs through MDX 3, which **dropped HTML-comment support entirely**. The four `create-docusaurus` template blog posts in `documentation/blog/` contain `<!-- truncate -->` markers that MDX 3 rejects:

\`\`\`
Unexpected character \`!\` (U+0021) before name [...]
to create a comment in MDX, use {/* text */}
\`\`\`

`build-doku` has been failing on every master push since `@docusaurus/faster` landed (this morning).

## Why disable, not patch

The blog plugin is **unused on this site**:
- no `/blog` link in `themeConfig.navbar`
- zero references in `sidebars.ts` or `src/`
- all 4 posts in `documentation/blog/` are unmodified Docusaurus templates (authors `slorber`, `yangshun`)

The Docusaurus team's own welcome-post template literally says: *"if you don't want a blog: just delete this directory, and use `blog: false` in your Docusaurus config."* This PR follows that guidance with `blog: false`, leaving the template files in place but inert (Docusaurus won't scan the directory).

If you do want a blog later, revert this commit and replace the `<!-- truncate -->` markers with `{/* truncate */}` per MDX 3.

## Test plan

- [ ] After merge, `build-doku` job in **Build and Push Docker Images** turns green
- [ ] After merge, `doku.gruenerator.eu` shows the April Work-Update newsletter and any other docs additions since 2026-04-26