### PR TITLE
fix(chat): preserve markdown formatting when chat action opens doc

### DIFF
--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -5,14 +5,7 @@ import {
   useAgentStore,
   type SharepicVariant,
 } from '@gruenerator/chat';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -160,16 +153,11 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
           return existingDocId;
         }
 
-        const htmlContent = content
-          .split('\n\n')
-          .map((block) => `<p>${block.replace(/\n/g, '<br />')}</p>`)
-          .join('');
-
         const response = await fetch('/api/docs/from-export', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ content: htmlContent, title, documentType: 'chat-response' }),
+          body: JSON.stringify({ content, title, documentType: 'chat-response' }),
         });
         if (!response.ok) throw new Error('Document creation failed');
         const data = (await response.json()) as { documentId?: string; title?: string };


### PR DESCRIPTION
## Summary

Fixes the chat **"Im Editor bearbeiten"** action button producing unstyled documents — markdown shows up as literal `## Heading`, `**bold**`, and `[1]` text instead of rendered headings, bold, and citations.

## Root cause

`apps/web/src/providers/GlobalChatProvider.tsx` — the `onEditInDocs` callback pre-wrapped the assistant message content in `<p>...</p>` blocks before POSTing to `/api/docs/from-export`:

```ts
const htmlContent = content
  .split('\n\n')
  .map((block) => `<p>${block.replace(/\n/g, '<br />')}</p>`)
  .join('');
```

The backend (`apps/api/routes/docs/exportToDocsController.ts:51-55`) then runs:

```ts
const isLikelyMarkdown =
  !content.trim().startsWith('<') && /\*\*|^#{1,3}\s|^[-*+]\s/m.test(content);
const htmlContent = isLikelyMarkdown
  ? new MarkdownService().markdownToHtml(content)
  : content;
```

Pre-wrapping made `content.trim().startsWith('<')` true → `isLikelyMarkdown` false → backend skipped `MarkdownService.markdownToHtml` and stored the raw markdown text inside `<p>` tags.

## Fix

Send the raw markdown body directly. The backend's `MarkdownService` (`marked` with `gfm: true, breaks: true`) is the same converter the **"Dokument generieren"** flow uses, so chat action button output now matches the backend doc-generation flow visually.

## Files

- `apps/web/src/providers/GlobalChatProvider.tsx` — 1 file, 2 insertions, 14 deletions

## Test plan

- [ ] Open chat, generate any AI response with markdown formatting (headings, bold, citations).
- [ ] Click the FileEdit ("Im Editor bearbeiten") icon in the action bar → opens `/docs/<new-id>` in a new tab.
- [ ] **Verify:** headings render as actual `<h1>/<h2>/<h3>`, `**bold**` renders bold, lists render as proper bullet/numbered lists, links are clickable.
- [ ] Cross-check parity: `/chat` → "dokument generieren" → click "Dokument öffnen" — both flows now produce identically-formatted documents.
- [ ] Existing `linkedDocId` reuse path (clicking the button twice on the same message) is unaffected — that branch goes through `existingDocId` handling, which doesn't touch the body conversion.

## Notes

- Local typecheck (`pnpm --filter @gruenerator/web typecheck`) is clean.
- Bug shipped via PR #737 which intentionally only delivered the new-tab routing change; the `<p>`-wrapping shim was pre-existing dead code that became user-visible once the new-tab path was activated. This PR removes it.