### PR TITLE
fix(chat): prevent Enter auto-submit while @docs/@datei picker is open

### DIFF
--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -252,11 +252,17 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (!mention.visible) return;
 
-      // In datei/docs mode, only handle Escape (cmdk handles arrow keys internally)
+      // In datei/docs mode, only handle Escape (cmdk handles arrow keys internally).
+      // Enter is swallowed so the textarea doesn't submit the form while the picker
+      // is open — the user must select via the picker or dismiss with Escape first.
       if (mention.mode === 'datei' || mention.mode === 'docs') {
         if (e.key === 'Escape') {
           e.preventDefault();
           dismissPopover();
+          return;
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Pressing Enter while the cmdk file/doc mention picker (mode `'datei'` or `'docs'`) was open submitted the message instead of operating on the picker.
- The composer's `handleKeyDown` early-returned for those modes, only handling Escape — so Enter fell through to `ComposerPrimitive.Input`'s default submit-on-Enter behavior.
- Fix swallows Enter via `preventDefault()` in those modes and adds an explicit `return` after Escape so the two branches don't overlap.

## Repro
1. In any chat composer, type `@docs`.
2. Press Enter — first Enter selects the docs trigger and opens the CollabDocMentionPopover (correct).
3. Press Enter again with focus still in the textarea (or open the picker via PlusMenu first) — **before fix**: form submits. **After fix**: no-op; user can mouse-select a doc or press Escape.

Same path covers `@datei` (FileMentionPopover) and PlusMenu-opened pickers.

## Out of scope (flagged)
cmdk's `<CommandInput>` inside the picker popovers does not auto-focus on open, so keyboard nav in the picker only works after a click. Worth fixing separately by `ref.focus()`-ing on `visible`.

## Test plan
- [ ] Type `@docs` + Enter → trigger selection works, second Enter does not submit.
- [ ] Type `@datei` + Enter → file picker opens, Enter does not submit.
- [ ] Open file/doc picker via PlusMenu → Enter does not submit.
- [ ] Escape still dismisses both pickers.
- [ ] Plain text (no picker open) + Enter → submits as before.
- [ ] `@notebook` / `/agent` mention selection (functions/skills modes) unaffected.