### PR TITLE
feat(web): merge experimentelle Tools and add Grünerators Favoriten

### DIFF
--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -10,7 +10,7 @@ import CreatorSection from './components/CreatorSection';
 import NotebooksSection from './components/NotebooksSection';
 import RecentlyCreatedSection from './components/RecentlyCreatedSection';
 import ReelsSection from './components/ReelsSection';
-import ToolsSection, { ExperimentalToolsSection } from './components/ToolsSection';
+import ToolsSection, { FavoritesSection } from './components/ToolsSection';
 
 function getGreeting(): string {
   const hour = new Date().getHours();
@@ -213,8 +213,8 @@ const WorkplacePage = () => {
         </section>
 
         <section className="mb-xl">
-          <SectionHeader title="Experimentelle Tools" />
-          <ExperimentalToolsSection />
+          <SectionHeader title="Grünerators Favoriten" />
+          <FavoritesSection />
         </section>
 
         {/* <GrassWithSheep /> */}

--- a/apps/web/src/features/workplace/components/ToolsSection.tsx
+++ b/apps/web/src/features/workplace/components/ToolsSection.tsx
@@ -14,6 +14,13 @@ interface ToolItem {
   devOnly?: boolean;
 }
 
+interface FavoriteItem {
+  id: string;
+  title: string;
+  href: string;
+  icon: IconType;
+}
+
 const MAIN_TOOLS: ToolItem[] = [
   {
     id: 'gruen-veraendern',
@@ -47,9 +54,6 @@ const MAIN_TOOLS: ToolItem[] = [
     icon: getIcon('actions', 'upload')!,
     devOnly: true,
   },
-];
-
-const EXPERIMENTAL_TOOLS: ToolItem[] = [
   {
     id: 'scanner',
     title: 'Text digitalisieren',
@@ -67,6 +71,39 @@ const EXPERIMENTAL_TOOLS: ToolItem[] = [
     title: 'Mit ChatGPT & co verbinden',
     path: '/apps',
     icon: getIcon('actions', 'link')!,
+  },
+];
+
+const FAVORITES: FavoriteItem[] = [
+  {
+    id: 'verdigado',
+    title: 'Verdigado',
+    href: 'https://verdigado.com/',
+    icon: getIcon('actions', 'link')!,
+  },
+  {
+    id: 'sunflower-theme',
+    title: 'Sunflower-Theme',
+    href: 'https://sunflower-theme.de/',
+    icon: getIcon('actions', 'link')!,
+  },
+  {
+    id: 'gruene-wolke',
+    title: 'Grüne Wolke',
+    href: 'https://wolke.netzbegruenung.de/',
+    icon: getIcon('actions', 'cloud')!,
+  },
+  {
+    id: 'gruenes-doodle',
+    title: 'Grünes Doodle',
+    href: 'https://termine.netzbegruenung.de',
+    icon: getIcon('actions', 'link')!,
+  },
+  {
+    id: 'netzbegruenung',
+    title: 'Netzbegrünung',
+    href: 'https://netzbegruenung.de/',
+    icon: getIcon('navigation', 'home')!,
   },
 ];
 
@@ -93,6 +130,24 @@ function ToolIconRow({ tools }: { tools: ToolItem[] }) {
   );
 }
 
+function FavoriteIconRow({ favorites }: { favorites: FavoriteItem[] }) {
+  return (
+    <IconButtonRow>
+      {favorites.map((fav) => {
+        const Icon = fav.icon;
+        return (
+          <IconButton
+            key={fav.id}
+            icon={<Icon />}
+            label={fav.title}
+            onClick={() => window.open(fav.href, '_blank', 'noopener,noreferrer')}
+          />
+        );
+      })}
+    </IconButtonRow>
+  );
+}
+
 const ToolsSection = React.memo(() => {
   const tools = filterTools(MAIN_TOOLS);
   return <ToolIconRow tools={tools} />;
@@ -100,11 +155,8 @@ const ToolsSection = React.memo(() => {
 
 ToolsSection.displayName = 'ToolsSection';
 
-export const ExperimentalToolsSection = React.memo(() => {
-  const tools = filterTools(EXPERIMENTAL_TOOLS);
-  return <ToolIconRow tools={tools} />;
-});
+export const FavoritesSection = React.memo(() => <FavoriteIconRow favorites={FAVORITES} />);
 
-ExperimentalToolsSection.displayName = 'ExperimentalToolsSection';
+FavoritesSection.displayName = 'FavoritesSection';
 
 export default ToolsSection;


### PR DESCRIPTION
## Summary
- Merge the three Experimentelle entries (Scanner, Transkription, Apps) into the main **Weitere Tools** row so users see one consolidated tool grid.
- Replace the now-empty Experimentelle section with **Grünerators Favoriten**, linking out in new tabs to Verdigado, Sunflower-Theme, Grüne Wolke, Grünes Doodle and Netzbegrünung.
- External links use `window.open(href, '_blank', 'noopener,noreferrer')` to avoid reverse-tabnabbing.

## Test plan
- [ ] `/desk` shows a single "Weitere Tools" row containing the previously experimentelle items.
- [ ] "Grünerators Favoriten" row renders with 5 icon buttons.
- [ ] Each favorite opens its target URL in a new tab.
- [ ] Dev-only tools (`vorlagen`, `transfer`) still hidden in production.