### PR TITLE
fix(deps): sync pnpm-lock.yaml for @gruenerator/chat

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1375,6 +1375,9 @@ importers:
       '@gruenerator/collab':
         specifier: workspace:*
         version: link:../collab
+      '@gruenerator/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@gruenerator/ui':
         specifier: workspace:*
         version: link:../ui
@@ -1382,7 +1385,7 @@ importers:
         specifier: workspace:*
         version: link:../voice
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       '@tanstack/react-query':
         specifier: ^5.0.0


### PR DESCRIPTION
## Summary
- 4-line lockfile patch that unblocks the **build-web** and **build-gruen-o-mat** Docker images on test-branch (run [25274475931](https://github.com/netzbegruenung/Gruenerator/actions/runs/25274475931) failed at \`pnpm install --frozen-lockfile\`).
- Adds the missing \`@gruenerator/shared\` workspace link in \`@gruenerator/chat\`'s importer block (the link was introduced in #755 when the shared model catalog was extracted, but the lockfile bump was skipped).
- Corrects the \`@hocuspocus/provider\` specifier in the same block from \`^3.4.3\` to \`^3.4.4\` to match \`packages/chat/package.json\` (pre-existing drift, unrelated to #755).

## Test plan
- [x] \`pnpm install --frozen-lockfile --filter @gruenerator/web...\` succeeds locally (mimics CI).
- [ ] CI build-web + build-gruen-o-mat green on this PR.