### PR TITLE
feat(chat): per-user model preselection in profile settings

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -11,6 +11,7 @@ import { rateLimitMiddleware } from './middleware/rateLimitMiddleware.js';
 import antraegeRouter from './routes/antraege/index.js';
 import { mountAuthStatusContractRouter } from './routes/auth/authStatusContractRouter.js';
 import authInitRouter from './routes/auth/initController.js';
+import { mountModelPreferencesContractRouter } from './routes/auth/modelPreferencesContractRouter.js';
 import { mountAdminVorlagenContractRouter } from './routes/auth/templates/adminVorlagenContractRouter.js';
 import { mountUserProfileContractRouter } from './routes/auth/userProfileContractRouter.js';
 import { mountBoardsContractRouter } from './routes/boards/boardsContractRouter.js';
@@ -529,7 +530,9 @@ export async function setupRoutes(app: Application): Promise<void> {
   // so contract-modeled routes match first; /stream SSE falls through to legacy.
   // requireAuth applied at prefix; notification-preferences also handled here.
   app.use('/api/notifications', requireAuth);
+  app.use('/api/auth/profile', requireAuth);
   mountNotificationsContractRouter(app);
+  mountModelPreferencesContractRouter(app);
   app.use('/api/notifications', requireAuth, publicReadLimiter, notificationsRouter);
   app.use('/api/media', requireAuth, authenticatedReadLimiter, mediaRouter);
   app.use('/api/og/docs', publicReadLimiter, ogDocsRouter);

--- a/apps/api/routes/auth/modelPreferencesContractRouter.ts
+++ b/apps/api/routes/auth/modelPreferencesContractRouter.ts
@@ -1,0 +1,59 @@
+/**
+ * ts-rest contract router for AI model preferences.
+ *
+ *   - GET   /api/auth/profile/model-preferences
+ *   - PATCH /api/auth/profile/model-preferences
+ *
+ * Auth: requireAuth must be applied at /api/auth/profile before this mount.
+ */
+
+import { modelPreferencesContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import {
+  getModelPreferencesForUser,
+  getDefaultModelPreferences,
+  setModelPreference,
+} from '../../services/user/modelPreferences.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { getAuthedUser } from '../../utils/getAuthedUser.js';
+import { createLogger } from '../../utils/logger.js';
+
+import type { Application } from 'express';
+
+const log = createLogger('modelPreferencesContractRouter');
+
+const s = initServer();
+
+export const modelPreferencesContractRouter = s.router(modelPreferencesContract, {
+  getPreferences: async (args) => {
+    try {
+      const userId = getAuthedUser(args.req).id;
+      const preferences = await getModelPreferencesForUser(userId);
+      const defaults = getDefaultModelPreferences();
+      return { status: 200 as const, body: { success: true, preferences, defaults } };
+    } catch (error) {
+      log.error('[modelPreferencesContract.getPreferences] Error:', error);
+      return { status: 500 as const, body: { error: 'Failed to load model preferences' } };
+    }
+  },
+
+  updatePreference: async (args) => {
+    try {
+      const userId = getAuthedUser(args.req).id;
+      const { modelId, enabled } = args.body;
+      const preferences = await setModelPreference(userId, modelId, enabled);
+      const defaults = getDefaultModelPreferences();
+      return { status: 200 as const, body: { success: true, preferences, defaults } };
+    } catch (error) {
+      log.error('[modelPreferencesContract.updatePreference] Error:', error);
+      return { status: 500 as const, body: { error: 'Failed to update model preferences' } };
+    }
+  },
+});
+
+export function mountModelPreferencesContractRouter(app: Application): void {
+  createExpressEndpoints(modelPreferencesContract, modelPreferencesContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'modelPreferencesContract'),
+  });
+}

--- a/apps/api/services/user/modelPreferences.ts
+++ b/apps/api/services/user/modelPreferences.ts
@@ -1,0 +1,76 @@
+import {
+  ALL_MODEL_IDS,
+  MODEL_BY_ID,
+  isModelEnabledByDefault,
+  type ModelId,
+} from '@gruenerator/shared/models';
+
+import { getProfileService } from './ProfileService.js';
+
+import type { UserProfile } from './types.js';
+
+export interface ModelPreference {
+  enabled: boolean;
+}
+
+export type ModelPreferencesMap = Record<ModelId, ModelPreference>;
+
+const USER_DEFAULTS_KEY = 'models';
+
+function isStoredPreference(value: unknown): value is ModelPreference {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).enabled === 'boolean'
+  );
+}
+
+function resolvePreference(stored: unknown, modelId: ModelId): ModelPreference {
+  if (isStoredPreference(stored)) {
+    return { enabled: stored.enabled };
+  }
+  return { enabled: isModelEnabledByDefault(modelId) };
+}
+
+export function getDefaultModelPreferences(): ModelPreferencesMap {
+  const result = {} as ModelPreferencesMap;
+  for (const id of ALL_MODEL_IDS) {
+    result[id] = { enabled: isModelEnabledByDefault(id) };
+  }
+  return result;
+}
+
+export async function getModelPreferencesForUser(
+  userId: string,
+  preloadedProfile?: UserProfile | null
+): Promise<ModelPreferencesMap> {
+  const profile =
+    preloadedProfile !== undefined
+      ? preloadedProfile
+      : await getProfileService().getProfileById(userId);
+
+  const stored = (profile?.user_defaults?.[USER_DEFAULTS_KEY] ?? {}) as Record<string, unknown>;
+
+  const result = {} as ModelPreferencesMap;
+  for (const id of ALL_MODEL_IDS) {
+    result[id] = resolvePreference(stored[id], id);
+  }
+  return result;
+}
+
+export async function setModelPreference(
+  userId: string,
+  modelId: ModelId,
+  enabled: boolean
+): Promise<ModelPreferencesMap> {
+  if (!MODEL_BY_ID[modelId]) {
+    throw new Error(`Unknown modelId: ${modelId}`);
+  }
+  await getProfileService().updateUserDefault(userId, USER_DEFAULTS_KEY, modelId, { enabled });
+  return getModelPreferencesForUser(userId);
+}
+
+export function isModelEnabledForUser(prefs: ModelPreferencesMap, modelId: ModelId): boolean {
+  return prefs[modelId]?.enabled ?? isModelEnabledByDefault(modelId);
+}

