### PR TITLE
fix(web): reset notebook page to landing on reload, not into chat

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -140,26 +140,32 @@ export const NotebookPageContent = ({
   const activeFiltersStore = useNotebookStore((s) => s.activeFilters);
   const [mode, setMode] = useState<'fast' | 'deep'>('fast');
   const [searchParams, setSearchParams] = useSearchParams();
-  const [threadId, setThreadId] = useState<string | null>(
-    threadIdProp || searchParams.get('thread')
-  );
-  const handleThreadCreated = useCallback(
-    (newThreadId: string) => {
-      setThreadId(newThreadId);
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          next.set('thread', newThreadId);
-          return next;
-        },
-        { replace: true }
-      );
-    },
-    [setSearchParams]
-  );
+  const [threadId, setThreadId] = useState<string | null>(threadIdProp ?? null);
+  const handleThreadCreated = useCallback((newThreadId: string) => {
+    setThreadId(newThreadId);
+  }, []);
+
+  // Strip a stale ?thread= query param once on mount: the chat is no longer
+  // restored from the URL, so leaving the param around just confuses bookmarks.
+  useEffect(() => {
+    if (!searchParams.get('thread')) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('thread');
+        return next;
+      },
+      { replace: true }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const location = useLocation();
-  const freshConversation = (location.state as { freshConversation?: boolean } | null)
-    ?.freshConversation;
+  const navState = location.state as
+    | { freshConversation?: boolean; resumeNotebookChat?: boolean }
+    | null;
+  const freshConversation = navState?.freshConversation;
+  const resumeFromCache = navState?.resumeNotebookChat ?? false;
 
   const localeCollections = useMemo(() => {
     if (!isMulti) return config.collections;
@@ -212,6 +218,7 @@ export const NotebookPageContent = ({
     collections: selectedCollections,
     persistMessages: config.persistMessages,
     freshConversation,
+    resumeFromCache,
   });
 
   const providerCollections = useMemo(

--- a/apps/web/src/features/notebook/hooks/useNotebookChatBridge.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookChatBridge.ts
@@ -17,6 +17,9 @@ interface UseNotebookChatBridgeOptions {
   persistMessages?: boolean;
   welcomeMessage?: string;
   freshConversation?: boolean;
+  // Default false. Setting true seeds initialMessages from cache so the chat
+  // view (not the landing page) is shown — used by the sidebar resume click.
+  resumeFromCache?: boolean;
 }
 
 function convertToThreadMessages(messages: NotebookChatMessage[]): ThreadMessageLike[] {
@@ -64,6 +67,7 @@ export function useNotebookChatBridge({
   persistMessages = true,
   welcomeMessage,
   freshConversation,
+  resumeFromCache = false,
 }: UseNotebookChatBridgeOptions) {
   const user = useAuthStore((s) => s.user);
   const { setGeneratedText, setGeneratedTextMetadata } = useGeneratedTextStore();
@@ -93,11 +97,16 @@ export function useNotebookChatBridge({
   // Read store imperatively — initialMessages is a seed value, not a live subscription.
   // This breaks the feedback loop: onComplete → addMessage → store update no longer
   // triggers initialMessages recalculation → no runtime reinitialization.
-  const initialMessages = useMemo(() => {
+  const initialMessages = useMemo<ThreadMessageLike[]>(() => {
     if (freshConversation && !freshHandled.current) return [];
     if (!persistMessages) return [];
-    const stored = useNotebookChatStore.getState().chats[collectionKey]?.messages || [];
-    if (stored.length === 0 && welcomeMessage) {
+
+    if (resumeFromCache) {
+      const stored = useNotebookChatStore.getState().chats[collectionKey]?.messages || [];
+      if (stored.length > 0) return convertToThreadMessages(stored);
+    }
+
+    if (welcomeMessage) {
       return convertToThreadMessages([
         {
           type: 'assistant',
@@ -107,8 +116,8 @@ export function useNotebookChatBridge({
         },
       ]);
     }
-    return convertToThreadMessages(stored);
-  }, [persistMessages, collectionKey, welcomeMessage, freshConversation]);
+    return [];
+  }, [persistMessages, collectionKey, welcomeMessage, freshConversation, resumeFromCache]);
 
   const onComplete = useCallback(
     (metadata: NotebookMessageMetadata) => {

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -109,7 +109,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
 
   const handleExternalClick = useCallback(
     (path: string) => {
-      void navigate(path);
+      void navigate(path, { state: { resumeNotebookChat: true } });
     },
     [navigate]
   );


### PR DESCRIPTION
## Summary
- Visiting `/notebooks/:slug` (e.g. `/notebooks/berlin`) silently auto-resumed a previous AI chat on every reload. `handleThreadCreated` wrote `?thread=<id>` to the URL on the first question and `useNotebookChatBridge` seeded `initialMessages` from the localStorage cache on mount — the `<ThreadPrimitive.Empty>` switch flipped to `<ThreadPrimitive.If empty={false}>` and the landing page became unreachable.
- Stop reading/writing `?thread=` to the URL and strip any stale param once on mount. Gate cache hydration on a new `resumeFromCache` flag (default `false`).
- The chat-sidebar entry list keeps working: `GlobalChatProvider`'s `handleExternalClick` now passes `state: { resumeNotebookChat: true }` via `navigate`, which is the only path that restores the chat view. Hard reloads always land on the landing page; the URL stays clean.

## Test plan
- [ ] `/notebooks/berlin` shows the landing page on first visit
- [ ] Asking a question switches to the chat view; answer streams as before
- [ ] F5 on the chat view reloads to the landing page; URL has no `?thread=`
- [ ] Open the global chat sidebar — the "Berlin" entry is still listed
- [ ] Click the sidebar entry → notebook page loads in chat view with restored messages
- [ ] F5 on that resumed view → landing page again (resume requires another sidebar click)
- [ ] `+ Neue Unterhaltung` flow still clears the cache (uses existing `freshConversation: true` location-state path)
- [ ] Multi-source notebook (e.g. Bundes­partei aggregate) behaves identically
- [ ] `pnpm --filter @gruenerator/web typecheck` passes