### PR TITLE
fix(chat): hide misleading citation numbers while streaming

### DIFF
--- a/packages/chat/src/components/message-parts/CitationPopover.tsx
+++ b/packages/chat/src/components/message-parts/CitationPopover.tsx
@@ -21,10 +21,14 @@ export const CitationBadge = memo(function CitationBadge({
   const citationPanel = useCitationPanel();
 
   if (!citation) {
+    // Numberless dot during streaming — the mid-stream IDs the LLM emits don't
+    // match the post-stream first-mention renumbering, so we keep the inline box
+    // (avoids reflow when chips swap in at done) but drop the digit.
     return (
-      <sup className="inline-flex items-center justify-center min-w-[1.1rem] h-[1.1rem] text-[10px] font-semibold bg-secondary-600 text-white dark:bg-primary-400 dark:text-grey-950 rounded-full px-0.5 mx-0.5 align-super">
-        {citationId}
-      </sup>
+      <sup
+        aria-hidden="true"
+        className="inline-flex items-center justify-center min-w-[1.1rem] h-[1.1rem] bg-secondary-600/40 dark:bg-primary-400/40 rounded-full px-0.5 mx-0.5 align-super"
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

While streaming, the LLM emits citation markers like `[22]`, `[4]`, `[11]` using the **prompt's** reference numbering — a dense `1..N` index over the up to 30 chunks retrieved from Qdrant (`buildReferencesMap`). The user briefly sees those raw IDs as solid green chips.

At end-of-stream, the server calls `renumberCitationsInOrder` (`apps/api/services/search/SearchResultProcessor.ts:236`) which scans the final draft, finds first-mention order, and rewrites every `[N]` to a compact `[1]..[K]`. Only then does the canonical `citations` array ship to the client, via `done`/`completion`.

Result: during streaming the chips display numbers that **do not match** the source cards that arrive at the end. The reader can see e.g. `[22]` in a paragraph but the source list only goes up to `[18]`.

This PR drops the digit from the streaming placeholder. The chip becomes a numberless translucent pill of the same inline-box dimensions (so paragraph reflow is still avoided when final chips swap in at `done`), with no false claim about which source it points to. Once the renumbered text and citations land, the badge swaps to its full numbered + clickable form as before.

## Why not fix it server-side instead?

- Streaming-side renumbering would require buffering partial `[\d*` runs across SSE token boundaries — non-trivial and adds latency.
- Streaming citation metadata progressively (per-ID `citation_assigned` events) would still leave numbers visually jumping mid-stream.
- This patch is the smallest change that removes the lie without touching the SSE or render pipelines.

## Out of scope (follow-up)

The example response that surfaced this had the same document (`Unser Wahlprogramm - Kapitel 1`) split into two source cards (`9 Abschnitte` + `2 Abschnitte`) — caused by Qdrant returning multiple `document_id`s for what's logically one document, plus near-duplicate chunks getting separate citation IDs. Tracking separately as a Qdrant dedup investigation.

## Test plan

- [ ] In dev, ask the chat a question that triggers document search (e.g. "Was sagen die Grünen Berlin zum Klimaschutz?").
- [ ] Verify that during streaming, citation markers render as small dim green dots without numbers.
- [ ] Verify that at end-of-stream they swap to the numbered, clickable chips with popovers.
- [ ] Verify line wrapping does not visibly shift between streaming and final state.
- [ ] Verify dark mode placeholder is also visible (uses `dark:bg-primary-400/40`).