--- a/apps/api/services/user/modelPreferences.vitest.ts
+++ b/apps/api/services/user/modelPreferences.vitest.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the model-preferences resolver.
+ *
+ * Pins the rule: a stored override wins; otherwise we fall back to the
+ * `offByDefault` flag in the canonical model catalog. Chinese (Qwen) models
+ * carry `offByDefault: true`, everything else defaults to enabled.
+ */
+
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+// Mocks must be declared before importing the module under test.
+const getProfileByIdMock = vi.fn();
+const updateUserDefaultMock = vi.fn();
+
+vi.mock('./ProfileService.js', () => ({
+  getProfileService: () => ({
+    getProfileById: getProfileByIdMock,
+    updateUserDefault: updateUserDefaultMock,
+  }),
+}));
+
+import {
+  getDefaultModelPreferences,
+  getModelPreferencesForUser,
+  isModelEnabledForUser,
+  setModelPreference,
+} from './modelPreferences.js';
+
+beforeEach(() => {
+  getProfileByIdMock.mockReset();
+  updateUserDefaultMock.mockReset();
+});
+
+describe('modelPreferences', () => {
+  describe('getDefaultModelPreferences', () => {
+    it('disables Chinese models and enables the rest by default', () => {
+      const defaults = getDefaultModelPreferences();
+      expect(defaults['qwen-regolo']).toEqual({ enabled: false });
+      expect(defaults['qwen3.6-regolo']).toEqual({ enabled: false });
+      expect(defaults['gemma-litellm']).toEqual({ enabled: true });
+      expect(defaults['gpt-oss-regolo']).toEqual({ enabled: true });
+      expect(defaults['litellm']).toEqual({ enabled: true });
+    });
+  });
+
+  describe('getModelPreferencesForUser', () => {
+    it('falls back to platform defaults when no overrides exist', async () => {
+      getProfileByIdMock.mockResolvedValue({
+        id: 'user-1',
+        user_defaults: {},
+      });
+      const prefs = await getModelPreferencesForUser('user-1');
+      expect(prefs['qwen-regolo'].enabled).toBe(false);
+      expect(prefs['gemma-litellm'].enabled).toBe(true);
+    });
+
+    it('falls back to platform defaults when profile is null', async () => {
+      getProfileByIdMock.mockResolvedValue(null);
+      const prefs = await getModelPreferencesForUser('ghost');
+      expect(prefs['qwen-regolo'].enabled).toBe(false);
+      expect(prefs['gpt-oss-regolo'].enabled).toBe(true);
+    });
+
+    it('respects an explicit override for an off-by-default model', async () => {
+      getProfileByIdMock.mockResolvedValue({
+        id: 'user-1',
+        user_defaults: { models: { 'qwen-regolo': { enabled: true } } },
+      });
+      const prefs = await getModelPreferencesForUser('user-1');
+      expect(prefs['qwen-regolo'].enabled).toBe(true);
+      expect(prefs['qwen3.6-regolo'].enabled).toBe(false);
+    });
+
+    it('respects an explicit disable for an on-by-default model', async () => {
+      getProfileByIdMock.mockResolvedValue({
+        id: 'user-1',
+        user_defaults: { models: { 'gemma-litellm': { enabled: false } } },
+      });
+      const prefs = await getModelPreferencesForUser('user-1');
+      expect(prefs['gemma-litellm'].enabled).toBe(false);
+      expect(prefs['gpt-oss-regolo'].enabled).toBe(true);
+    });
+
+    it('ignores malformed stored values and uses default', async () => {
+      getProfileByIdMock.mockResolvedValue({
+        id: 'user-1',
+        user_defaults: { models: { 'qwen-regolo': 'yes-please' } },
+      });
+      const prefs = await getModelPreferencesForUser('user-1');
+      expect(prefs['qwen-regolo'].enabled).toBe(false);
+    });
+
+    it('uses the preloaded profile when provided to skip the DB roundtrip', async () => {
+      const prefs = await getModelPreferencesForUser('user-1', {
+        id: 'user-1',
+        user_defaults: { models: { 'qwen-regolo': { enabled: true } } },
+      });
+      expect(prefs['qwen-regolo'].enabled).toBe(true);
+      expect(getProfileByIdMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setModelPreference', () => {
+    it('persists via ProfileService.updateUserDefault and returns refreshed prefs', async () => {
+      updateUserDefaultMock.mockResolvedValue(undefined);
+      getProfileByIdMock.mockResolvedValue({
+        id: 'user-1',
+        user_defaults: { models: { 'qwen-regolo': { enabled: true } } },
+      });
+
+      const prefs = await setModelPreference('user-1', 'qwen-regolo', true);
+
+      expect(updateUserDefaultMock).toHaveBeenCalledWith('user-1', 'models', 'qwen-regolo', {
+        enabled: true,
+      });
+      expect(prefs['qwen-regolo'].enabled).toBe(true);
+    });
+
+    it('rejects unknown model ids', async () => {
+      await expect(setModelPreference('user-1', 'nonsense' as never, true)).rejects.toThrow(
+        /Unknown modelId/
+      );
+      expect(updateUserDefaultMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isModelEnabledForUser', () => {
+    it('uses the resolved value from the prefs map', () => {
+      const prefs = getDefaultModelPreferences();
+      expect(isModelEnabledForUser(prefs, 'qwen-regolo')).toBe(false);
+      expect(isModelEnabledForUser(prefs, 'gemma-litellm')).toBe(true);
+    });
+
+    it('falls back to platform default for an id missing from the map', () => {
+      expect(isModelEnabledForUser({} as never, 'qwen-regolo')).toBe(false);
+      expect(isModelEnabledForUser({} as never, 'gemma-litellm')).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ModelSettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ModelSettingsSection.tsx
@@ -1,0 +1,137 @@
+import {
+  MODEL_OPTIONS,
+  REGION_LABELS,
+  REGION_ORDER,
+  type ModelIcon,
+  type ModelId,
+  type ModelOption,
+  type ModelRegion,
+} from '@gruenerator/shared/models';
+import { Switch } from '@gruenerator/ui';
+import { Brain, Server, Sparkles, Zap, Info, AlertTriangle } from 'lucide-react';
+import React from 'react';
+
+import { useModelPreferences } from '../../../../../models/hooks/useModelPreferences';
+
+interface ModelSettingsSectionProps {
+  onSuccessMessage: (message: string) => void;
+  onErrorMessage: (message: string) => void;
+}
+
+const ICONS: Record<ModelIcon, React.ComponentType<{ className?: string }>> = {
+  sparkles: Sparkles,
+  server: Server,
+  zap: Zap,
+  brain: Brain,
+};
+
+function groupByRegion(models: ModelOption[]): Map<ModelRegion, ModelOption[]> {
+  const grouped = new Map<ModelRegion, ModelOption[]>();
+  for (const model of models) {
+    const list = grouped.get(model.region) ?? [];
+    list.push(model);
+    grouped.set(model.region, list);
+  }
+  return grouped;
+}
+
+const ModelSettingsSection = React.memo(
+  ({ onSuccessMessage, onErrorMessage }: ModelSettingsSectionProps) => {
+    const { preferences, isLoading, toggleModel } = useModelPreferences();
+    const grouped = groupByRegion(MODEL_OPTIONS);
+
+    const handleToggle = async (modelId: ModelId, label: string, enabled: boolean) => {
+      try {
+        await toggleModel(modelId, enabled);
+        onSuccessMessage(`${label} ${enabled ? 'aktiviert' : 'deaktiviert'}.`);
+      } catch {
+        onErrorMessage('Modell-Einstellung konnte nicht gespeichert werden.');
+      }
+    };
+
+    if (isLoading) {
+      return (
+        <div className="animate-pulse">
+          <div className="h-32 rounded-lg bg-grey-100 dark:bg-grey-800" />
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-md">
+        <div>
+          <h3 className="text-sm font-medium text-foreground mb-xs">KI-Modelle</h3>
+          <p className="text-xs text-grey-500 dark:text-grey-400">
+            Wähle, welche Modelle in der Modellauswahl im Chat erscheinen.
+          </p>
+        </div>
+
+        <div className="flex items-start gap-sm p-md rounded-lg bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-800">
+          <Info className="w-4 h-4 mt-0.5 text-primary-600 dark:text-primary-400 shrink-0" />
+          <p className="text-sm text-primary-700 dark:text-primary-300">
+            Deaktivierte Modelle werden nicht in der Modellauswahl im Chat angezeigt. Chinesische
+            Modelle sind standardmäßig deaktiviert.
+          </p>
+        </div>
+
+        {REGION_ORDER.map((region) => {
+          const models = grouped.get(region);
+          if (!models?.length) return null;
+
+          return (
+            <div
+              key={region}
+              className="rounded-lg border border-grey-200 dark:border-grey-700 overflow-hidden"
+            >
+              <div className="px-md py-sm bg-grey-50 dark:bg-grey-800/50 border-b border-grey-200 dark:border-grey-700">
+                <h4 className="text-sm font-semibold text-foreground">{REGION_LABELS[region]}</h4>
+              </div>
+
+              <div className="divide-y divide-grey-100 dark:divide-grey-800">
+                {models.map((model) => {
+                  const Icon = ICONS[model.icon];
+                  const enabled = preferences[model.id]?.enabled ?? !model.offByDefault;
+
+                  return (
+                    <div
+                      key={model.id}
+                      className="flex items-start gap-md px-md py-sm hover:bg-grey-50 dark:hover:bg-grey-800/30 transition-colors"
+                    >
+                      <Icon className="w-4 h-4 mt-0.5 shrink-0 text-grey-400 dark:text-grey-500" />
+                      <div className="grow min-w-0">
+                        <p className="text-sm font-medium text-foreground">{model.name}</p>
+                        <p className="text-xs text-grey-500 dark:text-grey-400">
+                          {model.description}
+                        </p>
+                        {model.warning && (
+                          <p className="text-xs text-amber-600 dark:text-amber-500 flex items-start gap-xs mt-xs">
+                            <AlertTriangle className="w-3 h-3 mt-0.5 shrink-0" />
+                            <span>{model.warning}</span>
+                          </p>
+                        )}
+                      </div>
+                      <div className="shrink-0 pt-0.5">
+                        <Switch
+                          className="h-[20px] w-[40px] data-[state=checked]:bg-secondary-600 data-[state=unchecked]:bg-grey-200 dark:data-[state=unchecked]:bg-grey-700"
+                          checked={enabled}
+                          onCheckedChange={(checked: boolean) =>
+                            handleToggle(model.id, model.name, checked)
+                          }
+                          aria-label={`${model.name} aktivieren`}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+ModelSettingsSection.displayName = 'ModelSettingsSection';
+
+export default ModelSettingsSection;

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
@@ -8,6 +8,7 @@ import MemoriesSection from '../../../../../../components/profile/MemoriesSectio
 import { useAuthStore, type SupportedLocale } from '../../../../../../stores/authStore';
 import { cn } from '../../../../../../utils/cn';
 
+import ModelSettingsSection from './ModelSettingsSection';
 import RolesSection from './RolesSection';
 import SettingsSection from './SettingsSection';
 
@@ -200,6 +201,8 @@ const ProfileView = ({
       <RolesSection />
 
       <SettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
+
+      <ModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
 
       <MemoriesSection />
 

--- a/apps/web/src/features/models/hooks/useModelPreferences.ts
+++ b/apps/web/src/features/models/hooks/useModelPreferences.ts
@@ -1,0 +1,89 @@
+import { type ModelId } from '@gruenerator/shared/models';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import {
+  fetchModelPreferences,
+  updateModelPreference,
+} from '../../../hooks/useModelPreferencesTyped';
+
+interface ModelPreference {
+  enabled: boolean;
+}
+
+interface ModelPreferencesResponse {
+  success: boolean;
+  preferences: Record<string, ModelPreference>;
+  defaults: Record<string, ModelPreference>;
+}
+
+const QUERY_KEY = ['model-preferences'];
+
+export interface UseModelPreferencesOptions {
+  enabled?: boolean;
+}
+
+export function useModelPreferences(options: UseModelPreferencesOptions = {}) {
+  const { enabled = true } = options;
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      return fetchModelPreferences() as Promise<ModelPreferencesResponse>;
+    },
+    staleTime: 60_000,
+    enabled,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async ({ modelId, enabled }: { modelId: ModelId; enabled: boolean }) => {
+      return updateModelPreference(modelId, enabled) as Promise<ModelPreferencesResponse>;
+    },
+    onMutate: async ({ modelId, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+      const previous = queryClient.getQueryData<ModelPreferencesResponse>(QUERY_KEY);
+
+      if (previous) {
+        const updated: ModelPreferencesResponse = {
+          ...previous,
+          preferences: {
+            ...previous.preferences,
+            [modelId]: { enabled },
+          },
+        };
+        queryClient.setQueryData(QUERY_KEY, updated);
+      }
+
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+
+  const preferences = query.data?.preferences ?? {};
+
+  const enabledModelIds = useMemo(() => {
+    if (!query.data) return null;
+    const set = new Set<ModelId>();
+    for (const [id, pref] of Object.entries(preferences)) {
+      if (pref?.enabled) set.add(id as ModelId);
+    }
+    return set;
+  }, [preferences, query.data]);
+
+  return {
+    preferences,
+    defaults: query.data?.defaults ?? {},
+    enabledModelIds,
+    isLoading: query.isLoading,
+    toggleModel: (modelId: ModelId, enabled: boolean) => mutation.mutateAsync({ modelId, enabled }),
+    isSaving: mutation.isPending,
+  };
+}

--- a/apps/web/src/hooks/useModelPreferencesTyped.ts
+++ b/apps/web/src/hooks/useModelPreferencesTyped.ts
@@ -1,0 +1,27 @@
+/**
+ * useModelPreferencesTyped — typed ts-rest client wrappers for the
+ * model-preferences endpoints. Mirrors useNotificationsTyped.
+ */
+
+import { getContractsClient } from '@gruenerator/shared/api';
+import { type ModelId } from '@gruenerator/shared/models';
+
+export async function fetchModelPreferences() {
+  const client = getContractsClient();
+  const result = await client.modelPreferences.getPreferences();
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch model preferences (HTTP ${result.status})`);
+  }
+  return result.body;
+}
+
+export async function updateModelPreference(modelId: ModelId, enabled: boolean) {
+  const client = getContractsClient();
+  const result = await client.modelPreferences.updatePreference({
+    body: { modelId, enabled },
+  });
+  if (result.status !== 200) {
+    throw new Error(`Failed to update model preference (HTTP ${result.status})`);
+  }
+  return result.body;
+}

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -10,6 +10,7 @@ import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { renderSharepicToImage } from '../features/image-studio/renderSharepicToImage';
+import { useModelPreferences } from '../features/models/hooks/useModelPreferences';
 import { useNotebookChatStore } from '../features/notebook/stores/notebookChatStore';
 import useNotebookStore from '../features/notebook/stores/notebookStore';
 import { resolveNotebookChatEntries } from '../features/notebook/utils/notebookChatResolver';
@@ -57,6 +58,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const qaCollectionsLength = useNotebookStore((s) => s.qaCollections.length);
+  const { enabledModelIds } = useModelPreferences({ enabled: !!userId });
 
   // Notebook collections power @notebook mention metadata; fetch lazily when
   // an authenticated user actually needs them. React Query caches the result.
@@ -184,6 +186,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
       getExternalThreads={getExternalThreads}
       onExternalThreadClick={handleExternalClick}
       activePath={location.pathname}
+      enabledModelIds={enabledModelIds}
     >
       <TooltipProvider>
         {children}

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@assistant-ui/react-markdown": "0.12.9",
     "@gruenerator/collab": "workspace:*",
+    "@gruenerator/shared": "workspace:*",
     "@gruenerator/ui": "workspace:*",
     "@gruenerator/voice": "workspace:*",
     "@hocuspocus/provider": "^3.4.4",

--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, ChevronDown } from 'lucide-react';
 import {
   cn,
@@ -10,10 +10,12 @@ import {
   ResponsiveMenuItem,
 } from '@gruenerator/ui';
 import { useShallow } from 'zustand/shallow';
+import { isModelEnabledByDefault } from '@gruenerator/shared/models';
 
 import { MODEL_ICONS } from '../../lib/modelIcons';
 import { composerToolbarButtonClass } from '../../lib/utils';
 import { MODEL_OPTIONS, useAgentStore, type ModelId } from '../../stores/chatStore';
+import { useModelPreferencesContext } from '../../context/ModelPreferencesContext';
 
 export const ModelPicker = memo(function ModelPicker() {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -23,9 +25,25 @@ export const ModelPicker = memo(function ModelPicker() {
       setSelectedModel: s.setSelectedModel,
     }))
   );
+  const { enabledModelIds } = useModelPreferencesContext();
 
-  const current = MODEL_OPTIONS.find((m) => m.id === selectedModel) ?? MODEL_OPTIONS[0];
+  const visibleModels = useMemo(() => {
+    if (enabledModelIds) {
+      return MODEL_OPTIONS.filter((m) => enabledModelIds.has(m.id));
+    }
+    return MODEL_OPTIONS.filter((m) => isModelEnabledByDefault(m.id));
+  }, [enabledModelIds]);
+
+  const fallback = visibleModels[0] ?? MODEL_OPTIONS[0];
+  const current = visibleModels.find((m) => m.id === selectedModel) ?? fallback;
   const CurrentIcon = MODEL_ICONS[current.icon];
+
+  useEffect(() => {
+    if (!visibleModels.length) return;
+    if (!visibleModels.some((m) => m.id === selectedModel)) {
+      setSelectedModel(visibleModels[0].id);
+    }
+  }, [visibleModels, selectedModel, setSelectedModel]);
 
   const handleSelect = (id: string) => {
     setSelectedModel(id as ModelId);
@@ -34,35 +52,24 @@ export const ModelPicker = memo(function ModelPicker() {
 
   const desktopContent = (
     <>
-      {MODEL_OPTIONS.map((model) => {
-        const Icon = MODEL_ICONS[model.icon];
+      {visibleModels.map((model) => {
         const isActive = selectedModel === model.id;
         return (
           <DropdownMenuItem
             key={model.id}
             onSelect={() => setSelectedModel(model.id)}
             className={cn(
-              'flex-col items-stretch gap-1 py-2',
+              'flex items-center gap-2 py-1.5',
               isActive &&
                 'bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-400'
             )}
           >
-            <div className="flex items-center gap-2">
-              <Icon className="h-4 w-4 shrink-0" />
-              <span className="text-sm font-medium leading-tight">{model.name}</span>
-            </div>
-            <span
-              className={cn(
-                'text-[11px] leading-snug',
-                isActive ? 'text-primary-700/80 dark:text-primary-400/80' : 'text-foreground-muted'
-              )}
-            >
-              {model.description}
-            </span>
+            <span className="text-sm font-medium leading-tight">{model.name}</span>
             {model.warning && (
-              <span className="text-[11px] leading-snug text-amber-600 dark:text-amber-500">
-                {model.warning}
-              </span>
+              <AlertTriangle
+                className="h-3 w-3 text-amber-600 dark:text-amber-500"
+                aria-label={model.warning}
+              />
             )}
           </DropdownMenuItem>
         );
@@ -72,31 +79,23 @@ export const ModelPicker = memo(function ModelPicker() {
 
   const mobileContent = (
     <ResponsiveMenuSection title="Modell">
-      {MODEL_OPTIONS.map((model) => {
-        const Icon = MODEL_ICONS[model.icon];
-        return (
-          <ResponsiveMenuItem
-            key={model.id}
-            active={selectedModel === model.id}
-            onClick={() => handleSelect(model.id)}
-          >
-            <div className="flex w-full flex-col gap-1">
-              <div className="flex items-center gap-2">
-                <Icon className="h-4 w-4 shrink-0" />
-                <span className="font-medium">{model.name}</span>
-              </div>
-              <span className="text-[11px] leading-snug text-foreground-muted">
-                {model.description}
-              </span>
-              {model.warning && (
-                <span className="text-[11px] leading-snug text-amber-600 dark:text-amber-500">
-                  {model.warning}
-                </span>
-              )}
-            </div>
-          </ResponsiveMenuItem>
-        );
-      })}
+      {visibleModels.map((model) => (
+        <ResponsiveMenuItem
+          key={model.id}
+          active={selectedModel === model.id}
+          onClick={() => handleSelect(model.id)}
+        >
+          <div className="flex items-center gap-2">
+            <span className="font-medium">{model.name}</span>
+            {model.warning && (
+              <AlertTriangle
+                className="h-3 w-3 text-amber-600 dark:text-amber-500"
+                aria-label={model.warning}
+              />
+            )}
+          </div>
+        </ResponsiveMenuItem>
+      ))}
     </ResponsiveMenuSection>
   );
 
@@ -106,7 +105,7 @@ export const ModelPicker = memo(function ModelPicker() {
       onOpenChange={setMenuOpen}
       sheetTitle="Modell wählen"
       dropdownAlign="end"
-      dropdownClassName="min-w-[22rem] max-w-[90vw]"
+      dropdownClassName="min-w-[12rem] max-w-[90vw]"
       trigger={
         <button
           type="button"

--- a/packages/chat/src/context/ModelPreferencesContext.tsx
+++ b/packages/chat/src/context/ModelPreferencesContext.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { type ModelId } from '@gruenerator/shared/models';
+
+export interface ModelPreferencesContextValue {
+  enabledModelIds: ReadonlySet<ModelId> | null;
+}
+
+const ModelPreferencesContext = createContext<ModelPreferencesContextValue>({
+  enabledModelIds: null,
+});
+
+interface ModelPreferencesProviderProps {
+  children: ReactNode;
+  enabledModelIds?: ReadonlySet<ModelId> | null;
+}
+
+export function ModelPreferencesProvider({
+  children,
+  enabledModelIds = null,
+}: ModelPreferencesProviderProps) {
+  const value = useMemo<ModelPreferencesContextValue>(
+    () => ({ enabledModelIds: enabledModelIds ?? null }),
+    [enabledModelIds]
+  );
+  return (
+    <ModelPreferencesContext.Provider value={value}>{children}</ModelPreferencesContext.Provider>
+  );
+}
+
+export function useModelPreferencesContext(): ModelPreferencesContextValue {
+  return useContext(ModelPreferencesContext);
+}

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -21,6 +21,7 @@ import {
   RuntimeAdapterProvider,
   ExportedMessageRepository,
 } from '@assistant-ui/react';
+import { type ModelId } from '@gruenerator/shared/models';
 import { createChatApiClient } from '../context/ChatContext';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore, type ChatConfig } from '../stores/chatConfigStore';
@@ -38,6 +39,7 @@ import {
   type ExternalThreadEntry,
 } from './GrueneratorThreadListAdapter';
 import { ExternalThreadProvider } from '../context/ExternalThreadContext';
+import { ModelPreferencesProvider } from '../context/ModelPreferencesContext';
 import { grueneratorToolkit } from '../components/tool-ui/GrueneratorToolUIs';
 import { chatSuggestions } from '../lib/suggestions';
 import type {
@@ -55,6 +57,7 @@ interface GrueneratorChatProviderProps {
   getExternalThreads?: () => ExternalThreadEntry[];
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
+  enabledModelIds?: ReadonlySet<ModelId> | null;
 }
 
 interface PersistedToolCall {
@@ -383,6 +386,7 @@ export function GrueneratorChatProvider({
   getExternalThreads,
   onExternalThreadClick,
   activePath,
+  enabledModelIds,
 }: GrueneratorChatProviderProps) {
   // Sync config store during render (before any hooks read from it).
   // useEffect runs AFTER render, which creates a race: providerApiClient
@@ -413,19 +417,25 @@ export function GrueneratorChatProvider({
   }, []);
 
   if (!userId) {
-    return <>{children}</>;
+    return (
+      <ModelPreferencesProvider enabledModelIds={enabledModelIds}>
+        {children}
+      </ModelPreferencesProvider>
+    );
   }
 
   return (
-    <GrueneratorChatRuntimeProvider
-      userId={userId}
-      userName={userName}
-      getExternalThreads={getExternalThreads}
-      onExternalThreadClick={onExternalThreadClick}
-      activePath={activePath}
-    >
-      {children}
-    </GrueneratorChatRuntimeProvider>
+    <ModelPreferencesProvider enabledModelIds={enabledModelIds}>
+      <GrueneratorChatRuntimeProvider
+        userId={userId}
+        userName={userName}
+        getExternalThreads={getExternalThreads}
+        onExternalThreadClick={onExternalThreadClick}
+        activePath={activePath}
+      >
+        {children}
+      </GrueneratorChatRuntimeProvider>
+    </ModelPreferencesProvider>
   );
 }
 

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -1,6 +1,16 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import {
+  MODEL_OPTIONS,
+  MODEL_BY_ID,
+  type ModelId,
+  type ModelOption,
+  type Provider,
+} from '@gruenerator/shared/models';
 import type { ChatApiClient } from '../context/ChatContext';
+
+export { MODEL_OPTIONS };
+export type { ModelId, ModelOption, Provider };
 
 export interface CompactionState {
   summary: string | null;
@@ -28,86 +38,10 @@ interface TriggerCompactionResponse {
   compactionState: CompactionState;
 }
 
-export type Provider = 'mistral' | 'litellm' | 'regolo';
-
-export type ModelId =
-  | 'mistral-medium-3.5'
-  | 'gpt-oss-regolo'
-  | 'litellm'
-  | 'gemma-litellm'
-  | 'qwen-regolo'
-  | 'qwen3.6-regolo';
-
 export type ToolKey = 'search' | 'web' | 'examples' | 'research';
 
 export type ThreadMode = 'chat' | 'notebook' | 'search' | 'eigener';
 export type SearchMode = 'web' | 'deep';
-
-export interface ModelOption {
-  id: ModelId;
-  name: string;
-  description: string;
-  model: string;
-  provider: Provider;
-  icon: 'sparkles' | 'server' | 'zap' | 'brain';
-  warning?: string;
-}
-
-const QWEN_WARNING =
-  'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.';
-
-export const MODEL_OPTIONS: ModelOption[] = [
-  {
-    id: 'mistral-medium-3.5',
-    name: 'Mistral Medium 3.5',
-    description: 'Aktuelles Mistral-Modell (EU), stark bei Texten',
-    model: 'mistral-medium-2604',
-    provider: 'mistral',
-    icon: 'sparkles',
-  },
-  {
-    id: 'gemma-litellm',
-    name: 'Gemma 4',
-    description: 'Leichtgewichtig, antwortet schnell',
-    model: 'gpt-oss:120b',
-    provider: 'litellm',
-    icon: 'zap',
-  },
-  {
-    id: 'gpt-oss-regolo',
-    name: 'GPT-OSS',
-    description: 'Offenes Modell über Regolo',
-    model: 'gpt-oss-120b',
-    provider: 'regolo',
-    icon: 'sparkles',
-  },
-  {
-    id: 'litellm',
-    name: 'Verdigado',
-    description: 'Selbst gehostet bei Verdigado',
-    model: 'gpt-oss:120b',
-    provider: 'litellm',
-    icon: 'server',
-  },
-  {
-    id: 'qwen-regolo',
-    name: 'Qwen 120B',
-    description: 'Groß & vielseitig, für komplexe Aufgaben',
-    model: 'qwen3.5-122b',
-    provider: 'regolo',
-    icon: 'brain',
-    warning: QWEN_WARNING,
-  },
-  {
-    id: 'qwen3.6-regolo',
-    name: 'Qwen 3.6 27B',
-    description: 'Kompaktes Reasoning-Modell, denkt sichtbar mit',
-    model: 'qwen3.6-27b',
-    provider: 'regolo',
-    icon: 'brain',
-    warning: QWEN_WARNING,
-  },
-];
 
 export interface ProviderOption {
   id: Provider;
@@ -378,7 +312,7 @@ export const useAgentStore = create<AgentState>()(
           removeItem: (key: string) => mem.delete(key),
         };
       }),
-      version: 7,
+      version: 8,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -443,6 +377,14 @@ export const useAgentStore = create<AgentState>()(
             'qwen3.6-regolo',
           ]);
           if (!validIds.has(state.selectedModel as string)) {
+            state.selectedModel = 'gemma-litellm';
+            state.selectedProvider = 'litellm';
+          }
+        }
+        if (version < 8) {
+          const current = state.selectedModel as string | undefined;
+          const def = current ? MODEL_BY_ID[current as ModelId] : undefined;
+          if (def?.offByDefault) {
             state.selectedModel = 'gemma-litellm';
             state.selectedProvider = 'litellm';
           }

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -24,6 +24,7 @@ export { wordpressContract } from './wordpressContract.js';
 export { transferContract } from './transferContract.js';
 export { unsplashContract } from './unsplashContract.js';
 export { notificationsContract } from './notificationsContract.js';
+export { modelPreferencesContract } from './modelPreferencesContract.js';
 export { adminVorlagenContract } from './adminVorlagenContract.js';
 export { authStatusContract } from './authStatusContract.js';
 export { canvasAiContract } from './canvasAi.js';

--- a/packages/contracts/src/contracts/modelPreferencesContract.ts
+++ b/packages/contracts/src/contracts/modelPreferencesContract.ts
@@ -1,0 +1,47 @@
+/**
+ * ts-rest contract for AI model preferences.
+ *
+ * Two routes:
+ *   - GET   /api/auth/profile/model-preferences
+ *   - PATCH /api/auth/profile/model-preferences
+ *
+ * Both auth-protected (requireAuth at /api/auth/profile in routes.ts).
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  modelPreferencesResponseSchema,
+  modelPreferencesErrorResponseSchema,
+  updateModelPreferenceBodySchema,
+} from '../schemas/modelPreferences.js';
+
+const c = initContract();
+
+export const modelPreferencesContract = c.router(
+  {
+    getPreferences: {
+      method: 'GET',
+      path: '/api/auth/profile/model-preferences',
+      responses: {
+        200: modelPreferencesResponseSchema,
+        401: modelPreferencesErrorResponseSchema,
+        500: modelPreferencesErrorResponseSchema,
+      },
+      summary: 'Get AI model preferences',
+    },
+
+    updatePreference: {
+      method: 'PATCH',
+      path: '/api/auth/profile/model-preferences',
+      body: updateModelPreferenceBodySchema,
+      responses: {
+        200: modelPreferencesResponseSchema,
+        400: modelPreferencesErrorResponseSchema,
+        401: modelPreferencesErrorResponseSchema,
+        500: modelPreferencesErrorResponseSchema,
+      },
+      summary: 'Update a single AI model preference',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -35,6 +35,7 @@ export {
   transferContract,
   unsplashContract,
   notificationsContract,
+  modelPreferencesContract,
   adminVorlagenContract,
   authStatusContract,
   canvasAiContract,
@@ -63,6 +64,7 @@ export * from './schemas/wordpress.js';
 export * from './schemas/transfer.js';
 export * from './schemas/unsplash.js';
 export * from './schemas/notifications.js';
+export * from './schemas/modelPreferences.js';
 export * from './schemas/adminVorlagen.js';
 export * from './schemas/authStatus.js';
 export * from './schemas/canvasAi.js';

--- a/packages/contracts/src/schemas/modelPreferences.ts
+++ b/packages/contracts/src/schemas/modelPreferences.ts
@@ -1,0 +1,37 @@
+/**
+ * Zod schemas for AI model preferences endpoints.
+ *
+ * Per-user toggle of which chat models appear in the model picker.
+ * Stored under `profiles.user_defaults.models`.
+ */
+import { z } from 'zod';
+
+export const modelIdSchema = z.enum([
+  'mistral-medium-3.5',
+  'gpt-oss-regolo',
+  'litellm',
+  'gemma-litellm',
+  'qwen-regolo',
+  'qwen3.6-regolo',
+]);
+
+export const modelPreferenceSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export const modelPreferencesMapSchema = z.record(modelPreferenceSchema);
+
+export const modelPreferencesResponseSchema = z.object({
+  success: z.boolean(),
+  preferences: modelPreferencesMapSchema,
+  defaults: modelPreferencesMapSchema,
+});
+
+export const updateModelPreferenceBodySchema = z.object({
+  modelId: modelIdSchema,
+  enabled: z.boolean(),
+});
+
+export const modelPreferencesErrorResponseSchema = z.object({
+  error: z.string(),
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -119,6 +119,12 @@
       "types": "./src/groups/index.ts",
       "import": "./dist/groups/index.js",
       "default": "./dist/groups/index.js"
+    },
+    "./models": {
+      "development": "./src/models/index.ts",
+      "types": "./src/models/index.ts",
+      "import": "./dist/models/index.js",
+      "default": "./dist/models/index.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -26,6 +26,7 @@ import {
   wordpressContract,
   transferContract,
   notificationsContract,
+  modelPreferencesContract,
   adminVorlagenContract,
   authStatusContract,
 } from '@gruenerator/contracts';
@@ -131,6 +132,7 @@ const _notebookClient = () => initClient(notebookContract, CLIENT_OPTS);
 const _wordpressClient = () => initClient(wordpressContract, CLIENT_OPTS);
 const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
 const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS);
+const _modelPreferencesClient = () => initClient(modelPreferencesContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
 const _authStatusClient = () => initClient(authStatusContract, CLIENT_OPTS);
 
@@ -144,6 +146,7 @@ export interface ContractsClient {
   wordpress: ReturnType<typeof _wordpressClient>;
   transfer: ReturnType<typeof _transferClient>;
   notifications: ReturnType<typeof _notificationsClient>;
+  modelPreferences: ReturnType<typeof _modelPreferencesClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
   authStatus: ReturnType<typeof _authStatusClient>;
 }
@@ -174,6 +177,7 @@ export function getContractsClient(): ContractsClient {
     wordpress: _wordpressClient(),
     transfer: _transferClient(),
     notifications: _notificationsClient(),
+    modelPreferences: _modelPreferencesClient(),
     adminVorlagen: _adminVorlagenClient(),
     authStatus: _authStatusClient(),
   };

--- a/packages/shared/src/models/catalog.ts
+++ b/packages/shared/src/models/catalog.ts
@@ -1,0 +1,112 @@
+export type Provider = 'mistral' | 'litellm' | 'regolo';
+
+export type ModelId =
+  | 'mistral-medium-3.5'
+  | 'gpt-oss-regolo'
+  | 'litellm'
+  | 'gemma-litellm'
+  | 'qwen-regolo'
+  | 'qwen3.6-regolo';
+
+export type ModelRegion = 'eu' | 'us' | 'cn' | 'self-hosted';
+
+export type ModelIcon = 'sparkles' | 'server' | 'zap' | 'brain';
+
+export interface ModelOption {
+  id: ModelId;
+  name: string;
+  description: string;
+  model: string;
+  provider: Provider;
+  icon: ModelIcon;
+  region: ModelRegion;
+  warning?: string;
+  offByDefault?: boolean;
+}
+
+export const QWEN_WARNING =
+  'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.';
+
+export const MODEL_OPTIONS: ModelOption[] = [
+  {
+    id: 'mistral-medium-3.5',
+    name: 'Mistral Medium 3.5',
+    description: 'Aktuelles Mistral-Modell (EU), stark bei Texten',
+    model: 'mistral-medium-2604',
+    provider: 'mistral',
+    icon: 'sparkles',
+    region: 'eu',
+  },
+  {
+    id: 'gemma-litellm',
+    name: 'Gemma 4',
+    description: 'Leichtgewichtig, antwortet schnell',
+    model: 'gpt-oss:120b',
+    provider: 'litellm',
+    icon: 'zap',
+    region: 'self-hosted',
+  },
+  {
+    id: 'gpt-oss-regolo',
+    name: 'GPT-OSS',
+    description: 'Offenes Modell über Regolo',
+    model: 'gpt-oss-120b',
+    provider: 'regolo',
+    icon: 'sparkles',
+    region: 'eu',
+  },
+  {
+    id: 'litellm',
+    name: 'Verdigado',
+    description: 'Selbst gehostet bei Verdigado',
+    model: 'gpt-oss:120b',
+    provider: 'litellm',
+    icon: 'server',
+    region: 'self-hosted',
+  },
+  {
+    id: 'qwen-regolo',
+    name: 'Qwen 120B',
+    description: 'Groß & vielseitig, für komplexe Aufgaben',
+    model: 'qwen3.5-122b',
+    provider: 'regolo',
+    icon: 'brain',
+    region: 'cn',
+    offByDefault: true,
+    warning: QWEN_WARNING,
+  },
+  {
+    id: 'qwen3.6-regolo',
+    name: 'Qwen 3.6 27B',
+    description: 'Kompaktes Reasoning-Modell, denkt sichtbar mit',
+    model: 'qwen3.6-27b',
+    provider: 'regolo',
+    icon: 'brain',
+    region: 'cn',
+    offByDefault: true,
+    warning: QWEN_WARNING,
+  },
+];
+
+export const MODEL_BY_ID: Record<ModelId, ModelOption> = MODEL_OPTIONS.reduce(
+  (acc, m) => {
+    acc[m.id] = m;
+    return acc;
+  },
+  {} as Record<ModelId, ModelOption>
+);
+
+export const ALL_MODEL_IDS: ModelId[] = MODEL_OPTIONS.map((m) => m.id);
+
+export function isModelEnabledByDefault(id: ModelId): boolean {
+  return !MODEL_BY_ID[id]?.offByDefault;
+}
+
+export const REGION_LABELS: Record<ModelRegion, string> = {
+  'self-hosted': 'Selbst gehostet',
+  eu: 'EU',
+  us: 'USA',
+  cn: 'Chinesisch',
+};
+
+export const REGION_ORDER: ModelRegion[] = ['self-hosted', 'eu', 'us', 'cn'];

--- a/packages/shared/src/models/index.ts
+++ b/packages/shared/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './catalog.js';


### PR DESCRIPTION
## Summary
- New profile-settings section letting users toggle which AI models appear in the chat model picker. Mirrors the notification-preferences pattern (declarative defaults, JSONB at \`profiles.user_defaults.models\`, ts-rest \`GET\`/\`PATCH\` endpoints, React Query optimistic updates).
- Chinese models (Qwen 120B, Qwen 3.6 27B) are now **off by default** for everyone via a new \`offByDefault\` flag on the canonical model catalog. Existing users who had Qwen selected get reset to Gemma 4 by a v8 persist migration; they can re-enable it in /profile.
- Canonical model catalog extracted to \`@gruenerator/shared/models\` so the API and frontends share one source of truth (no more divergence between picker and resolver).
- Chat **model picker tightened**: rows now show only the model name plus a small warning icon for cn-region models — icons + descriptions removed for compactness; trigger button keeps the current-model icon.

## Test plan
- [ ] \`pnpm --filter @gruenerator/api test services/user/modelPreferences.vitest.ts\` (11 tests, covers default-off for cn region, override semantics, malformed-value handling)
- [ ] As a fresh user, open chat picker → only 4 models visible (no Qwen)
- [ ] Open /profile → AI-Modelle section → toggle Qwen 120B on → picker now shows it
- [ ] Toggle Gemma 4 off while it's currently selected → picker auto-falls back to next visible model
- [ ] Existing user with \`selectedModel='qwen-regolo'\` in localStorage: reload → v8 migration resets to \`gemma-litellm\`
- [ ] Sign out + back in on another browser → preferences persist (cross-device, JSONB-backed)