### PR TITLE
refactor(web): remove inline DocsEditorModal — open editor in new tab everywhere

### DIFF
--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -6,8 +6,6 @@ import {
   type SharepicVariant,
 } from '@gruenerator/chat';
 import {
-  lazy,
-  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -24,8 +22,6 @@ import useNotebookStore from '../features/notebook/stores/notebookStore';
 import { resolveNotebookChatEntries } from '../features/notebook/utils/notebookChatResolver';
 import { useAuthStore } from '../stores/authStore';
 import { buildLoginUrl, isPublicPage } from '../utils/authRedirect';
-
-const DocsEditorModal = lazy(() => import('@/components/common/DocsEditorModal'));
 
 const PORTAL_SLOT_ID = 'chat-thread-portal-slot';
 
@@ -68,13 +64,6 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const qaCollectionsLength = useNotebookStore((s) => s.qaCollections.length);
-
-  const [editorModal, setEditorModal] = useState<{
-    documentId: string;
-    initialContent: string;
-    title: string;
-  } | null>(null);
-  const editorModalSetterRef = useRef(setEditorModal);
 
   const mentionablesActivated = useAgentStore((s) => s.mentionablesActivated);
   useEffect(() => {
@@ -167,11 +156,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
       },
       onEditInDocs: async (content: string, title?: string, existingDocId?: string) => {
         if (existingDocId) {
-          editorModalSetterRef.current({
-            documentId: existingDocId,
-            initialContent: content,
-            title: title || 'Dokument',
-          });
+          window.open(`/docs/${existingDocId}`, '_blank', 'noopener,noreferrer');
           return existingDocId;
         }
 
@@ -189,11 +174,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
         if (!response.ok) throw new Error('Document creation failed');
         const data = (await response.json()) as { documentId?: string; title?: string };
         if (data.documentId) {
-          editorModalSetterRef.current({
-            documentId: data.documentId,
-            initialContent: content,
-            title: title ?? data.title ?? 'Dokument',
-          });
+          window.open(`/docs/${data.documentId}`, '_blank', 'noopener,noreferrer');
           return data.documentId;
         }
       },
@@ -214,16 +195,6 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
         {children}
         {userId && <ChatThreadPortal />}
       </TooltipProvider>
-      {editorModal && (
-        <Suspense fallback={null}>
-          <DocsEditorModal
-            documentId={editorModal.documentId}
-            initialContent={editorModal.initialContent}
-            title={editorModal.title}
-            onClose={() => setEditorModal(null)}
-          />
-        </Suspense>
-      )}
     </GrueneratorChatProvider>
   );
 }

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -20,7 +20,7 @@ export interface ChatConfig {
   };
   /** Base URL for the Docs app. Auto-detected from hostname if not set. */
   docsBaseUrl?: string;
-  /** Opens content in an inline docs editor instead of a new tab. Returns documentId for reuse. */
+  /** Optional override for the "Edit in Docs" action. If unset, MessageActions falls back to opening `${getDocsUrl()}/document/${id}` in a new tab. Returns documentId for reuse. */
   onEditInDocs?: (
     content: string,
     title?: string,


### PR DESCRIPTION
## Summary

Collapses the dual "edit in docs" pathway (inline modal + new tab) into a single new-tab path that opens `/docs/:id` (the immersive web-app route, `routes.ts:395`) across **all** surfaces:

- **Chat** (`MessageActions` "Im Editor bearbeiten" + `DocumentCreatedCard` "Dokument öffnen") — already aligned in commit 6978f2eb.
- **Scanner** results view (`DisplaySection` → `ActionButtons` → `ExportDropdown` → "In Docs bearbeiten" menu item).
- **Transcription** page action bar (`useContentActions.handleOpenInDocs`, `handleCreateTodoList`).

## Why one URL pattern

Before this PR, the codebase used two competing docs URL conventions:
- `/docs/:id` — modern web-app immersive route (used by chat).
- `${getDocsUrl()}/document/:id` — pointed at the `apps/docs` subdomain, which `CLAUDE.md` lists as **deprecated** ("New docs features → `apps/web/src/features/docs/` + `packages/docs/`").

Every consumer now uses `/docs/:id`. No more cognitive overhead about "which subdomain handles docs?".

## What got removed

- `apps/web/src/components/common/DocsEditorModal.tsx` — **deleted** (155 lines). The component pulled in `useCollaboration`, `BlockNoteEditor`, full Yjs sync as a lazy chunk; no remaining consumers.
- `DisplaySection`'s `handleEditInDocsInline` plus its `useDocumentStore`/`createDocsApiClient`/`webAppDocsAdapter` import chain.
- `ActionButtons`/`ExportDropdown` props `onEditInDocsInline`/`editInDocsInlineLoading` (the menu item using them was already commented-out — pure dead code).
- `useContentActions`'s `EditorModalState` interface, `editorModal` state, and `closeEditorModal` from the return type.
- `GlobalChatProvider`'s in-file modal scaffold (`editorModal` state, `editorModalSetterRef`, lazy `DocsEditorModal` import, `<Suspense>` wrapper).

**Diff totals:** 8 files changed, ~16 insertions(+), ~330 deletions(-). The deletions/insertions ratio confirms this is mostly removing dead/redundant infrastructure rather than building anything new.

## Files touched

- `apps/web/src/providers/GlobalChatProvider.tsx`
- `apps/web/src/hooks/useContentActions.ts`
- `apps/web/src/features/scanner/tabs/ScannerTab.tsx`
- `apps/web/src/features/transkription/TranskriptionPage.tsx`
- `apps/web/src/components/common/ContentDisplay/DisplaySection.tsx`
- `apps/web/src/components/common/ActionButtons.tsx`
- `apps/web/src/components/common/ExportDropdown.tsx`
- `apps/web/src/components/common/DocsEditorModal.tsx` (deleted)
- `packages/chat/src/stores/chatConfigStore.ts` (JSDoc only)

## Test plan

- [ ] **Chat:** generate any AI response → hover → click "Im Editor bearbeiten" (FileEdit icon) → opens `/docs/<new-id>` in a new tab with the immersive editor. Click again → reopens `/docs/<same-id>` (linkedDocId reuse still works).
- [ ] **Chat ("Dokument generieren"):** ask the chat to generate a document → click "Dokument öffnen" on the resulting card → same `/docs/:id` new-tab behavior.
- [ ] **Scanner:** upload a PDF, run OCR, click the "In Docs bearbeiten" menu item in the export dropdown → opens `/docs/:id` in a new tab (was: opened `${docsBase}/document/:id` on the deprecated subdomain).
- [ ] **Scanner action bar:** click "In Docs öffnen" / "Aufgaben-Liste erstellen" buttons → both open `/docs/:id` in a new tab (was: opened the inline `DocsEditorModal`).
- [ ] **Transcription:** transcribe an audio file → click "In Docs öffnen" / "Aufgaben-Liste erstellen" → same new-tab behavior.
- [ ] **Typecheck:** `pnpm --filter @gruenerator/web typecheck` — verified clean locally.
- [ ] **Mobile unaffected:** `apps/mobile/components/content/ContentDisplay.tsx` is a separately-named file with its own logic; mobile flows untouched.

## Notes

- `DocsEditorModal.tsx` is deleted because all four call sites were removed in this PR. If anything in the future needs an inline collaborative editor, the `BlockNoteEditor` from `@gruenerator/docs` is still available as the building block (the modal was just a thin shell around it plus Yjs setup).
- `DisplaySection` has exactly one production consumer (`ScannerTab.tsx`) — verified via repo-wide grep before refactoring its internals.