### PR TITLE
fix(chat): @recherche searches, fallback titles, paste-to-summarize

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -424,14 +424,20 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         };
         const { depth, maxSources } = depthConfig[complexity];
 
-        // Use research brief (compressed intent) when available, fall back to raw query
-        const question = state.researchBrief || searchQuery || '';
+        // The brief is a natural-language research plan written for the LLM
+        // synthesis step — it must NOT be used as a search-engine query.
+        // Pass the raw user query to the searcher and forward the brief
+        // separately as synthesis context.
+        const question = searchQuery || '';
+        const brief = state.researchBrief;
         log.info(
-          `[Search] Research depth: ${depth}, maxSources: ${maxSources} (complexity: ${complexity}, brief: ${!!state.researchBrief})`
+          `[Search] Research depth: ${depth}, maxSources: ${maxSources} (complexity: ${complexity}, brief: ${!!brief})`
         );
 
         const researchResult = await executeResearch({
           question,
+          brief,
+          aiWorkerPool: state.aiWorkerPool,
           depth,
           maxSources,
         });

--- a/apps/api/agents/langgraph/ChatGraph/nodes/summarizeNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/summarizeNode.ts
@@ -22,6 +22,10 @@ const SINGLE_PASS_THRESHOLD = 4000;
 const MAP_REDUCE_THRESHOLD = 12000;
 const SEGMENT_SIZE = 6000;
 const SEGMENT_OVERLAP = 200;
