### PR TITLE
fix(web): drop beta-feature gates causing UI flicker

### DIFF
--- a/apps/web/src/components/common/ActionButtons.tsx
+++ b/apps/web/src/components/common/ActionButtons.tsx
@@ -8,7 +8,6 @@ import {
   IoArrowRedoOutline,
 } from 'react-icons/io5';
 
-import { useBetaFeatures } from '../../hooks/useBetaFeatures';
 import { awaitDeferredTitle } from '../../hooks/useDeferredTitle';
 import { useSaveToLibrary } from '../../hooks/useSaveToLibrary';
 import { useAuthStore } from '../../stores/authStore';
@@ -107,7 +106,6 @@ const ActionButtons = ({
   hideDefaultExportOptions = false,
 }: ActionButtonsProps): JSX.Element => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const { getBetaFeatureState } = useBetaFeatures();
   const getGeneratedText = useGeneratedTextStore((state) => state.getGeneratedText);
   const getGeneratedTextMetadata = useGeneratedTextStore((state) => state.getGeneratedTextMetadata);
   const generatedText = getGeneratedText(componentName);
@@ -139,7 +137,7 @@ const ActionButtons = ({
     );
   });
 
-  const hasDatabaseAccess = isAuthenticated && getBetaFeatureState('database');
+  const hasDatabaseAccess = isAuthenticated;
 
   // Use generatedContent prop if available, fall back to store's generatedText
   const activeContent = generatedContent || generatedText;

--- a/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
+++ b/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
@@ -7,7 +7,6 @@ import { HiCog6Tooth } from 'react-icons/hi2';
 import SearchBar from '../../../features/search/components/SearchBar';
 import apiClient from '../../utils/apiClient';
 import AddTemplateModal from '../AddTemplateModal/AddTemplateModal';
-import BetaFeatureWrapper from '../BetaFeatureWrapper';
 import IndexCard from '../IndexCard';
 import TemplatePreviewModal from '../TemplatePreviewModal';
 
