### PR TITLE
fix(research): show date filter + cross-encoder rerank for relevance

### DIFF
--- a/apps/api/routes/research/researchController.ts
+++ b/apps/api/routes/research/researchController.ts
@@ -278,7 +278,7 @@ router.get('/filters', async (req: Request, res: Response): Promise<void> => {
           const existing = mergedFilters[result.field];
           if (result.min && (!existing.min || result.min < existing.min)) existing.min = result.min;
           if (result.max && (!existing.max || result.max > existing.max)) existing.max = result.max;
-        } else if (result.min || result.max) {
+        } else {
           mergedFilters[result.field] = {
             label: result.label,
             type: 'date_range',
@@ -705,7 +705,7 @@ export async function warmFilterCache(): Promise<void> {
           const existing = mergedFilters[result.field];
           if (result.min && (!existing.min || result.min < existing.min)) existing.min = result.min;
           if (result.max && (!existing.max || result.max > existing.max)) existing.max = result.max;
-        } else if (result.min || result.max) {
+        } else {
           mergedFilters[result.field] = {
             label: result.label,
             type: 'date_range',

--- a/apps/api/routes/research/researchController.ts
+++ b/apps/api/routes/research/researchController.ts
@@ -16,6 +16,7 @@ import { getQdrantInstance } from '../../database/services/QdrantService/index.j
 import { scrollDocuments } from '../../database/services/QdrantService/operations/batchOperations.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { getQdrantDocumentService } from '../../services/document-services/index.js';
+import { rerankPipeline } from '../../services/search/rerankPipeline.js';
 import { createLogger } from '../../utils/logger.js';
 
 import type { DocumentResult, TopChunk } from '../../services/BaseSearchService/types.js';
@@ -427,8 +428,32 @@ router.post(
 
       let deduped = Array.from(dedupMap.values()).filter((r) => r.similarity_score >= 0.35);
 
-      // Sort
-      if (sortBy === 'date_desc') {
+      // Cross-encoder rerank for relevance mode. Bi-encoder embeddings can't tell
+      // "Artenschutz" from "Datenschutz" (both project to "Schutz" topics);
+      // a cross-encoder reads query+document together and scores the actual match.
+      if (sortBy === 'relevance' && deduped.length > 3) {
+        const rerankInputLimit = 30;
+        const candidates = deduped.slice(0, rerankInputLimit);
+        const items = candidates.map((r) => ({
+          title: r.title ?? '',
+          content: (r.relevant_content ?? '').slice(0, 500),
+          relevance: r.similarity_score,
+        }));
+        const { rankedIndices, scores } = await rerankPipeline({
+          query: trimmedQuery,
+          items,
+          inputLimit: rerankInputLimit,
+          outputLimit: effectiveLimit,
+          minRelevance: 0.05,
+          minKeep: Math.min(5, candidates.length),
+          applyDiversity: true,
+        });
+        deduped = rankedIndices.flatMap((i) => {
+          const c = candidates[i];
+          if (!c) return [];
+          return [{ ...c, similarity_score: scores.get(i) ?? c.similarity_score }];
+        });
+      } else if (sortBy === 'date_desc') {
         deduped.sort((a, b) => {
           const dateA = a.published_at || '';
           const dateB = b.published_at || '';


### PR DESCRIPTION
## Summary

Two related fixes to the manual research panel (\`/notebooks/<slug>\` → Manuelle Recherche), both surfaced from a single user report on \`/notebooks/berlin\`:

1. **Date filter popover always showed _\"Kein Zeitfilter verfügbar.\"_** — the controller dropped the \`date_range\` filter entry whenever Qdrant returned null bounds for \`published_at\`. Since \`published_at\` is registered as a \`keyword\` payload index (not numeric/datetime), \`order_by\` raises Bad Request, \`getDateRange()\` swallows it and returns \`{min: null, max: null}\`, and the entry was conditionally omitted. Now we always emit the entry; \`<input type=date>\` works fine without min/max.
2. **Off-topic results scoring 90%+** — searching \"artenschutz\" returned Datenschutz/Cybersicherheit chunks at 93% because bi-encoder embeddings can't separate German compounds that share the \"Schutz\" suffix. Bolted the existing Regolo cross-encoder pipeline (already used by ChatGraph and NotebookQA) onto \`/research/search\` for relevance mode.

## Commits

- \`fix(research): always emit date_range filter entries even with null bounds\`
- \`feat(research): cross-encoder rerank in /research/search\`

## Test plan

- [ ] \`/notebooks/berlin\` → Manuelle Recherche → click **Zeitraum**: two date inputs render (no \"Kein Zeitfilter verfügbar.\")
- [ ] Search \"artenschutz\" in Berlin notebook: Datenschutz/Cybersicherheit chunks no longer dominate top results; on-topic results (Wildtiere, Stadtgrün, Tag des Baumes, biologische Vielfalt) float up
- [ ] Switch sort to **Neueste** / **Älteste**: rerank is skipped (date sorts unchanged)
- [ ] Search with \`REGOLO_API_KEY\` unset (or temporarily wrong): pipeline falls back to original order via \`regoloRerankService\` graceful degradation, no error to user
- [ ] Backend log shows \`[RerankPipeline] N → M results in Xms\` line per search
- [ ] Repeat date filter check on at least one other notebook (\`/notebooks/bundestag\`, \`/notebooks/gruene-at\`)

## Out of scope

- The deeper indexing issue — that \`published_at\` is keyword-indexed and Qdrant therefore can't compute real min/max bounds — would need a Qdrant payload-index migration. Worth doing later to populate proper bounds in the date inputs, but the popover is functional without them.
- Notebook QA / Chat already had rerank; only manual research was missing it.