### PR TITLE
fix(canvas-editor): hide settings tab icon to avoid sidebar shift

### DIFF
--- a/packages/canvas-editor/src/configs/dreizeilen_full.config.tsx
+++ b/packages/canvas-editor/src/configs/dreizeilen_full.config.tsx
@@ -256,23 +256,11 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
     chatTab,
   ],
 
-  getVisibleTabs: (_state, context) => {
-    const base: (
-      | 'image-background'
-      | 'settings'
-      | 'text'
-      | 'assets'
-      | 'uploads'
-      | 'ai'
-      | 'chat'
-      | 'share'
-    )[] =
+  getVisibleTabs: () => {
     // 'ai' tab kept registered but hidden — Chat tab now drives canvas-AI suggestions.
-      ['image-background', 'text', 'assets', 'uploads', 'chat', 'share'];
-    if (context?.selectedElement?.includes('balken')) {
-      return ['image-background', 'settings', ...base.slice(1)];
-    }
-    return base;
+    // 'settings' tab kept registered but hidden — opened via getAutoSwitchTab on balken
+    // selection so the icon strip doesn't shift when a balken is clicked.
+    return ['image-background', 'text', 'assets', 'uploads', 'chat', 'share'];
   },
 
   getAutoSwitchTab: (selectedElement) => {


### PR DESCRIPTION
## Summary
- Selecting a balken in the dreizeilen canvas no longer adds a settings icon to the sidebar tab strip — the panel still opens via `getAutoSwitchTab`, but the icon list stays stable.
- Removes the conditional logic in `getVisibleTabs` that inserted `'settings'` (and shifted every other icon down by one) on balken selection.
- Uses the existing "registered-but-invisible" tab pattern already used for the `'ai'` tab.

## Test plan
- [ ] Open a dreizeilen design in the canvas editor.
- [ ] Click each sidebar icon (Hintergrund, Text, Elemente, Uploads, Chat, Teilen) and confirm their order/positions are stable.
- [ ] Click a balken element and confirm the BalkenSettings panel opens automatically.
- [ ] Verify the icon strip does NOT show an extra Einstellungen icon and other icons do not shift.
- [ ] Click outside the balken (deselect) and confirm the previously active tab is restored.