### PR TITLE
fix(web): disable code-splitting to halt prod chunk-init crashes

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -143,80 +143,31 @@ export default defineConfig(({ command }) => ({
           }
           return 'assets/[name].[hash][extname]';
         },
-      },
-      codeSplitting: {
-        groups: [
-          {
-            name: 'core-vendor',
-            test: /node_modules[\\/](react|react-dom|react-router)/,
-            priority: 20,
-          },
-          {
-            name: 'state-vendor',
-            test: /node_modules[\\/](@tanstack[\\/]react-query|zustand)/,
-            priority: 10,
-          },
-          {
-            name: 'ui-vendor',
-            test: /node_modules[\\/](react-tooltip|react-hook-form|react-dropzone)/,
-            priority: 10,
-          },
-          {
-            name: 'utils-vendor',
-            test: /node_modules[\\/](uuid|dompurify)/,
-            priority: 10,
-          },
-          {
-            name: 'motion-vendor',
-            test: /node_modules[\\/]motion/,
-            priority: 10,
-          },
-          {
-            name: 'canvas-vendor',
-            test: /node_modules[\\/](konva|react-konva|use-image)/,
-            priority: 10,
-          },
-          {
-            name: 'ai-vendor',
-            test: /node_modules[\\/](onnxruntime-web|@imgly[\\/]background-removal)/,
-            priority: 10,
-          },
-          {
-            name: 'editor-vendor',
-            test: /node_modules[\\/](@mdxeditor[\\/]editor|marked|react-markdown)/,
-            priority: 10,
-          },
-          {
-            name: 'chat-vendor',
-            test: /node_modules[\\/](@assistant-ui[\\/]react|lucide-react)/,
-            priority: 10,
-          },
-          {
-            name: 'shared-pkg',
-            test: /packages[\\/]shared[\\/]src/,
-            priority: 5,
-          },
-          {
-            name: 'canvas-editor-pkg',
-            test: /packages[\\/]canvas-editor[\\/]src/,
-            priority: 5,
-          },
-          {
-            name: 'chat-pkg',
-            test: /packages[\\/]chat[\\/]src/,
-            priority: 5,
-          },
-          {
-            name: 'docs-pkg',
-            test: /packages[\\/]docs[\\/]src/,
-            priority: 5,
-          },
-          {
-            name: 'collab-pkg',
-            test: /packages[\\/]collab[\\/]src/,
-            priority: 5,
-          },
-        ],
+        // Disable code-splitting entirely as an emergency safety measure.
+        //
+        // The previous `codeSplitting.groups` config has been silently dead
+        // since the Vite 8 → Rolldown migration: Rolldown's `codeSplitting`
+        // accepts either a boolean or `AdvancedChunksSchema`, but
+        // AdvancedChunksSchema does not include a `groups` field, so the
+        // entire vendor-grouping block was being dropped at config parse.
+        // With no manual chunking active, Rolldown's auto-chunker had been
+        // producing a chunk topology with multiple circular cross-chunk
+        // imports — surfacing in production as both
+        //   "TypeError: s is not a function" (in the react-markdown chunk,
+        //    where bindings from the still-initializing entry chunk were
+        //    used at module-init time)
+        // and
+        //   "Cannot read properties of undefined (reading 'displayName')"
+        //    (at radix-ui's Primitive factory in another chunk, same root
+        //    cause: a sibling-chunk binding undefined at use time).
+        //
+        // `codeSplitting: false` puts all modules into one chunk and
+        // inlines every dynamic `import()`, eliminating all cross-chunk
+        // imports and therefore any possibility of circular-init bugs.
+        // The cost is initial bundle size (no on-demand splits) — a real
+        // regression we'll claw back in a follow-up PR with a working
+        // chunking config plus a CI smoke test that catches cycles.
+        codeSplitting: false,
       },
     },
   },


### PR DESCRIPTION
## Production status: OFFLINE

Two cascading chunk-init errors on every page load:

```
TypeError: s is not a function
  at react-markdown.<hash>.js:2:8492

TypeError: Cannot read properties of undefined (reading 'displayName')
  at <feature-chunk>.<hash>.js  (radix-ui Primitive factory)
```

Both are circular cross-chunk imports: a chunk reads a binding from a sibling chunk that is still mid-init, so the binding is `undefined` at use time. The first halts JS evaluation, masking the second until the first is fixed.

## Root cause

The `codeSplitting.groups` block in `apps/web/vite.config.ts` has been silently dead since the Vite 8 → Rolldown migration (commit `7c5a428`). Verified by inspecting build output: **no** `core-vendor.*.js`, `editor-vendor.*.js`, etc. chunks were ever emitted. With no manual chunking active, Rolldown's auto-chunker has produced a topology containing multiple init-order cycles. Yesterday's `pnpm update -r` (`736b547e3`) and today's BlockNote 0.49 lockfile refresh (`0493464c5`) perturbed the import graph enough to expose them.

## Fix

`output.codeSplitting: false` puts every module into one chunk and inlines all dynamic `import()` calls. One chunk → no cross-chunk barriers → no init-order cycles possible → entire class of bug structurally impossible.

## Cost (accepted explicitly as emergency trade-off)

- Single bundle: ~22MB (vs. current many-chunk topology).
- Initial paint will be slower — no on-demand splits.
- This is restored-service grade, not optimal grade.

## Test plan

- [ ] CI green
- [ ] Deploy to test-branch first, verify `/`, `/chat`, `/notebook`, `/profile` all load with no console errors
- [ ] Promote to master, monitor Sentry for new errors
- [ ] Open follow-up PR to reintroduce splitting properly with a working `manualChunks` function + CI smoke test (see ~/.claude/plans/rank-these-changes-and-eventual-flute.md)

## Supersedes

Closes #710 — the `@assistant-ui/react-markdown` version pin was a red herring. The real bug is in chunking, not deps. Pinning didn't fix it because the cycle exists regardless of which assistant-ui version is installed.

## Verification done locally

- Local prod build with this change succeeds (1m57s).
- Resulting `index.<hash>.js` is single-bundle (~22MB), no chunk imports across files.
- The previous broken topology had `react-markdown.<hash>.js` importing 16 named symbols from `index.<hash>.js` — that import line no longer exists.