### PR TITLE
fix(scrapers): BE-wahlprogramm dup via curated_lists tag

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -58,8 +58,23 @@ export interface LandesverbandSource {
   dormant?: boolean; // Optional: when true, scrapeAllSources skips this source. Set for sources that no longer publish (e.g. dissolved Fraktionen). Direct scrapeSource(id) calls are unaffected.
 }
 
+/**
+ * A curated list tags existing scraped documents (matched by URL) with a
+ * category id. The same document can appear in multiple lists. Use this when
+ * a sub-set of canonical content should be filterable independently of the
+ * scraper that produced it (e.g. "Wahlprogramm" inside a generic Beschlüsse
+ * sitemap), without re-fetching the same URLs under aliases.
+ */
+export interface CuratedList {
+  id: string;
+  label: string;
+  shortName?: string;
+  urls: string[];
+}
+
 export interface LandesverbaendeConfig {
   sources: LandesverbandSource[];
+  curatedLists?: CuratedList[];
 }
 
 export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
@@ -438,48 +453,6 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       },
       excludePatterns: ['/tag/', '/author/', '/wp-content/', '/wp-admin/', '#', 'javascript:'],
     },
-    {
-      id: 'berlin-lv-wahlprogramm',
-      name: 'Grüne Berlin Wahlprogramm',
-      shortName: 'BE',
-      type: 'landesverband',
-      baseUrl: 'https://gruene.berlin',
-      cms: 'typo3',
-      maxAgeYears: 5,
-      contentPaths: [
-        {
-          type: 'wahlprogramm',
-          path: '/news',
-          listSelector: 'h2 a[href], h3 a[href]',
-          staticUrls: [
-            'https://gruene.berlin/news/unser-wahlprogramm_3762',
-            'https://gruene.berlin/news/unser-wahlprogramm-1_3763',
-            'https://gruene.berlin/news/unser-wahlprogramm-kapitel-2_3764',
-            'https://gruene.berlin/news/unser-wahlprogramm-kapitel-3_3765',
-            'https://gruene.berlin/news/unser-wahlprogramm-kapitel-4_3766',
-            'https://gruene.berlin/news/unser-wahlprogramm-kapitel-5_3767',
-            'https://gruene.berlin/news/unser-wahlprogramm-kapitel-6_3768',
-          ],
-        },
-      ],
-      contentSelectors: {
-        title: ['h1', 'meta[property="og:title"]'],
-        date: ['time[datetime]', '.tx_xblog_pi1 .date', 'meta[property="article:published_time"]'],
-        content: ['.tx_xblog_pi1', '.bodytext', 'article', 'main .content'],
-        categories: ['.tx_xblog_pi1 .tags a', '.categories a'],
-        author: ['.author', '.byline'],
-      },
-      excludePatterns: [
-        '/fileadmin/',
-        '/typo3/',
-        'tx_xblog_pi1[catKey]',
-        '#',
-        'javascript:',
-        '.pdf',
-        '.jpg',
-        '.png',
-      ],
-    },
 
     // ═══════════════════════════════════════════════════════════════════
     // THÜRINGEN
@@ -675,6 +648,22 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       excludePatterns: ['/fileadmin/', '/typo3/', '#', 'javascript:', '.jpg', '.png'],
     },
   ],
