### PR TITLE
fix(gruen-o-mat): alias @gruenerator/shared to src for vite build

### DIFF
--- a/apps/gruen-o-mat/vite.config.ts
+++ b/apps/gruen-o-mat/vite.config.ts
@@ -16,6 +16,12 @@ export default defineConfig(({ command }) => ({
     alias: {
       '@': path.resolve(__dirname, 'src'),
       '@gruenerator/chat': path.resolve(__dirname, '../../packages/chat/src'),
+      // Aliases don't cascade through workspace deps — chatStore.ts in
+      // @gruenerator/chat imports @gruenerator/shared/models, and shared
+      // uses conditional exports (development → src, import → dist) where
+      // dist is only present in published builds. Aliasing the source
+      // directly bypasses the dist requirement, matching apps/web's setup.
+      '@gruenerator/shared': path.resolve(__dirname, '../../packages/shared/src'),
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- Unblocks **build-gruen-o-mat** Docker image on test-branch (failing in [run 25275602081](https://github.com/netzbegruenung/Gruenerator/actions/runs/25275602081)).
- Root cause: \`@gruenerator/chat\` (which gruen-o-mat consumes via its own vite alias) now imports \`@gruenerator/shared/models\` (added in #755). \`@gruenerator/shared\` uses conditional exports (\`development\` → \`src/\`, \`import\` → \`dist/\`). Production builds don't activate the \`development\` condition, so vite/Rolldown tries to resolve \`dist/models/index.js\` — which doesn't exist because the gruen-o-mat Dockerfile never builds shared.
- Fix: add a vite alias for \`@gruenerator/shared\` pointing at \`packages/shared/src/\`, matching the pattern already used by \`apps/web/vite.config.ts\`.

## Why apps/web was unaffected
\`apps/web/vite.config.ts\` already aliases \`@gruenerator/shared\` and \`@gruenerator/contracts\` for exactly this reason — there's even a comment about Rolldown failing to resolve workspace imports without explicit aliases.

## Test plan
- [x] \`pnpm --filter @gruenerator/gruen-o-mat build\` succeeds locally (25s, ✓ built).
- [ ] CI build-gruen-o-mat green on this PR.