### PR TITLE
fix(sidebar): hide Studio entry in production

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -59,14 +59,16 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
     activePaths: ['/docs'],
   };
 
-  items.studio = {
-    id: 'studio',
-    path: '/studio',
-    title: 'Studio',
-    description: 'Sharepics erstellen und gemeinsam bearbeiten',
-    icon: getIcon('navigation', 'sharepic'),
-    activePaths: ['/studio'],
-  };
+  if (import.meta.env.DEV) {
+    items.studio = {
+      id: 'studio',
+      path: '/studio',
+      title: 'Studio',
+      description: 'Sharepics erstellen und gemeinsam bearbeiten',
+      icon: getIcon('navigation', 'sharepic'),
+      activePaths: ['/studio'],
+    };
+  }
 
   return items;
 };


### PR DESCRIPTION
## Summary
- `/studio*` routes are gated `devOnly: true` in `apps/web/src/config/routes.ts:418`, so production builds 404 the Studio link reported on https://gruenerator.eu/studio.
- Mirror the same `import.meta.env.DEV` gate on the sidebar menu item in `menuData.tsx` so the entry only appears where the route exists.

## Test plan
- [ ] `pnpm dev:web` — Studio entry still visible in dev sidebar and `/studio` loads
- [ ] Production build (or `import.meta.env.DEV === false`) — Studio entry no longer rendered in sidebar