### PR TITLE
feat(ai): replace Mistral Large 3 with Mistral Medium 3.5

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/llmConfig.ts
+++ b/apps/api/agents/langgraph/ChatGraph/llmConfig.ts
@@ -25,9 +25,10 @@ export interface AgentLLMConfig {
  */
 const MODEL_MAP: Record<string, string> = {
   // 'mistral' is intentionally absent — it uses agent defaults (like 'auto')
-  // Legacy IDs kept for backward compatibility
-  'mistral-large': 'mistral-large-latest',
-  'mistral-medium': 'mistral-medium-latest',
+  'mistral-medium-3.5': 'mistral-medium-2604',
+  // Legacy IDs kept for backward compatibility — repointed to current Medium 3.5
+  'mistral-large': 'mistral-medium-2604',
+  'mistral-medium': 'mistral-medium-2604',
   'pixtral-large': 'pixtral-large-latest',
 };
 

--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -49,9 +49,15 @@ export interface ModelConfig {
 
 export const AVAILABLE_MODELS: Record<string, ModelConfig> = {
   // 'mistral' is intentionally absent — it uses agent defaults (like 'auto')
-  // Legacy IDs kept for backward compatibility (old stored client preferences)
-  'mistral-large': { provider: 'mistral', model: 'mistral-large-latest', contextWindow: 128000 },
-  'mistral-medium': { provider: 'mistral', model: 'mistral-medium-latest', contextWindow: 128000 },
+  'mistral-medium-3.5': {
+    provider: 'mistral',
+    model: 'mistral-medium-2604',
+    contextWindow: 128000,
+    fallback: 'gemma-litellm',
+  },
+  // Legacy IDs — repointed to current Mistral generation (Medium 3.5)
+  'mistral-large': { provider: 'mistral', model: 'mistral-medium-2604', contextWindow: 128000 },
+  'mistral-medium': { provider: 'mistral', model: 'mistral-medium-2604', contextWindow: 128000 },
   'pixtral-large': { provider: 'mistral', model: 'pixtral-large-latest', contextWindow: 128000 },
   litellm: {
     provider: 'litellm',

--- a/apps/api/routes/docs/aiController.ts
+++ b/apps/api/routes/docs/aiController.ts
@@ -74,8 +74,8 @@ interface AIRequestBody {
 const DOCS_AI_MODELS: Record<AgentConfig['provider'], string> = {
   litellm: 'gpt-oss:120b',
   regolo: 'mistral-small-4-119b',
-  mistral: 'mistral-large-latest',
-  anthropic: 'mistral-large-latest',
+  mistral: 'mistral-medium-2604',
+  anthropic: 'mistral-medium-2604',
 };
 
 /**
@@ -101,8 +101,7 @@ export async function handleAiRequest(req: RateLimitRequest, res: Response) {
 
     log.info(`[DocsAI] Tool definitions received: ${Object.keys(toolDefinitions).join(', ')}`);
 
-    // Order: mistral first (mistral-large-latest — gold standard, the model
-    // BlockNote's xl-ai prompts were authored against), then regolo
+    // Order: mistral first (mistral-medium-2604 / Medium 3.5), then regolo
     // (mistral-small-4-119b), litellm last (gpt-oss).
     const providerChain: AgentConfig['provider'][] = ['mistral', 'regolo', 'litellm'];
     const provider = providerChain.find((p) => isProviderConfigured(p));

--- a/apps/api/routes/docs/aiController.vitest.ts
+++ b/apps/api/routes/docs/aiController.vitest.ts
@@ -242,7 +242,7 @@ describe('aiController – POST /api/docs/ai', () => {
 
       await handleAiRequest(req, res);
 
-      expect(mockGetModel).toHaveBeenCalledWith('mistral', 'mistral-large-latest');
+      expect(mockGetModel).toHaveBeenCalledWith('mistral', 'mistral-medium-2604');
     });
 
     it('falls back to regolo when mistral is not configured', async () => {

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -30,6 +30,8 @@ interface OpenAIModelsResponse {
 }
 
 const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision: boolean }> = {
+  'mistral-medium-2604': { name: 'Mistral Medium 3.5', reasoning: false, vision: false },
+  'mistral-medium-3.5': { name: 'Mistral Medium 3.5', reasoning: false, vision: false },
   'mistral-large-2512': { name: 'Mistral Large', reasoning: false, vision: false },
   'mistral-large-latest': { name: 'Mistral Large', reasoning: false, vision: false },
   'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
@@ -175,7 +177,7 @@ function fetchModelsForProvider(provider: ProviderName): Promise<PlaygroundModel
   return fetchProviderModels(provider, endpoint.url(), endpoint.getApiKey());
 }
 
-const FALLBACK_MODELS: PlaygroundModel[] = ['mistral-large-2512', 'mistral-small-latest']
+const FALLBACK_MODELS: PlaygroundModel[] = ['mistral-medium-2604', 'mistral-small-latest']
   .map((id) => enrichModel(id, 'mistral'))
   .concat(
     [

--- a/apps/api/services/ai/providers.ts
+++ b/apps/api/services/ai/providers.ts
@@ -22,7 +22,7 @@ export type ProviderName = 'mistral' | 'litellm' | 'ionos' | 'regolo';
 
 // Default models per provider
 const PROVIDER_DEFAULTS = {
-  mistral: 'mistral-large-2512',
+  mistral: 'mistral-medium-2604',
   litellm: 'gpt-oss:120b',
   ionos: 'openai/gpt-oss-120b',
   regolo: env.REGOLO_DEFAULT_MODEL ?? 'qwen3.5-122b',

--- a/apps/api/services/aiSearchAgent.ts
+++ b/apps/api/services/aiSearchAgent.ts
@@ -390,7 +390,7 @@ class AISearchAgent {
             },
           ],
           options: {
-            model: 'mistral-large-2512',
+            model: 'mistral-medium-2604',
             max_tokens: 1000,
             temperature: 0.3,
             provider: 'mistral',

--- a/apps/api/services/mistral/MistralWebSearchService/MistralWebSearchService.ts
+++ b/apps/api/services/mistral/MistralWebSearchService/MistralWebSearchService.ts
@@ -50,7 +50,7 @@ export class MistralWebSearchService {
       console.log(`[MistralWebSearchService] Creating ${config.name}`);
 
       const agent = await this.client!.beta.agents.create({
-        model: 'mistral-large-2512',
+        model: 'mistral-medium-2604',
         name: config.name,
         instructions: config.instructions,
         description: config.description,

--- a/apps/api/services/providers/providerFallback.ts
+++ b/apps/api/services/providers/providerFallback.ts
@@ -41,7 +41,7 @@ export function getPrivacyModelForProvider(provider: ProviderName): ModelName {
     case 'litellm':
       return 'gpt-oss:120b';
     case 'mistral':
-      return 'mistral-large-2512';
+      return 'mistral-medium-2604';
     case 'regolo':
       return env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b';
     default:
@@ -55,7 +55,7 @@ export function getPrivacyModelForProvider(provider: ProviderName): ModelName {
 export function getSharepicFallbackModel(provider: ProviderName): ModelName {
   switch (provider) {
     case 'mistral':
-      return 'mistral-large-2512';
+      return 'mistral-medium-2604';
     case 'ionos':
       return 'openai/gpt-oss-120b';
     case 'litellm':
@@ -63,7 +63,7 @@ export function getSharepicFallbackModel(provider: ProviderName): ModelName {
     case 'regolo':
       return env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b';
     default:
-      return 'mistral-large-2512';
+      return 'mistral-medium-2604';
   }
 }
 

--- a/apps/api/services/providers/providerSelector.ts
+++ b/apps/api/services/providers/providerSelector.ts
@@ -19,7 +19,7 @@ import type {
 export function isLiteLLMCompatibleModel(modelName: string = ''): boolean {
   const name = String(modelName || '').toLowerCase();
   // LiteLLM models typically use prefixes like gpt-oss, or are mistral/mixtral variants
-  // Exclude Mistral API models (mistral-large-2512, etc.)
+  // Exclude Mistral API models (mistral-medium-2604, etc.)
   if (name.includes('gpt-oss') || name.includes('gpt-4') || name.includes('gpt-3')) {
     return true;
   }
@@ -113,12 +113,12 @@ export function selectProviderAndModel({
   // Notebook enrichment - fast model
   if (type === 'notebook_enrich') {
     provider = 'mistral';
-    model = options.model || 'mistral-large-2512';
+    model = options.model || 'mistral-medium-2604';
   }
   // Fast mode QA draft - fast model
   else if (type === 'qa_draft_fast') {
     provider = 'mistral';
-    model = options.model || 'mistral-large-2512';
+    model = options.model || 'mistral-medium-2604';
   }
   // QA draft (final answer) — GPT-OSS with reasoning
   else if (type === 'qa_draft') {
@@ -128,7 +128,7 @@ export function selectProviderAndModel({
   // QA intermediate steps (planner, repair, tools) — fast model
   else if (type === 'qa_tools' || type === 'qa_planner' || type === 'qa_repair') {
     provider = 'mistral';
-    model = options.model || 'mistral-large-2512';
+    model = options.model || 'mistral-medium-2604';
   }
   // Legislative documents — GPT-OSS (reasoning handled via reasoningEffort)
   else if (

--- a/apps/api/workers/providers/mistralAdapter.ts
+++ b/apps/api/workers/providers/mistralAdapter.ts
@@ -236,7 +236,7 @@ async function execute(requestId: string, data: AIRequestData): Promise<AIWorker
     );
   }
 
-  const model = options.model || 'mistral-large-2512';
+  const model = options.model || 'mistral-medium-2604';
   const platforms = (requestMetadata as { platforms?: string[] }).platforms;
 
   // Get content-type specific configuration

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -31,6 +31,7 @@ interface TriggerCompactionResponse {
 export type Provider = 'mistral' | 'litellm' | 'regolo';
 
 export type ModelId =
+  | 'mistral-medium-3.5'
   | 'gpt-oss-regolo'
   | 'litellm'
   | 'gemma-litellm'
@@ -56,6 +57,14 @@ const QWEN_WARNING =
   'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.';
 
 export const MODEL_OPTIONS: ModelOption[] = [
+  {
+    id: 'mistral-medium-3.5',
+    name: 'Mistral Medium 3.5',
+    description: 'Aktuelles Mistral-Modell (EU), stark bei Texten',
+    model: 'mistral-medium-2604',
+    provider: 'mistral',
+    icon: 'sparkles',
+  },
   {
     id: 'gemma-litellm',
     name: 'Gemma 4',
@@ -369,7 +378,7 @@ export const useAgentStore = create<AgentState>()(
           removeItem: (key: string) => mem.delete(key),
         };
       }),
-      version: 6,
+      version: 7,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -422,6 +431,21 @@ export const useAgentStore = create<AgentState>()(
             'qwen3.6-regolo': 'regolo',
           };
           state.selectedProvider = providerByModel[state.selectedModel as string] ?? 'litellm';
+        }
+        if (version < 7) {
+          // Mistral Medium 3.5 added as selectable option. Existing valid IDs stay.
+          const validIds = new Set([
+            'mistral-medium-3.5',
+            'gpt-oss-regolo',
+            'litellm',
+            'gemma-litellm',
+            'qwen-regolo',
+            'qwen3.6-regolo',
+          ]);
+          if (!validIds.has(state.selectedModel as string)) {
+            state.selectedModel = 'gemma-litellm';
+            state.selectedProvider = 'litellm';
+          }
         }
         return state;
       },


### PR DESCRIPTION
## Summary
- Switch every Mistral default from `mistral-large-2512` / `mistral-large-latest` to `mistral-medium-2604` (Mistral Medium 3.5) across the API, worker pool, web search service, fallback chains, ChatGraph LLM config, and the BlockNote/xl-ai docs editor (`aiController.ts`).
- Pin to the explicit dated ID — `mistral-medium-latest` still resolves to `mistral-medium-2508` (Medium 3.x), so the alias would *not* deliver 3.5. Verified against `https://api.mistral.ai/v1/models`.
- Expose **Mistral Medium 3.5** as a user-selectable model in the chat / chatgraph picker:
  - new `'mistral-medium-3.5'` entry in `MODEL_OPTIONS` (chatStore) and `AVAILABLE_MODELS` (chat agents/providers)
  - bumped persisted-state version 6 → 7 with migration that keeps existing valid IDs and falls back to `gemma-litellm` for anything unknown
  - added metadata entry in `modelDiscovery.ts` (display name "Mistral Medium 3.5")
- Legacy aliases (`'mistral-large'`, `'mistral-medium'`) are repointed to `mistral-medium-2604` so any persisted client preferences keep working.

## Test plan
- [ ] Verify chat picker shows "Mistral Medium 3.5" as the first option and it can be selected.
- [ ] Send a message via chat with Mistral Medium 3.5 selected — expect a normal response routed through the Mistral provider.
- [ ] Use the docs AI editor (BlockNote `applyDocumentOperations`) — expect tool calls handled via `mistral-medium-2604` when the Mistral provider is configured.
- [ ] Confirm `apps/api/routes/docs/aiController.vitest.ts` passes (assertion now expects `'mistral-medium-2604'`).
- [ ] Hit a fallback path (e.g. trigger sharepic generation) and confirm it routes to Medium 3.5 on the Mistral branch.
- [ ] Reload an existing user session — chatStore migration v7 should leave valid IDs intact.

## Notes
- Pre-existing TypeScript errors in `apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts` and `ragQualityEval.test.ts` are unrelated state-shape drift on master (these are `*.test.ts` standalone scripts, not CI tests).