### PR TITLE
fix(api): route docs AI per provider, drop unportable model id

### DIFF
--- a/apps/api/routes/docs/aiController.ts
+++ b/apps/api/routes/docs/aiController.ts
@@ -67,6 +67,17 @@ interface AIRequestBody {
   toolDefinitions: Record<string, unknown>;
 }
 
+// Per-provider model map. Model IDs are not portable across providers — LiteLLM's
+// verdigado proxy has no Mistral models, and Regolo's gpt-oss endpoint leaks
+// reasoning into content (verified failure for tool calls). Each entry below was
+// probed against a tool-call request and confirmed to return finish_reason:tool_calls.
+const DOCS_AI_MODELS: Record<AgentConfig['provider'], string> = {
+  litellm: 'gpt-oss:120b',
+  regolo: 'mistral-small-4-119b',
+  mistral: 'mistral-large-latest',
+  anthropic: 'mistral-large-latest',
+};
+
 /**
  * @route   POST /api/docs/ai
  * @desc    Process AI requests for document editing
@@ -98,8 +109,9 @@ export async function handleAiRequest(req: RateLimitRequest, res: Response) {
       return res.status(500).json({ error: 'AI provider not configured' });
     }
 
-    log.info(`[DocsAI] Using provider: ${provider}`);
-    const model = getModel(provider, 'mistral-large-latest');
+    const modelId = DOCS_AI_MODELS[provider];
+    log.info(`[DocsAI] Using provider: ${provider}, model: ${modelId}`);
+    const model = getModel(provider, modelId);
 
     const messagesWithDocState = injectDocumentStateMessages(messages);
     log.info(
@@ -126,6 +138,7 @@ export async function handleAiRequest(req: RateLimitRequest, res: Response) {
       tools,
       toolChoice: 'auto',
       maxOutputTokens: 4096,
+      maxRetries: 1,
       temperature: 0.3,
       onFinish: ({ toolCalls, text, finishReason, usage }) => {
         log.info(

--- a/apps/api/routes/docs/aiController.vitest.ts
+++ b/apps/api/routes/docs/aiController.vitest.ts
@@ -243,7 +243,7 @@ describe('aiController – POST /api/docs/ai', () => {
 
       await handleAiRequest(req, res);
 
-      expect(mockGetModel).toHaveBeenCalledWith('litellm', 'mistral-large-latest');
+      expect(mockGetModel).toHaveBeenCalledWith('litellm', 'gpt-oss:120b');
     });
 
     it('falls back to regolo when litellm is not configured', async () => {
@@ -257,7 +257,7 @@ describe('aiController – POST /api/docs/ai', () => {
 
       await handleAiRequest(req, res);
 
-      expect(mockGetModel).toHaveBeenCalledWith('regolo', 'mistral-large-latest');
+      expect(mockGetModel).toHaveBeenCalledWith('regolo', 'mistral-small-4-119b');
     });
 
     it('falls back to mistral when litellm and regolo are not configured', async () => {


### PR DESCRIPTION
## Summary

DocsAI was sending `mistral-large-latest` to whichever provider won the chain `[litellm, regolo, mistral]`. With LiteLLM configured (the dev default), every request hit the verdigado proxy with a model name it doesn't serve and got back `HTTP 503 "Model 'mistral-large-latest' not available on any backend"`. The AI SDK retried 3× before surfacing it as `Service Unavailable`.

Replaced the constant with a per-provider map (each entry probed live against a tool-call request):

| Provider | Model | Probe result |
|---|---|---|
| litellm | `gpt-oss:120b` | `finish_reason: tool_calls`, reasoning isolated in `reasoning` field (Ollama harmony template) |
| regolo  | `mistral-small-4-119b` | `finish_reason: tool_calls`, 10-token clean response |
| mistral | `mistral-large-latest` | gold standard, unchanged |

Deliberately **not** used: `gpt-oss-120b` on Regolo. Probe confirmed it leaks `reasoning_content` into the assistant `content` field and exhausts `max_tokens` before ever firing the tool — the harmony template that LiteLLM/Ollama applies isn't applied on Regolo's vLLM-style endpoint, so the same weights behave very differently. (This is a latent footgun in `AVAILABLE_MODELS['gpt-oss-regolo']` for any tool-calling agent that lands on that fallback. Out of scope here, but worth a follow-up.)

Also dropped `streamText`'s `maxRetries` from 3 → 1: a config-level 503 ("model unknown to proxy") is deterministic and not worth the ~4s of extra spinner time for a user editing a doc.

## Test plan

- [x] `pnpm --filter @gruenerator/api exec vitest run routes/docs/aiController.vitest` — 34/34 pass
- [ ] Manual: open a doc, invoke AI edit with LiteLLM as primary, verify a real BlockNote operation roundtrips (synthetic tool probe ≠ strict-prompt fidelity)
- [ ] Manual: same flow with `LITELLM_API_KEY` unset so `regolo` wins, confirm `mistral-small-4-119b` produces valid BlockNote ops