### PR TITLE
fix(docs): await markdown serialization in chat context provider

### DIFF
--- a/apps/web/src/features/docs/DocsAssistantChat.tsx
+++ b/apps/web/src/features/docs/DocsAssistantChat.tsx
@@ -152,10 +152,10 @@ function DocsAssistantThreadShell({
   // text into every outgoing request as attachmentContext. Read at request
   // time so edits made between sends are reflected.
   useEffect(() => {
-    const provider = (): ChatRequestContext => {
+    const provider = async (): Promise<ChatRequestContext> => {
       const editor = useEditorStore.getState().getEditor(documentId);
       if (!editor) return {};
-      const markdown = editor.blocksToMarkdownLossy(editor.document);
+      const markdown = await editor.blocksToMarkdownLossy(editor.document);
       const selection = editor.getSelectedText() || undefined;
       return {
         documentChatIds: [documentId],


### PR DESCRIPTION
## Summary
- `DocsAssistantChat`'s context provider passed the **unawaited** Promise from `editor.blocksToMarkdownLossy()` as `attachmentContext`.
- By the time `GrueneratorModelAdapter` joined parts into the request body, the Promise coerced to the literal string `"[object Promise]"`, so the backend forwarded garbage to the LLM. Symptom: the AI claims it doesn't know the document and asks the user for the topic, audience, length, etc.
- Fix: make the provider `async` and `await` the serializer. `ChatRequestContextProvider` already supports both sync and async returns and the adapter does `await provider()` — no callers need to change.

## Why this slipped past TS
`attachmentContext: string | undefined` happily accepted a non-nullable `Promise<string>` (the union didn't reject it). The runtime stringification was silent. A possible follow-up is to tighten `ChatRequestContext` to forbid non-string values explicitly — out of scope here.

## Test plan
- [ ] Open a document in the new docs chat tab, type something into the editor, send "fasse das zusammen" — assistant should reference document content
- [ ] Select a passage and send "verbessere den ausgewählten Text" — assistant should reference the selection (`## Auswahl:` block)
- [ ] Edit the document between two messages — second response should reflect the edit (provider runs at request time)