### PR TITLE
fix(api): unbreak master typecheck on diagnose-federated-links

### DIFF
--- a/apps/api/diagnose-federated-links.ts
+++ b/apps/api/diagnose-federated-links.ts
@@ -55,7 +55,7 @@ function parseArgs(): { email?: string; fix: boolean; verbose: boolean } {
     }
   }
 
-  return { email, fix, verbose };
+  return { ...(email ? { email } : {}), fix, verbose };
 }
 
 async function getAllKeycloakUsers(client: KeycloakApiClient): Promise<KeycloakUser[]> {
@@ -167,7 +167,8 @@ async function main() {
 
     if (db) {
       try {
-        const profile = await db.queryOne(
+        type ProfileRow = { id: string; keycloak_id: string; email: string };
+        const profile = await db.queryOne<ProfileRow>(
           'SELECT id, keycloak_id, email FROM profiles WHERE keycloak_id = $1',
           [user.id]
         );
@@ -177,7 +178,7 @@ async function main() {
           result.profileKeycloakId = profile.keycloak_id;
         } else {
           const profileByEmail = user.email
-            ? await db.queryOne(
+            ? await db.queryOne<ProfileRow>(
                 'SELECT id, keycloak_id, email FROM profiles WHERE LOWER(email) = LOWER($1)',
                 [user.email]
               )


### PR DESCRIPTION
## Summary
PR #728 was merged at the original commit, before three strict-mode TS errors were fixed. Master CI is now red on those errors:

```
diagnose-federated-links.ts(58,3): TS2375 (exactOptionalPropertyTypes)
diagnose-federated-links.ts(177,11): TS2322 unknown not assignable to string
diagnose-federated-links.ts(188,13): TS2322 unknown not assignable to string
```

This PR re-applies the fixes that didn't make it into #728:
- `parseArgs()` now spreads `email` only when set, instead of returning an explicit `email: undefined`. Matches the project's "no undefined values" rule.
- `db.queryOne` calls now pass a `ProfileRow` generic so `keycloak_id` is typed.

## Test plan
- [x] Local `tsc --noEmit` in `apps/api` passes.
- [ ] CI green.