### PR TITLE
fix(api): link recent image cards to share viewer

### DIFF
--- a/apps/api/routes/workplace/recentActivityController.ts
+++ b/apps/api/routes/workplace/recentActivityController.ts
@@ -232,7 +232,7 @@ export async function fetchRecentImages(
     title: row.title || 'Ohne Titel',
     date: row.created_at,
     type: 'image' as const,
-    href: '/studio/gallery',
+    href: `/share/${row.share_token}`,
     thumbnailUrl: row.thumbnail_path ? `/api/share/${row.share_token}/thumbnail` : undefined,
     deleteEndpoint: `/api/share/${row.share_token}`,
   }));


### PR DESCRIPTION
## Summary
- Recent-activity image cards in the Workplace ("Zuletzt erstellt") pointed to `/studio/gallery`, a `devOnly` route that does not exist in production. React Router's catch-all then sent users to `/studio` (also `devOnly`), leaving them stranded on a useless page.
- Backend now returns `/share/${share_token}` as the image card href — the same per-image viewer that's already used for thumbnails and the public share link.

## Test plan
- [ ] Open Workplace, scroll to "Zuletzt erstellt"
- [ ] Click an image card → lands on `/share/<token>` and the image renders
- [ ] Verify owner sees the same media (no auth-wall regression — `SharedMediaPage` already handles authenticated owners)
- [ ] Confirm video, doc, board, presentation cards still navigate to their existing destinations