### PR TITLE
feat(content-sync): per-LV jobs with per-LV emails

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -2,12 +2,16 @@ name: Content Sync
 
 on:
   schedule:
-    - cron: '0 4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20 * * *' # Hourly 06-22 CET → landesverbaende only
+    - cron: '0 4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20 * * *' # Hourly 06-22 CET → landesverbände only
     - cron: '0 2 * * *' # Daily 03:00 CET → all sources
   workflow_dispatch:
     inputs:
       source:
-        description: 'Source group (empty = all). Options: landesverbaende, gruenblog, gruene-at, kommunalwiki, boell-stiftung, bundestag'
+        description: 'Single non-LV source (gruenblog, gruene-at, kommunalwiki, boell-stiftung, bundestag). Mutually exclusive with landesverband.'
+        required: false
+        type: string
+      landesverband:
+        description: 'Single Landesverband shortName prefix (BB, BE, HH, LSA, MV, TH). Mutually exclusive with source.'
         required: false
         type: string
       dry_run:
@@ -33,37 +37,117 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-      use_matrix: ${{ steps.set-matrix.outputs.use_matrix }}
+      lv_matrix: ${{ steps.set.outputs.lv_matrix }}
+      source_matrix: ${{ steps.set.outputs.source_matrix }}
+      single_kind: ${{ steps.set.outputs.single_kind }}
+      single_value: ${{ steps.set.outputs.single_value }}
     steps:
-      - id: set-matrix
+      - id: set
         env:
           SCHEDULE: ${{ github.event.schedule }}
-          SOURCE: ${{ inputs.source }}
+          INPUT_SOURCE: ${{ inputs.source }}
+          INPUT_LV: ${{ inputs.landesverband }}
         run: |
-          if [ -n "$SOURCE" ]; then
-            # Manual single-source run
-            echo 'use_matrix=false' >> $GITHUB_OUTPUT
-            echo "matrix={\"source\":[\"$SOURCE\"]}" >> $GITHUB_OUTPUT
-          elif [ "$SCHEDULE" = "0 2 * * *" ] || [ -z "$SCHEDULE" ]; then
-            # Daily 3 AM CET or manual dispatch (no source) → all sources
-            echo 'use_matrix=true' >> $GITHUB_OUTPUT
-            echo 'matrix={"source":["landesverbaende","gruenblog","gruene-at","kommunalwiki","boell-stiftung","bundestag"]}' >> $GITHUB_OUTPUT
-          else
-            # Hourly schedule → landesverbaende only
-            echo 'use_matrix=false' >> $GITHUB_OUTPUT
-            echo 'matrix={"source":["landesverbaende"]}' >> $GITHUB_OUTPUT
+          ALL_LVS='["BB","BE","HH","LSA","MV","TH"]'
+          ALL_SOURCES='["gruenblog","gruene-at","kommunalwiki","boell-stiftung","bundestag"]'
+          EMPTY='[]'
+
+          if [ -n "$INPUT_SOURCE" ] && [ -n "$INPUT_LV" ]; then
+            echo "::error::Provide either 'source' or 'landesverband', not both."
+            exit 1
           fi
 
