### PR TITLE
feat(web): hide "Grünerators Favoriten" on workplace for AT users

### DIFF
--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -5,6 +5,7 @@ import withAuthRequired from '../../components/common/LoginRequired/withAuthRequ
 import PageContainer from '../../components/common/PageContainer';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import { useFirstName } from '../../hooks/useFirstName';
+import { useAuthStore } from '../../stores/authStore';
 
 import CreatorSection from './components/CreatorSection';
 import NotebooksSection from './components/NotebooksSection';
@@ -183,6 +184,8 @@ Sun.displayName = 'Sun';
 
 const WorkplacePage = () => {
   const firstName = useFirstName();
+  const locale = useAuthStore((state) => state.locale);
+  const isAustrian = locale === 'de-AT';
 
   return (
     <ErrorBoundary>
@@ -212,10 +215,12 @@ const WorkplacePage = () => {
           <ToolsSection />
         </section>
 
-        <section className="mb-xl">
-          <SectionHeader title="Grünerators Favoriten" />
-          <FavoritesSection />
-        </section>
+        {!isAustrian && (
+          <section className="mb-xl">
+            <SectionHeader title="Grünerators Favoriten" />
+            <FavoritesSection />
+          </section>
+        )}
 
         {/* <GrassWithSheep /> */}
       </PageContainer>


### PR DESCRIPTION
## Summary
- Wraps the **Grünerators Favoriten** section on `WorkplacePage` in a `!isAustrian` guard so users on the `de-AT` locale don't see the (DE-centric) curated favorites row.
- Mirrors the existing pattern used by `NotebooksSection`, `NotebookGallery`, `RecherchePage`, etc. — read `locale` from `useAuthStore`, derive `isAustrian = locale === 'de-AT'`, render conditionally.
- AT users still see Creator, RecentlyCreated, Notebooks, and Weitere Tools — only the Favoriten row is hidden.

## Test plan
- [ ] Log in as a `de-DE` user → "Grünerators Favoriten" row visible.
- [ ] Switch profile locale to `de-AT` (Profile → flag toggle) → row disappears without page reload (Zustand selector subscribes to locale).
- [ ] Other workplace sections (Creator, Recently Created, Notebooks, Weitere Tools) remain visible for AT users.
- [ ] No new console errors.