### PR TITLE
feat(docs): collaborative AI chat panel for documents

### DIFF
--- a/apps/api/database/postgres/migrations/add_chat_threads_doc_id.sql
+++ b/apps/api/database/postgres/migrations/add_chat_threads_doc_id.sql
@@ -1,0 +1,14 @@
+-- Link a chat_threads row to a collaborative_documents row so the docs editor
+-- can resolve "which thread belongs to this doc?" deterministically. One thread
+-- per doc, shared across users via the existing permissions JSONB. NULL for
+-- regular (non-doc) threads, hence the partial unique index.
+
+ALTER TABLE chat_threads ADD COLUMN IF NOT EXISTS doc_id UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_chat_threads_doc_id
+  ON chat_threads(doc_id)
+  WHERE doc_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_chat_threads_doc_id
+  ON chat_threads(doc_id)
+  WHERE doc_id IS NOT NULL;

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -104,6 +104,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         textIds: rawTextIds,
         documentChatIds: rawDocumentChatIds,
         documentChatMode,
+        attachmentContext: rawClientAttachmentContext,
         defaultNotebookId: rawDefaultNotebookId,
         boardIds: rawBoardIds,
         docMentionIds: rawDocMentionIds,
@@ -210,10 +211,20 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       }
 
       // === Process attachments ===
-      const { attachmentContext, imageAttachments, processedMeta } = await processAttachments(
-        attachments as ProcessedAttachment[] | undefined,
-        requestId
-      );
+      const {
+        attachmentContext: derivedAttachmentContext,
+        imageAttachments,
+        processedMeta,
+      } = await processAttachments(attachments as ProcessedAttachment[] | undefined, requestId);
+
+      // Merge any client-injected context (e.g. docs editor markdown + selection)
+      // with what processAttachments derived from uploaded files.
+      const clientAttachmentContext =
+        (rawClientAttachmentContext as string | null | undefined)?.trim() || undefined;
+      const attachmentContext =
+        clientAttachmentContext && derivedAttachmentContext
+          ? `${clientAttachmentContext}\n\n---\n\n${derivedAttachmentContext}`
+          : clientAttachmentContext || derivedAttachmentContext;
 
       const docAttachments =
         (attachments as ProcessedAttachment[] | undefined)?.filter((a) => !a.isImage) ?? [];