-  # ─── Matrix: one job per source group ──────────────────────────
-  sync:
-    name: Sync ${{ matrix.source }}
+          if [ -n "$INPUT_LV" ]; then
+            echo "single_kind=landesverband" >> "$GITHUB_OUTPUT"
+            echo "single_value=$INPUT_LV" >> "$GITHUB_OUTPUT"
+            echo "lv_matrix=$EMPTY" >> "$GITHUB_OUTPUT"
+            echo "source_matrix=$EMPTY" >> "$GITHUB_OUTPUT"
+          elif [ -n "$INPUT_SOURCE" ]; then
+            echo "single_kind=source" >> "$GITHUB_OUTPUT"
+            echo "single_value=$INPUT_SOURCE" >> "$GITHUB_OUTPUT"
+            echo "lv_matrix=$EMPTY" >> "$GITHUB_OUTPUT"
+            echo "source_matrix=$EMPTY" >> "$GITHUB_OUTPUT"
+          elif [ "$SCHEDULE" = "0 2 * * *" ] || [ -z "$SCHEDULE" ]; then
+            # Daily 3 AM CET or manual dispatch (no input) → both matrices
+            echo "single_kind=" >> "$GITHUB_OUTPUT"
+            echo "single_value=" >> "$GITHUB_OUTPUT"
+            echo "lv_matrix=$ALL_LVS" >> "$GITHUB_OUTPUT"
+            echo "source_matrix=$ALL_SOURCES" >> "$GITHUB_OUTPUT"
+          else
+            # Hourly schedule → LVs only
+            echo "single_kind=" >> "$GITHUB_OUTPUT"
+            echo "single_value=" >> "$GITHUB_OUTPUT"
+            echo "lv_matrix=$ALL_LVS" >> "$GITHUB_OUTPUT"
+            echo "source_matrix=$EMPTY" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── Per-Landesverband matrix: one job, one mail per LV ────────
+  sync-lv:
+    name: Sync LV ${{ matrix.lv }}
     needs: setup