@@ -143,137 +142,135 @@ const VorlagenGallery = memo((): JSX.Element => {
   const showCategoryFilter = categories.length > 0;
 
   return (
-    <BetaFeatureWrapper featureKey="vorlagen" fallbackPath="/">
-      <div className="mx-auto mt-[60px] max-w-[1200px] flex-col px-lg box-border max-md:mt-0 max-md:px-md max-md:py-lg">
-        <div className="text-center">
-          <h1 className="mb-4 text-[2.5rem] font-semibold text-foreground-heading max-md:text-[1.75rem]">
-            Vorlagen-Datenbank
-          </h1>
-          <p className="mx-auto mb-xl max-w-[800px] text-center text-[1.1rem] leading-relaxed text-foreground">
-            Durchsuche hier Design-Vorlagen für Canva, InDesign und mehr.
-          </p>
+    <div className="mx-auto mt-[60px] max-w-[1200px] flex-col px-lg box-border max-md:mt-0 max-md:px-md max-md:py-lg">
+      <div className="text-center">
+        <h1 className="mb-4 text-[2.5rem] font-semibold text-foreground-heading max-md:text-[1.75rem]">
+          Vorlagen-Datenbank
+        </h1>
+        <p className="mx-auto mb-xl max-w-[800px] text-center text-[1.1rem] leading-relaxed text-foreground">
+          Durchsuche hier Design-Vorlagen für Canva, InDesign und mehr.
+        </p>
 
-          <div className="mx-auto mb-xl flex w-full justify-center px-md box-border">
-            <div className="gallery-controls">
-              <div className="gallery-controls-row">
-                <SearchBar
-                  onSearch={() => {}}
-                  value={inputValue}
-                  onChange={setInputValue}
-                  placeholder="Vorlagen durchsuchen..."
-                  hideExamples
-                  hideDisclaimer
-                  settingsContent={
-                    showCategoryFilter ? (
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <button
-                            type="button"
-                            className="flex items-center justify-center rounded-full border-none bg-transparent p-2 text-foreground opacity-70 transition-colors hover:bg-background-alt hover:text-primary-500 hover:opacity-100"
-                            aria-label="Einstellungen"
-                            title="Einstellungen"
-                          >
-                            <HiCog6Tooth className="size-5" />
-                          </button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                          align="end"
-                          sideOffset={8}
-                          className="w-[16rem] space-y-3 p-3"
+        <div className="mx-auto mb-xl flex w-full justify-center px-md box-border">
+          <div className="gallery-controls">
+            <div className="gallery-controls-row">
+              <SearchBar
+                onSearch={() => {}}
+                value={inputValue}
+                onChange={setInputValue}
+                placeholder="Vorlagen durchsuchen..."
+                hideExamples
+                hideDisclaimer
+                settingsContent={
+                  showCategoryFilter ? (
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className="flex items-center justify-center rounded-full border-none bg-transparent p-2 text-foreground opacity-70 transition-colors hover:bg-background-alt hover:text-primary-500 hover:opacity-100"
+                          aria-label="Einstellungen"
+                          title="Einstellungen"
                         >
-                          <div>
-                            <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
-                              Kategorie
-                            </span>
-                            <div className="flex flex-wrap gap-1.5">
-                              {categories.map((category) => (
-                                <button
-                                  key={category.id}
-                                  type="button"
-                                  className={cn(
-                                    'rounded-2xl border px-2.5 py-1 text-xs font-medium transition-colors',
-                                    selectedCategory === category.id
-                                      ? 'border-transparent bg-primary-500 text-white'
-                                      : 'border-grey-300 text-grey-700 hover:border-grey-400 dark:border-grey-600 dark:text-grey-300'
-                                  )}
-                                  onClick={() => setSelectedCategory(category.id)}
-                                >
-                                  {category.label}
-                                </button>
-                              ))}
-                            </div>
+                          <HiCog6Tooth className="size-5" />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        align="end"
+                        sideOffset={8}
+                        className="w-[16rem] space-y-3 p-3"
+                      >
+                        <div>
+                          <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                            Kategorie
+                          </span>
+                          <div className="flex flex-wrap gap-1.5">
+                            {categories.map((category) => (
+                              <button
+                                key={category.id}
+                                type="button"
+                                className={cn(
+                                  'rounded-2xl border px-2.5 py-1 text-xs font-medium transition-colors',
+                                  selectedCategory === category.id
+                                    ? 'border-transparent bg-primary-500 text-white'
+                                    : 'border-grey-300 text-grey-700 hover:border-grey-400 dark:border-grey-600 dark:text-grey-300'
+                                )}
+                                onClick={() => setSelectedCategory(category.id)}
+                              >
+                                {category.label}
+                              </button>
+                            ))}
                           </div>
-                        </PopoverContent>
-                      </Popover>
-                    ) : null
-                  }
-                />
-                <button
-                  type="button"
-                  className="pabtn pabtn--primary pabtn--s"
-                  onClick={() => setShowAddModal(true)}
-                >
-                  <HiPlus className="pabtn__icon" />
-                  <span className="pabtn__label">Vorlage hinzufügen</span>
-                </button>
-              </div>
-
-              <AddTemplateModal
-                isOpen={showAddModal}
-                onClose={() => setShowAddModal(false)}
-                onSuccess={() => dataQuery.refetch()}
+                        </div>
+                      </PopoverContent>
+                    </Popover>
+                  ) : null
+                }
               />
+              <button
+                type="button"
+                className="pabtn pabtn--primary pabtn--s"
+                onClick={() => setShowAddModal(true)}
+              >
+                <HiPlus className="pabtn__icon" />
+                <span className="pabtn__label">Vorlage hinzufügen</span>
+              </button>
             </div>
+
+            <AddTemplateModal
+              isOpen={showAddModal}
+              onClose={() => setShowAddModal(false)}
+              onSuccess={() => dataQuery.refetch()}
+            />
           </div>
         </div>
+      </div>
 
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-2xl max-lg:grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-md:grid-cols-[repeat(auto-fill,minmax(250px,1fr))] max-md:gap-4">
-          {dataQuery.isLoading && items.length === 0 ? (
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-md col-span-full">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <div key={i} className="animate-pulse rounded-md bg-background-alt h-[180px]" />
-              ))}
-            </div>
-          ) : dataQuery.error ? (
-            <p className="col-span-full text-center text-error">
-              {dataQuery.error.message || 'Fehler beim Laden'}
-            </p>
-          ) : items.length === 0 ? (
-            <p className="col-span-full text-center">Keine Vorlagen gefunden.</p>
-          ) : (
-            items.map((item) => {
-              const templateType = item.template_type
-                ? item.template_type.charAt(0).toUpperCase() + item.template_type.slice(1)
-                : '';
-              return (
-                <IndexCard
-                  key={String(item.id)}
-                  title={item.title || 'Unbenannte Vorlage'}
-                  description={item.description || ''}
-                  meta={templateType}
-                  tags={Array.isArray(item.tags) ? item.tags.slice(0, 5) : []}
-                  thumbnailUrl={item.thumbnail_url || ''}
-                  onTagClick={handleTagClick}
-                  onClick={() => setPreviewTemplate(item)}
-                  className="vorlagen-card"
-                  authorName={item.metadata?.author_name || ''}
-                  authorEmail={item.metadata?.contact_email || ''}
-                />
-              );
-            })
-          )}
-        </div>
-
-        {previewTemplate && (
-          <TemplatePreviewModal
-            isOpen={!!previewTemplate}
-            onClose={() => setPreviewTemplate(null)}
-            template={previewTemplate}
-            onTagClick={handleTagClick}
-          />
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-2xl max-lg:grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-md:grid-cols-[repeat(auto-fill,minmax(250px,1fr))] max-md:gap-4">
+        {dataQuery.isLoading && items.length === 0 ? (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-md col-span-full">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="animate-pulse rounded-md bg-background-alt h-[180px]" />
+            ))}
+          </div>
+        ) : dataQuery.error ? (
+          <p className="col-span-full text-center text-error">
+            {dataQuery.error.message || 'Fehler beim Laden'}
+          </p>
+        ) : items.length === 0 ? (
+          <p className="col-span-full text-center">Keine Vorlagen gefunden.</p>
+        ) : (
+          items.map((item) => {
+            const templateType = item.template_type
+              ? item.template_type.charAt(0).toUpperCase() + item.template_type.slice(1)
+              : '';
+            return (
+              <IndexCard
+                key={String(item.id)}
+                title={item.title || 'Unbenannte Vorlage'}
+                description={item.description || ''}
+                meta={templateType}
+                tags={Array.isArray(item.tags) ? item.tags.slice(0, 5) : []}
+                thumbnailUrl={item.thumbnail_url || ''}
+                onTagClick={handleTagClick}
+                onClick={() => setPreviewTemplate(item)}
+                className="vorlagen-card"
+                authorName={item.metadata?.author_name || ''}
+                authorEmail={item.metadata?.contact_email || ''}
+              />
+            );
+          })
         )}
       </div>
