### PR TITLE
fix(logger): expose structured metadata + email smoke test workflow

### DIFF
--- a/.github/workflows/email-test.yml
+++ b/.github/workflows/email-test.yml
@@ -1,0 +1,36 @@
+name: Email Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      to:
+        description: 'Recipient address (defaults to CONTENT_SYNC_EMAIL var)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  send:
+    name: Send test email
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile --filter @gruenerator/api...
+
+      - name: Send test email
+        env:
+          BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
+          BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
+          BREVO_SMTP_USER: ${{ secrets.BREVO_SMTP_USER }}
+          BREVO_SMTP_PASS: ${{ secrets.BREVO_SMTP_PASS }}
+          EMAIL_FROM: ${{ vars.EMAIL_FROM || 'Grünerator <info@gruenerator.eu>' }}
+          TEST_EMAIL_TO: ${{ inputs.to || vars.CONTENT_SYNC_EMAIL }}
+        run: npx tsx apps/api/test-email.ts

--- a/apps/api/config/env.ts
+++ b/apps/api/config/env.ts
@@ -140,6 +140,7 @@ const envSchema = z.object({
   // ── Scraping / crawling ────────────────────────────────────────────────
   CRAWLER_MODE: z.string().optional(),
   CONTENT_SYNC_EMAIL: z.string().optional(),
+  TEST_EMAIL_TO: z.string().optional(),
   BACKUP_DIR: z.string().optional(),
   STATS_OUTPUT_PATH: z.string().optional(),
   SYNC_SUMMARY_PATH: z.string().optional(),

--- a/apps/api/test-email.ts
+++ b/apps/api/test-email.ts
@@ -1,0 +1,79 @@
+/**
+ * Email Smoke Test
+ *
+ * Sends one minimal email via the same Brevo SMTP path the content sync uses.
+ * Designed to be invoked from the email-test GitHub workflow when SMTP fails
+ * silently in production runs — surfaces the actual nodemailer error so we can
+ * tell `Sender address rejected` from `Authentication failed` from a TLS issue.
+ *
+ * Usage:
+ *   TEST_EMAIL_TO=foo@example.com npx tsx apps/api/test-email.ts
+ *   npx tsx apps/api/test-email.ts --to foo@example.com
+ *
+ * Reads SMTP credentials from env (BREVO_SMTP_HOST/PORT/USER/PASS, EMAIL_FROM).
+ * Writes a config diagnostic line BEFORE the send so a synchronous reject still
+ * leaves a trail of what was attempted.
+ */
+
+import { env } from './config/env.js';
+import { sendEmail } from './services/email/emailService.js';
+
+function parseRecipient(): string {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--to') return args[++i] ?? '';
+  }
+  return env.TEST_EMAIL_TO ?? env.CONTENT_SYNC_EMAIL ?? '';
+}
+
+function mask(value: string | undefined): string {
+  if (!value) return '<unset>';
+  if (value.length <= 4) return '***';
+  return `${value.slice(0, 2)}***${value.slice(-2)} (len=${value.length})`;
+}
+
+async function main() {
+  const to = parseRecipient();
+  if (!to) {
+    console.error(
+      'No recipient. Pass --to <addr> or set TEST_EMAIL_TO / CONTENT_SYNC_EMAIL.'
+    );
+    process.exit(2);
+  }
+
+  console.log('=== Email Smoke Test ===');
+  console.log(`Recipient:        ${to}`);
+  console.log(`EMAIL_FROM:       ${env.EMAIL_FROM ?? '<unset, will fall back to BRAND default>'}`);
+  console.log(`BREVO_SMTP_HOST:  ${env.BREVO_SMTP_HOST ?? '<unset>'}`);
+  console.log(`BREVO_SMTP_PORT:  ${env.BREVO_SMTP_PORT ?? '<unset>'}`);
+  console.log(`BREVO_SMTP_USER:  ${mask(env.BREVO_SMTP_USER)}`);
+  console.log(`BREVO_SMTP_PASS:  ${mask(env.BREVO_SMTP_PASS)}`);
+  console.log('');
+
+  const subject = `Grünerator email smoke test (${new Date().toISOString()})`;
+  const body =
+    'This is an automated email-deliverability smoke test triggered from the ' +
+    '`email-test` GitHub workflow. If you received it, the Brevo SMTP path is ' +
+    'healthy. If the workflow failed, check the workflow logs for the underlying ' +
+    'nodemailer error (now visible thanks to the structured-metadata logger fix).';
+
+  const ok = await sendEmail({
+    to,
+    subject,
+    text: body,
+    html: `<p>${body}</p>`,
+  });
+
+  if (ok) {
+    console.log('✓ sendEmail returned true');
+    process.exit(0);
+  } else {
+    console.error('✗ sendEmail returned false — see [Email] log line above for the error');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/apps/api/utils/logger.ts
+++ b/apps/api/utils/logger.ts
@@ -13,9 +13,18 @@ const logger = winston.createLogger({
     // specifiers appear literally in output. Template literals continue to
     // work either way; splat only activates when extra args are passed.
     winston.format.splat(),
-    winston.format.printf(({ level, message, timestamp, service }) => {
+    winston.format.printf(({ level, message, timestamp, service, ...rest }) => {
       const svc = service ? `[${service}]` : '';
-      return `${timestamp} ${level.toUpperCase().padEnd(5)} ${svc} ${message}`;
+      // Serialize structured metadata so log.error('msg', { error }) actually
+      // surfaces the error in stdout. Without this, second-arg objects are
+      // silently dropped by the formatter and failures look mysterious in CI.
+      const meta = Object.keys(rest).length
+        ? ' ' +
+          JSON.stringify(rest, (_k, v) =>
+            v instanceof Error ? { name: v.name, message: v.message, stack: v.stack } : v
+          )
+        : '';
+      return `${timestamp} ${level.toUpperCase().padEnd(5)} ${svc} ${message}${meta}`;
     })
   ),
   transports: [new winston.transports.Console()],


### PR DESCRIPTION
## Summary

- **Logger fix** (`apps/api/utils/logger.ts`): the custom winston `printf` formatter only kept `level/message/timestamp/service` and silently dropped any structured metadata. That's why recent content-sync runs showed `[Email] Failed to send` with no detail — the actual nodemailer error was being thrown away by our own formatter.
- **New email smoke test** (`apps/api/test-email.ts` + `.github/workflows/email-test.yml`): a focused 5-min `workflow_dispatch` that sends one raw email via the same Brevo SMTP path, prints the config (secrets masked), and — combined with the logger fix — now surfaces the real error.

## Why

The Aggregate & Report job in run [25003609174](https://github.com/netzbegruenung/Gruenerator/actions/runs/25003609174) showed:

```
15:43:21 INFO  [email] [Email] SMTP transporter created
15:43:21 ERROR [email] [Email] Failed to send
Email sending skipped (SMTP not configured)   ← misleading caller log
```

The 15 ms gap between transporter-creation and failure points to a **synchronous validation rejection** (most likely Brevo refusing the `from` address as an unverified sender, or auth credentials malformed). But we couldn't tell which because the formatter was dropping the actual error.

## Files

- `apps/api/utils/logger.ts` — printf now rest-spreads remaining meta and JSON-stringifies it with a custom `Error` replacer for stack traces. `splat()` semantics preserved (it runs earlier and consumes its args before printf sees them).
- `apps/api/test-email.ts` — new minimal script: parses `--to` or env, prints config diagnostic, calls raw `sendEmail`, exits with status code matching the result.
- `.github/workflows/email-test.yml` — new `workflow_dispatch`-only workflow with optional `to` input. Defaults to the existing `CONTENT_SYNC_EMAIL` var so a no-arg run works out of the box.
- `apps/api/config/env.ts` — adds `TEST_EMAIL_TO` to the zod schema.

## Test plan

- [ ] Merge → trigger `Email Smoke Test` workflow with no inputs
- [ ] Read the workflow log: should now show the actual nodemailer error if delivery fails (e.g. `Sender address rejected: not verified`, `Invalid login: 535-5.7.8 Username and Password not accepted`, etc.)
- [ ] If success: confirm the test email landed in moritz-waechter@outlook.de
- [ ] Once root cause is known, follow-up PR fixes Brevo config (likely add `noreply@gruenerator.eu` as a verified sender or switch `EMAIL_FROM` to an already-verified address)