### PR TITLE
fix(docs): chat sees the open document + thin scrollbar

### DIFF
--- a/apps/api/routes/chat/services/contextEnrichmentService.ts
+++ b/apps/api/routes/chat/services/contextEnrichmentService.ts
@@ -235,7 +235,14 @@ export async function enrichContext(opts: {
 
   // Clear raw attachment text for vectorized docs only.
   // Small docs (<4K chars) keep their inline attachmentContext.
-  if (initialState.documentChatIds && initialState.documentChatIds.length > 0) {
+  // Gated on docAttachments.length: documentChatIds can arrive without any
+  // file attachments (pre-supplied references), in which case attachmentContext
+  // is the live inline content and must be preserved.
+  if (
+    docAttachments.length > 0 &&
+    initialState.documentChatIds &&
+    initialState.documentChatIds.length > 0
+  ) {
     if (largeDocAttachments.length === docAttachments.length) {
       initialState.attachmentContext = null;
     } else {

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -589,7 +589,7 @@ function EditorContent() {
       )}
 
       <div className="flex-1 flex flex-row overflow-hidden max-md:flex-col">
-        <main className="flex-1 min-w-0 overflow-y-auto py-4 px-6 bg-grey-100 dark:bg-grey-900 max-sm:px-0 max-sm:pt-0 max-sm:pb-[var(--mobile-keyboard-offset,0px)] max-sm:bg-background dark:max-sm:bg-background">
+        <main className="flex-1 min-w-0 overflow-y-auto scrollbar-thin py-4 px-6 bg-grey-100 dark:bg-grey-900 max-sm:px-0 max-sm:pt-0 max-sm:pb-[var(--mobile-keyboard-offset,0px)] max-sm:bg-background dark:max-sm:bg-background">
           <MemoizedBlockNoteEditor
             documentId={id!}
             initialContent={initialContent}


### PR DESCRIPTION
## Summary

Two small fixes to the docs editor:

- **`fix(api/chat)`** — the in-editor chat now actually sees the document. The vectorized-upload cleanup branch in `enrichContext` was nulling `attachmentContext` for any request carrying `documentChatIds` regardless of whether file attachments existed (`0 === 0` triggered it), so the live BlockNote markdown the docs frontend sent was wiped before reaching the system prompt. Gated the cleanup on `docAttachments.length > 0` so it only owns the upload→vectorize path; editor-sourced `documentChatIds` + inline `attachmentContext` now flow through untouched. Frontend was already correct.
- **`style(docs/web)`** — added `scrollbar-thin` to the document editor main pane to match the chat viewport (already uses `scrollbar-thin` via `GrueneratorThread`). The class is provided globally by `chat-embedded.css`, imported from `apps/web/src/assets/styles/index.css`.

Repro of the chat bug before fix: open `/docs/<id>`, ask "wie würdest du dieses dokument verbessern?" — assistant replies as if no document is attached and asks for the text.

## Test plan

- [ ] Open `/docs/<id>`, ask "fasse dieses dokument zusammen" — assistant references actual content (titles, sections), no longer asks for the text.
- [ ] Edit the doc without saving, ask another question — assistant sees the unsaved edits (confirms live markdown path).
- [ ] Select a passage, ask "verbessere diese stelle" — response focuses on the selection (`## Auswahl:` block intact).
- [ ] In `/chat`, drop a small (<4K char) text file as an attachment and ask about it — inline answer (regression check, no `documentChatIds` cleanup needed).
- [ ] In `/chat`, drop a large (>4K char) file — receive `document_indexed` SSE event and a RAG-cited answer (regression check, cleanup branch still runs because `docAttachments.length > 0`).
- [ ] Confirm the document scroll area in `/docs/<id>` shows the thin scrollbar matching the chat side.