+  curatedLists: [
+    {
+      id: 'wahlprogramm-be',
+      label: 'Wahlprogramm',
+      shortName: 'BE',
+      urls: [
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm_3762',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-1_3763',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-2_3764',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-3_3765',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-4_3766',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-5_3767',
+        'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-6_3768',
+      ],
+    },
+  ],
 };
 
 export const CONTENT_TYPE_LABELS: Record<ContentType, string> = {
@@ -709,6 +698,47 @@ export function getSourcesByLandesverband(shortName: string): LandesverbandSourc
 
 export function getAllSourceIds(): string[] {
   return LANDESVERBAENDE_CONFIG.sources.map((s) => s.id);
+}
+
+/**
+ * Extract the trailing TYPO3-style id (e.g. `_3763`) from a URL pathname,
+ * keyed by hostname so /beschluesse/foo_3763 and /news/foo_3763 collide
+ * but /beschluesse/foo_3763 on different domains do not.
+ */
+function trailingSlugKey(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const m = u.pathname.match(/_(\d+)$/);
+    return m ? `${u.hostname}#_${m[1]}` : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the curated-list ids whose `urls` include the given URL. Matches
+ * either by exact URL or by trailing TYPO3 slug id within the same hostname,
+ * so curated lists keep working when a CMS aliases the same entry under
+ * multiple paths (e.g. /beschluesse/x_NNN vs /news/x_NNN).
+ */
+export function getCuratedListsForUrl(url: string): string[] {
+  const lists = LANDESVERBAENDE_CONFIG.curatedLists;
+  if (!lists?.length) return [];
+
+  const targetSlug = trailingSlugKey(url);
+  const matched: string[] = [];
+
+  for (const list of lists) {
+    if (list.urls.includes(url)) {
+      matched.push(list.id);
+      continue;
+    }
+    if (targetSlug && list.urls.some((u) => trailingSlugKey(u) === targetSlug)) {
+      matched.push(list.id);
+    }
+  }
+
+  return matched;
 }
 
 export default LANDESVERBAENDE_CONFIG;

--- a/apps/api/config/systemCollectionsConfig.ts
+++ b/apps/api/config/systemCollectionsConfig.ts
@@ -274,9 +274,16 @@ export const SYSTEM_COLLECTIONS: Record<string, SystemCollectionConfig> = {
         valueLabels: {
           'berlin-lv-presse': 'LV Presse',
           'berlin-lv-beschluesse': 'LV Beschlüsse',
-          'berlin-lv-wahlprogramm': 'LV Wahlprogramm',
           'berlin-fraktion-presse': 'Fraktion Presse',
           'berlin-fraktion-beschluesse': 'Fraktion Beschlüsse',
+        },
+      },
+      {
+        field: 'curated_lists',
+        label: 'Liste',
+        type: 'keyword',
+        valueLabels: {
+          'wahlprogramm-be': 'Wahlprogramm',
         },
       },
       { field: 'published_at', label: 'Datum', type: 'date_range' },
@@ -437,6 +444,7 @@ export function buildSubcategoryFilter(
     'landesverband',
     'gremium',
     'source_id',
+    'curated_lists',
   ];
 
   for (const filterKey of filterKeys) {

--- a/apps/api/scrape-berlin.ts
+++ b/apps/api/scrape-berlin.ts
@@ -20,7 +20,6 @@ import { landesverbandScraperService } from './services/scrapers/implementations
 const BERLIN_SOURCES = [
   'berlin-lv-presse',
   'berlin-lv-beschluesse',
-  'berlin-lv-wahlprogramm',
   'berlin-fraktion-presse',
   'berlin-fraktion-beschluesse',
 ];

--- a/apps/api/scripts/migrate-be-wahlprogramm.ts
+++ b/apps/api/scripts/migrate-be-wahlprogramm.ts
@@ -1,0 +1,234 @@
+/**
+ * Migrate Berlin LV Wahlprogramm vectors to the curated_lists model.
+ *
+ * Background: berlin-lv-wahlprogramm was a separate scraper that re-fetched
+ * the same TYPO3 entries under /news/ paths the BE Beschlüsse sitemap already
+ * indexed under /beschluesse/. This created two Qdrant document_ids per
+ * chapter. We now express the wahlprogramm tag as a curated_list overlay on
+ * the canonical /beschluesse/ copy, then delete the redundant /news/ copy.
+ *
+ * For each known chapter URL pair:
+ *   - if both copies exist: tag the /beschluesse/ copy with
+ *     curated_lists: ['wahlprogramm-be'], delete the /news/ copy.
+ *   - if only the /news/ copy exists: do nothing, log a warning so a human
+ *     can decide whether to re-scrape via the canonical path.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/migrate-be-wahlprogramm.ts            # dry run
+ *   npx tsx apps/api/scripts/migrate-be-wahlprogramm.ts --execute  # apply
+ *
+ * Requires: QDRANT_URL, QDRANT_API_KEY, QDRANT_BASIC_AUTH_USERNAME,
+ * QDRANT_BASIC_AUTH_PASSWORD.
+ */
+
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+import { env } from '../config/env.js';
+
+const QDRANT_URL = (env.QDRANT_URL ?? '').replace(/\/+$/, '');
+const QDRANT_API_KEY = env.QDRANT_API_KEY ?? '';
+const BASIC_USER = env.QDRANT_BASIC_AUTH_USERNAME;
+const BASIC_PASS = env.QDRANT_BASIC_AUTH_PASSWORD;
+const COLLECTION = 'landesverbaende_documents';
+const CURATED_LIST_ID = 'wahlprogramm-be';
+const DRY_RUN = !process.argv.includes('--execute');
+
+const URL_PAIRS: Array<{ news: string; canonical: string }> = [
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm_3762',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm_3762',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-1_3763',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-1_3763',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-kapitel-2_3764',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-2_3764',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-kapitel-3_3765',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-3_3765',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-kapitel-4_3766',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-4_3766',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-kapitel-5_3767',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-5_3767',
+  },
+  {
+    news: 'https://gruene.berlin/news/unser-wahlprogramm-kapitel-6_3768',
+    canonical: 'https://gruene.berlin/beschluesse/unser-wahlprogramm-kapitel-6_3768',
+  },
+];
+
+function buildHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'api-key': QDRANT_API_KEY,
+  };
+  if (BASIC_USER && BASIC_PASS) {
+    headers['Authorization'] =
+      `Basic ${Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString('base64')}`;
+  }
+  return headers;
+}
+
+async function qdrantPost<T = unknown>(
+  path: string,
+  body: Record<string, unknown> = {}
+): Promise<T> {
+  const resp = await fetch(`${QDRANT_URL}${path}`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Qdrant ${path} failed (${resp.status}): ${text}`);
+  }
+  return resp.json() as Promise<T>;
+}
+
+interface ScrollPoint {
+  id: string | number;
+  payload?: { document_id?: string; chunk_index?: number; curated_lists?: string[] };
+}
+
+interface ScrollResponse {
+  result?: { points?: ScrollPoint[]; next_page_offset?: string | number | null };
+}
+
+async function scrollByUrl(url: string): Promise<ScrollPoint[]> {
+  const points: ScrollPoint[] = [];
+  let offset: string | number | null = null;
+
+  while (true) {
+    const body: Record<string, unknown> = {
+      limit: 200,
+      with_payload: { include: ['document_id', 'chunk_index', 'curated_lists'] },
+      with_vector: false,
+      filter: { must: [{ key: 'source_url', match: { value: url } }] },
+    };
+    if (offset !== null) body.offset = offset;
+
+    const data = await qdrantPost<ScrollResponse>(
+      `/collections/${COLLECTION}/points/scroll`,
+      body
+    );
+    const batch = data.result?.points ?? [];
+    if (batch.length === 0) break;
+    points.push(...batch);
+    offset = data.result?.next_page_offset ?? null;
+    if (offset === null) break;
+  }
+
+  return points;
+}
+
+async function setCuratedListTag(url: string): Promise<void> {
+  await qdrantPost(`/collections/${COLLECTION}/points/payload`, {
+    payload: { curated_lists: [CURATED_LIST_ID] },
+    filter: { must: [{ key: 'source_url', match: { value: url } }] },
+  });
+}
+
+async function deleteByUrl(url: string): Promise<void> {
+  await qdrantPost(`/collections/${COLLECTION}/points/delete`, {
+    filter: { must: [{ key: 'source_url', match: { value: url } }] },
+  });
+}
+
+interface PairResult {
+  pair: { news: string; canonical: string };
+  newsCount: number;
+  canonicalCount: number;
+  action: 'migrate' | 'news-only-skipped' | 'canonical-only-skipped' | 'neither';
+}
+
+async function main() {
+  if (!QDRANT_URL || !QDRANT_API_KEY) {
+    console.error('QDRANT_URL and QDRANT_API_KEY are required');
+    process.exit(1);
+  }
+
+  console.log(
+    `\n${DRY_RUN ? 'DRY RUN' : 'EXECUTE'}  Migrating ${URL_PAIRS.length} BE wahlprogramm chapter pairs\n`
+  );
+
+  const results: PairResult[] = [];
+
+  for (const pair of URL_PAIRS) {
+    const [newsPoints, canonicalPoints] = await Promise.all([
+      scrollByUrl(pair.news),
+      scrollByUrl(pair.canonical),
+    ]);
+
+    const newsCount = newsPoints.length;
+    const canonicalCount = canonicalPoints.length;
+
+    let action: PairResult['action'];
+    if (canonicalCount > 0 && newsCount > 0) action = 'migrate';
+    else if (newsCount > 0) action = 'news-only-skipped';
+    else if (canonicalCount > 0) action = 'canonical-only-skipped';
+    else action = 'neither';
+
+    results.push({ pair, newsCount, canonicalCount, action });
+
+    const slug = pair.canonical.split('/').pop();
+    console.log(`  ${slug}`);
+    console.log(`    /news/        ${newsCount} chunks`);
+    console.log(`    /beschluesse/ ${canonicalCount} chunks`);
+    console.log(`    action:       ${action}`);
+
+    if (action === 'migrate' && !DRY_RUN) {
+      await setCuratedListTag(pair.canonical);
+      await deleteByUrl(pair.news);
+      console.log(`    applied: tagged canonical, deleted ${newsCount} news chunks`);
+    }
+    console.log();
+  }
+
+  const tally = {
+    migrate: results.filter((r) => r.action === 'migrate').length,
+    newsOnly: results.filter((r) => r.action === 'news-only-skipped').length,
+    canonicalOnly: results.filter((r) => r.action === 'canonical-only-skipped').length,
+    neither: results.filter((r) => r.action === 'neither').length,
+  };
+  const totalDeleted = results
+    .filter((r) => r.action === 'migrate')
+    .reduce((sum, r) => sum + r.newsCount, 0);
+  const totalTagged = results
+    .filter((r) => r.action === 'migrate')
+    .reduce((sum, r) => sum + r.canonicalCount, 0);
+
+  console.log('─── Summary ───────────────────────────────');
+  console.log(`  pairs to migrate:        ${tally.migrate}`);
+  console.log(`  /news/ only (skipped):   ${tally.newsOnly}`);
+  console.log(`  canonical only (no-op):  ${tally.canonicalOnly}`);
+  console.log(`  neither side present:    ${tally.neither}`);
+  console.log(`  chunks to tag canonical: ${totalTagged}`);
+  console.log(`  chunks to delete (news): ${totalDeleted}`);
+  console.log();
+
+  if (tally.newsOnly > 0) {
+    console.log('NOTE: /news/-only entries were left untouched. Re-scrape their canonical');
+    console.log('      /beschluesse/ URL via the sitemap-driven berlin-lv-beschluesse');
+    console.log('      scraper, then re-run this migration to clean them up.');
+    console.log();
+  }
+
+  if (DRY_RUN && tally.migrate > 0) {
+    console.log('Run with --execute to apply.');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
@@ -4,7 +4,10 @@
  * Handles: validation, age filter, deduplication, chunking, embedding, storage
  */
 
-import { CONTENT_TYPE_LABELS } from '../../../../../config/landesverbaendeConfig.js';
+import {
+  CONTENT_TYPE_LABELS,
+  getCuratedListsForUrl,
+} from '../../../../../config/landesverbaendeConfig.js';
 import {
   scrollDocuments,
   batchDelete,
@@ -122,6 +125,7 @@ export class DocumentProcessor {
     const embeddings = await mistralEmbeddingService.generateBatchEmbeddings(chunkTexts);
 
     // STEP 8: Build Qdrant points (with quality scoring)
+    const curatedLists = getCuratedListsForUrl(url);
     const points = chunks.map((chunk, index) => ({
       id: this.generatePointId(url, index),
       vector: embeddings[index],
@@ -145,6 +149,7 @@ export class DocumentProcessor {
         published_at: publishedAt || null,
         indexed_at: new Date().toISOString(),
         source: 'landesverbaende_gruene',
+        ...(curatedLists.length > 0 ? { curated_lists: curatedLists } : {}),
         ...(index === 0 ? { full_text: text } : {}),
       },
     }));

--- a/packages/shared/src/search/collections/config.ts
+++ b/packages/shared/src/search/collections/config.ts
@@ -196,9 +196,15 @@ export const COLLECTIONS: CollectionConfigMap = {
         valueLabels: {
           'berlin-lv-presse': 'LV Presse',
           'berlin-lv-beschluesse': 'LV Beschlüsse',
-          'berlin-lv-wahlprogramm': 'LV Wahlprogramm',
           'berlin-fraktion-presse': 'Fraktion Presse',
           'berlin-fraktion-beschluesse': 'Fraktion Beschlüsse',
+        },
+      },
+      curated_lists: {
+        label: 'Liste',
+        type: 'keyword',
+        valueLabels: {
+          'wahlprogramm-be': 'Wahlprogramm',
         },
       },
       published_at: { label: 'Datum', type: 'date_range' },


### PR DESCRIPTION
## Summary

The `berlin-lv-wahlprogramm` scraper re-fetched 7 Wahlprogramm chapters under `gruene.berlin/news/...` even though the same TYPO3 entries are already in the `/beschluesse/` sitemap that `berlin-lv-beschluesse` consumes. Page chrome differs slightly between the two URL forms → different `content_hash` → different `lv_*` document_ids in Qdrant → the same chapter appeared as two source cards in chat answers.

This PR removes the duplicate-scraper hack and replaces it with a **curated lists** overlay on `LandesverbaendeConfig`. Documents are indexed once via the canonical scraper; curated lists stamp a category id (e.g. `wahlprogramm-be`) onto a subset of URLs at write time. The Berlin system collection exposes that field as a separate filter ('Liste' → 'Wahlprogramm') so the user-facing 'Wahlprogramm' filter chip keeps working.

## Why curated lists (vs. just deleting the scraper)

A simple delete would have lost the wahlprogramm filterability — those chapters would have collapsed into the generic Beschlüsse pile. The schema was overloading `source_id` to mean both *which scraper produced this* and *what category does this content belong to*. Curated lists separate those concerns:

- One canonical document per URL, no duplicate vectors.
- A document can belong to multiple lists (no schema gymnastics).
- New lists can be added without spinning up new scrapers.
- The mechanism is reusable for any future "Grundsatzprogramm", "Klimaprogramm", cross-LV reading-list filter etc.

URL matching uses exact URL or trailing TYPO3 slug id (`_NNNN`) within the same hostname, so curated lists keep working when a CMS aliases the same entry under multiple paths.

## Scope (LV-only)

The curated-lists abstraction lives on `LandesverbaendeConfig` for now. If/when other system collections (`grundsatz_documents`, `bundestag_content`, …) want curated overlays, the same `CuratedList` interface can be promoted up to `SystemCollectionConfig` — that's a follow-up; this PR keeps the surface tight.

## Files changed

- `apps/api/config/landesverbaendeConfig.ts` — `CuratedList` interface, `curatedLists` field on the config root, `wahlprogramm-be` list with the 7 canonical `/beschluesse/` URLs, `getCuratedListsForUrl` helper. `berlin-lv-wahlprogramm` scraper entry removed.
- `apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts` — stamp `curated_lists` onto each chunk's Qdrant payload when the URL matches a list.
- `apps/api/config/systemCollectionsConfig.ts` — replace `'berlin-lv-wahlprogramm'` `source_id` valueLabel with a separate `curated_lists` filterable field; add `'curated_lists'` to `buildSubcategoryFilter`'s allowlist.
- `packages/shared/src/search/collections/config.ts` — same swap on the shared client-side filter config.
- `apps/api/scrape-berlin.ts` — drop `'berlin-lv-wahlprogramm'` from the Berlin source list.
- `apps/api/scripts/migrate-be-wahlprogramm.ts` (new) — one-shot migration script. **Defaults to dry-run.** For each of the 7 known URL pairs: if both copies exist, tag the canonical `/beschluesse/` chunks with `curated_lists: ['wahlprogramm-be']` and delete the `/news/` chunks. If only the `/news/` copy exists, log a warning and leave it alone (operator should re-scrape via canonical first).

## Migration path

Existing duplicate vectors stay in Qdrant until the migration script runs. Order of operations once this PR ships:

1. Merge + deploy this PR. New scrapes won't add fresh duplicates.
2. Run `npx tsx apps/api/scripts/migrate-be-wahlprogramm.ts` (dry-run by default) to inspect what would change.
3. Approve and run with `--execute` to apply. Print summary keeps a log of what was tagged/deleted.

## What this PR does NOT do

- Does not add a Qdrant payload index on `curated_lists`. The Berlin filter is rare and runs inside an already-narrow `landesverband: BE` predicate, so unindexed filtering is fine for now. Add an index later if scan cost shows up in latency monitoring.
- Does not generalize curated lists to non-LV system collections. Out of scope for this PR; same interface can be promoted later.
- Does not run the migration script. That's a separate, operator-approved step.

## Test plan

- [ ] CI typecheck + lint pass.
- [ ] After deploy, trigger a Berlin scrape (`apps/api/scrape-berlin.ts --source berlin-lv-beschluesse`); verify a Wahlprogramm chapter chunk in Qdrant has `curated_lists: ['wahlprogramm-be']`.
- [ ] In dev, open the Berlin system collection; verify the 'Liste' filter renders with 'Wahlprogramm' as an option and that selecting it returns only Wahlprogramm chapters.
- [ ] Run `migrate-be-wahlprogramm.ts` (dry-run) against staging; verify the printed plan shows 7 'migrate' actions and zero 'news-only-skipped'.
- [ ] After running with `--execute`, repeat the chat query "Was sagen die Grünen Berlin zum Klimaschutz?" — verify "Unser Wahlprogramm - Kapitel 1" appears as exactly one source card.