### PR TITLE
fix(theme): restore user preference persistence + prevent flash

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -46,7 +46,41 @@
     }
     </script>
     <link rel="canonical" href="https://www.gruenerator.de" />
-    
+
+    <!-- Pre-paint theme application: prevents flash of wrong theme. Must mirror
+         the storage format used by src/components/hooks/useDarkMode.ts -->
+    <script>
+      (function () {
+        try {
+          var EXPIRY = 7 * 24 * 60 * 60 * 1000;
+          var dark = null;
+          var saved = localStorage.getItem('darkMode');
+          if (saved) {
+            try {
+              var parsed = JSON.parse(saved);
+              if (
+                parsed &&
+                typeof parsed.value === 'boolean' &&
+                typeof parsed.timestamp === 'number' &&
+                Date.now() - parsed.timestamp < EXPIRY
+              ) {
+                dark = parsed.value;
+              }
+            } catch (e) {}
+          }
+          if (dark === null) {
+            var legacy = localStorage.getItem('theme');
+            if (legacy === 'dark') dark = true;
+            else if (legacy === 'light') dark = false;
+          }
+          if (dark === null) {
+            dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          }
+          document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+        } catch (e) {}
+      })();
+    </script>
+
     <!-- React Scan (dev only) - highlights unnecessary re-renders -->
     <script>
       if (location.hostname === 'localhost' || location.hostname === '127.0.0.1') {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -94,16 +94,6 @@ function App() {
   }, []);
 
   useEffect(() => {
-    if (darkMode) {
-      document.body.classList.add('dark-mode');
-      document.body.classList.remove('light-mode');
-    } else {
-      document.body.classList.add('light-mode');
-      document.body.classList.remove('dark-mode');
-    }
-  }, [darkMode]);
-
-  useEffect(() => {
     window.history.scrollRestoration = 'manual';
     window.scrollTo({
       top: 0,

--- a/apps/web/src/components/hooks/useDarkMode.ts
+++ b/apps/web/src/components/hooks/useDarkMode.ts
@@ -1,71 +1,78 @@
 import { useState, useEffect } from 'react';
 
 const STORAGE_KEY = 'darkMode';
-const USER_PREFERENCE_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days in milliseconds
+const LEGACY_KEY = 'theme';
+const USER_PREFERENCE_EXPIRY = 7 * 24 * 60 * 60 * 1000;
 
-const isMobile = (): boolean => {
-  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-};
-
-const useDarkMode = (): [boolean, () => void] => {
-  const [darkMode, setDarkMode] = useState<boolean>(() => {
-    if (isMobile()) {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
-
-    const savedMode = localStorage.getItem(STORAGE_KEY);
-    if (savedMode) {
-      const { value, timestamp } = JSON.parse(savedMode) as { value: boolean; timestamp: number };
-      const now = new Date().getTime();
-      if (now - timestamp < USER_PREFERENCE_EXPIRY) {
+const readSavedPreference = (): boolean | null => {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    try {
+      const { value, timestamp } = JSON.parse(saved) as { value: boolean; timestamp: number };
+      if (Date.now() - timestamp < USER_PREFERENCE_EXPIRY) {
         return value;
       }
+    } catch {
+      // fall through to legacy key
     }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches;
-  });
+  }
+  const legacy = localStorage.getItem(LEGACY_KEY);
+  if (legacy === 'dark' || legacy === 'light') {
+    return legacy === 'dark';
+  }
+  return null;
+};
+
+const getInitialDarkMode = (): boolean => {
+  const saved = readSavedPreference();
+  if (saved !== null) return saved;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+const listeners = new Set<(value: boolean) => void>();
+
+const useDarkMode = (): [boolean, () => void] => {
+  const [darkMode, setDarkMode] = useState<boolean>(getInitialDarkMode);
+
+  useEffect(() => {
+    listeners.add(setDarkMode);
+    const onStorage = (e: StorageEvent): void => {
+      if (e.key !== STORAGE_KEY && e.key !== LEGACY_KEY) return;
+      const next = readSavedPreference();
+      if (next !== null) setDarkMode(next);
+    };
+    window.addEventListener('storage', onStorage);
+    return () => {
+      listeners.delete(setDarkMode);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = (e: MediaQueryListEvent): void => {
-      if (isMobile()) {
-        setDarkMode(e.matches);
-        return;
-      }
-
-      const savedMode = localStorage.getItem(STORAGE_KEY);
-      if (
-        !savedMode ||
-        (JSON.parse(savedMode) as { timestamp: number }).timestamp + USER_PREFERENCE_EXPIRY <
-          new Date().getTime()
-      ) {
+      if (readSavedPreference() === null) {
         setDarkMode(e.matches);
       }
     };
-
-    mediaQuery.addListener(handleChange);
-    return () => mediaQuery.removeListener(handleChange);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
   useEffect(() => {
-    if (!isMobile()) {
-      const data = JSON.stringify({
-        value: darkMode,
-        timestamp: new Date().getTime(),
-      });
-      localStorage.setItem(STORAGE_KEY, data);
-    }
-
-    if (darkMode) {
-      document.documentElement.setAttribute('data-theme', 'dark');
-    } else {
-      document.documentElement.setAttribute('data-theme', 'light');
-    }
+    document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ value: darkMode, timestamp: Date.now() })
+    );
+    localStorage.removeItem(LEGACY_KEY);
+    listeners.forEach((cb) => {
+      if (cb !== setDarkMode) cb(darkMode);
+    });
   }, [darkMode]);
 
   const toggleDarkMode = (): void => {
-    if (!isMobile()) {
-      setDarkMode((prevMode) => !prevMode);
-    }
+    setDarkMode((prev) => !prev);
   };
 
   return [darkMode, toggleDarkMode];

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import { useAuthStore } from '../../../stores/authStore';
 import useSidebarFavouritesStore from '../../../stores/sidebarFavouritesStore';
 import useSidebarStore from '../../../stores/sidebarStore';
 import { StatusBadge } from '../../common/StatusBadge';
+import useDarkMode from '../../hooks/useDarkMode';
 import {
   getMenuItems,
   getDirectMenuItems,
@@ -70,9 +71,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
 
   const [activeSection, setActiveSection] = useState<string | null>(null);
   const newMenuOpenRef = useRef(false);
-  const [darkMode, setDarkMode] = useState(
-    () => document.documentElement.getAttribute('data-theme') === 'dark'
-  );
+  const [darkMode, toggleDarkMode] = useDarkMode();
 
   const menuItems = useMemo(() => getMenuItems({ isAustrian }), [isAustrian]);
 
@@ -92,18 +91,6 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
       close();
     }
   }, [location.pathname]);
-
-  useEffect(() => {
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (mutation.attributeName === 'data-theme') {
-          setDarkMode(document.documentElement.getAttribute('data-theme') === 'dark');
-        }
-      });
-    });
-    observer.observe(document.documentElement, { attributes: true });
-    return () => observer.disconnect();
-  }, []);
 
   // Keyboard shortcuts: Escape to close, Ctrl/Cmd+B to toggle
   useEffect(() => {
@@ -160,13 +147,6 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
       void navigate('/chat');
     }
   }, [navigate, onNavigate, location.pathname]);
-
-  const toggleDarkMode = useCallback(() => {
-    const newTheme = darkMode ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', newTheme);
-    localStorage.setItem('theme', newTheme);
-    setDarkMode(!darkMode);
-  }, [darkMode]);
 
   const handleMouseLeave = useCallback(() => {
     if (!newMenuOpenRef.current) {


### PR DESCRIPTION
## Summary

Dark/light mode toggle never persisted across reloads — the app silently fell back to `prefers-color-scheme` (dark on most modern OSes), which is why it felt "always dark."

- **Root cause:** `useDarkMode` read `localStorage['darkMode']` while `Sidebar.tsx` and `FirstRunWizard.tsx` wrote `localStorage['theme']`. Two writers, no shared reader, so toggles were dropped on reload.
- **Fix (commit 1):** `useDarkMode` is now the single source of truth. Reads both keys (one-time legacy migration), uses a module-level pub-sub so multiple hook instances stay in lockstep, listens for `storage` events for cross-tab sync, and removes the mobile lock so the toggle actually works on phones. `Sidebar` consumes the hook instead of mirroring state via `MutationObserver`. `App.tsx` drops body classes (`dark-mode`/`light-mode`) that no CSS reads.
- **Fix (commit 2):** Inline pre-paint script in `index.html` applies `data-theme` synchronously before parser reaches `<body>`, eliminating the flash before React's deferred module script mounts. The script mirrors the hook's storage format exactly so pre-paint and post-mount agree.

## Test plan

- [ ] Toggle theme via sidebar — confirm preference persists across reload
- [ ] Open the app in two tabs, toggle in one — confirm the other tab updates without reload
- [ ] On mobile (touch device), tap sun/moon icon in sidebar — confirm it now toggles (was a no-op before)
- [ ] Hard reload — confirm no FOIT (no flash of wrong theme before React mounts)
- [ ] First-run wizard (Tauri only) — confirm picking light/dark/auto still works (legacy `'theme'` key migration covers this)
- [ ] Clear localStorage, reload — confirm initial theme matches OS preference
- [ ] With `prefers-color-scheme: light` and saved `dark` preference — confirm saved wins