-    if: needs.setup.outputs.use_matrix == 'true'
+    if: needs.setup.outputs.lv_matrix != '[]' && needs.setup.outputs.lv_matrix != ''
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
-      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+      matrix:
+        lv: ${{ fromJSON(needs.setup.outputs.lv_matrix) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile --filter @gruenerator/api...
+
+      - name: Run LV sync (sends own email if anything changed)
+        id: sync
+        continue-on-error: true
+        run: |
+          ARGS="--landesverband ${{ matrix.lv }}"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
+          npx tsx apps/api/update-all-content.ts $ARGS
+        env:
+          QDRANT_URL: ${{ secrets.QDRANT_URL }}
+          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+          QDRANT_BASIC_AUTH_USERNAME: ${{ secrets.QDRANT_BASIC_AUTH_USERNAME }}
+          QDRANT_BASIC_AUTH_PASSWORD: ${{ secrets.QDRANT_BASIC_AUTH_PASSWORD }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          APIFY_TOKEN: ${{ secrets.APIFY_TOKEN }}
+          BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
+          BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
+          BREVO_SMTP_USER: ${{ secrets.BREVO_SMTP_USER }}
+          BREVO_SMTP_PASS: ${{ secrets.BREVO_SMTP_PASS }}
+          EMAIL_FROM: ${{ vars.EMAIL_FROM || 'Grünerator <info@gruenerator.eu>' }}
+          CONTENT_SYNC_EMAIL: ${{ vars.CONTENT_SYNC_EMAIL }}
+          SYNC_SUMMARY_PATH: ${{ github.workspace }}/sync-summary.json
+
+      - name: Upload summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-summary-lv-${{ matrix.lv }}
+          path: sync-summary.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Fail if sync had errors
+        if: steps.sync.outcome == 'failure'
+        run: exit 1
+
+  # ─── Non-LV source matrix: aggregator handles email ────────────
+  sync-source:
+    name: Sync ${{ matrix.source }}
+    needs: setup
+    if: needs.setup.outputs.source_matrix != '[]' && needs.setup.outputs.source_matrix != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        source: ${{ fromJSON(needs.setup.outputs.source_matrix) }}
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -101,7 +185,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: sync-summary-${{ matrix.source }}
+          name: sync-summary-source-${{ matrix.source }}
           path: sync-summary.json
           if-no-files-found: warn
           retention-days: 7
@@ -110,11 +194,11 @@ jobs:
         if: steps.sync.outcome == 'failure'
         run: exit 1
 
-  # ─── Aggregate matrix results ──────────────────────────────────
+  # ─── Aggregate digest: one mail to admin covering ALL artifacts ─
   aggregate:
     name: Aggregate & Report
-    needs: [setup, sync]
-    if: always() && needs.setup.outputs.use_matrix == 'true'
+    needs: [setup, sync-lv, sync-source]
+    if: always() && (needs.setup.outputs.lv_matrix != '[]' || needs.setup.outputs.source_matrix != '[]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -156,7 +240,6 @@ jobs:
             exit 0
           fi
 
-          # Parse JSON summary
           TIMESTAMP=$(jq -r '.timestamp' "$SUMMARY_FILE")
           DRY_RUN=$(jq -r '.dryRun' "$SUMMARY_FILE")
           FORCE=$(jq -r '.force' "$SUMMARY_FILE")
@@ -170,7 +253,6 @@ jobs:
           ERRORS=$(jq -r '.totals.errors' "$SUMMARY_FILE")
           DURATION=$(jq -r '.totalDuration' "$SUMMARY_FILE")
 
-          # Determine status
           if [ "$FAILED" -gt 0 ] || [ "$ERRORS" -gt 0 ]; then
             STATUS_ICON="⚠️"
           else
@@ -183,7 +265,6 @@ jobs:
             TITLE="$STATUS_ICON Content Sync Report"
           fi
 
-          # Build summary
           {
             echo "## $TITLE"
             echo ""
@@ -212,7 +293,6 @@ jobs:
 
             echo ""
 
-            # Show failed sources with error messages
             FAILED_SOURCES=$(jq -r '.sources[] | select(.status == "failed") | "- **\(.name):** \(.error)"' "$SUMMARY_FILE")
             if [ -n "$FAILED_SOURCES" ]; then
               echo "### ❌ Failed Sources"
@@ -221,7 +301,6 @@ jobs:
               echo ""
             fi
 
-            # Show sources with new content
             NEW_CONTENT=$(jq -r '.sources[] | select(.stored > 0) | "- **\(.name):** +\(.stored) new documents"' "$SUMMARY_FILE")
             if [ -n "$NEW_CONTENT" ]; then
               echo "### 📥 New Content"
@@ -252,11 +331,11 @@ jobs:
           delete-branch: true
           labels: automated
 
-  # ─── Single-source run (no matrix overhead) ────────────────────
+  # ─── Single-source / single-LV manual dispatch ─────────────────
   sync-single:
-    name: Sync ${{ inputs.source }}
+    name: Sync ${{ needs.setup.outputs.single_value }}
     needs: setup
-    if: needs.setup.outputs.use_matrix == 'false'
+    if: needs.setup.outputs.single_kind != ''
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -271,13 +350,9 @@ jobs:
       - name: Run content sync
         id: sync
         continue-on-error: true
-        run: |
-          ARGS="--source ${{ inputs.source || 'landesverbaende' }}"
-          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
-          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
-          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
-          npx tsx apps/api/update-all-content.ts $ARGS
         env:
+          KIND: ${{ needs.setup.outputs.single_kind }}
+          VAL: ${{ needs.setup.outputs.single_value }}
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           QDRANT_BASIC_AUTH_USERNAME: ${{ secrets.QDRANT_BASIC_AUTH_USERNAME }}
@@ -291,6 +366,17 @@ jobs:
           EMAIL_FROM: ${{ vars.EMAIL_FROM || 'Grünerator <info@gruenerator.eu>' }}
           CONTENT_SYNC_EMAIL: ${{ vars.CONTENT_SYNC_EMAIL }}
           SYNC_SUMMARY_PATH: ${{ github.workspace }}/sync-summary.json
+        run: |
+          if [ "$KIND" = "landesverband" ]; then
+            FLAG="--landesverband"
+          else
+            FLAG="--source"
+          fi
+          ARGS="$FLAG $VAL"
+          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
+          npx tsx apps/api/update-all-content.ts $ARGS
 
       - name: Generate job summary
         if: always()
@@ -312,7 +398,7 @@ jobs:
           DURATION=$(jq -r '.totalDuration' "$SUMMARY_FILE")
 
           if [ "$ERRORS" -gt 0 ]; then STATUS_ICON="⚠️"; else STATUS_ICON="✅"; fi
-          if [ "$DRY_RUN" = "true" ]; then TITLE="$STATUS_ICON ${{ inputs.source }} — Dry Run"; else TITLE="$STATUS_ICON ${{ inputs.source }}"; fi
+          if [ "$DRY_RUN" = "true" ]; then TITLE="$STATUS_ICON ${{ needs.setup.outputs.single_value }} — Dry Run"; else TITLE="$STATUS_ICON ${{ needs.setup.outputs.single_value }}"; fi
 
           {
             echo "## $TITLE"

--- a/apps/api/config/landesverbaendeContacts.json
+++ b/apps/api/config/landesverbaendeContacts.json
@@ -1,0 +1,8 @@
+{
+  "BB": "moritz-waechter@outlook.de",
+  "BE": "moritz-waechter@outlook.de",
+  "HH": "moritz-waechter@outlook.de",
+  "LSA": "moritz-waechter@outlook.de",
+  "MV": "moritz-waechter@outlook.de",
+  "TH": "moritz-waechter@outlook.de"
+}

--- a/apps/api/update-all-content.ts
+++ b/apps/api/update-all-content.ts
@@ -5,23 +5,31 @@
  * Each source handles its own deduplication (Qdrant URL check + content hash).
  *
  * Flags:
- *   --source <id>      Run only one source group (landesverbaende, gruenblog,
- *                       gruene-at, kommunalwiki, boell-stiftung)
- *   --force            Force re-process even if already stored
- *   --dry-run          Preview without storing (only supported by landesverbaende)
- *   --concurrency <n>  Max parallel source groups (default: 2)
+ *   --source <id>            Run only one source group (landesverbaende, gruenblog,
+ *                             gruene-at, kommunalwiki, boell-stiftung, bundestag)
+ *   --landesverband <code>   Run only one Landesverband by shortName prefix
+ *                             (e.g. BE = Berlin, BB = Brandenburg, HH = Hamburg,
+ *                             LSA = Sachsen-Anhalt, MV = Mecklenburg-Vorpommern,
+ *                             TH = Thüringen). Email recipient is read from
+ *                             apps/api/config/landesverbaendeContacts.json and
+ *                             only sent when stored/updated/errors > 0.
+ *   --force                  Force re-process even if already stored
+ *   --dry-run                Preview without storing (only supported by landesverbaende)
+ *   --concurrency <n>        Max parallel source groups (default: 2)
  *
  * Examples:
- *   npx tsx apps/api/update-all-content.ts                         # Sync all
- *   npx tsx apps/api/update-all-content.ts --source gruenblog      # Only Gruenblog
- *   npx tsx apps/api/update-all-content.ts --dry-run               # Preview
- *   npx tsx apps/api/update-all-content.ts --force                 # Force re-index
+ *   npx tsx apps/api/update-all-content.ts                              # Sync all
+ *   npx tsx apps/api/update-all-content.ts --source gruenblog           # Only Gruenblog
+ *   npx tsx apps/api/update-all-content.ts --landesverband BE           # Only Berlin LV
+ *   npx tsx apps/api/update-all-content.ts --dry-run                    # Preview
+ *   npx tsx apps/api/update-all-content.ts --force                      # Force re-index
  *
  * Run: npx tsx apps/api/update-all-content.ts
  */
 
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { Mistral } from '@mistralai/mistralai';
 
@@ -33,11 +41,13 @@ import { gruenblogScraperService } from './services/scrapers/implementations/Gru
 import { grueneAtScraperService } from './services/scrapers/implementations/GrueneAtScraper.js';
 import { kommunalwikiScraper } from './services/scrapers/implementations/KommunalwikiScraper.js';
 import { landesverbandScraperService } from './services/scrapers/implementations/LandesverbandScraper/index.js';
+import { getSourcesByLandesverband } from './config/landesverbaendeConfig.js';
 import { scrapeAndIndexSocialMedia } from './services/scrapers/implementations/SocialMediaExamplesScraper.js';
 import { type SourceGroupResult, type SyncSummary } from './types/syncTypes.js';
 
 interface CliArgs {
   source?: string;
+  landesverband?: string;
   force: boolean;
   dryRun: boolean;
   concurrency: number;
@@ -52,6 +62,9 @@ function parseArgs(): CliArgs {
     switch (args[i]) {
       case '--source':
         result.source = args[++i];
+        break;
+      case '--landesverband':
+        result.landesverband = args[++i];
         break;
       case '--force':
         result.force = true;
@@ -69,6 +82,20 @@ function parseArgs(): CliArgs {
   }
 
   return result;
+}
+
+function loadLandesverbandContacts(): Record<string, string> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const contactsPath = path.join(here, 'config', 'landesverbaendeContacts.json');
+  try {
+    const raw = readFileSync(contactsPath, 'utf-8');
+    return JSON.parse(raw) as Record<string, string>;
+  } catch (err) {
+    console.warn(
+      `Could not load ${contactsPath} (${err instanceof Error ? err.message : err}); falling back to CONTENT_SYNC_EMAIL`
+    );
+    return {};
+  }
 }
 
 interface SourceGroup {
@@ -335,7 +362,38 @@ async function main() {
 
   // Resolve which groups to run
   let groups = SOURCE_GROUPS;
-  if (args.source) {
+  if (args.landesverband) {
+    const lvCode = args.landesverband;
+    const matchingSources = getSourcesByLandesverband(lvCode);
+    if (matchingSources.length === 0) {
+      console.error(`Unknown landesverband: ${lvCode}`);
+      console.error(
+        `Hint: shortName prefix from landesverbaendeConfig.ts (e.g. BB, BE, HH, LSA, MV, TH)`
+      );
+      process.exit(1);
+    }
+    groups = [
+      {
+        id: `landesverband-${lvCode}`,
+        name: `Landesverband ${lvCode} (${matchingSources.length} sources)`,
+        async run(a) {
+          await landesverbandScraperService.init();
+          const result = await landesverbandScraperService.scrapeAllSources({
+            forceUpdate: a.force,
+            dryRun: a.dryRun,
+            landesverband: lvCode,
+          });
+          return {
+            stored: result.stored,
+            updated: result.updated,
+            skipped: result.skipped,
+            fetchErrors: result.errors,
+            errors: 0,
+          };
+        },
+      },
+    ];
+  } else if (args.source) {
     groups = SOURCE_GROUPS.filter((g) => g.id === args.source);
     if (groups.length === 0) {
       console.error(`Unknown source: ${args.source}`);
@@ -434,31 +492,47 @@ async function main() {
   writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
   console.log(`Summary written to ${summaryPath}`);
 
-  // Send email notification via existing Brevo SMTP (never crash on email failure)
-  const emailTo = env.CONTENT_SYNC_EMAIL;
-  if (emailTo && !args.noEmail) {
-    try {
-      const runId = env.GITHUB_RUN_ID;
-      const repo = env.GITHUB_REPOSITORY;
-      const server = env.GITHUB_SERVER_URL ?? 'https://github.com';
-      const runUrl = runId && repo ? `${server}/${repo}/actions/runs/${runId}` : undefined;
+  // Send email notification via existing Brevo SMTP (never crash on email failure).
+  // Per-LV runs (--landesverband): recipient comes from landesverbaendeContacts.json,
+  // and the email is suppressed when nothing changed (stored + updated + hard errors == 0).
+  // Other invocations (no flag, --source <id>) keep the previous behavior.
+  if (!args.noEmail) {
+    const isLvRun = !!args.landesverband;
+    const hasChanges = totals.stored + totals.updated + totals.errors > 0;
 
-      const sent = await sendContentSyncEmail(emailTo, {
-        timestamp: summary.timestamp,
-        totalDuration: summary.totalDuration,
-        sources: summary.sources,
-        totals: summary.totals,
-        runUrl,
-        dryRun: args.dryRun,
-      });
+    if (isLvRun && !hasChanges) {
       console.log(
-        sent ? `Email sent to ${emailTo}` : 'Email sending skipped (SMTP not configured)'
+        `Per-LV run ${args.landesverband}: no new/updated docs and no hard errors — skipping email`
       );
-    } catch (err) {
-      console.error(
-        'Email notification failed (non-fatal):',
-        err instanceof Error ? err.message : err
-      );
+    } else {
+      const emailTo = isLvRun
+        ? (loadLandesverbandContacts()[args.landesverband as string] ?? env.CONTENT_SYNC_EMAIL)
+        : env.CONTENT_SYNC_EMAIL;
+      if (emailTo) {
+        try {
+          const runId = env.GITHUB_RUN_ID;
+          const repo = env.GITHUB_REPOSITORY;
+          const server = env.GITHUB_SERVER_URL ?? 'https://github.com';
+          const runUrl = runId && repo ? `${server}/${repo}/actions/runs/${runId}` : undefined;
+
+          const sent = await sendContentSyncEmail(emailTo, {
+            timestamp: summary.timestamp,
+            totalDuration: summary.totalDuration,
+            sources: summary.sources,
+            totals: summary.totals,
+            runUrl,
+            dryRun: args.dryRun,
+          });
+          console.log(
+            sent ? `Email sent to ${emailTo}` : 'Email sending skipped (SMTP not configured)'
+          );
+        } catch (err) {
+          console.error(
+            'Email notification failed (non-fatal):',
+            err instanceof Error ? err.message : err
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Splits the landesverbaende sync into a parallel matrix — one job per state (BB, BE, HH, LSA, MV, TH) — instead of a single ~30-45 min serial job.
- Each LV job emails its own report via Brevo SMTP, **only when stored + updated + hard errors > 0** (silent on no-op hourly runs to avoid inbox spam).
- The admin still gets one combined digest at the end via the existing `aggregate` job, which now fans in artifacts from both the LV matrix and the non-LV source matrix.

## Why

Today the hourly content-sync wedges 16 sources for one LV scrape into a single matrix slot. One slow LV site stalls the whole 45-min job, and any "X new docs in Berlin" signal gets buried in a daily digest that goes only to admin. Per-LV jobs give:

- ✅ Faster wall-clock (6 LVs in parallel instead of serial)
- ✅ One bad LV doesn't block visibility into the others
- ✅ Per-LV recipients (all moritz-waechter@outlook.de for now; trivially extended via `apps/api/config/landesverbaendeContacts.json`)
- ✅ Changes-only gate prevents 6× hourly empty mails

## Files

- `apps/api/update-all-content.ts` — adds `--landesverband <CODE>` flag wiring through to existing `scrapeAllSources({ landesverband })`. Email block now branches: per-LV runs use a contacts-map recipient and skip when nothing changed; non-LV runs preserve previous behavior.
- `apps/api/config/landesverbaendeContacts.json` — new shortName→email map.
- `.github/workflows/content-sync.yml` — setup job emits two parallel matrices (`lv_matrix`, `source_matrix`); new `sync-lv` and renamed `sync-source` jobs; aggregate job depends on both; `sync-single` handles both single-source and single-LV manual dispatches via a `KIND`/`VAL` env-var dispatch.

## Schedule behavior (preserved)

- **Hourly 06–22 CET cron** → LV matrix only (today's behavior, just parallelized)
- **Daily 03 CET cron / manual no input** → both matrices + aggregate digest
- **Manual `source=<id>`** → single non-LV job
- **Manual `landesverband=<code>`** → single LV job (with the same changes-only email gate)

## Test plan

- [ ] Manual dispatch with `landesverband=BE` (Berlin has fresh content; should send a per-LV email)
- [ ] Manual dispatch with `landesverband=HH` on a quiet day (should NOT send a per-LV email; aggregate still fires)
- [ ] Manual dispatch with `source=gruenblog` (single-source path, single email via aggregator pattern stays unchanged — this run does not invoke aggregate)
- [ ] Manual dispatch with no inputs (both matrices fire, aggregate sends one digest)
- [ ] Wait for next hourly cron and confirm: 6 LV jobs run in parallel, only states with new docs send LV mails, no aggregate triggers if `source_matrix` is empty (note: aggregate still runs for the `lv_matrix` to update content stats and send the admin digest covering LV results)