### PR TITLE
fix(chat): load @docs mentionables via React Query

### DIFF
--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -2,9 +2,9 @@ import {
   GrueneratorChatProvider,
   ChatThreadList,
   TooltipProvider,
-  useAgentStore,
   type SharepicVariant,
 } from '@gruenerator/chat';
+import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -58,11 +58,17 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
   const location = useLocation();
   const qaCollectionsLength = useNotebookStore((s) => s.qaCollections.length);
 
-  const mentionablesActivated = useAgentStore((s) => s.mentionablesActivated);
-  useEffect(() => {
-    if (!mentionablesActivated || qaCollectionsLength > 0) return;
-    void useNotebookStore.getState().fetchQACollections();
-  }, [mentionablesActivated, qaCollectionsLength]);
+  // Notebook collections power @notebook mention metadata; fetch lazily when
+  // an authenticated user actually needs them. React Query caches the result.
+  useQuery({
+    queryKey: ['qa-collections', userId],
+    queryFn: async () => {
+      await useNotebookStore.getState().fetchQACollections();
+      return useNotebookStore.getState().qaCollections;
+    },
+    enabled: !!userId && qaCollectionsLength === 0,
+    staleTime: 5 * 60_000,
+  });
 
   useEffect(() => {
     const handler = (e: Event) => {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -38,6 +38,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": ">=0.12.0",
+    "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwindcss": "4",

--- a/packages/chat/src/components/thread/CollabDocMentionPopover.tsx
+++ b/packages/chat/src/components/thread/CollabDocMentionPopover.tsx
@@ -8,7 +8,7 @@ import {
   CommandList,
   ScrollArea,
 } from '@gruenerator/ui';
-import { getDocMentionables } from '../../lib/mentionables';
+import { useDocMentionables } from '../../hooks/useMentionablesQuery';
 
 export interface CollabDocSelection {
   id: string;
@@ -38,11 +38,11 @@ export function CollabDocMentionPopover({
     [onDismiss]
   );
 
-  if (!visible) return null;
+  // useQuery dedupes with the same query in GrueneratorComposer so this is just
+  // a cache subscription — popover re-renders automatically when docs arrive.
+  const docs = useDocMentionables();
 
-  const docs = getDocMentionables().filter(
-    (m) => m.identifier !== 'dokument-erstellen' && m.identifier !== 'docs-picker-trigger'
-  );
+  if (!visible) return null;
 
   return (
     <div

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -17,6 +17,7 @@ import { PlusMenu } from './PlusMenu';
 import { ModelPicker } from './ModelPicker';
 import { getCaretCoords } from '../../lib/caretPosition';
 import { registerDocumentSlug } from '../../lib/documentMentionables';
+import { useMentionablesQuery } from '../../hooks/useMentionablesQuery';
 import type { Mentionable } from '../../lib/mentionables';
 import type { DocumentMention } from '../../lib/documentMentionables';
 
@@ -120,6 +121,10 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const uploadRef = useRef<HTMLButtonElement>(null);
   const [mention, setMention] = useState<MentionState>(INITIAL_MENTION_STATE);
+
+  // Composer mount drives lazy fetching of mentionable data (custom agents,
+  // boards, docs). The query is deduplicated across consumers via React Query.
+  useMentionablesQuery();
 
   const dismissPopover = useCallback(() => setMention(INITIAL_MENTION_STATE), []);
 

--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -1,0 +1,140 @@
+/**
+ * React Query hooks that fetch dynamic @mention data (custom agents, boards,
+ * docs) and keep the module-level mentionable lists in sync for synchronous
+ * consumers like mentionParser.resolveMentionable.
+ *
+ * Mounting any consumer (typically GrueneratorComposer) triggers the queries.
+ * React Query handles caching, deduplication, retry and refetch — replacing
+ * the previous useEffect/setState dance plus a manual mentionablesActivated
+ * flag.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useChatConfigStore } from '../stores/chatConfigStore';
+import { createChatApiClient } from '../context/ChatContext';
+import {
+  setBoardMentionables,
+  setCustomAgents,
+  setDocMentionables,
+  type CustomAgentMentionable,
+  type Mentionable,
+} from '../lib/mentionables';
+
+interface BoardListItem {
+  id: string;
+  title: string;
+}
+
+interface DocListItem {
+  id: string;
+  title: string;
+  document_subtype?: string;
+}
+
+const STALE_TIME = 60_000;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[äÄ]/g, 'ae')
+    .replace(/[öÖ]/g, 'oe')
+    .replace(/[üÜ]/g, 'ue')
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function useApiClient() {
+  const fetchFn = useChatConfigStore((s) => s.fetch);
+  const onUnauthorized = useChatConfigStore((s) => s.onUnauthorized);
+  return useMemo(() => createChatApiClient(fetchFn, onUnauthorized), [fetchFn, onUnauthorized]);
+}
+
+export function useCustomAgentsQuery() {
+  const apiClient = useApiClient();
+  return useQuery<CustomAgentMentionable[]>({
+    queryKey: ['mention-custom-agents'],
+    queryFn: async () => {
+      const [ownPrompts, savedPrompts] = await Promise.all([
+        apiClient.get<{ prompts?: CustomAgentMentionable[] }>('/auth/custom_prompts'),
+        apiClient.get<{ prompts?: CustomAgentMentionable[] }>('/auth/saved_prompts'),
+      ]);
+      const seenIds = new Set<string>();
+      const merged: CustomAgentMentionable[] = [];
+      for (const p of [...(ownPrompts?.prompts ?? []), ...(savedPrompts?.prompts ?? [])]) {
+        if (!seenIds.has(p.id)) {
+          seenIds.add(p.id);
+          merged.push(p);
+        }
+      }
+      setCustomAgents(merged);
+      return merged;
+    },
+    staleTime: STALE_TIME,
+    retry: 1,
+  });
+}
+
+export function useBoardsQuery() {
+  const apiClient = useApiClient();
+  return useQuery<BoardListItem[]>({
+    queryKey: ['mention-boards'],
+    queryFn: async () => {
+      const boards = await apiClient.get<BoardListItem[]>('/api/boards');
+      const list = Array.isArray(boards) ? boards : [];
+      setBoardMentionables(list.map((b) => ({ id: b.id, title: b.title, slug: slugify(b.title) })));
+      return list;
+    },
+    staleTime: STALE_TIME,
+    retry: 1,
+  });
+}
+
+export function useDocsQuery() {
+  const apiClient = useApiClient();
+  return useQuery<DocListItem[]>({
+    queryKey: ['mention-docs'],
+    queryFn: async () => {
+      const docs = await apiClient.get<DocListItem[]>('/api/docs');
+      const list = Array.isArray(docs) ? docs.filter((d) => d.document_subtype !== 'boards') : [];
+      setDocMentionables(list.map((d) => ({ id: d.id, title: d.title, slug: slugify(d.title) })));
+      return list;
+    },
+    staleTime: STALE_TIME,
+    retry: 1,
+  });
+}
+
+/**
+ * Convenience hook that triggers all three queries — call from the chat
+ * composer so dynamic mentionables are warm by the time @-popovers open.
+ */
+export function useMentionablesQuery(): void {
+  useCustomAgentsQuery();
+  useBoardsQuery();
+  useDocsQuery();
+}
+
+/**
+ * Returns the user's collaborative documents formatted as Mentionables, ready
+ * for the @docs picker. Re-renders automatically when the docs query resolves.
+ */
+export function useDocMentionables(): Mentionable[] {
+  const { data } = useDocsQuery();
+  return useMemo(() => {
+    if (!data) return [];
+    return data.map<Mentionable>((d) => ({
+      type: 'doc',
+      category: 'function',
+      trigger: '@',
+      identifier: d.id,
+      title: d.title,
+      description: d.title,
+      avatar: '📝',
+      backgroundColor: '#0891B2',
+      mention: slugify(d.title),
+    }));
+  }, [data]);
+}

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -25,12 +25,6 @@ import { createChatApiClient } from '../context/ChatContext';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore, type ChatConfig } from '../stores/chatConfigStore';
 import { getDefaultAgent } from '../lib/agents';
-import {
-  setCustomAgents,
-  setBoardMentionables,
-  setDocMentionables,
-  type CustomAgentMentionable,
-} from '../lib/mentionables';
 import { useChatCollaboration } from '../hooks/useChatCollaboration';
 import { ChatCollaborationProvider } from '../context/ChatCollaborationContext';
 import { VoxtralDictationAdapter } from '@gruenerator/voice';
@@ -475,109 +469,10 @@ function GrueneratorChatRuntimeProvider({
     [fetchFn, onUnauthorized]
   );
 
-  // Auto-activate mentionables on chat-related routes
-  const mentionablesActivated = useAgentStore((s) => s.mentionablesActivated);
-  useEffect(() => {
-    if (mentionablesActivated) return;
-    const isChatRoute =
-      activePath?.startsWith('/chat') ||
-      activePath?.startsWith('/gruene-') ||
-      activePath?.startsWith('/kommunalwiki') ||
-      activePath?.startsWith('/boell-stiftung') ||
-      activePath?.startsWith('/gruenblog') ||
-      activePath?.startsWith('/notebook') ||
-      activePath?.startsWith('/gruenerator-notebook') ||
-      activePath?.startsWith('/suche') ||
-      activePath?.startsWith('/ask') ||
-      activePath?.startsWith('/gruen-o-mat');
-    if (isChatRoute) {
-      useAgentStore.getState().activateMentionables();
-    }
-  }, [activePath, mentionablesActivated]);
-
-  // Load @mention data (custom agents, boards, docs) — deferred until chat is used
-  useEffect(() => {
-    if (!mentionablesActivated) return;
-
-    const loadCustomAgents = async () => {
-      try {
-        const [ownPrompts, savedPrompts] = await Promise.all([
-          providerApiClient.get<{ prompts?: CustomAgentMentionable[] }>('/auth/custom_prompts'),
-          providerApiClient.get<{ prompts?: CustomAgentMentionable[] }>('/auth/saved_prompts'),
-        ]);
-        const own = ownPrompts?.prompts || [];
-        const saved = savedPrompts?.prompts || [];
-        const seenIds = new Set<string>();
-        const merged: CustomAgentMentionable[] = [];
-        for (const p of [...own, ...saved]) {
-          if (!seenIds.has(p.id)) {
-            seenIds.add(p.id);
-            merged.push(p);
-          }
-        }
-        setCustomAgents(merged);
-      } catch {
-        // Silently ignore — custom agents in @mention are optional
-      }
-    };
-    loadCustomAgents();
-
-    const loadBoards = async () => {
-      try {
-        const boards =
-          await providerApiClient.get<Array<{ id: string; title: string }>>('/api/boards');
-        if (Array.isArray(boards)) {
-          setBoardMentionables(
-            boards.map((b) => ({
-              id: b.id,
-              title: b.title,
-              slug: b.title
-                .toLowerCase()
-                .replace(/[äÄ]/g, 'ae')
-                .replace(/[öÖ]/g, 'oe')
-                .replace(/[üÜ]/g, 'ue')
-                .replace(/ß/g, 'ss')
-                .replace(/[^a-z0-9]+/g, '-')
-                .replace(/^-|-$/g, ''),
-            }))
-          );
-        }
-      } catch {
-        // Silently ignore — boards in @mention are optional
-      }
-    };
-    loadBoards();
-
-    const loadDocs = async () => {
-      try {
-        const docs =
-          await providerApiClient.get<
-            Array<{ id: string; title: string; document_subtype?: string }>
-          >('/api/docs');
-        if (Array.isArray(docs)) {
-          setDocMentionables(
-            docs
-              .filter((d) => d.document_subtype !== 'boards')
-              .map((d) => ({
-                id: d.id,
-                title: d.title,
-                slug: d.title
-                  .toLowerCase()
-                  .replace(/[äÄ]/g, 'ae')
-                  .replace(/[öÖ]/g, 'oe')
-                  .replace(/[üÜ]/g, 'ue')
-                  .replace(/ß/g, 'ss')
-                  .replace(/[^a-z0-9]+/g, '-')
-                  .replace(/^-|-$/g, ''),
-              }))
-          );
-        }
-      } catch {
-        // Silently ignore — docs in @mention are optional
-      }
-    };
-    loadDocs();
-  }, [providerApiClient, userId, mentionablesActivated]);
+  // Dynamic @mention data (custom agents, boards, docs) is fetched via
+  // useMentionablesQuery() inside GrueneratorComposer — keeps loading lazy
+  // (only fires once a chat composer mounts) and removes manual cache
+  // management.
 
   const getExternalThreadsRef = useRef(getExternalThreads);
   getExternalThreadsRef.current = getExternalThreads;

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -147,7 +147,6 @@ interface AgentState {
   customSystemPrompt: string | null;
   customRoleName: string | null;
   customEnabledTools: Record<string, boolean> | null;
-  mentionablesActivated: boolean;
   setSelectedAgent: (agentId: string | null) => void;
   setSelectedProvider: (provider: Provider) => void;
   setSelectedModel: (model: ModelId) => void;
@@ -170,7 +169,6 @@ interface AgentState {
   setCustomEnabledTools: (tools: Record<string, boolean> | null) => void;
   loadThreadSettings: (threadId: string, apiClient: ChatApiClient) => Promise<void>;
   saveThreadSettings: (threadId: string, apiClient: ChatApiClient) => Promise<void>;
-  activateMentionables: () => void;
 }
 
 const DEFAULT_ENABLED_TOOLS: Record<ToolKey, boolean> = {
@@ -208,7 +206,6 @@ export const useAgentStore = create<AgentState>()(
       customSystemPrompt: null,
       customRoleName: null,
       customEnabledTools: null,
-      mentionablesActivated: false,
 
       setSelectedAgent: (agentId) => set({ selectedAgentId: agentId }),
 
@@ -356,8 +353,6 @@ export const useAgentStore = create<AgentState>()(
           console.error('Failed to save thread settings:', error);
         }
       },
-
-      activateMentionables: () => set({ mentionablesActivated: true }),
     }),
     {
       name: 'gruenerator-chat-store',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1384,6 +1384,9 @@ importers:
       '@hocuspocus/provider':
         specifier: ^3.4.3
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.100.5(react@19.2.4)
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.4)


### PR DESCRIPTION
## Summary
- Fixes `@docs` popover showing **"Keine Dokumente gefunden"** even when the user has many collaborative documents.
- Replaces the manual `useEffect → fetch → setState` loaders + `mentionablesActivated` flag with TanStack Query hooks.
- Composer mount is now the chat-context signal (lazy fetch trigger). The popover subscribes via `useDocMentionables` and re-renders automatically when data arrives — no more empty-flicker race.

## Bug root cause
Two compounding issues in `GrueneratorChatProvider`:
1. The activation gate used a path allowlist (`/chat`, `/notebook`, `/gruene-`, …) that **missed `/workplace`** even though it renders `<GrueneratorComposer>`.
2. `mentionablesActivated` was missing from `chatStore`'s `partialize`, so it reset to `false` on every page reload, leaving the picker permanently empty on non-allowlisted routes.

A latent race also existed: `dynamicDocMentionables` was plain module-level state with no React subscription, so the popover wouldn't re-render when `loadDocs` eventually completed.

## Approach
Use React Query (already in web + mobile) instead of hand-rolled `useEffect`/setState:
- New `useMentionablesQuery()` hook in `packages/chat/src/hooks/useMentionablesQuery.ts` runs three `useQuery` calls (custom agents, boards, docs).
- The `queryFn` does double duty: returns data for RQ consumers (popover gets reactive re-renders) **and** updates the module setters so synchronous consumers like `mentionParser.resolveMentionable` keep working.
- Composer mount-only consumption gives us lazy loading without a flag.
- Migrated `GlobalChatProvider`'s `qaCollections` fetch to `useQuery` for consistency.

## Files changed
- **New**: `packages/chat/src/hooks/useMentionablesQuery.ts`
- `packages/chat/src/components/thread/GrueneratorComposer.tsx` — calls `useMentionablesQuery()` once on mount
- `packages/chat/src/components/thread/CollabDocMentionPopover.tsx` — uses `useDocMentionables()` instead of module state
- `packages/chat/src/runtime/GrueneratorChatProvider.tsx` — deletes ~80 lines of manual loaders
- `packages/chat/src/stores/chatStore.ts` — removes `mentionablesActivated` flag entirely
- `packages/chat/package.json` + `pnpm-lock.yaml` — adds `@tanstack/react-query` peer dep
- `apps/web/src/providers/GlobalChatProvider.tsx` — migrates `qaCollections` fetch to `useQuery`

## Test plan
- [ ] `pnpm install` to pick up new peer dep
- [ ] On `/chat`, `/workplace`, `/notebook/*`, `/gruene-*` — type `@docs` → "Dokument einfügen" → popover lists user's collaborative docs
- [ ] Reload page on each of those routes → @docs still works (no flag-dependent regression)
- [ ] Type `@docs` immediately after page load (before fetch could complete) → popover shows docs once they arrive (no stale empty state)
- [ ] `@notebook` mentions still resolve (qaCollections still load)
- [ ] Mobile (`apps/mobile`) — `MentionSuggestions` still works (uses static lists, unaffected)

## Notes
- Mobile is unaffected — it doesn't render `GrueneratorComposer` and doesn't read `mentionablesActivated`.
- Master CI is currently failing on **lint errors in unrelated files** (`@typescript-eslint/no-unsafe-assignment` in `apps/sites`/etc.). This PR doesn't touch those.