### PR TITLE
fix(content-sync): skip aggregate digest when nothing noteworthy

### DIFF
--- a/apps/api/aggregate-sync-summaries.ts
+++ b/apps/api/aggregate-sync-summaries.ts
@@ -74,31 +74,43 @@ async function main() {
 
   const emailTo = env.CONTENT_SYNC_EMAIL;
   if (emailTo) {
-    const runId = env.GITHUB_RUN_ID;
-    const repo = env.GITHUB_REPOSITORY;
-    const server = env.GITHUB_SERVER_URL ?? 'https://github.com';
-    const runUrl = runId && repo ? `${server}/${repo}/actions/runs/${runId}` : undefined;
-
-    try {
-      const params: Parameters<typeof sendContentSyncEmail>[1] = {
-        timestamp: merged.timestamp,
-        totalDuration: merged.totalDuration,
-        sources: merged.sources,
-        totals: merged.totals,
-        dryRun: merged.dryRun,
-      };
-      if (runUrl != null) {
-        params.runUrl = runUrl;
-      }
-      const sent = await sendContentSyncEmail(emailTo, params);
+    // Skip the digest when nothing of interest happened: no new/updated docs,
+    // no hard errors, no job failures. Transient fetchErrors don't count —
+    // flaky-site retries shouldn't spam the inbox. Mirrors the per-LV gate
+    // in update-all-content.ts so a fully quiet hour produces zero emails.
+    const t = merged.totals;
+    const noteworthy = t.stored + t.updated + t.errors + t.failed > 0;
+    if (!noteworthy) {
       console.log(
-        sent ? `Email sent to ${emailTo}` : 'Email sending skipped (SMTP not configured)'
+        'Aggregate digest: nothing noteworthy (stored=0, updated=0, errors=0, failed=0) — skipping email'
       );
-    } catch (err) {
-      console.error(
-        'Email notification failed (non-fatal):',
-        err instanceof Error ? err.message : err
-      );
+    } else {
+      const runId = env.GITHUB_RUN_ID;
+      const repo = env.GITHUB_REPOSITORY;
+      const server = env.GITHUB_SERVER_URL ?? 'https://github.com';
+      const runUrl = runId && repo ? `${server}/${repo}/actions/runs/${runId}` : undefined;
+
+      try {
+        const params: Parameters<typeof sendContentSyncEmail>[1] = {
+          timestamp: merged.timestamp,
+          totalDuration: merged.totalDuration,
+          sources: merged.sources,
+          totals: merged.totals,
+          dryRun: merged.dryRun,
+        };
+        if (runUrl != null) {
+          params.runUrl = runUrl;
+        }
+        const sent = await sendContentSyncEmail(emailTo, params);
+        console.log(
+          sent ? `Email sent to ${emailTo}` : 'Email sending skipped (SMTP not configured)'
+        );
+      } catch (err) {
+        console.error(
+          'Email notification failed (non-fatal):',
+          err instanceof Error ? err.message : err
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Mirrors the per-LV email gate at the aggregator level. The digest now sends only when `stored + updated + errors + failed > 0` — i.e. real new content, hard errors, or crashed jobs. Transient `fetchErrors` (flaky-site retries) don't trigger mail.

## Why

Per request: on a quiet hour with no new content and no errors, the aggregate digest is just inbox noise. With this gate, hourly cron runs that find nothing produce zero emails. Errors still always reach the inbox.

## Test plan

- [ ] Merge → next quiet hourly run produces no aggregate email; log shows `Aggregate digest: nothing noteworthy ... — skipping email`
- [ ] Next run with actual new content → digest arrives as before
- [ ] If a job fails or errors, digest arrives even if stored/updated are zero
- [ ] Existing aggregate-test workflow still passes (test sources have stored=1 each, so merged total > 0)