+// Below this many characters in the last user message, summary intent will
+// fall through to the conversation summary; above it the message body is
+// treated as the document to summarize (paste-to-summarize).
+const LONG_PASTE_THRESHOLD = 500;
 
 const SINGLE_PASS_PROMPT = `Du bist ein Zusammenfassungs-Assistent. Erstelle eine strukturierte Zusammenfassung des folgenden Dokuments.
 
@@ -331,6 +335,35 @@ export async function summarizeNode(state: ChatGraphState): Promise<Partial<Chat
 
       const summaryTimeMs = Date.now() - startTime;
       return { summaryContext: summary, summaryTimeMs };
+    }
+
+    // Paste-to-summarize: when the user pasted a long block of text directly
+    // into their message instead of attaching a document, treat that body as
+    // the document to summarize before falling through to conversation summary.
+    const lastUserMessage = [...state.messages].reverse().find((m) => m.role === 'user');
+    if (lastUserMessage) {
+      const userText =
+        typeof lastUserMessage.content === 'string'
+          ? lastUserMessage.content
+          : Array.isArray(lastUserMessage.content)
+            ? lastUserMessage.content
+                .filter((p) => p && typeof p === 'object' && p.type === 'text')
+                .map((p) => (p as { text: string }).text)
+                .join('')
+            : String(lastUserMessage.content || '');
+
+      if (userText.length > LONG_PASTE_THRESHOLD) {
+        log.info(
+          `[Summarize] Using long user message (${userText.length} chars) as paste-to-summarize input`
+        );
+        const summary =
+          userText.length <= MAP_REDUCE_THRESHOLD
+            ? await singlePassSummarize(aiWorkerPool, 'Eingefügter Text', userText)
+            : await mapReduceSummarize(aiWorkerPool, 'Eingefügter Text', userText);
+
+        const summaryTimeMs = Date.now() - startTime;
+        return { summaryContext: summary, summaryTimeMs };
+      }
     }
 
     // Final fallback: summarize conversation

--- a/apps/api/routes/chat/agents/researchOrchestrator.ts
+++ b/apps/api/routes/chat/agents/researchOrchestrator.ts
@@ -13,7 +13,9 @@ import {
   stripUngroundedCitations,
 } from '../../../services/search/CitationGrounder.js';
 import { applyMMR } from '../../../services/search/DiversityReranker.js';
+import { expandQuery } from '../../../services/search/QueryExpansionService.js';
 import { createLogger } from '../../../utils/logger.js';
+import { type AIWorkerPool } from '../../../workers/types.js';
 
 import { executeDirectSearch, executeDirectWebSearch } from './directSearchExecutors.js';
 import { getIntermediateModel } from './providers.js';
@@ -119,9 +121,14 @@ function planResearch(question: string): SearchPlan {
 
 /**
  * Execute all planned searches and collect sources.
+ *
+ * Web queries are run through `expandQuery` (when an `aiWorkerPool` is supplied)
+ * to generate keyword variants — same coverage strategy used by the @web tool —
+ * and the variants are searched in parallel and deduplicated by URL.
  */
 async function executeSearches(
-  plan: SearchPlan
+  plan: SearchPlan,
+  aiWorkerPool?: AIWorkerPool
 ): Promise<{ sources: CollectedSource[]; searchSteps: ResearchResult['searchSteps'] }> {
   const sources: CollectedSource[] = [];
   const searchSteps: ResearchResult['searchSteps'] = [];
@@ -131,26 +138,49 @@ async function executeSearches(
     try {
       switch (query.tool) {
         case 'web_search': {
-          const webResults = await executeDirectWebSearch({
-            query: query.query,
-            searchType: 'general',
-            maxResults: 5,
-          });
-          searchSteps.push({
-            tool: 'web_search',
-            query: query.query,
-            resultsCount: webResults.resultsCount,
-          });
-          for (const result of webResults.results) {
-            sources.push({
-              id: sourceId++,
-              title: result.title,
-              url: result.url,
-              domain: result.domain,
-              snippet: result.snippet,
-              relevance: 1 - (result.rank - 1) * 0.1,
-              sourceType: 'web',
+          let variants = [query.query];
+          if (aiWorkerPool) {
+            const expanded = await expandQuery(query.query, aiWorkerPool);
+            if (expanded.alternatives.length > 0) {
+              variants = [query.query, ...expanded.alternatives];
+              log.info(`[Research] Expanded query into ${variants.length} variants`);
+            }
+          }
+
+          const webResultsList = await Promise.all(
+            variants.map((q) =>
+              executeDirectWebSearch({
+                query: q,
+                searchType: 'general',
+                maxResults: 5,
+              }).catch((err: unknown) => {
+                log.warn(
+                  `[Research] Web search failed for variant "${q}": ${err instanceof Error ? err.message : String(err)}`
+                );
+                return null;
+              })
+            )
+          );
+
+          for (let i = 0; i < variants.length; i++) {
+            const webResults = webResultsList[i];
+            if (!webResults) continue;
+            searchSteps.push({
+              tool: 'web_search',
+              query: variants[i],
+              resultsCount: webResults.resultsCount,
             });
+            for (const result of webResults.results) {
+              sources.push({
+                id: sourceId++,
+                title: result.title,
+                url: result.url,
+                domain: result.domain,
+                snippet: result.snippet,
+                relevance: 1 - (result.rank - 1) * 0.1,
+                sourceType: 'web',
+              });
+            }
           }
           break;
         }
@@ -323,7 +353,8 @@ function synthesizeAnswer(
 async function synthesizeAnswerWithLLM(
   question: string,
   sources: CollectedSource[],
-  strategy: string
+  strategy: string,
+  brief?: string | null
 ): Promise<{ answer: string; confidence: 'high' | 'medium' | 'low' }> {
   if (sources.length === 0) {
     return {
@@ -349,13 +380,17 @@ Regeln:
     .map((s, i) => `[${i + 1}] ${s.title} (${s.domain})\n${s.snippet}`)
     .join('\n\n');
 
+  const userContent = brief
+    ? `Frage: ${question}\n\nRecherche-Auftrag (zur Orientierung beim Synthetisieren — nicht als Quelle zitieren):\n${brief}\n\nQuellen:\n${sourcesText}`
+    : `Frage: ${question}\n\nQuellen:\n${sourcesText}`;
+
   try {
     const result = await generateText({
       model: aiModel,
       messages: [
         {
           role: 'user',
-          content: `Frage: ${question}\n\nQuellen:\n${sourcesText}`,
+          content: userContent,
         },
       ],
       system: systemPrompt,
@@ -392,14 +427,15 @@ async function synthesizeWithFallback(
   question: string,
   sources: CollectedSource[],
   strategy: string,
-  useLLM: boolean
+  useLLM: boolean,
+  brief?: string | null
 ): Promise<{ answer: string; confidence: 'high' | 'medium' | 'low' }> {
   if (!useLLM) {
     return synthesizeAnswer(question, sources, strategy);
   }
 
   try {
-    return await synthesizeAnswerWithLLM(question, sources, strategy);
+    return await synthesizeAnswerWithLLM(question, sources, strategy, brief);
   } catch (error: unknown) {
     log.warn('[Research] LLM synthesis failed, falling back to template', {
       error: error instanceof Error ? error.message : String(error),
@@ -412,18 +448,32 @@ async function synthesizeWithFallback(
  * Execute a structured research workflow with planning, searching, and synthesis.
  * This is the main entry point for the research tool.
  *
- * @param params.question - The research question to answer
+ * @param params.question - Search-friendly query (short, keyword-focused). Used for
+ *   the planner heuristics and the search engines.
+ * @param params.brief - Optional natural-language research plan to forward to the
+ *   LLM synthesis stage as additional orientation. Must NOT be used as a search
+ *   query — keyword indexes don't match prose directives.
+ * @param params.aiWorkerPool - Required to run query expansion on web searches.
  * @param params.depth - Search depth: 'quick' (default) or 'thorough'
  * @param params.maxSources - Maximum number of sources to include (default: 8)
  * @param params.useLLMSynthesis - Use Mistral-small for coherent synthesis (default: true)
  */
 export async function executeResearch(params: {
   question: string;
+  brief?: string | null;
+  aiWorkerPool?: AIWorkerPool;
   depth?: 'quick' | 'thorough';
   maxSources?: number;
   useLLMSynthesis?: boolean;
 }): Promise<ResearchResult> {
-  const { question, depth = 'quick', maxSources = 8, useLLMSynthesis = true } = params;
+  const {
+    question,
+    brief,
+    aiWorkerPool,
+    depth = 'quick',
+    maxSources = 8,
+    useLLMSynthesis = true,
+  } = params;
 
   log.info(`[Research] Starting research for: "${truncateText(question, 100)}" (depth: ${depth})`);
 
@@ -462,7 +512,7 @@ export async function executeResearch(params: {
   );
 
   // Phase 2: Execute searches
-  const { sources, searchSteps } = await executeSearches(plan);
+  const { sources, searchSteps } = await executeSearches(plan, aiWorkerPool);
   log.info(`[Research] Collected ${sources.length} sources from ${searchSteps.length} searches`);
 
   // B3: Apply MMR diversity to sources before synthesis
@@ -482,7 +532,8 @@ export async function executeResearch(params: {
     question,
     limitedSources,
     plan.synthesisStrategy,
-    useLLMSynthesis
+    useLLMSynthesis,
+    brief
   );
 
   // B4: Validate citation grounding

--- a/apps/api/services/chat/threadTitleService.ts
+++ b/apps/api/services/chat/threadTitleService.ts
@@ -30,13 +30,50 @@ export async function updateThreadTitleInDB(threadId: string, title: string): Pr
     .where(eq(chatThreads.id, threadId));
 }
 
+// Salutations that often start a German letter/email/post and make a poor
+// thread title. When matched at the start of a sentence we skip it and try
+// the next sentence.
+const SALUTATION_PATTERNS = [
+  /^liebe[*r]?\s/i,
+  /^liebes\s/i,
+  /^sehr\s+geehrte[r]?\s/i,
+  /^hallo\b/i,
+  /^guten\s+(tag|morgen|abend)\b/i,
+  /^moin\b/i,
+];
+
+function stripMarkdown(input: string): string {
+  return input
+    .replace(/\*\*/g, '')
+    .replace(/__/g, '')
+    .replace(/(^|\s)[*_]([^*_\s][^*_]*)[*_](?=\s|$|[.,;:!?])/g, '$1$2')
+    .replace(/`/g, '')
+    .replace(/^\s*#+\s+/, '')
+    .replace(/^\s*>\s+/, '')
+    .replace(/^\s*[-*+]\s+/, '')
+    .replace(/^\s*\d+\.\s+/, '')
+    .trim();
+}
+
 /**
  * Extract a fallback title from text using the first-sentence heuristic.
+ *
+ * Sanitises the assistant response so that titles do not contain raw
+ * markdown (`**Visuelle Idee:**`), salutations (`Liebe Freundinnen…`),
+ * or literal newlines.
  */
 export function extractFallbackTitle(text: string, hasImage?: boolean): string | null {
   if (text && text.length > 10) {
-    const firstSentence = text.split(/[.!?]/)[0];
-    return firstSentence.length > 50 ? firstSentence.slice(0, 50) + '...' : firstSentence;
+    const collapsed = text.replace(/\s+/g, ' ').trim();
+    const sentences = collapsed.split(/(?<=[.!?])\s+/).filter((s) => s.length > 0);
+
+    for (const raw of sentences) {
+      const cleaned = stripMarkdown(raw).trim();
+      if (cleaned.length < 10) continue;
+      if (SALUTATION_PATTERNS.some((re) => re.test(cleaned))) continue;
+      const trimmed = cleaned.replace(/[.!?]+$/, '');
+      return trimmed.length > 50 ? trimmed.slice(0, 50) + '...' : trimmed;
+    }
   }
   if (hasImage) {
     return 'Generiertes Bild';


### PR DESCRIPTION
## Summary

Three production-log issues affecting chat behaviour, found while reviewing live API logs.

### 1. `@recherche` returned 0 sources for queries `@web` answered with 5

The research path was passing `BriefGenerator`'s natural-language research instruction ("Bitte recherchiere den aktuellen Planungsstand und die offiziellen Genehmigungsunterlagen für ein geplantes Drohnenfabrik-Projekt…") **verbatim as a SearXNG search query**. SearXNG's keyword index has no document containing that prose, so it returned nothing. The brief was always meant to be an LLM synthesis plan, not a search query.

The original short user query is now sent to the search engines (matching the `@web` contract) and the brief is forwarded separately to the LLM synthesis stage as orientation context. `expandQuery` is wired into the research path so web variants get the same coverage `@web` has had.

**Before/after, log evidence (same prompt: "Wie ist der Stand zum Thema Drohnenfabrik in Hallbergmoos?"):**

`@recherche` before:
```
[DirectSearch] [Direct Web Search] query="Bitte recherchiere den aktuellen Planungsstand und die offiziellen Genehmigungsunterlagen für ein geplantes Drohnenfabrik-Projekt auf dem privaten Gelände der Senderwiese in Hallbergmoos…"
🔍 [SearXNG] 0 results (0 with content)
[Research] Complete: 0 citations, confidence: low
```

`@web` (what users worked around with):
```
[Direct Web Search] query="Drohnenfabrik Hallbergmoos"
🔍 [SearXNG] 5 results (5 with content)
```

After this PR, `@recherche` will issue short keyword queries (with expansion variants) and converge on the same sources `@web` finds, plus deeper LLM synthesis informed by the brief.

### 2. Fallback thread titles render raw markdown / salutations / newlines

`extractFallbackTitle` took the first 50 chars of the assistant response, split on `.!?`. When responses begin with markdown bold (`**Visuelle Idee:**`), a salutation (`Liebe Freundinnen und Freunde,`), or a literal newline, the title written to the DB rendered raw markup until the AI title overwrote it ~1s later.

`extractFallbackTitle` now collapses whitespace, strips common markdown markers (bold, italic, inline code, headings, blockquotes, list bullets), and skips German salutations to find a real first sentence.

### 3. Summary intent ignored in-message pasted content

When users pasted a long text directly into a chat message (no attached document), classifier correctly detected `intent: summary` but `summarizeNode` only checked `documentChatIds`, `documentIds`, then `attachmentContext` — never the raw user message — and fell through to `summarize conversation`, returning a generic conversation summary instead of summarizing the pasted text.

A new paste-to-summarize branch sits after the `attachmentContext` fallback: a >500-char user message is treated as the document to summarize using the existing `singlePassSummarize` / `mapReduceSummarize` helpers.

## Out of scope (deferred to follow-up PRs)

- Mem0 LLM-adapter returning prose instead of JSON → silent memory loss on every extraction
- ts-rest `ERR_HTTP_HEADERS_SENT` log spam (existing monkey-patch in `SSEWriter.end()` stays in place on the canvas branch)
- Greeting heuristic over-firing on messages starting with "hi" but containing substantive content
- Compaction trigger threshold (cost optimization, not a bug)

## Test plan

- [ ] `pnpm --filter @gruenerator/api typecheck` (passes locally)
- [ ] `@recherche Wie ist der Stand zum Thema Drohnenfabrik in Hallbergmoos?` → log shows `[Research] Expanded query into N variants` and short keyword query going to SearXNG; `[SearXNG] 5 results`; final response cites `merkur.de` / `br.de` with `confidence: medium|high`
- [ ] `@web` regression check on the same query — log identical to baseline
- [ ] `@recherche Was sagt das Wahlprogramm zur Schuldenbremse?` → `gruenerator_search` runs with the original short query (not the brief)
- [ ] Force `expandQuery` to throw → confirm `[Research] Web search failed for variant…` warning and original query still returns results
- [ ] Send a chat whose response begins with `**Visuelle Idee:**` → DB row's title contains no `**`
- [ ] Send a chat whose response begins with `Liebe Freundinnen und Freunde,…` → fallback title starts with the next real sentence
- [ ] Paste a 5000+ char Pressemitteilung and ask "Fasse den Text zusammen." → log shows `[Summarize] Using long user message (N chars) as paste-to-summarize input`; response is a summary of the pasted text
- [ ] Send a short user message ("Erkläre den GEAS") with summary intent → paste branch does NOT fire; conversation fallback runs