### PR TITLE
feat(texte): unify presse Zitatgeber input with antrag tag-pill UI

### DIFF
--- a/apps/web/src/features/texte/components/ModeToolbar.tsx
+++ b/apps/web/src/features/texte/components/ModeToolbar.tsx
@@ -43,15 +43,17 @@ const ModeToolbar: React.FC<ModeToolbarProps> = memo(
             onChange={(val) => onStateChange(config.key, val)}
           />
         ))}
-        {def?.tagInputs?.map((config) => (
-          <SettingsTagInput
-            key={config.key}
-            items={(state[config.key] as string[]) ?? []}
-            onChange={(items) => onStateChange(config.key, items)}
-            triggerLabel={config.label}
-            placeholder={config.placeholder}
-          />
-        ))}
+        {def?.tagInputs
+          ?.filter((config) => !config.condition || config.condition(state))
+          .map((config) => (
+            <SettingsTagInput
+              key={config.key}
+              items={(state[config.key] as string[]) ?? []}
+              onChange={(items) => onStateChange(config.key, items)}
+              triggerLabel={config.label}
+              placeholder={config.placeholder}
+            />
+          ))}
       </>
     );
   }

--- a/apps/web/src/features/texte/components/PresseSocialInner.tsx
+++ b/apps/web/src/features/texte/components/PresseSocialInner.tsx
@@ -75,10 +75,15 @@ const PresseSocialInner: React.FC<PresseSocialInnerProps> = memo(({ def }) => {
 
     setStoreIsLoading(true);
     try {
+      const zitatgeberRaw = currentState.zitatgeber;
+      const zitatgeber = Array.isArray(zitatgeberRaw)
+        ? zitatgeberRaw.join(', ')
+        : (zitatgeberRaw as string) || '';
+
       const formData: PresseSocialFormData = {
         inhalt: currentPrompt,
         platforms: filteredPlatforms,
-        zitatgeber: (currentState.zitatgeber as string) || '',
+        zitatgeber,
       };
 
       const result = setup.features.useAgentMode

--- a/apps/web/src/features/texte/modes/presseSocial.ts
+++ b/apps/web/src/features/texte/modes/presseSocial.ts
@@ -31,10 +31,10 @@ export const presseSocialMode: ModeDefinition = {
       multiple: true,
     },
   ],
-  extraFields: [
+  tagInputs: [
     {
       key: 'zitatgeber',
-      type: 'input',
+      label: 'Wer wird zitiert',
       placeholder: 'Name der*des Zitatgeber*in...',
       condition: (state) => {
         const platforms = state.platforms;
@@ -44,6 +44,6 @@ export const presseSocialMode: ModeDefinition = {
   ],
   defaults: {
     platforms: ['instagram'],
-    zitatgeber: '',
+    zitatgeber: [],
   },
 };

--- a/apps/web/src/features/texte/modes/types.ts
+++ b/apps/web/src/features/texte/modes/types.ts
@@ -18,6 +18,7 @@ export interface TagInputConfig {
   key: string;
   label: string;
   placeholder: string;
+  condition?: (state: ModeState) => boolean;
 }
 
 export interface ModeDefinition {


### PR DESCRIPTION
## Summary
- Replaces the stacked plain-Input \"Wer wird zitiert\" field above the press release prompt with the same toolbar popover-pill UI that Antrag uses for Gliederung.
- Adds an optional `condition` predicate to `TagInputConfig` (parity with `ExtraFieldConfig`) so the pill only renders when Pressemitteilung is among selected formats.
- Backend contract is unchanged: the `string[]` of Zitatgeber*innen is comma-joined to a single string at the submit boundary, so `social.json`, `SocialAgentGraph`, and `PresseSocialFormData.zitatgeber: string` stay untouched.
- Bonus: enables multiple Zitatgeber*innen on a press release.

## Files
- `apps/web/src/features/texte/modes/types.ts` — `TagInputConfig.condition?: (state) => boolean`
- `apps/web/src/features/texte/components/ModeToolbar.tsx` — filter `tagInputs` by `condition`
- `apps/web/src/features/texte/modes/presseSocial.ts` — `zitatgeber` moved from `extraFields` → `tagInputs`, default `[]`, label \"Wer wird zitiert\"
- `apps/web/src/features/texte/components/PresseSocialInner.tsx` — `string[]` → comma-joined `string` at submit

## Test plan
- [ ] On `/desk` (Workplace), open the creator and pick the Pressemitteilung format pill — the \"Wer wird zitiert\" pill appears next to it
- [ ] Add one and then several Zitatgeber*innen via the popover
- [ ] Deselect Pressemitteilung — the pill disappears
- [ ] Submit with one and with multiple Zitatgeber*innen — generated press release picks up the speaker name(s)
- [ ] Antrag mode still has its Gliederung pill working unchanged