### PR TITLE
fix(api): make mistral-large primary for docs AI

### DIFF
--- a/apps/api/routes/docs/aiController.ts
+++ b/apps/api/routes/docs/aiController.ts
@@ -101,16 +101,14 @@ export async function handleAiRequest(req: RateLimitRequest, res: Response) {
 
     log.info(`[DocsAI] Tool definitions received: ${Object.keys(toolDefinitions).join(', ')}`);
 
-    // Order: regolo first (mistral-small-4-119b — fast Mistral-family, follows
-    // BlockNote's HTML format conventions), then mistral direct (mistral-large
-    // gold standard), litellm last (gpt-oss over-wraps list items in <ul>,
-    // which BlockNote's tryParseHTMLToBlocks rejects — see
-    // aiController.htmlFormat.vitest.ts).
-    const providerChain: AgentConfig['provider'][] = ['regolo', 'mistral', 'litellm'];
+    // Order: mistral first (mistral-large-latest — gold standard, the model
+    // BlockNote's xl-ai prompts were authored against), then regolo
+    // (mistral-small-4-119b), litellm last (gpt-oss).
+    const providerChain: AgentConfig['provider'][] = ['mistral', 'regolo', 'litellm'];
     const provider = providerChain.find((p) => isProviderConfigured(p));
 
     if (!provider) {
-      log.error('[DocsAI] No AI provider configured (tried: regolo, mistral, litellm)');
+      log.error('[DocsAI] No AI provider configured (tried: mistral, regolo, litellm)');
       return res.status(500).json({ error: 'AI provider not configured' });
     }
 

--- a/apps/api/routes/docs/aiController.vitest.ts
+++ b/apps/api/routes/docs/aiController.vitest.ts
@@ -212,11 +212,11 @@ describe('aiController – POST /api/docs/ai', () => {
       await handleAiRequest(req, res);
 
       expect(mockLogError).toHaveBeenCalledWith(
-        '[DocsAI] No AI provider configured (tried: regolo, mistral, litellm)'
+        '[DocsAI] No AI provider configured (tried: mistral, regolo, litellm)'
       );
     });
 
-    it('tries providers in order: regolo → mistral → litellm', async () => {
+    it('tries providers in order: mistral → regolo → litellm', async () => {
       mockIsProviderConfigured.mockReturnValue(false);
       const { res } = createMockRes();
       const req = createMockReq({
@@ -226,26 +226,12 @@ describe('aiController – POST /api/docs/ai', () => {
 
       await handleAiRequest(req, res);
 
-      expect(mockIsProviderConfigured).toHaveBeenCalledWith('regolo');
       expect(mockIsProviderConfigured).toHaveBeenCalledWith('mistral');
+      expect(mockIsProviderConfigured).toHaveBeenCalledWith('regolo');
       expect(mockIsProviderConfigured).toHaveBeenCalledWith('litellm');
     });
 
-    it('selects regolo when it is the first configured provider', async () => {
-      setupHappyPath();
-      mockIsProviderConfigured.mockImplementation((p: string) => p === 'regolo');
-      const { res } = createMockRes();
-      const req = createMockReq({
-        messages: sampleMessages,
-        toolDefinitions: sampleToolDefinitions,
-      });
-
-      await handleAiRequest(req, res);
-
-      expect(mockGetModel).toHaveBeenCalledWith('regolo', 'mistral-small-4-119b');
-    });
-
-    it('falls back to mistral when regolo is not configured', async () => {
+    it('selects mistral when it is the first configured provider', async () => {
       setupHappyPath();
       mockIsProviderConfigured.mockImplementation((p: string) => p === 'mistral');
       const { res } = createMockRes();
@@ -259,7 +245,21 @@ describe('aiController – POST /api/docs/ai', () => {
       expect(mockGetModel).toHaveBeenCalledWith('mistral', 'mistral-large-latest');
     });
 
-    it('falls back to litellm when regolo and mistral are not configured', async () => {
+    it('falls back to regolo when mistral is not configured', async () => {
+      setupHappyPath();
+      mockIsProviderConfigured.mockImplementation((p: string) => p === 'regolo');
+      const { res } = createMockRes();
+      const req = createMockReq({
+        messages: sampleMessages,
+        toolDefinitions: sampleToolDefinitions,
+      });
+
+      await handleAiRequest(req, res);
+
+      expect(mockGetModel).toHaveBeenCalledWith('regolo', 'mistral-small-4-119b');
+    });
+
+    it('falls back to litellm when mistral and regolo are not configured', async () => {
       setupHappyPath();
       mockIsProviderConfigured.mockImplementation((p: string) => p === 'litellm');
       const { res } = createMockRes();


### PR DESCRIPTION
## Summary

Diagnostic follow-up to #731. After regolo/`mistral-small-4-119b` was made primary, the BlockNote frontend still failed with:

```
ChunkExecutionError: Tool execution failed: html diff
  at Object.transform (...)
```

This isn't a streaming/transport error — it's BlockNote's **xl-ai pre-flight check**. The `rebaseTool` for an update operation does:

```js
let i = await blocksToHTMLLossy([{...existingBlock, children: []}]);
let o = await tryParseHTMLToBlocks(i);
if (o.length !== 1) throw Error('html diff invalid block count');
let s = o[0]; s.id = e;
if (z({id:e, block:s}, n.doc).length) throw Error('html diff', { cause: { html: i, htmlBlock: s } });
```

If the round-trip diff is non-empty (existing block ≠ parse(serialize(existing block))), BlockNote refuses to apply the AI edit. So either:
1. The model's output is subtly different from what BlockNote canonically produces (model bug), or
2. The block in the user's document doesn't survive the round-trip (BlockNote/serializer bug)

This PR tests hypothesis 1 by making `mistral-large-latest` the primary. mistral-large is the model BlockNote's xl-ai prompt template was authored against, so its output is the most likely to match the round-trip identity.

## Change

```diff
-const providerChain = ['regolo', 'mistral', 'litellm'];
+const providerChain = ['mistral', 'regolo', 'litellm'];
```

Resolution order in dev: mistral/`mistral-large-latest` → regolo/`mistral-small-4-119b` → litellm/`gpt-oss:120b`.

## What we learn from the result

- **If the editor stops erroring**: hypothesis 1 confirmed — the LLM was producing structurally different HTML, and mistral-large gets it right. We then add a comparison test that diffs the actual `block` HTML output across models against the canonical BlockNote serialization.
- **If the editor still throws `html diff`**: hypothesis 1 falsified — the bug is upstream in BlockNote's serializer, and we move investigation there (probably by walking `editor.document` and finding which block type fails the round-trip).

Either result is useful; the change is one line and the tests stay aligned.

## Test plan

- [x] `pnpm --filter @gruenerator/api exec vitest run routes/docs/aiController.vitest` — 34/34 pass
- [ ] Manual: trigger same AI edit on the Newsletter doc that was failing — confirm whether `Error calling LLM Object` still appears