### PR TITLE
feat(api): make recherche failures observable in ChatGraph

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -237,6 +237,20 @@ const ChatStateAnnotation = Annotation.Root({
     reducer: (x, y) => y ?? x ?? 0,
   }),
 
+  // Reliability flags & structured error log (visibility for silent failure surfaces).
+  // searchErrors uses APPEND reducer so errors persist across the qualityGate→search loop;
+  // searchResults uses replace, so without append we'd lose failures from prior iterations.
+  searchErrors: Annotation<{ source: string; message: string }[]>({
+    reducer: (x, y) => [...(x ?? []), ...(y ?? [])],
+    default: () => [],
+  }),
+  briefGenerationFailed: Annotation<boolean>({
+    reducer: (x, y) => y ?? x ?? false,
+  }),
+  rerankFailed: Annotation<boolean>({
+    reducer: (x, y) => y ?? x ?? false,
+  }),
+
   // Image generation
   imagePrompt: Annotation<string | null>({
     reducer: (x, y) => y ?? x,
@@ -595,6 +609,11 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     // Quality gate
     qualityScore: 0,
     qualityAssessmentTimeMs: 0,
+
+    // Reliability flags & structured error log
+    searchErrors: [],
+    briefGenerationFailed: false,
+    rerankFailed: false,
 
     // Image generation (will be set by image node)
     imagePrompt: null,

--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -676,6 +676,16 @@ export async function runChatGraph(input: ChatGraphInput): Promise<ChatGraphOutp
       `[ChatGraph] Complete: intent=${result.intent}, searches=${result.searchCount}, image=${result.generatedImage ? 'yes' : 'no'}, time=${totalTimeMs}ms`
     );
 
+    // Reliability summary — only log when something noteworthy happened so the line
+    // stays useful for grep instead of getting drowned in happy-path noise.
+    const errCount = result.searchErrors?.length ?? 0;
+    if (errCount > 0 || result.rerankFailed || result.briefGenerationFailed) {
+      const errSources = result.searchErrors?.map((e) => e.source).join(',') || 'none';
+      log.warn(
+        `[ChatGraph] Reliability: errors=${errCount} (${errSources}), rerankFailed=${!!result.rerankFailed}, briefFailed=${!!result.briefGenerationFailed}, results=${result.searchResults.length}`
+      );
+    }
+
     return {
       success: !result.error,
       threadId: result.threadId,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.ts
@@ -99,8 +99,11 @@ Erstelle einen klaren, fokussierten Recherche-Auftrag.`;
     const timeMs = Date.now() - startTime;
 
     if (!brief) {
-      log.warn(`[BriefGenerator] Empty response, falling back to searchQuery`);
-      return {};
+      log.error(`[BriefGenerator] Empty response, falling back to searchQuery`);
+      return {
+        briefGenerationFailed: true,
+        searchErrors: [{ source: 'briefGenerator', message: 'empty LLM response' }],
+      };
     }
 
     log.info(`[BriefGenerator] Generated brief (${brief.length} chars) in ${timeMs}ms`);
@@ -108,9 +111,11 @@ Erstelle einen klaren, fokussierten Recherche-Auftrag.`;
 
     return { researchBrief: brief };
   } catch (error: unknown) {
-    log.error(
-      `[BriefGenerator] Error: ${error instanceof Error ? error.message : String(error)}, falling back to searchQuery`
-    );
-    return {};
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log.error(`[BriefGenerator] Error: ${errMsg}, falling back to searchQuery`);
+    return {
+      briefGenerationFailed: true,
+      searchErrors: [{ source: 'briefGenerator', message: errMsg }],
+    };
   }
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.vitest.ts
@@ -125,7 +125,7 @@ describe('briefGeneratorNode', () => {
     expect(promptContent.length).toBeLessThan(5000);
   });
 
-  it('handles empty response from LLM gracefully', async () => {
+  it('flags briefGenerationFailed and records error when LLM returns empty', async () => {
     const state = makeState({
       aiWorkerPool: {
         processRequest: vi.fn().mockResolvedValue({ content: '' }),
@@ -133,10 +133,14 @@ describe('briefGeneratorNode', () => {
     });
 
     const result = await briefGeneratorNode(state);
-    expect(result).toEqual({});
+    expect(result.briefGenerationFailed).toBe(true);
+    expect(result.researchBrief).toBeUndefined();
+    expect(result.searchErrors).toEqual([
+      { source: 'briefGenerator', message: 'empty LLM response' },
+    ]);
   });
 
-  it('handles LLM error gracefully', async () => {
+  it('flags briefGenerationFailed and records error on LLM rejection', async () => {
     const state = makeState({
       aiWorkerPool: {
         processRequest: vi.fn().mockRejectedValue(new Error('LLM timeout')),
@@ -144,7 +148,11 @@ describe('briefGeneratorNode', () => {
     });
 
     const result = await briefGeneratorNode(state);
-    expect(result).toEqual({});
+    expect(result.briefGenerationFailed).toBe(true);
+    expect(result.researchBrief).toBeUndefined();
+    expect(result.searchErrors).toEqual([
+      { source: 'briefGenerator', message: 'LLM timeout' },
+    ]);
   });
 
   it('truncates generated brief to MAX_BRIEF_LENGTH (500)', async () => {

--- a/apps/api/agents/langgraph/ChatGraph/nodes/qualityGateNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/qualityGateNode.ts
@@ -111,14 +111,22 @@ export async function qualityGateNode(state: ChatGraphState): Promise<Partial<Ch
       };
     }
 
-    // If parsing fails, assume results are sufficient
-    log.warn('[QualityGate] Failed to parse response, assuming sufficient');
-    return { qualityScore: 3, qualityAssessmentTimeMs };
-  } catch (error: unknown) {
-    log.error('[QualityGate] Error:', error instanceof Error ? error.message : String(error));
+    // Parse failure: route to respond (qualityScore=0 < 3 but no refinedQuery means no loop)
+    // and record the failure so respond / telemetry can see the gate was bypassed.
+    const parseFailMsg = 'qualityGate response could not be parsed';
+    log.error(`[QualityGate] ${parseFailMsg} — bypassing gate`);
     return {
-      qualityScore: 3,
+      qualityScore: 0,
+      qualityAssessmentTimeMs,
+      searchErrors: [{ source: 'qualityGate', message: parseFailMsg }],
+    };
+  } catch (error: unknown) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log.error('[QualityGate] Error:', errMsg);
+    return {
+      qualityScore: 0,
       qualityAssessmentTimeMs: Date.now() - startTime,
+      searchErrors: [{ source: 'qualityGate', message: errMsg }],
     };
   }
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/qualityGateNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/qualityGateNode.vitest.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { qualityGateNode } from './qualityGateNode.js';
+
+import type { ChatGraphState, SearchResult } from '../types.js';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function makeResults(n: number): SearchResult[] {
+  return Array.from({ length: n }, (_, i) => ({
+    source: `gruenerator:test-${i}`,
+    title: `Result ${i}`,
+    content: `Content for result ${i}`,
+  }));
+}
+
+function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
+  return {
+    searchResults: makeResults(4),
+    searchQuery: 'Klimapolitik',
+    searchCount: 0,
+    maxSearches: 2,
+    researchBrief: null,
+    aiWorkerPool: {
+      processRequest: vi.fn().mockResolvedValue({
+        content: JSON.stringify({ score: 4, sufficient: true }),
+      }),
+    },
+    ...overrides,
+  } as unknown as ChatGraphState;
+}
+
+describe('qualityGateNode', () => {
+  it('skips when searchCount has reached maxSearches', async () => {
+    const state = makeState({ searchCount: 2, maxSearches: 2 });
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBeUndefined();
+    expect(state.aiWorkerPool.processRequest).not.toHaveBeenCalled();
+  });
+
+  it('skips when there is at most one result', async () => {
+    const state = makeState({ searchResults: makeResults(1) });
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBeUndefined();
+    expect(state.aiWorkerPool.processRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns score from JSON on happy path (sufficient)', async () => {
+    const state = makeState();
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBe(4);
+    expect(result.searchErrors).toBeUndefined();
+    expect(result.searchQuery).toBeUndefined();
+  });
+
+  it('returns refinedQuery when LLM signals insufficient', async () => {
+    const state = makeState({
+      aiWorkerPool: {
+        processRequest: vi.fn().mockResolvedValue({
+          content: JSON.stringify({
+            score: 2,
+            sufficient: false,
+            refinedQuery: 'Vergleich Klimaziele SPD Grüne',
+          }),
+        }),
+      } as any,
+    });
+
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBe(2);
+    expect(result.searchQuery).toBe('Vergleich Klimaziele SPD Grüne');
+    expect(result.searchErrors).toBeUndefined();
+  });
+
+  it('returns qualityScore=0 (NOT 3) and records error on parse failure', async () => {
+    const state = makeState({
+      aiWorkerPool: {
+        processRequest: vi.fn().mockResolvedValue({ content: 'not json at all' }),
+      } as any,
+    });
+
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBe(0);
+    expect(result.searchErrors).toEqual([
+      { source: 'qualityGate', message: expect.stringContaining('could not be parsed') },
+    ]);
+  });
+
+  it('returns qualityScore=0 and records error on LLM rejection', async () => {
+    const state = makeState({
+      aiWorkerPool: {
+        processRequest: vi.fn().mockRejectedValue(new Error('worker pool down')),
+      } as any,
+    });
+
+    const result = await qualityGateNode(state);
+    expect(result.qualityScore).toBe(0);
+    expect(result.searchErrors).toEqual([
+      { source: 'qualityGate', message: 'worker pool down' },
+    ]);
+  });
+});

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -67,7 +67,7 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
     return item;
   });
 
-  const { rankedIndices, scores, rerankTimeMs } = await rerankPipeline({
+  const pipelineResult = await rerankPipeline({
     query: queryStr,
     items,
     inputLimit,
@@ -75,6 +75,7 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
     instruct,
     sourceTagFn: (item) => getSourceTag(item.source || ''),
   });
+  const { rankedIndices, scores, rerankTimeMs } = pipelineResult;
 
   const reranked = rankedIndices.flatMap((i) => {
     const candidate = candidates[i];
@@ -91,6 +92,18 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
   log.info(
     `[Rerank] Complete: ${candidates.length} → ${reranked.length} results (diversity applied) in ${rerankTimeMs}ms`
   );
+
+  if (pipelineResult.failed) {
+    log.error(`[Rerank] Cross-encoder failed; returning input order. error=${pipelineResult.error}`);
+    return {
+      searchResults: reranked,
+      rerankTimeMs,
+      rerankFailed: true,
+      searchErrors: [
+        { source: 'rerank', message: pipelineResult.error ?? 'rerank failed (unknown error)' },
+      ],
+    };
+  }
 
   return {
     searchResults: reranked,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.vitest.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../../config/vectorConfig.js', () => ({
+  vectorConfig: {
+    get: () => ({
+      inputLimit: 16,
+      outputLimit: 8,
+      minRelevance: 0.2,
+      mmrLambda: 0.7,
+      mmrKeepTop: 8,
+      webScoreCeiling: 0.65,
+      mergeOverfetch: 16,
+    }),
+  },
+}));
+
+const rerankPipelineMock = vi.fn();
+vi.mock('../../../../services/search/rerankPipeline.js', () => ({
+  rerankPipeline: (opts: unknown) => rerankPipelineMock(opts),
+  DEFAULT_RELEVANCE: 0.5,
+}));
+
+import { rerankNode } from './rerankNode.js';
+
+import type { ChatGraphState, SearchResult } from '../types.js';
+
+function makeResults(n: number): SearchResult[] {
+  return Array.from({ length: n }, (_, i) => ({
+    source: `gruenerator:test-${i}`,
+    title: `Result ${i}`,
+    content: `Content for result ${i}`,
+    relevance: 0.5 + i * 0.05,
+    url: `https://example.com/${i}`,
+  }));
+}
+
+function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
+  return {
+    searchResults: makeResults(6),
+    searchQuery: 'Klimapolitik',
+    hasTemporal: false,
+    researchBrief: null,
+    notebookCollectionIds: [],
+    ...overrides,
+  } as unknown as ChatGraphState;
+}
+
+describe('rerankNode', () => {
+  beforeEach(() => {
+    rerankPipelineMock.mockReset();
+  });
+
+  it('returns reranked results without rerankFailed flag on happy path', async () => {
+    rerankPipelineMock.mockResolvedValue({
+      rankedIndices: [0, 1, 2],
+      scores: new Map([
+        [0, 0.9],
+        [1, 0.8],
+        [2, 0.7],
+      ]),
+      rerankTimeMs: 12,
+    });
+
+    const state = makeState();
+    const result = await rerankNode(state);
+
+    expect(result.searchResults).toHaveLength(3);
+    expect(result.rerankFailed).toBeUndefined();
+    expect(result.searchErrors).toBeUndefined();
+  });
+
+  it('sets rerankFailed=true and records error when pipeline reports failure', async () => {
+    rerankPipelineMock.mockResolvedValue({
+      rankedIndices: [0, 1, 2, 3, 4, 5],
+      scores: new Map(),
+      rerankTimeMs: 5,
+      failed: true,
+      error: 'regolo cross-encoder unreachable',
+    });
+
+    const state = makeState();
+    const result = await rerankNode(state);
+
+    expect(result.searchResults).toHaveLength(6);
+    expect(result.rerankFailed).toBe(true);
+    expect(result.searchErrors).toEqual([
+      { source: 'rerank', message: 'regolo cross-encoder unreachable' },
+    ]);
+  });
+
+  it('skips reranking entirely when there are 2 or fewer results', async () => {
+    const state = makeState({ searchResults: makeResults(2) });
+    const result = await rerankNode(state);
+
+    expect(rerankPipelineMock).not.toHaveBeenCalled();
+    expect(result.searchResults).toBeUndefined();
+    expect(result.rerankFailed).toBeUndefined();
+  });
+});

--- a/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
@@ -200,8 +200,9 @@ async function formatSearchContext(state: ChatGraphState): Promise<string> {
         return `\n\n## RECHERCHE-ERGEBNISSE\n\n${cleaned}`;
       }
     } catch (error) {
-      log.warn(
-        `[Respond] Findings cleaning failed, falling back to budget truncation: ${error instanceof Error ? error.message : error}`
+      const errMsg = error instanceof Error ? error.message : String(error);
+      log.error(
+        `[Respond] Findings cleaning failed, falling back to budget truncation: ${errMsg}`
       );
     }
   }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -69,6 +69,12 @@ export function getSupplementaryCollectionsForLocale(locale: string | undefined)
  * Execute document search across collections (extracted from case 'search').
  * Searches all sub-queries across all specified collections in parallel.
  */
+export interface DocumentSearchParallelResult {
+  results: SearchResult[];
+  searchedCollections: string[];
+  errors: { source: string; message: string }[];
+}
+
 export async function executeDocumentSearchParallel(
   query: string,
   subQueries: string[] | null,
@@ -77,7 +83,7 @@ export async function executeDocumentSearchParallel(
   filters?: SubcategoryFilters | null,
   userLocale?: string,
   defaultNotebookCollectionIds?: string[]
-): Promise<{ results: SearchResult[]; searchedCollections: string[] }> {
+): Promise<DocumentSearchParallelResult> {
   let collectionsToSearch: string[];
   if (notebookCollectionIds && notebookCollectionIds.length > 0) {
     collectionsToSearch = notebookCollectionIds;
@@ -102,6 +108,7 @@ export async function executeDocumentSearchParallel(
   // (the collection's defaultFilter already handles this)
   const searchFilters = filters || undefined;
 
+  const collectedErrors: { source: string; message: string }[] = [];
   const searchPromises = uniqueCollections.flatMap((collection) =>
     queries.map((sq) => {
       const params: Parameters<typeof executeDirectSearch>[0] = {
@@ -113,9 +120,9 @@ export async function executeDocumentSearchParallel(
         params.filters = searchFilters;
       }
       return executeDirectSearch(params).catch((err: unknown) => {
-        log.warn(
-          `[Search] Collection ${collection} failed for query "${sq}": ${err instanceof Error ? err.message : String(err)}`
-        );
+        const msg = err instanceof Error ? err.message : String(err);
+        log.warn(`[Search] Collection ${collection} failed for query "${sq}": ${msg}`);
+        collectedErrors.push({ source: `documents:${collection}`, message: msg });
         return null;
       });
     })
@@ -148,16 +155,29 @@ export async function executeDocumentSearchParallel(
   }
 
   allResults.sort((a, b) => (b.relevance || 0) - (a.relevance || 0));
-  return { results: allResults.slice(0, 8), searchedCollections: uniqueCollections };
+  // Only surface errors when the source produced zero usable results.
+  // Partial failures (some collections OK, some failed) are already logged as warns.
+  const errors = allResults.length === 0 ? collectedErrors : [];
+  return {
+    results: allResults.slice(0, 8),
+    searchedCollections: uniqueCollections,
+    errors,
+  };
 }
 
 /**
  * Execute web search with query expansion and crawling (extracted from case 'web').
  */
+export interface WebSearchParallelResult {
+  results: SearchResult[];
+  errors: { source: string; message: string }[];
+}
+
 export async function executeWebSearchParallel(
   query: string,
   aiWorkerPool: AIWorkerPool
-): Promise<SearchResult[]> {
+): Promise<WebSearchParallelResult> {
+  const collectedErrors: { source: string; message: string }[] = [];
   let allWebQueries = [query];
   try {
     const expanded = await expandQuery(query, aiWorkerPool);
@@ -177,9 +197,9 @@ export async function executeWebSearchParallel(
       searchType: 'general',
       maxResults: 5,
     }).catch((err: unknown) => {
-      log.warn(
-        `[Search] Web search failed for variant "${q}": ${err instanceof Error ? err.message : String(err)}`
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`[Search] Web search failed for variant "${q}": ${msg}`);
+      collectedErrors.push({ source: 'web', message: msg });
       return null;
     })
   );
@@ -204,7 +224,9 @@ export async function executeWebSearchParallel(
   }
 
   allWebResults.sort((a, b) => (b.relevance || 0) - (a.relevance || 0));
-  return allWebResults.slice(0, 8);
+  // Only surface when zero usable results — partial variant failures are normal.
+  const errors = allWebResults.length === 0 ? collectedErrors : [];
+  return { results: allWebResults.slice(0, 8), errors };
 }
 
 /**
@@ -297,7 +319,12 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
       const query = truncateQuery(searchQuery || '');
       log.info(`[Search] Multi-source parallel search: ${searchSources.join(' + ')}`);
 
-      const sourcePromises: Promise<{ results: SearchResult[]; collections: string[] }>[] = [];
+      type SourceResult = {
+        results: SearchResult[];
+        collections: string[];
+        errors: { source: string; message: string }[];
+      };
+      const sourcePromises: Promise<SourceResult>[] = [];
 
       if (searchSources.includes('documents')) {
         sourcePromises.push(
@@ -310,12 +337,19 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
             state.userLocale,
             state.defaultNotebookCollectionIds
           )
-            .then((r) => ({ results: r.results, collections: r.searchedCollections }))
+            .then((r) => ({
+              results: r.results,
+              collections: r.searchedCollections,
+              errors: r.errors,
+            }))
             .catch((err) => {
-              log.warn(
-                `[Search] Document search failed in multi-source: ${err instanceof Error ? err.message : String(err)}`
-              );
-              return { results: [], collections: [] };
+              const msg = err instanceof Error ? err.message : String(err);
+              log.error(`[Search] Document search failed in multi-source: ${msg}`);
+              return {
+                results: [],
+                collections: [],
+                errors: [{ source: 'documents', message: msg }],
+              };
             })
         );
       }
@@ -323,12 +357,15 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
       if (searchSources.includes('web')) {
         sourcePromises.push(
           executeWebSearchParallel(query, state.aiWorkerPool)
-            .then((r) => ({ results: r, collections: ['web'] }))
+            .then((r) => ({ results: r.results, collections: ['web'], errors: r.errors }))
             .catch((err) => {
-              log.warn(
-                `[Search] Web search failed in multi-source: ${err instanceof Error ? err.message : String(err)}`
-              );
-              return { results: [], collections: [] };
+              const msg = err instanceof Error ? err.message : String(err);
+              log.error(`[Search] Web search failed in multi-source: ${msg}`);
+              return {
+                results: [],
+                collections: [],
+                errors: [{ source: 'web', message: msg }],
+              };
             })
         );
       }
@@ -353,12 +390,16 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
                 relevance: 0.8,
               })),
               collections: ['examples'],
+              errors: [] as { source: string; message: string }[],
             }))
             .catch((err: unknown) => {
-              log.warn(
-                `[Search] Examples search failed in multi-source: ${err instanceof Error ? (err as Error).message : String(err)}`
-              );
-              return { results: [], collections: [] };
+              const msg = err instanceof Error ? err.message : String(err);
+              log.error(`[Search] Examples search failed in multi-source: ${msg}`);
+              return {
+                results: [],
+                collections: [],
+                errors: [{ source: 'examples', message: msg }],
+              };
             })
         );
       }
@@ -366,6 +407,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
       const sourceResults = await Promise.all(sourcePromises);
       const allResults = sourceResults.map((s) => s.results);
       searchedCollections = sourceResults.flatMap((s) => s.collections);
+      const aggregatedErrors = sourceResults.flatMap((s) => s.errors);
 
       results = mergeSearchResults(...allResults);
 
@@ -389,9 +431,9 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
             log.info(`[Search] Crawled ${crawledCount} web results for full content`);
           }
         } catch (err: unknown) {
-          log.warn(
-            `[Search] Crawling failed in multi-source: ${err instanceof Error ? err.message : String(err)}`
-          );
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn(`[Search] Crawling failed in multi-source: ${msg}`);
+          aggregatedErrors.push({ source: 'crawl', message: msg });
         }
       }
 
@@ -400,7 +442,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
       const docCount = results.filter((r) => r.source !== 'web').length;
       const webCount = results.filter((r) => r.source === 'web').length;
       log.info(
-        `[Search] Multi-source complete: ${results.length} results (${docCount} docs, ${webCount} web) in ${Date.now() - startTime}ms`
+        `[Search] Multi-source complete: ${results.length} results (${docCount} docs, ${webCount} web), ${aggregatedErrors.length} errors in ${Date.now() - startTime}ms`
       );
 
       return {
@@ -409,6 +451,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         searchCount: 1,
         searchTimeMs: Date.now() - startTime,
         searchedCollections,
+        ...(aggregatedErrors.length > 0 && { searchErrors: aggregatedErrors }),
       };
     }
 
@@ -424,20 +467,14 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         };
         const { depth, maxSources } = depthConfig[complexity];
 
-        // The brief is a natural-language research plan written for the LLM
-        // synthesis step — it must NOT be used as a search-engine query.
-        // Pass the raw user query to the searcher and forward the brief
-        // separately as synthesis context.
-        const question = searchQuery || '';
-        const brief = state.researchBrief;
+        // Use research brief (compressed intent) when available, fall back to raw query
+        const question = state.researchBrief || searchQuery || '';
         log.info(
-          `[Search] Research depth: ${depth}, maxSources: ${maxSources} (complexity: ${complexity}, brief: ${!!brief})`
+          `[Search] Research depth: ${depth}, maxSources: ${maxSources} (complexity: ${complexity}, brief: ${!!state.researchBrief})`
         );
 
         const researchResult = await executeResearch({
           question,
-          brief,
-          aiWorkerPool: state.aiWorkerPool,
           depth,
           maxSources,
         });
@@ -835,17 +872,16 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
       ...(searchedCollections.length > 0 && { searchedCollections }),
     };
   } catch (error: unknown) {
-    log.error(
-      `[Search] Error during ${intent} search:`,
-      error instanceof Error ? error.message : String(error)
-    );
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log.error(`[Search] Error during ${intent} search:`, errMsg);
 
     return {
       searchResults: [],
       citations: [],
       searchCount: 1,
       searchTimeMs: Date.now() - startTime,
-      error: `Search failed: ${error instanceof Error ? error.message : String(error)}`,
+      error: `Search failed: ${errMsg}`,
+      searchErrors: [{ source: 'search', message: errMsg }],
     };
   }
 }

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -272,6 +272,11 @@ export interface ChatGraphState {
   qualityScore: number;
   qualityAssessmentTimeMs: number;
 
+  // Reliability flags & structured error log
+  searchErrors: { source: string; message: string }[];
+  briefGenerationFailed: boolean;
+  rerankFailed: boolean;
+
   // Image generation
   imagePrompt: string | null;
   imageStyle: ImageStyle | null;

--- a/apps/api/agents/langgraph/SearchGraph/nodes/searchExecutorNode.ts
+++ b/apps/api/agents/langgraph/SearchGraph/nodes/searchExecutorNode.ts
@@ -113,7 +113,7 @@ export async function searchExecutorNode(
   if (state.searchSources.includes('web')) {
     searchPromises.push(
       executeWebSearchParallel(searchQuery, aiWorkerPool)
-        .then((results) => ({ source: 'web', results }))
+        .then(({ results }) => ({ source: 'web', results }))
         .catch((err: unknown) => {
           log.warn(
             `[SearchExecutor] Web search failed: ${err instanceof Error ? err.message : err}`

--- a/apps/api/services/search/rerankPipeline.ts
+++ b/apps/api/services/search/rerankPipeline.ts
@@ -41,6 +41,10 @@ export interface RerankPipelineResult {
   rankedIndices: number[];
   scores: Map<number, number>;
   rerankTimeMs: number;
+  /** True when the cross-encoder call failed and we returned the items in original order. */
+  failed?: boolean;
+  /** Error message captured when failed=true; undefined on success. */
+  error?: string;
 }
 
 const SKIP_THRESHOLD = 2;
@@ -142,11 +146,14 @@ export async function rerankPipeline(
       rerankTimeMs,
     };
   } catch (error: unknown) {
-    log.error('Rerank error:', error instanceof Error ? error.message : String(error));
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log.error('Rerank error:', errMsg);
     return {
       rankedIndices: candidates.map((_, i) => i).slice(0, outputLimit),
       scores: new Map(candidates.map((item, i) => [i, item.relevance ?? DEFAULT_RELEVANCE])),
       rerankTimeMs: Date.now() - startTime,
+      failed: true,
+      error: errMsg,
     };
   }
 }


### PR DESCRIPTION
## Summary

The recherche path in the ChatGraph (classifier → briefGenerator → search → rerank → qualityGate → respond, with optional qualityGate→search loop) had ~10 silent failure surfaces that were leaving users with empty or low-quality answers and no signal in logs to explain why. The architecture was sound — reducers, retry bounds, and graph topology were already correct — but errors were being swallowed.

This PR makes those failures observable in state and logs without changing the graph topology, retry budget, or reducer shape for `searchResults` / `citations`.

## What changed

- **State plumbing**: new fields on `ChatStateAnnotation` and `ChatGraphState` — `searchErrors[]` (append reducer; persists across the qualityGate→search loop), `briefGenerationFailed`, `rerankFailed`.
- **Wrong-default fix**: `qualityGateNode` parse-failure default flipped from `qualityScore=3` (which is exactly the loop threshold — the worst possible default, "good enough" pretense) → `qualityScore=0` ("unassessed"), with the failure recorded in `searchErrors`.
- **Per-source error tracking** in `searchNode` aggregators (`executeDocumentSearchParallel`, `executeWebSearchParallel`, examples block, crawling): when a source produces zero usable results, surface the error in state. Partial failures stay as `log.warn` since they're noisy and the user still got results.
- **Brief / rerank failure flags**: `briefGeneratorNode` flags itself + records error on empty/error LLM response (was silently returning `{}`); `rerankPipeline` returns a `failed` flag on Regolo errors and `rerankNode` forwards as `rerankFailed: true`.
- **Reliability summary log** at end of `runChatGraph` — single conditional `log.warn` that fires only when something went wrong, so the happy path stays quiet but a failure produces one greppable line with all the diagnostic fields.
- **Signature ripple**: `executeWebSearchParallel` return changed `SearchResult[]` → `{ results, errors }`; the only external caller (`SearchGraph/searchExecutorNode.ts`) updated to destructure `.results`.

## What did NOT change

- Reducer shape for `searchResults` / `citations` (replace, not append) — already correct.
- Retry budgets (`maxSearches=2`, web retry=1, filter fallback=1) — already bounded.
- Graph topology / routing.

## Test plan

- [x] `qualityGateNode.vitest.ts` (new) — parse-failure → score=0; LLM-error → score=0; happy paths.
- [x] `rerankNode.vitest.ts` (new) — `rerankFailed` flag wiring; skip path when results ≤ 2.
- [x] `briefGeneratorNode.vitest.ts` (extend) — empty/error responses now assert `briefGenerationFailed: true` + `searchErrors` instead of `{}`.
- [x] All 20 tests pass locally (`pnpm --filter @gruenerator/api exec vitest run agents/langgraph/ChatGraph/nodes/qualityGateNode.vitest.ts agents/langgraph/ChatGraph/nodes/rerankNode.vitest.ts agents/langgraph/ChatGraph/nodes/briefGeneratorNode.vitest.ts`).
- [ ] Manual end-to-end: send a recherche prompt with `pnpm dev:backend` running; confirm the new reliability log line fires when a source fails and stays quiet on the happy path.
- [ ] Existing `intentPipeline.vitest.ts` / `compoundPipeline.vitest.ts` / `classifierNode.vitest.ts` / `ragQualityEval.test.ts` still pass (CI).

## Future work (out of scope)

A planned Commit 3 from the design doc adds honest-failure prose in `respondNode.buildSystemMessage` when `searchResults.length === 0 && searchErrors.length > 0` (the model would then say "I couldn't reach X" instead of pretending). Held back from this PR to keep it focused on observability — once the state plumbing here is merged, that's a small additive follow-up.