### PR TITLE
fix(api): ship federated-link diagnostic in dist/

### DIFF
--- a/apps/api/diagnose-federated-links.ts
+++ b/apps/api/diagnose-federated-links.ts
@@ -6,7 +6,8 @@
  * that cause the "Das Benutzerkonto existiert bereits" error on login.
  *
  * Usage:
- *   npx tsx scripts/diagnose-federated-links.ts [options]
+ *   In dev:        npx tsx diagnose-federated-links.ts [options]
+ *   In container:  node dist/diagnose-federated-links.js [options]
  *
  * Options:
  *   --email <email>   Check a specific user by email
@@ -22,8 +23,8 @@ import {
   KeycloakApiClient,
   type KeycloakUser,
   type FederatedIdentity,
-} from '../utils/keycloak/apiClient.js';
-import { getPostgresInstance, type PostgresService } from '../database/services/PostgresService.js';
+} from './utils/keycloak/apiClient.js';
+import { getPostgresInstance, type PostgresService } from './database/services/PostgresService.js';
 
 const KEYCLOAK_USERS_PAGE_SIZE = 50;
 


### PR DESCRIPTION
## Summary
- Moves `apps/api/scripts/diagnose-federated-links.ts` to `apps/api/diagnose-federated-links.ts`.
- `scripts/` is excluded by `apps/api/tsconfig.json`, so the file currently never lands in `dist/` and is therefore unrunnable in the prod image (no `tsx`, no source).
- Updates the two relative imports (`../utils/...` → `./utils/...`, `../database/...` → `./database/...`) to match the new location.

After this lands and the image is rebuilt:

```bash
sudo docker exec gruenerator-api-1 node dist/diagnose-federated-links.js \
  --email <user@example.com> --verbose
sudo docker exec gruenerator-api-1 node dist/diagnose-federated-links.js \
  --email <user@example.com> --fix
```

## Why
A user reported "Ein Benutzer mit Email xxx existiert bereits" on Grünes-Netz login (Keycloak's `federatedIdentityEmailExists` message). The existing diagnostic script is the right tool to check stale federated links + orphaned `profiles.keycloak_id`, but on prod it can only be run via a throwaway container with bind-mounts + manual `pnpm install` — too painful for a routine support workflow.

## Test plan
- [ ] CI build passes (image now contains `dist/diagnose-federated-links.js`).
- [ ] After redeploy, `docker exec gruenerator-api-1 node dist/diagnose-federated-links.js --email <known-good-email> --verbose` prints the diagnostic header and resolves Keycloak + DB without import errors.
- [ ] Read-only run still safe (no `--fix`).