### PR TITLE
fix(deps): align @hocuspocus/provider override with package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
       "react-dom": "19.2.4",
       "@types/react": "^19.2.14",
       "@types/react-dom": "^19.2.3",
-      "@hocuspocus/provider": "^3.4.3",
+      "@hocuspocus/provider": "^3.4.4",
       "@isaacs/brace-expansion": ">=5.0.1",
       "diff": ">=5.2.2",
       "hono": ">=4.12.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   react-dom: 19.2.4
   '@types/react': ^19.2.14
   '@types/react-dom': ^19.2.3
-  '@hocuspocus/provider': ^3.4.3
+  '@hocuspocus/provider': ^3.4.4
   '@isaacs/brace-expansion': '>=5.0.1'
   diff: '>=5.2.2'
   hono: '>=4.12.12'
@@ -444,7 +444,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wolke
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       '@react-pdf/renderer':
         specifier: ^4.5.1
@@ -961,7 +961,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wolke
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       '@imgly/background-removal':
         specifier: ^1.7.0
@@ -1303,7 +1303,7 @@ importers:
         specifier: workspace:*
         version: link:../ui
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       '@iconify/react':
         specifier: ^6.0.2
@@ -1437,7 +1437,7 @@ importers:
   packages/collab:
     dependencies:
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       react:
         specifier: 19.2.4
@@ -1505,7 +1505,7 @@ importers:
         specifier: workspace:*
         version: link:../ui
       '@hocuspocus/provider':
-        specifier: ^3.4.3
+        specifier: ^3.4.4
         version: 3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30)
       '@tanstack/react-query':
         specifier: ^5.0.0


### PR DESCRIPTION
## Summary
- Unblocks **build-web** and **build-gruen-o-mat** Docker images on test-branch (failing since [run 25274832451](https://github.com/netzbegruenung/Gruenerator/actions/runs/25274832451) and again on subsequent runs).
- Root cause: the per-package \`package.json\` files were bumped to \`^3.4.4\` (likely a prior dependabot PR) but the **root \`pnpm.overrides\` entry was still pinned to \`^3.4.3\`**. \`pnpm.overrides\` mutates the *effective* spec for every dependent package, so the lockfile correctly used \`^3.4.3\` while the file content read \`^3.4.4\` — \`pnpm install --frozen-lockfile\` then errored with \`ERR_PNPM_OUTDATED_LOCKFILE\`.
- Fix: bump the override to \`^3.4.4\` (1 line in \`package.json\`) and update the 5 affected importer specifiers in \`pnpm-lock.yaml\`. The resolved version \`3.4.4\` was already what pnpm installed — this is metadata-only alignment, no behavior change.
- Supersedes the partial fix in #756 (which only patched chat's importer block).

## Why the error message was misleading
pnpm reports \`specs in package.json\` as the post-override effective spec, not the literal file content. That's why \`grep\` on the actual files showed \`^3.4.4\` everywhere but pnpm's error said \`^3.4.3\` — the override was silently rewriting it.

## Test plan
- [x] \`pnpm install --frozen-lockfile --filter @gruenerator/web...\` succeeds locally (mimics CI exactly).
- [ ] CI build-web + build-gruen-o-mat green on this PR.