### PR TITLE
chore(api): remove unused download-whisper script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,6 @@
     "start:hocuspocus": "cross-env NODE_OPTIONS=--conditions=development npx tsx ../../services/hocuspocus/src/index.ts",
     "start:prod": "cross-env NODE_ENV=production npm run start:backend",
     "test:embedding": "node scripts/testEmbedding.mjs",
-    "download-whisper": "npx nodejs-whisper download",
     "offboarding": "node scripts/offboarding-cron.js",
     "offboarding:status": "node -e \"require('./services/offboardingService').OffboardingService.validateConfig(); console.log('✓ Offboarding configuration is valid');\"",
     "backfill:previews": "node scripts/backfillContentPreviews.mjs",


### PR DESCRIPTION
## Summary
- Drops the orphaned \`download-whisper\` npm script from \`apps/api/package.json\`. The script invoked \`npx nodejs-whisper download\` but:
  - \`nodejs-whisper\` is not in any workspace's dependencies
  - No source file imports it (grep across \`apps/api/{services,routes,scripts}\`)
  - The Dockerfile never invoked the script
- Per CLAUDE.md, transcription runs through AssemblyAI/Gladia. This script is leftover from a removed local-Whisper experiment.

## Test plan
- [x] \`grep -rn nodejs-whisper apps/ packages/ services/\` returns no hits.
- [ ] CI builds green (no behavior change).