-    </BetaFeatureWrapper>
+
+      {previewTemplate && (
+        <TemplatePreviewModal
+          isOpen={!!previewTemplate}
+          onClose={() => setPreviewTemplate(null)}
+          template={previewTemplate}
+          onTagClick={handleTagClick}
+        />
+      )}
+    </div>
   );
 });
 

--- a/apps/web/src/components/layout/Header/ProfileButton.tsx
+++ b/apps/web/src/components/layout/Header/ProfileButton.tsx
@@ -9,7 +9,6 @@ import { useProfile } from '../../../features/auth/hooks/useProfileData';
 import { getAvatarDisplayProps } from '../../../features/auth/services/profileApiService';
 import NotificationList from '../../../features/notifications/components/NotificationList';
 import { useUnreadCount } from '../../../features/notifications/hooks/useNotifications';
-import { useBetaFeatures } from '../../../hooks/useBetaFeatures';
 import { useAuthStore } from '../../../stores/authStore';
 
 import type { AvatarDisplay, Profile } from '../../../features/auth/services/profileApiService';
@@ -23,11 +22,10 @@ interface NavItem {
   label: string;
   path: string;
   icon: IconType;
-  betaFeature?: string;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { key: 'gruppen', label: 'Gruppen', path: '/gruppen', icon: FaUsers, betaFeature: 'groups' },
+  { key: 'gruppen', label: 'Gruppen', path: '/gruppen', icon: FaUsers },
   { key: 'inhalte', label: 'Dateien', path: '/profile/inhalte', icon: FaFolder },
   { key: 'wolke', label: 'Wolke', path: '/profile/wolke', icon: FaCloud },
   { key: 'einstellungen', label: 'Einstellungen', path: '/profile', icon: HiCog },
@@ -79,7 +77,6 @@ const ProfileDropdownContent = memo(({ user, unreadCount }: ProfileDropdownConte
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
   const navigate = useNavigate();
   const location = useLocation();
-  const { shouldShowTab } = useBetaFeatures();
 
   const { data: profile } = useProfile(user.id);
 
@@ -91,10 +88,6 @@ const ProfileDropdownContent = memo(({ user, unreadCount }: ProfileDropdownConte
     display_name: displayName,
     email: user.email,
   });
-
-  const filteredNavItems = NAV_ITEMS.filter((item) =>
-    item.betaFeature ? shouldShowTab(item.betaFeature) : true
-  );
 
   return (
     <>
@@ -114,7 +107,7 @@ const ProfileDropdownContent = memo(({ user, unreadCount }: ProfileDropdownConte
       </div>
 
       <div className="flex items-center justify-center gap-xs px-md py-sm">
-        {filteredNavItems.map((item) => {
+        {NAV_ITEMS.map((item) => {
           const isActive =
             item.key === 'einstellungen'
               ? location.pathname === '/profile'

--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -4,10 +4,7 @@ import type { BadgeType } from '../../common/StatusBadge';
 import type { JSX, ComponentType } from 'react';
 import type { IconType } from 'react-icons';
 
-// Beta features interface
-export interface BetaFeatures {
-  databaseBetaEnabled?: boolean;
-  youBetaEnabled?: boolean;
+export interface MenuFlags {
   isAustrian?: boolean;
 }
 
@@ -42,7 +39,7 @@ export interface MenuItemsResult {
 export type DirectMenuItemsResult = Record<string, MenuItemType>;
 
 // Direkte Menüpunkte ohne Dropdown
-export const getDirectMenuItems = (betaFeatures: BetaFeatures = {}): DirectMenuItemsResult => {
+export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResult => {
   const items: DirectMenuItemsResult = {};
 
   items.startseite = {
@@ -96,7 +93,7 @@ export const getFooterLinks = (): MenuItemType[] => [
 ];
 
 // Funktion zur Generierung der Hauptmenüstruktur - simplified, no more dropdowns
-export const getMenuItems = (betaFeatures: BetaFeatures = {}): MenuItemsResult => {
+export const getMenuItems = (_flags: MenuFlags = {}): MenuItemsResult => {
   // All items moved to direct menu items - keeping this for backwards compatibility
   const result: MenuItemsResult = {
     bildUndVideo: { title: 'Bild und Video', items: [] },

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -13,7 +13,6 @@ import { PiSun, PiMoon, PiStarFill, PiSignIn } from 'react-icons/pi';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { getFavouriteItemsById } from '../../../config/sidebarFavouritesConfig';
-import { useBetaFeatures } from '../../../hooks/useBetaFeatures';
 import { useAuthStore } from '../../../stores/authStore';
 import useSidebarFavouritesStore from '../../../stores/sidebarFavouritesStore';
 import useSidebarStore from '../../../stores/sidebarStore';
@@ -65,9 +64,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
 
   const user = useAuthStore((s) => s.user);
   const setLoginIntent = useAuthStore((s) => s.setLoginIntent);
-  const { getBetaFeatureState } = useBetaFeatures();
 
-  const databaseBetaEnabled = useMemo(() => getBetaFeatureState('database'), [getBetaFeatureState]);
   const locale = useAuthStore((state) => state.locale);
   const isAustrian = locale === 'de-AT';
 
@@ -77,19 +74,9 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
     () => document.documentElement.getAttribute('data-theme') === 'dark'
   );
 
-  const menuItems = useMemo(
-    () =>
-      getMenuItems({
-        databaseBetaEnabled,
-        isAustrian,
-      }),
-    [databaseBetaEnabled, isAustrian]
-  );
+  const menuItems = useMemo(() => getMenuItems({ isAustrian }), [isAustrian]);
 
-  const directMenuItems = useMemo(
-    () => getDirectMenuItems({ databaseBetaEnabled, isAustrian }),
-    [databaseBetaEnabled, isAustrian]
-  );
+  const directMenuItems = useMemo(() => getDirectMenuItems({ isAustrian }), [isAustrian]);
   const mobileOnlyItems = useMemo(() => getMobileOnlyMenuItems(), []);
   const additionalItems = useMemo<MenuItemType[]>(
     () => [...Object.values(directMenuItems), ...Object.values(mobileOnlyItems)],

--- a/apps/web/src/components/profile/MemoriesSection.tsx
+++ b/apps/web/src/components/profile/MemoriesSection.tsx
@@ -8,7 +8,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  FeatureToggle,
 } from '@gruenerator/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -30,7 +29,6 @@ import {
   type Memory,
   type MemoryCategory,
 } from '@/features/auth/services/profileApiService';
-import { useBetaFeatures } from '@/hooks/useBetaFeatures';
 import { useAuthStore } from '@/stores/authStore';
 
 // Kept inline because apps/web cannot import from apps/api.
@@ -78,8 +76,6 @@ const CONFIDENCE_COLORS: Record<string, string> = {
 export default memo(function MemoriesSection() {
   const user = useAuthStore((s) => s.user);
   const userId = user?.id;
-  const { getBetaFeatureState, updateUserBetaFeatures } = useBetaFeatures();
-  const memoriesEnabled = getBetaFeatureState('memories');
   const queryClient = useQueryClient();
 
   const queryKey = ['memories', userId];
@@ -91,7 +87,7 @@ export default memo(function MemoriesSection() {
   } = useQuery<Memory[]>({
     queryKey,
     queryFn: () => profileApiService.getMemories(userId!),
-    enabled: !!userId && memoriesEnabled,
+    enabled: !!userId,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -229,32 +225,22 @@ export default memo(function MemoriesSection() {
   return (
     <div>
       <div className="flex items-center gap-sm mb-sm">
-        <FeatureToggle
-          isActive={memoriesEnabled}
-          onToggle={(checked) => updateUserBetaFeatures('memories', checked)}
-          label={
-            memoriesEnabled ? `Erinnerungen (${isLoading ? '…' : memories.length})` : 'Erinnerungen'
-          }
-          icon={Brain}
-          noBorder
-          className="flex-1 p-0"
-        />
-        {memoriesEnabled && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-grey-500 hover:text-foreground"
-            onClick={() => setShowAddForm(!showAddForm)}
-          >
-            <Plus className="size-4" />
-            Hinzufügen
-          </Button>
-        )}
+        <div className="flex-1 flex items-center gap-xs text-sm font-medium text-foreground-heading">
+          <Brain className="size-4 text-grey-500" />
+          Erinnerungen ({isLoading ? '…' : memories.length})
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-grey-500 hover:text-foreground"
+          onClick={() => setShowAddForm(!showAddForm)}
+        >
+          <Plus className="size-4" />
+          Hinzufügen
+        </Button>
       </div>
 
-      {!memoriesEnabled && <p className="text-sm text-grey-400">Erinnerungen sind deaktiviert.</p>}
-
-      {memoriesEnabled && error && (
+      {error && (
         <div className="flex items-center gap-sm rounded-md border border-red-300 bg-red-50 p-sm mb-md text-sm text-red-700 dark:border-red-800 dark:bg-red-950 dark:text-red-300">
           <AlertTriangle className="size-4 shrink-0" />
           <span className="flex-1">{error}</span>
@@ -264,7 +250,7 @@ export default memo(function MemoriesSection() {
         </div>
       )}
 
-      {memoriesEnabled && showAddForm && (
+      {showAddForm && (
         <div className="flex flex-col gap-sm rounded-lg bg-background-alt p-md mb-md">
           <textarea
             value={newText}
@@ -307,7 +293,7 @@ export default memo(function MemoriesSection() {
       )}
 
       {/* Search & Filter bar */}
-      {memoriesEnabled && memories.length > 0 && (
+      {memories.length > 0 && (
         <div className="flex flex-col gap-sm mb-md sm:flex-row sm:items-center">
           <div className="relative flex-1">
             <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-grey-400" />
@@ -338,7 +324,7 @@ export default memo(function MemoriesSection() {
         </div>
       )}
 
-      {!memoriesEnabled ? null : isLoading ? (
+      {isLoading ? (
         <div className="space-y-sm">
           {[1, 2, 3].map((i) => (
             <div key={i} className="animate-pulse rounded-lg bg-background-alt p-md">
@@ -471,7 +457,7 @@ export default memo(function MemoriesSection() {
         </div>
       )}
 
-      {memoriesEnabled && memories.length > 0 && (
+      {memories.length > 0 && (
         <div className="mt-md flex items-center justify-between">
           <Button
             variant="ghost"

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -221,7 +221,7 @@ const standardRoutes: RouteConfig[] = [
   { path: '/admin', component: AdminDashboardPage },
   { path: '/admin/gruene-api', component: GrueneApiTestPage },
   { path: '/playground', component: PlaygroundPage },
-  { path: '/datenbank/vorlagen', component: GrueneratorenBundle.VorlagenListe },
+  { path: '/datenbank/vorlagen', component: GrueneratorenBundle.VorlagenListe, devOnly: true },
   { path: '/suche', component: GrueneratorenBundle.Search, withForm: true },
   { path: '/kommunal', component: GrueneratorenBundle.Oparl },
   {
@@ -312,7 +312,7 @@ const standardRoutes: RouteConfig[] = [
   { path: '/reel/beta', component: SubtitlerBetaPage },
   { path: '/reel/studio', component: SubStudioPage },
   { path: '/scanner', component: GrueneratorenBundle.Scanner },
-  { path: '/transfer', component: GrueneratorenBundle.Transfer },
+  { path: '/transfer', component: GrueneratorenBundle.Transfer, devOnly: true },
   { path: '/transkription', component: GrueneratorenBundle.Transkription },
   { path: '/subtitler/share/:shareToken', component: SharedVideoPage, layoutMode: 'noChrome' },
   { path: '/share/:shareToken', component: SharedMediaPage, layoutMode: 'noChrome' },

--- a/apps/web/src/features/auth/components/profile/ProfileMenu.tsx
+++ b/apps/web/src/features/auth/components/profile/ProfileMenu.tsx
@@ -8,15 +8,12 @@ import React, { useState } from 'react';
 import { FaChevronDown, FaChevronUp, FaCloud, FaFolder, FaUsers } from 'react-icons/fa';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
-import { useBetaFeatures } from '../../../../hooks/useBetaFeatures';
-
 import type { IconType } from 'react-icons';
 
 interface MenuItem {
   key: string;
   label: string;
   path: string;
-  betaFeature?: string;
   icon: IconType;
   hasSubmenu?: boolean;
 }
@@ -38,7 +35,6 @@ const PROFILE_MENU_ITEMS: MenuItem[] = [
     key: 'gruppen',
     label: 'Gruppen',
     path: '/gruppen',
-    betaFeature: 'groups',
     icon: FaUsers,
     hasSubmenu: true,
   },
@@ -54,15 +50,7 @@ const ProfileMenu = ({
 }: ProfileMenuProps): React.ReactElement => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { shouldShowTab } = useBetaFeatures();
   const [expandedSubmenu, setExpandedSubmenu] = useState<string | null>(null);
-
-  const filteredItems = PROFILE_MENU_ITEMS.filter((item) => {
-    if (item.betaFeature) {
-      return shouldShowTab(item.betaFeature);
-    }
-    return true;
-  });
 
   const isActive = (path: string): boolean => {
     if (path === '/profile') {
@@ -80,7 +68,7 @@ const ProfileMenu = ({
   if (variant === 'dropdown') {
     return (
       <div className={className}>
-        {filteredItems.map((item) => {
+        {PROFILE_MENU_ITEMS.map((item) => {
           const hasGroups = item.key === 'gruppen' && item.hasSubmenu && groups.length > 0;
 
           if (hasGroups) {
@@ -131,7 +119,7 @@ const ProfileMenu = ({
 
   return (
     <div className={`profile-menu profile-menu--sidebar ${className}`}>
-      {filteredItems.map((item) => {
+      {PROFILE_MENU_ITEMS.map((item) => {
         const hasGroups = item.key === 'gruppen' && item.hasSubmenu && groups.length > 0;
         const isExpanded = expandedSubmenu === item.key;
 

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
@@ -68,7 +68,6 @@ interface ProfileViewProps {
   deleteAccountError: string;
   isDeletingAccount: boolean;
   onDeleteAccountSubmit: (e: FormEvent<HTMLFormElement>) => void;
-  isBetaFeaturesUpdating: boolean;
   onSuccessMessage: (message: string) => void;
 }
 
@@ -98,7 +97,6 @@ const ProfileView = ({
   deleteAccountError,
   isDeletingAccount,
   onDeleteAccountSubmit,
-  isBetaFeaturesUpdating,
   onSuccessMessage,
 }: ProfileViewProps) => {
   const { locale, updateLocale } = useAuthStore();
@@ -201,13 +199,7 @@ const ProfileView = ({
       {/* Dein Grünerator — inline role management */}
       <RolesSection />
 
-      {/* Experimental Features */}
-      <SettingsSection
-        isActive={true}
-        isBetaFeaturesUpdating={isBetaFeaturesUpdating}
-        onSuccessMessage={onSuccessMessage}
-        onErrorMessage={() => {}}
-      />
+      <SettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
 
       <MemoriesSection />
 

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.tsx
@@ -1,34 +1,14 @@
-import { Badge } from '@gruenerator/ui';
 import React, { memo } from 'react';
-import { type IconType } from 'react-icons';
-import { HiOutlineDatabase, HiOutlineUsers } from 'react-icons/hi';
 
 import FeatureToggle from '../../../../../../components/common/FeatureToggle';
 import { getEmailPreferenceTypes } from '../../../../../../features/notifications/notificationConfig';
-import { useBetaFeatures } from '../../../../../../hooks/useBetaFeatures';
 import { useUserDefaults } from '../../../../../../hooks/useUserDefaults';
 import { useAuthStore, type SupportedLocale } from '../../../../../../stores/authStore';
 
 interface SettingsSectionProps {
-  isActive: boolean;
   onSuccessMessage: (message: string) => void;
   onErrorMessage: (message: string) => void;
-  isBetaFeaturesUpdating: boolean;
 }
-
-interface BetaFeatureUIConfig {
-  title: string;
-  description: string;
-  checked: boolean;
-  setter: (value: boolean) => Promise<void>;
-  featureName: string;
-  checkboxLabel: string;
-  linkTo?: string;
-  linkText?: string;
-  icon: IconType | React.ComponentType;
-}
-
-type BetaViewKey = (typeof BETA_VIEWS)[keyof typeof BETA_VIEWS];
 
 const LocaleSelector: React.FC = () => {
   const { locale, updateLocale } = useAuthStore();
@@ -57,94 +37,10 @@ const LocaleSelector: React.FC = () => {
   );
 };
 
-const BETA_VIEWS = {
-  DATABASE: 'database',
-  COLLAB: 'collab',
-  VORLAGEN: 'vorlagen',
-};
-
 const SettingsSection: React.FC<SettingsSectionProps> = memo(
-  ({ isActive, onSuccessMessage, onErrorMessage, isBetaFeaturesUpdating }) => {
-    const { getBetaFeatureState, updateUserBetaFeatures, availableFeatures, isAdmin } =
-      useBetaFeatures();
-
-    const getBetaFeatureConfig = (viewKey: BetaViewKey): BetaFeatureUIConfig | null => {
-      switch (viewKey) {
-        case BETA_VIEWS.DATABASE:
-          return {
-            title: 'Texte & Vorlagen',
-            description: 'Datenbank für Texte und Vorlagen',
-            checked: getBetaFeatureState('database'),
-            setter: (value: boolean) => updateUserBetaFeatures('database', value),
-            featureName: 'Datenbank',
-            checkboxLabel:
-              "'Texte & Vorlagen'-Tab (Datenbank) anzeigen und Funktionalität aktivieren",
-            linkTo: '/datenbank/agents',
-            linkText: 'Zu Agenten & Skills',
-            icon: HiOutlineDatabase,
-          };
-        case BETA_VIEWS.COLLAB:
-          return {
-            title: 'Kollaborative Bearbeitung',
-            description: 'Echtzeit-Zusammenarbeit an Dokumenten',
-            checked: getBetaFeatureState('collab'),
-            setter: (value: boolean) => updateUserBetaFeatures('collab', value),
-            featureName: 'Kollaborative Bearbeitung',
-            checkboxLabel: 'Kollaborative Bearbeitung aktivieren',
-            icon: HiOutlineUsers,
-          };
-        case BETA_VIEWS.VORLAGEN:
-          return {
-            title: 'Vorlagen & Galerie',
-            description: 'Persönliche und öffentliche Vorlagen',
-            checked: getBetaFeatureState('vorlagen'),
-            setter: (value: boolean) => updateUserBetaFeatures('vorlagen', value),
-            featureName: 'Vorlagen & Galerie',
-            checkboxLabel: 'Meine Vorlagen und Vorlagen-Galerie aktivieren',
-            linkTo: '/profile/inhalte/vorlagen',
-            linkText: 'Zu Meine Vorlagen',
-            icon: HiOutlineDatabase,
-          };
-        default:
-          return null;
-      }
-    };
-
-    const renderToggle = (feature: { key: string; isAdminOnly: boolean }) => {
-      const config = getBetaFeatureConfig(feature.key);
-      if (!config) return null;
-      const description = `${config.description} (Experimentell)`;
-      return (
-        <div key={feature.key} className="flex items-center gap-sm">
-          <FeatureToggle
-            isActive={config.checked}
-            onToggle={(checked) => {
-              void config.setter(checked);
-              onSuccessMessage(`${config.featureName} ${checked ? 'aktiviert' : 'deaktiviert'}.`);
-            }}
-            label={config.title}
-            icon={config.icon}
-            description={description}
-            className="flex-1"
-          />
-          {feature.isAdminOnly && <Badge variant="secondary">Admin</Badge>}
-        </div>
-      );
-    };
-
+  ({ onSuccessMessage, onErrorMessage }) => {
     return (
-      <div className="flex flex-col gap-lg">
-        {availableFeatures.length > 0 && (
-          <div>
-            <div className="text-sm font-medium text-foreground mb-md">Einstellungen</div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-md">
-              {availableFeatures.map((f) => renderToggle(f))}
-            </div>
-          </div>
-        )}
-
-        <NotificationToggles onSuccessMessage={onSuccessMessage} onErrorMessage={onErrorMessage} />
-      </div>
+      <NotificationToggles onSuccessMessage={onSuccessMessage} onErrorMessage={onErrorMessage} />
     );
   }
 );

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/index.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/index.tsx
@@ -10,7 +10,6 @@ import React, {
 } from 'react';
 
 import { useAutosave } from '../../../../../../hooks/useAutosave';
-import { useBetaFeatures } from '../../../../../../hooks/useBetaFeatures';
 import { useAuthStore } from '../../../../../../stores/authStore';
 import { useProfileStore } from '../../../../../../stores/profileStore';
 import { useProfile } from '../../../../hooks/useProfileData';
@@ -64,12 +63,6 @@ const ProfileInfoTabContainer = ({
   const profile = profileData as Profile | undefined;
   const updateAvatarOptimistic = useProfileStore((s) => s.updateAvatarOptimistic);
   const syncProfile = useProfileStore((s) => s.syncProfile);
-
-  const {
-    getBetaFeatureState,
-    updateUserBetaFeatures,
-    isUpdating: isBetaFeaturesUpdating,
-  } = useBetaFeatures();
 
   // State hooks - must be called unconditionally
   const [displayName, setDisplayName] = useState('');
@@ -363,7 +356,6 @@ const ProfileInfoTabContainer = ({
         deleteAccountError={deleteAccountError}
         isDeletingAccount={isDeletingAccount}
         onDeleteAccountSubmit={handleDeleteAccountSubmit}
-        isBetaFeaturesUpdating={isBetaFeaturesUpdating}
         onSuccessMessage={onSuccessMessage}
       />
 

--- a/apps/web/src/hooks/useNotificationSSE.ts
+++ b/apps/web/src/hooks/useNotificationSSE.ts
@@ -4,8 +4,6 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useAuthStore } from '../stores/authStore';
 import { useNotificationStore } from '../stores/notificationStore';
 
-import { useBetaFeatures } from './useBetaFeatures';
-
 const RECONNECT_BASE_DELAY = 1000;
 const RECONNECT_MAX_DELAY = 30000;
 
@@ -18,7 +16,6 @@ type OnNotificationCallback = (data: SSENotificationData) => void;
 
 export function useNotificationSSE(onNotification?: OnNotificationCallback): void {
   const user = useAuthStore((s) => s.user);
-  const { canAccessBetaFeature } = useBetaFeatures();
   const queryClient = useQueryClient();
   const eventSourceRef = useRef<EventSource | null>(null);
   const reconnectAttemptRef = useRef(0);
@@ -26,7 +23,7 @@ export function useNotificationSSE(onNotification?: OnNotificationCallback): voi
   const onNotificationRef = useRef(onNotification);
   onNotificationRef.current = onNotification;
 
-  const isEnabled = !!user?.id && canAccessBetaFeature('workplace');
+  const isEnabled = !!user?.id;
 
   const connect = useCallback(() => {
     if (eventSourceRef.current) {


### PR DESCRIPTION
## Summary

Beta-feature gates were applied to features that aren't beta anymore. Each gate added a hydration-race window where the gated UI flickered or failed to appear on first render — the original Gruppen-icon bug was bug #1 of a class. This PR removes the entire current-gate surface.

The `useBetaFeatures` hook, `betaFeaturesStore`, and `BetaFeatureWrapper` are **kept** for future re-use.

## What changed

**Beta gates removed** (race condition root cause for each):
| Feature | File | Behavior change |
|---|---|---|
| `groups` | `ProfileButton.tsx`, `ProfileMenu.tsx` | Gruppen icon always visible (original bug fix) |
| `workplace` | `useNotificationSSE.ts` | SSE notifications connect for any authed user |
| `database` | `ActionButtons.tsx`, `Sidebar.tsx` | Save button + sidebar item always available |
| `memories` | `MemoriesSection.tsx` | Memories list always rendered |
| `database`/`collab`/`vorlagen` | `SettingsSection.tsx` | Labor toggles UI dropped (no beta features left to toggle) |

**Moved to `devOnly` (matches existing `routes.ts:418` pattern):**
- `/datenbank/vorlagen` route — only registered when `import.meta.env.DEV`
- `/transfer` route — only registered when `import.meta.env.DEV`
- (Entry-point tiles in `ToolsSection.tsx` already use `devOnly: true`; this just gates direct URL access too.)

**Deleted as dead code orphaned by the above:**
- `databaseBetaEnabled` parameter threading in `menuData.tsx` + `Sidebar.tsx`
- `BETA_VIEWS`, `getBetaFeatureConfig`, `renderToggle`, `availableFeatures.map(...)` block in `SettingsSection.tsx`
- `isBetaFeaturesUpdating` prop chain (`ProfileInfo/index.tsx` → `ProfileView.tsx` → `SettingsSection.tsx`)

**Kept for future use** (no consumers remain after this PR, but infrastructure stays):
- `apps/web/src/hooks/useBetaFeatures.ts`
- `apps/web/src/stores/betaFeaturesStore.ts`
- `apps/web/src/components/common/BetaFeatureWrapper.tsx`

## UX consequences

- **Memories opt-out toggle removed.** The `FeatureToggle` in `MemoriesSection` was the only way users could disable memory storage; it's gone. If we want to keep that opt-out, re-introduce it as a real profile preference (separate column / API), not as a beta-features flag.
- **`/datenbank/vorlagen` and `/transfer` are not registered in production builds.** Direct URL access in prod falls through to the route catch-all. This matches the existing pattern (e.g., `/image-studio` already uses `devOnly: true`).

## Test plan

- [ ] Open the app fresh, log in, immediately open the profile dropdown — Gruppen icon visible without flicker (original bug)
- [ ] Throttle network to Slow 3G, hard-refresh — Gruppen, sidebar `/datenbank` item, and ActionButtons save button all appear without delay
- [ ] Notifications: confirm SSE connects and unread count works for a fresh login (no `workplace` gate anymore)
- [ ] Profile → memories: list renders without the FeatureToggle, "Hinzufügen" button works
- [ ] Profile → Labor area: only E-Mail-Benachrichtigungen toggles remain (no more Datenbank/Vorlagen/Kollab toggles)
- [ ] **Dev build:** `/datenbank/vorlagen` and `/transfer` work as before
- [ ] **Prod build:** direct URL `/transfer` and `/datenbank/vorlagen` redirect to home (route not registered)
- [x] `pnpm --filter @gruenerator/web typecheck` passes (verified locally — exit 0)

## Follow-ups (separate PRs)
- Backend `/auth/profile/beta-features` endpoint + `ba_user_beta_features` table can be deleted once the frontend has been on this PR for a release cycle without regressions.
- Re-introduce a memory opt-out as a real profile preference if product wants it.