--- a/apps/api/routes/chat/chatGraphController.ts
+++ b/apps/api/routes/chat/chatGraphController.ts
@@ -98,6 +98,7 @@ const chatStreamSchema = z.object({
   textIds: z.array(z.string()).nullish(),
   documentChatIds: z.array(z.string()).nullish(),
   documentChatMode: z.boolean().nullish(),
+  attachmentContext: z.string().nullish(),
   defaultNotebookId: z.string().nullish(),
   boardIds: z.array(z.string()).nullish(),
   docMentionIds: z.array(z.string()).nullish(),
@@ -118,6 +119,7 @@ type ChatStreamBody = {
   textIds?: string[];
   documentChatIds?: string[];
   documentChatMode?: boolean;
+  attachmentContext?: string;
   defaultNotebookId?: string;
   boardIds?: string[];
   docMentionIds?: string[];
@@ -165,6 +167,7 @@ router.post(
         textIds: rawTextIds,
         documentChatIds: rawDocumentChatIds,
         documentChatMode,
+        attachmentContext: rawClientAttachmentContext,
         defaultNotebookId: rawDefaultNotebookId,
         boardIds: rawBoardIds,
         docMentionIds: rawDocMentionIds,
@@ -269,10 +272,20 @@ router.post(
       }
 
       // === Process attachments ===
-      const { attachmentContext, imageAttachments, processedMeta } = await processAttachments(
-        attachments,
-        requestId
-      );
+      const {
+        attachmentContext: derivedAttachmentContext,
+        imageAttachments,
+        processedMeta,
+      } = await processAttachments(attachments, requestId);
+
+      // Merge any client-injected context (e.g. docs editor markdown + selection)
+      // with what processAttachments derived from uploaded files. Both can be
+      // present; concatenate with a separator so neither is lost.
+      const clientAttachmentContext = rawClientAttachmentContext?.trim() || undefined;
+      const attachmentContext =
+        clientAttachmentContext && derivedAttachmentContext
+          ? `${clientAttachmentContext}\n\n---\n\n${derivedAttachmentContext}`
+          : clientAttachmentContext || derivedAttachmentContext;
 
       const docAttachments = attachments?.filter((a) => !a.isImage) ?? [];
 

--- a/apps/api/routes/chat/services/threadPersistenceService.ts
+++ b/apps/api/routes/chat/services/threadPersistenceService.ts
@@ -61,6 +61,30 @@ export async function createThread(
 }
 
 /**
+ * Ensure a chat thread exists for the given collaborative document. Idempotent —
+ * one thread per doc, shared across all collaborators (real-time sharing rides
+ * the existing thread permissions/collab layer). The first user to open the doc
+ * becomes user_id; downstream access checks should consult both user_id and
+ * the doc's permissions.
+ */
+export async function ensureDocChatThread(
+  docId: string,
+  userId: string,
+  agentId: string = 'gruenerator-universal'
+): Promise<{ id: string }> {
+  const postgres = getPostgresInstance();
+  const result = (await postgres.query(
+    `INSERT INTO chat_threads (user_id, agent_id, title, thread_type, doc_id)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (doc_id) WHERE doc_id IS NOT NULL
+     DO UPDATE SET updated_at = CURRENT_TIMESTAMP
+     RETURNING id`,
+    [userId, agentId, 'Dokument-Chat', 'chat', docId]
+  )) as { id: string }[];
+  return result[0];
+}
+
+/**
  * Save a message to the thread.
  */
 export async function createMessage(

--- a/apps/api/routes/docs/docChatThreadController.ts
+++ b/apps/api/routes/docs/docChatThreadController.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolves the shared chat thread for a collaborative document. One thread per
+ * doc, shared across all collaborators. The thread row carries doc_id (added by
+ * migration add_chat_threads_doc_id) so this endpoint is idempotent — calling it
+ * repeatedly always returns the same thread UUID.
+ */
+
+import { Router, type Response } from 'express';
+
+import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+import { type AuthRequest } from '../auth/types.js';
+import { ensureDocChatThread } from '../chat/services/threadPersistenceService.js';
+
+import { checkDocumentAccess } from './documentAccess.js';
+import { type CollaborativeDocument } from './types.js';
+
+const router = Router();
+
+router.get('/:docId/chat-thread', async (req: AuthRequest, res: Response) => {
+  const userId = req.user?.id;
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const docIdParam = req.params.docId;
+  const docId = Array.isArray(docIdParam) ? docIdParam[0] : docIdParam;
+  if (!docId) {
+    res.status(400).json({ error: 'Missing docId' });
+    return;
+  }
+
+  const db = getPostgresInstance();
+  const docs = (await db.query(
+    `SELECT id, created_by, permissions, is_public, share_mode FROM collaborative_documents WHERE id = $1 LIMIT 1`,
+    [docId]
+  )) as CollaborativeDocument[];
+  const doc = docs[0];
+  if (!doc) {
+    res.status(404).json({ error: 'Document not found' });
+    return;
+  }
+
+  const access = await checkDocumentAccess(doc, userId);
+  if (!access.hasAccess) {
+    res.status(403).json({ error: 'No access to document' });
+    return;
+  }
+
+  const thread = await ensureDocChatThread(docId, doc.created_by);
+  res.json({ threadId: thread.id });
+});
+
+export default router;

--- a/apps/api/routes/docs/index.ts
+++ b/apps/api/routes/docs/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 
 import aiController from './aiController.js';
+import docChatThreadController from './docChatThreadController.js';
 import documentController from './documentController.js';
 import exportController from './exportController.js';
 import exportToDocsController from './exportToDocsController.js';
@@ -22,6 +23,7 @@ router.use('/', exportToDocsController);
 router.use('/', importController);
 router.use('/', snapshotController);
 router.use('/', aiController);
+router.use('/', docChatThreadController);
 router.use('/', documentController);
 
 export default router;

--- a/apps/web/src/features/docs/DocsAssistantChat.tsx
+++ b/apps/web/src/features/docs/DocsAssistantChat.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import {
+  AssistantRuntimeProvider,
+  AuiProvider,
+  useAui,
+  useLocalRuntime,
+} from '@assistant-ui/react';
+import {
+  ChatCollaborationProvider,
+  GrueneratorAttachmentAdapter,
+  GrueneratorThread,
+  convertToThreadMessageLike,
+  createGrueneratorModelAdapter,
+  useChatCollaboration,
+  useChatConfigStore,
+  useDocumentChatStore,
+  type ChatRequestContext,
+  type GrueneratorAdapterConfig,
+} from '@gruenerator/chat';
+import { useEditorStore } from '@gruenerator/docs';
+import { useQuery } from '@tanstack/react-query';
+import { type ReactNode, useEffect, useMemo, useRef } from 'react';
+
+interface DocsAssistantChatProps {
+  documentId: string;
+  userId: string | null;
+  userName: string | null;
+}
+
+interface ChatThreadResponse {
+  threadId: string;
+}
+
+/**
+ * Resets the AUI context so useLocalRuntime creates a standalone runtime
+ * instead of detecting the parent GlobalChatProvider's runtime. Without this,
+ * AUI nests and our doc-thread runtime would conflict with the global one.
+ * Mirrors NotebookChatProvider's NotebookAuiReset.
+ */
+function DocsAuiReset({ children }: { children: ReactNode }) {
+  const freshAui = useAui({}, { parent: null });
+  return <AuiProvider value={freshAui}>{children}</AuiProvider>;
+}
+
+export function DocsAssistantChat({ documentId, userId, userName }: DocsAssistantChatProps) {
+  if (!userId) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-foreground-muted">
+        Bitte melde dich an, um den KI-Assistenten zu nutzen.
+      </div>
+    );
+  }
+
+  return (
+    <DocsAuiReset>
+      <DocsAssistantChatInner documentId={documentId} userId={userId} userName={userName} />
+    </DocsAuiReset>
+  );
+}
+
+function DocsAssistantChatInner({
+  documentId,
+  userId,
+  userName,
+}: {
+  documentId: string;
+  userId: string;
+  userName: string | null;
+}) {
+  const fetchFn = useChatConfigStore((s) => s.fetch);
+
+  const { data: threadResp } = useQuery<ChatThreadResponse>({
+    queryKey: ['docs', documentId, 'chat-thread'],
+    queryFn: async () => {
+      const res = await fetchFn(`/api/docs/${documentId}/chat-thread`);
+      if (!res.ok) throw new Error(`Chat thread lookup failed: ${res.status}`);
+      return (await res.json()) as ChatThreadResponse;
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const threadId = threadResp?.threadId ?? null;
+
+  if (!threadId) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-foreground-muted">
+        Lade Chat...
+      </div>
+    );
+  }
+
+  return (
+    <DocsAssistantThreadShell
+      key={threadId}
+      threadId={threadId}
+      documentId={documentId}
+      userId={userId}
+      userName={userName}
+    />
+  );
+}
+
+interface LoadedMessageShape {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+function DocsAssistantThreadShell({
+  threadId,
+  documentId,
+  userId,
+  userName,
+}: {
+  threadId: string;
+  documentId: string;
+  userId: string;
+  userName: string | null;
+}) {
+  const fetchFn = useChatConfigStore((s) => s.fetch);
+  const endpoints = useChatConfigStore((s) => s.endpoints);
+  const registerContextProvider = useChatConfigStore((s) => s.registerContextProvider);
+  const addDocToThread = useDocumentChatStore((s) => s.addToThread);
+
+  // Load existing messages once (fresh runtime is created with these as
+  // initial state). Reloads on hard refresh; live multi-user sync is not
+  // wired in v1 — see plan file's "Risks & gotchas".
+  const { data: initialMessages, isLoading: messagesLoading } = useQuery({
+    queryKey: ['chat-thread-messages', threadId],
+    queryFn: async () => {
+      const res = await fetchFn(`${endpoints.messages}?threadId=${threadId}`);
+      if (!res.ok) return [];
+      const raw = (await res.json()) as LoadedMessageShape[];
+      // convertToThreadMessageLike expects the package's LoadedMessage shape;
+      // the wire format matches structurally (id/role/content/metadata).
+      return convertToThreadMessageLike(
+        raw as unknown as Parameters<typeof convertToThreadMessageLike>[0]
+      );
+    },
+    staleTime: 30_000,
+  });
+
+  // Bind the doc to this thread so the model adapter automatically forwards
+  // documentChatIds on every send (see GrueneratorModelAdapter line ~915).
+  useEffect(() => {
+    addDocToThread(threadId, documentId);
+  }, [threadId, documentId, addDocToThread]);
+
+  // Per-thread context registry: feed the editor's current markdown + selected
+  // text into every outgoing request as attachmentContext. Read at request
+  // time so edits made between sends are reflected.
+  useEffect(() => {
+    const provider = (): ChatRequestContext => {
+      const editor = useEditorStore.getState().getEditor(documentId);
+      if (!editor) return {};
+      const markdown = editor.blocksToMarkdownLossy(editor.document);
+      const selection = editor.getSelectedText() || undefined;
+      return {
+        documentChatIds: [documentId],
+        attachmentContext: markdown,
+        selectionText: selection,
+      };
+    };
+    return registerContextProvider(threadId, provider);
+  }, [threadId, documentId, registerContextProvider]);
+
+  // Keep the adapter stable across renders. Without ref-stabilized config the
+  // runtime gets recreated on every prop churn and resets streaming state.
+  const threadIdRef = useRef(threadId);
+  threadIdRef.current = threadId;
+
+  const getConfig = useMemo<() => GrueneratorAdapterConfig>(
+    () => () => ({
+      agentId: 'gruenerator-universal',
+      modelId: 'gemma-litellm',
+      enabledTools: { search: true, web: true, examples: true, research: true },
+      threadId: threadIdRef.current,
+      threadMode: 'chat',
+    }),
+    []
+  );
+
+  const adapter = useMemo(() => createGrueneratorModelAdapter(getConfig, {}), [getConfig]);
+  const attachmentAdapter = useMemo(() => new GrueneratorAttachmentAdapter(), []);
+
+  const runtime = useLocalRuntime(adapter, {
+    initialMessages: initialMessages ?? [],
+    adapters: { attachments: attachmentAdapter },
+  });
+
+  // Presence + typing indicators across users on the same doc thread.
+  const collabUser = useMemo(() => ({ id: userId, name: userName ?? userId }), [userId, userName]);
+  const collab = useChatCollaboration(threadId, collabUser);
+
+  if (messagesLoading) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-foreground-muted">
+        Lade Verlauf...
+      </div>
+    );
+  }
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ChatCollaborationProvider value={collab}>
+        <GrueneratorThread firstName={userName ?? null} />
+      </ChatCollaborationProvider>
+    </AssistantRuntimeProvider>
+  );
+}

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -45,6 +45,9 @@ const ShareModal = lazyWithRetry(() =>
 const ChatSidebar = lazyWithRetry(() =>
   import('@gruenerator/docs').then((m) => ({ default: m.ChatSidebar }))
 );
+const DocsAssistantChat = lazyWithRetry(() =>
+  import('./DocsAssistantChat').then((m) => ({ default: m.DocsAssistantChat }))
+);
 
 const GUEST_COLORS = [
   '#FF6B6B',
@@ -89,11 +92,18 @@ function getOrCreateGuestIdentity(): GuestIdentity {
   return identity;
 }
 
-const SIDEBAR_TABS = [
-  { label: 'Chat', value: 'chat' as const },
-  { label: 'Kommentare', value: 'comments' as const },
-  { label: 'Versionen', value: 'versions' as const },
+type SidebarTab = 'chat' | 'legacy-chat' | 'comments' | 'versions';
+
+const BASE_SIDEBAR_TABS: { label: string; value: SidebarTab }[] = [
+  { label: 'Chat', value: 'chat' },
+  { label: 'Kommentare', value: 'comments' },
+  { label: 'Versionen', value: 'versions' },
 ];
+
+const LEGACY_CHAT_TAB: { label: string; value: SidebarTab } = {
+  label: 'Älterer Chat',
+  value: 'legacy-chat',
+};
 
 function EditorFAB({
   showDisconnected,
@@ -186,7 +196,7 @@ function EditorContent() {
   const [showWolkeModal, setShowWolkeModal] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [sidebarTab, setSidebarTab] = useState<'chat' | 'comments' | 'versions'>('chat');
+  const [sidebarTab, setSidebarTab] = useState<SidebarTab>('chat');
   const [editor, setEditor] = useState<BlockNoteEditor | null>(null);
 
   const exportMenuRef = useRef<HTMLDivElement>(null);
@@ -415,6 +425,17 @@ function EditorContent() {
 
   const localUser = getLocalUser();
 
+  const hasLegacyMessages = messages.length > 0;
+  const visibleSidebarTabs: { label: string; value: SidebarTab }[] = hasLegacyMessages
+    ? [BASE_SIDEBAR_TABS[0], LEGACY_CHAT_TAB, ...BASE_SIDEBAR_TABS.slice(1)]
+    : BASE_SIDEBAR_TABS;
+
+  // If the user landed on legacy-chat but the messages disappeared (rare race),
+  // fall through to the AI chat content. Derived during render — no setState
+  // round-trip — per project convention to avoid useEffect+setState patterns.
+  const effectiveSidebarTab: SidebarTab =
+    sidebarTab === 'legacy-chat' && !hasLegacyMessages ? 'chat' : sidebarTab;
+
   return (
     <div className="h-full flex flex-col relative">
       {isEmbedded ? (
@@ -584,12 +605,12 @@ function EditorContent() {
             <div className="py-2 px-3 border-b border-grey-200 dark:border-grey-700 shrink-0">
               <div className="flex items-center gap-2">
                 <div className="inline-flex flex-1 rounded-lg bg-grey-100 p-0.5 dark:bg-grey-800">
-                  {SIDEBAR_TABS.map((tab) => (
+                  {visibleSidebarTabs.map((tab) => (
                     <button
                       key={tab.value}
                       onClick={() => setSidebarTab(tab.value)}
                       className={`flex-1 rounded-md px-3 py-1 text-xs font-medium transition-all ${
-                        sidebarTab === tab.value
+                        effectiveSidebarTab === tab.value
                           ? 'bg-background-pure text-foreground shadow-sm'
                           : 'text-grey-500 hover:text-grey-700 dark:text-grey-400 dark:hover:text-grey-200'
                       }`}
@@ -608,28 +629,44 @@ function EditorContent() {
               </div>
             </div>
 
-            {sidebarTab === 'chat' && (
+            {effectiveSidebarTab === 'chat' && id && (
               <Suspense fallback={null}>
-                <ChatSidebar
-                  messages={messages}
-                  currentUserId={localUser?.id ?? null}
-                  onSend={sendMessage}
-                  isConnected={isConnected}
-                  hideHeader
-                  typingUsers={typingUsers}
-                  onTypingChange={setTyping}
-                  embedded
+                <DocsAssistantChat
+                  documentId={id}
+                  userId={user ? String(user.id) : null}
+                  userName={user?.display_name ?? null}
                 />
               </Suspense>
             )}
 
-            {sidebarTab === 'comments' && (
+            {effectiveSidebarTab === 'legacy-chat' && hasLegacyMessages && (
+              <div className="flex flex-1 flex-col overflow-hidden">
+                <div className="bg-amber-50 dark:bg-amber-950/40 border-l-4 border-amber-400 px-3 py-2 text-sm text-amber-900 dark:text-amber-200 shrink-0">
+                  Dieser Chat wurde durch den KI-Assistenten ersetzt. Verlauf bleibt einsehbar; neue
+                  Nachrichten bitte im KI-Chat.
+                </div>
+                <Suspense fallback={null}>
+                  <ChatSidebar
+                    messages={messages}
+                    currentUserId={localUser?.id ?? null}
+                    onSend={sendMessage}
+                    isConnected={isConnected}
+                    hideHeader
+                    typingUsers={typingUsers}
+                    onTypingChange={setTyping}
+                    embedded
+                  />
+                </Suspense>
+              </div>
+            )}
+
+            {effectiveSidebarTab === 'comments' && (
               <div className="flex-1 overflow-y-auto">
                 <div className="p-2" ref={commentsPortalRef} />
               </div>
             )}
 
-            {sidebarTab === 'versions' && id && (
+            {effectiveSidebarTab === 'versions' && id && (
               <VersionHistory
                 documentId={id}
                 apiClient={apiClient}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -24,10 +24,15 @@ export {
   useChatEndpoints,
   type ChatConfig,
   type ResolvedEndpoints,
+  type ChatRequestContext,
+  type ChatRequestContextProvider,
 } from './stores/chatConfigStore';
 
 // Runtime
-export { GrueneratorChatProvider } from './runtime/GrueneratorChatProvider';
+export {
+  GrueneratorChatProvider,
+  convertToThreadMessageLike,
+} from './runtime/GrueneratorChatProvider';
 export { GrueneratorAttachmentAdapter } from './runtime/GrueneratorAttachmentAdapter';
 export {
   createGrueneratorModelAdapter,
@@ -44,6 +49,13 @@ export {
 
 // External Thread Context
 export { ExternalThreadProvider, useExternalThread } from './context/ExternalThreadContext';
+
+// Chat Collaboration (presence, typing) — surface-scoped, e.g. for docs editor
+export {
+  ChatCollaborationProvider,
+  useChatCollaborationContext,
+} from './context/ChatCollaborationContext';
+export { useChatCollaboration } from './hooks/useChatCollaboration';
 
 // Notebook Runtime
 export {

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -106,7 +106,7 @@ function extractContent(content: unknown): string {
   return content;
 }
 
-function convertToThreadMessageLike(messages: LoadedMessage[]): ThreadMessageLike[] {
+export function convertToThreadMessageLike(messages: LoadedMessage[]): ThreadMessageLike[] {
   return messages.map((m) => {
     const textContent = extractContent(m.content);
 

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -671,6 +671,13 @@ async function* parseSSEStream(
   }
 }
 
+function truncateAttachmentContext(text: string, maxChars: number): string | undefined {
+  if (!text) return undefined;
+  if (text.length <= maxChars) return text;
+  const half = Math.floor((maxChars - 40) / 2);
+  return `${text.slice(0, half)}\n\n[...gekürzt...]\n\n${text.slice(-half)}`;
+}
+
 export function createGrueneratorModelAdapter(
   getConfig: () => GrueneratorAdapterConfig,
   callbacks: GrueneratorAdapterCallbacks
@@ -914,7 +921,37 @@ export function createGrueneratorModelAdapter(
       const dcStore = useDocumentChatStore.getState();
       const documentChatIds = dcStore.getForThread(config.threadId);
 
-      const { fetch: configFetch, endpoints } = useChatConfigStore.getState();
+      const { fetch: configFetch, endpoints, contextProviders } = useChatConfigStore.getState();
+
+      // Surface-injected context (e.g. docs editor markdown + selected text).
+      // Keyed by threadId, so global chat threads and the docs thread coexist.
+      let injectedDocIds: string[] = [];
+      let injectedAttachmentContext: string | undefined;
+      if (config.threadId) {
+        const provider = contextProviders.get(config.threadId);
+        if (provider) {
+          try {
+            const ctx = await provider();
+            if (ctx.documentChatIds?.length) injectedDocIds = ctx.documentChatIds;
+            const parts: string[] = [];
+            if (ctx.selectionText) parts.push(`## Auswahl:\n${ctx.selectionText}`);
+            if (ctx.attachmentContext) parts.push(ctx.attachmentContext);
+            const merged = parts.join('\n\n');
+            // Cap at 80k chars to keep request bodies bounded.
+            injectedAttachmentContext = truncateAttachmentContext(merged, 80_000);
+          } catch (err) {
+            console.warn(
+              '[ChatAdapter] contextProvider threw, continuing without injected context',
+              err
+            );
+          }
+        }
+      }
+
+      const mergedDocChatIds = injectedDocIds.length
+        ? Array.from(new Set([...documentChatIds, ...injectedDocIds]))
+        : documentChatIds;
+
       const threadMode = config.threadMode || 'chat';
 
       // Mode-aware endpoint selection
@@ -968,8 +1005,9 @@ export function createGrueneratorModelAdapter(
           textIds: textIds.length > 0 ? textIds : undefined,
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
-          documentChatIds: documentChatIds.length > 0 ? documentChatIds : undefined,
-          documentChatMode: hasDocumentChat || documentChatIds.length > 0 || undefined,
+          documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
+          documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
+          attachmentContext: injectedAttachmentContext,
           defaultNotebookId: config.selectedNotebookId || undefined,
           customSystemPrompt: config.customSystemPrompt || undefined,
           roleName: config.customRoleName || undefined,
@@ -991,8 +1029,9 @@ export function createGrueneratorModelAdapter(
           textIds: textIds.length > 0 ? textIds : undefined,
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
-          documentChatIds: documentChatIds.length > 0 ? documentChatIds : undefined,
-          documentChatMode: hasDocumentChat || documentChatIds.length > 0 || undefined,
+          documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
+          documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
+          attachmentContext: injectedAttachmentContext,
           defaultNotebookId: config.selectedNotebookId || undefined,
           customSystemPrompt: config.customSystemPrompt || undefined,
         };

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -55,6 +55,19 @@ interface ResolvedChatConfig {
   docsBaseUrl?: string;
 }
 
+/**
+ * Per-message context a chat surface (e.g. the docs editor) can inject into
+ * outgoing requests without owning the model adapter. Keyed by threadId in
+ * `contextProviders` so multiple surfaces coexist without clobbering each other.
+ */
+export interface ChatRequestContext {
+  documentChatIds?: string[];
+  attachmentContext?: string;
+  selectionText?: string;
+}
+
+export type ChatRequestContextProvider = () => Promise<ChatRequestContext> | ChatRequestContext;
+
 interface ChatConfigStore extends ResolvedChatConfig {
   configure: (config?: ChatConfig) => void;
   getDocsUrl: () => string;
@@ -68,6 +81,10 @@ interface ChatConfigStore extends ResolvedChatConfig {
     canvasType: string,
     initialProps: Record<string, unknown>
   ) => Promise<string | null>;
+  /** threadId → context-getter, populated by host surfaces (e.g. docs editor). */
+  contextProviders: Map<string, ChatRequestContextProvider>;
+  /** Register a context provider for a thread. Returns the unregister function. */
+  registerContextProvider: (threadId: string, provider: ChatRequestContextProvider) => () => void;
 }
 
 const DEFAULT_ENDPOINTS: ResolvedEndpoints = {
@@ -122,6 +139,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
   endpoints: DEFAULT_ENDPOINTS,
   docsBaseUrl: undefined,
   onEditInDocs: undefined,
+  contextProviders: new Map(),
 
   configure: (config?: ChatConfig) => {
     set({
@@ -133,6 +151,19 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
       onEditSharepic: config?.onEditSharepic,
       renderSharepic: config?.renderSharepic,
     });
+  },
+
+  registerContextProvider: (threadId, provider) => {
+    const next = new Map(get().contextProviders);
+    next.set(threadId, provider);
+    set({ contextProviders: next });
+    return () => {
+      const after = new Map(get().contextProviders);
+      if (after.get(threadId) === provider) {
+        after.delete(threadId);
+        set({ contextProviders: after });
+      }
+    };
   },
 
   getDocsUrl: () => resolveDocsUrl(get().docsBaseUrl),

--- a/packages/contracts/src/schemas/chatGraph.ts
+++ b/packages/contracts/src/schemas/chatGraph.ts
@@ -31,6 +31,7 @@ export const chatStreamBodySchema = z.object({
   textIds: z.array(z.string()).nullish(),
   documentChatIds: z.array(z.string()).nullish(),
   documentChatMode: z.boolean().nullish(),
+  attachmentContext: z.string().nullish(),
   defaultNotebookId: z.string().nullish(),
   boardIds: z.array(z.string()).nullish(),
   docMentionIds: z.array(z.string()).nullish(),

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -20,8 +20,11 @@ export { TemplateCarousel } from './components/document/TemplateCarousel';
 export { TemplatePicker } from './components/document/TemplatePicker';
 
 // Components — Chat
+/** @deprecated Replaced by `DocsAssistantChat` in apps/web/src/features/docs/. Kept only to render legacy Yjs chat history on documents created before the AI-chat migration. */
 export { ChatSidebar } from './components/chat/ChatSidebar';
+/** @deprecated See {@link ChatSidebar}. */
 export { ChatMessageComponent } from './components/chat/ChatMessage';
+/** @deprecated See {@link ChatSidebar}. */
 export { ChatComposer } from './components/chat/ChatComposer';
 
 // Components — Permissions
@@ -35,6 +38,7 @@ export { ErrorBoundary } from './components/common/ErrorBoundary';
 
 // Hooks
 export { useCollaborators, type CollaborationUser } from '@gruenerator/collab';
+/** @deprecated Yjs peer-to-peer chat replaced by `DocsAssistantChat`. Hook is retained so the legacy tab can still display history on docs that have prior messages. */
 export { useDocumentChat, type ChatMessage } from './hooks/useDocumentChat';
 export { useBlockNoteComments } from './hooks/useBlockNoteComments';
 export {


### PR DESCRIPTION
## Summary

Replaces the Yjs peer-to-peer chat in the docs editor sidebar with a ChatGraph-backed AI assistant that auto-attaches the current document's markdown and selected text on every send. Per-doc thread is shared across collaborators (one thread per doc).

## What changes

- **New backend**: \`chat_threads.doc_id\` column + partial unique index, idempotent \`ensureDocChatThread()\` helper, and \`GET /api/docs/:docId/chat-thread\` endpoint that returns the shared thread for a document.
- **Schema extension**: \`chatStream\` request body accepts \`attachmentContext\` so clients can inject markdown context directly. Merged with whatever \`processAttachments\` derives from uploaded files.
- **Per-thread context registry** in \`useChatConfigStore\`: \`Map<threadId, getter>\` that the model adapter awaits before assembling each request body. Adds an attachmentContext block built from \`## Auswahl:\\n<selection>\\n\\n<markdown>\`, capped at 80k chars.
- **\`DocsAssistantChat\`** component (\`apps/web/src/features/docs/\`) mounts a fresh AUI runtime via \`useAui({ parent: null })\`, reuses \`createGrueneratorModelAdapter\` unchanged, hydrates persisted history from \`/api/chat-service/messages\`, and wires presence/typing via \`useChatCollaboration\`. On mount it registers the doc with \`useDocumentChatStore\` so \`documentChatIds\` flows end-to-end into ChatGraph (which already branches on it in \`classifierNode\`, \`searchNode\`, \`respondNode\`, \`summarizeNode\`).
- **\`DocsEditorPage\`** sidebar gains a \`legacy-chat\` tab that **only renders when the doc already has Yjs chat history**. The legacy ChatSidebar is kept behind a deprecation banner so existing conversations remain readable. New tab visibility is derived during render — no \`useEffect\`+\`setState\`.
- Legacy \`ChatSidebar\` / \`ChatComposer\` / \`ChatMessageComponent\` / \`useDocumentChat\` are marked \`@deprecated\` in \`packages/docs\`.

## Out of scope (Phase 2)

The BlockNote \`@blocknote/xl-ai\` extension and \`/api/docs/ai\` transport (already wired in \`BlockNoteEditor.tsx\`) handle in-document text edits via the slash menu / AI toolbar. Letting the chat *trigger* those edits via \`sendMessageWithAIRequest\` is a follow-up that can land on top — \`DocsAssistantChat\` already holds the editor reference it would need.

## Test plan

- [ ] Open \`/docs/<id>\` as user A. Type a question → POST \`/api/chat-graph/stream\` body contains \`documentChatIds: [\"<id>\"]\`, \`documentChatMode: true\`, and \`attachmentContext\` containing the doc's markdown.
- [ ] Select a paragraph, send \"Erkläre die Auswahl\" → request body's \`attachmentContext\` starts with \`## Auswahl:\\n<text>\` then full markdown.
- [ ] Reload page → chat history rehydrates via \`GET /api/chat-service/messages?threadId=<uuid>\`.
- [ ] Open same doc as user B → user B sees the same threadId resolved by \`GET /api/docs/:docId/chat-thread\` (shared per-doc).
- [ ] Open a doc with prior Yjs chat history → \"Älterer Chat\" tab visible with deprecation banner. Open a doc without → tab hidden.
- [ ] Backend log spot-check: \`searchNode.ts:509\` emits \`[Search] Using document-chat search: 1 doc(s), higher limits\`.
- [ ] Migration applied: \`SELECT column_name FROM information_schema.columns WHERE table_name = 'chat_threads' AND column_name = 'doc_id';\` returns one row.
- [ ] No regressions in the global \`/chat\` surface — distinct provider, distinct threads.
- [ ] Typecheck \`@gruenerator/{api,chat,docs,contracts,web}\`.