### PR TITLE
feat(templates): user-saved Vorlagen for boards and docs

### DIFF
--- a/apps/api/routes/auth/templates/userTemplates.ts
+++ b/apps/api/routes/auth/templates/userTemplates.ts
@@ -13,6 +13,7 @@ import {
   urlCrawlerService,
   UrlValidator,
 } from '../../../services/scrapers/implementations/UrlCrawler/index.js';
+import { createDocFromTemplate } from '../../../services/templates/collaborativeTemplateService.js';
 import { createLogger } from '../../../utils/logger.js';
 
 import type { AuthRequest } from '../types.js';
@@ -187,14 +188,25 @@ router.get(
       const postgres = getPostgresInstance();
       await postgres.ensureInitialized();
 
+      const templateTypeFilter =
+        typeof req.query.template_type === 'string' ? req.query.template_type : null;
+
       // Fetch user's templates from user_templates table (excluding examples)
-      const templates = await postgres.query(
-        `SELECT * FROM user_templates
+      const templates = templateTypeFilter
+        ? await postgres.query(
+            `SELECT * FROM user_templates
+       WHERE user_id = $1 AND type = $2 AND is_example = $3 AND template_type = $4
+       ORDER BY updated_at DESC`,
+            [userId, 'template', false, templateTypeFilter],
+            { table: 'user_templates' }
+          )
+        : await postgres.query(
+            `SELECT * FROM user_templates
        WHERE user_id = $1 AND type = $2 AND is_example = $3
        ORDER BY updated_at DESC`,
-        [userId, 'template', false],
-        { table: 'user_templates' }
-      );
+            [userId, 'template', false],
+            { table: 'user_templates' }
+          );
 
       // Transform data to match frontend expectations
       const formattedTemplates = (
@@ -669,6 +681,58 @@ router.delete(
       res.status(500).json({
         success: false,
         message: err.message || 'Failed to perform bulk delete of templates',
+      });
+    }
+  }
+);
+
+// === INSTANTIATE: create a new collaborative document from a template ===
+
+const instantiateSchema = z.object({
+  title: z.string().min(1).max(200),
+});
+
+router.post(
+  '/user-templates/:id/instantiate',
+  ensureAuthenticated,
+  validateBody(instantiateSchema),
+  async (
+    req: TypedRequest<z.infer<typeof instantiateSchema>, { id: string }>,
+    res: Response
+  ): Promise<void> => {
+    try {
+      const userId = req.user!.id;
+      const { id } = req.params;
+      const { title } = req.body;
+
+      const result = await createDocFromTemplate(userId, id, title);
+
+      res.status(201).json({
+        success: true,
+        data: { documentId: result.documentId, subtype: result.subtype },
+      });
+    } catch (error) {
+      const err = error as Error;
+      log.error('[User Templates /user-templates/:id/instantiate POST] Error:', err);
+      const message = err.message || '';
+      if (message.includes('not found')) {
+        res.status(404).json({ success: false, message: 'Vorlage nicht gefunden.' });
+        return;
+      }
+      if (message.includes('Not authorized')) {
+        res.status(403).json({ success: false, message: 'Keine Berechtigung für diese Vorlage.' });
+        return;
+      }
+      if (message.includes('no Yjs content')) {
+        res.status(400).json({
+          success: false,
+          message: 'Vorlage enthält keinen Inhalt zum Wiederherstellen.',
+        });
+        return;
+      }
+      res.status(500).json({
+        success: false,
+        message: 'Fehler beim Erstellen aus Vorlage.',
       });
     }
   }

--- a/apps/api/routes/docs/documentController.ts
+++ b/apps/api/routes/docs/documentController.ts
@@ -13,6 +13,10 @@ import { z } from 'zod';
 
 import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
+import {
+  snapshotCollaborativeDoc,
+  subtypeToTemplateType,
+} from '../../services/templates/collaborativeTemplateService.js';
 
 import { DOCS_SUBTYPES } from './constants.js';
 import { checkDocumentAccess } from './documentAccess.js';
@@ -23,6 +27,16 @@ const updateDocSchema = z.object({
   folder_id: z.unknown().optional(),
   content: z.string().optional(),
   wolke_live_sync: z.boolean().optional(),
+});
+
+const saveAsTemplateSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  is_private: z.boolean().optional(),
+  preview: z.record(z.unknown()).optional(),
+  thumbnail_url: z.string().optional(),
+  categories: z.array(z.unknown()).optional(),
+  tags: z.array(z.unknown()).optional(),
 });
 
 const router = Router();
@@ -271,5 +285,105 @@ router.post('/:id/duplicate', async (req: Request, res: Response) => {
     return res.status(500).json({ error: 'Failed to duplicate document', details: message });
   }
 });
+
+/**
+ * @route   POST /api/docs/:id/save-as-template
+ * @desc    Snapshot the current Yjs state of a doc/board and store it as a
+ *          user_template. Returns the new template id.
+ * @access  Private (any user with read access to the document)
+ */
+router.post(
+  '/:id/save-as-template',
+  validateBody(saveAsTemplateSchema),
+  async (
+    req: TypedRequest<z.infer<typeof saveAsTemplateSchema>, { id: string }>,
+    res: Response
+  ) => {
+    try {
+      const { id } = req.params;
+      const userId = req.user?.id;
+
+      if (!userId) {
+        return res.status(401).json({ error: 'User not authenticated' });
+      }
+
+      const checkResult = (await db.query(
+        `SELECT id, created_by, permissions, is_public, share_mode, document_subtype, title
+         FROM collaborative_documents
+         WHERE id = $1 AND document_subtype = ANY($2::text[]) AND is_deleted = false`,
+        [id, DOCS_SUBTYPES]
+      )) as CollaborativeDocument[];
+
+      if (checkResult.length === 0) {
+        return res.status(404).json({ error: 'Document not found' });
+      }
+
+      const document = checkResult[0];
+      const { hasAccess } = await checkDocumentAccess(document, userId);
+      if (!hasAccess) {
+        return res.status(403).json({ error: 'Access denied' });
+      }
+
+      const snapshot = await snapshotCollaborativeDoc(id);
+      const templateType = subtypeToTemplateType(snapshot.subtype);
+
+      const {
+        title,
+        description,
+        is_private = true,
+        preview,
+        thumbnail_url,
+        categories = [],
+        tags = [],
+      } = req.body;
+
+      const contentData = {
+        yjs: snapshot.yjs,
+        subtype: snapshot.subtype,
+        ...(preview ? { preview } : {}),
+      };
+
+      const inserted = (await db.query(
+        `INSERT INTO user_templates
+          (user_id, type, title, description, template_type, thumbnail_url,
+           images, categories, tags, content_data, metadata, is_private, is_example, status)
+         VALUES ($1, 'template', $2, $3, $4, $5,
+                 '[]'::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, '{}'::jsonb, $9, false, $10)
+         RETURNING id, title, template_type, is_private, status, created_at`,
+        [
+          userId,
+          title.trim(),
+          description ? description.trim() : null,
+          templateType,
+          thumbnail_url || null,
+          JSON.stringify(Array.isArray(categories) ? categories : []),
+          JSON.stringify(Array.isArray(tags) ? tags : []),
+          JSON.stringify(contentData),
+          is_private,
+          is_private ? 'draft' : 'pending_review',
+        ]
+      )) as Array<{
+        id: string;
+        title: string;
+        template_type: string;
+        is_private: boolean;
+        status: string;
+        created_at: string;
+      }>;
+
+      return res.status(201).json({
+        success: true,
+        data: inserted[0],
+        message: is_private
+          ? 'Vorlage wurde erstellt.'
+          : 'Vorlage wurde eingereicht und wird geprüft.',
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[Docs] Error saving as template:', error);
+      return res.status(500).json({ error: 'Failed to save as template', details: message });
+    }
+  }
+);
 
 export default router;

--- a/apps/api/services/templates/collaborativeTemplateService.ts
+++ b/apps/api/services/templates/collaborativeTemplateService.ts
@@ -1,0 +1,204 @@
+/**
+ * Snapshots and instantiates collaborative documents (boards/docs) as
+ * user_templates. Yjs state is stored gzipped+base64 in
+ * `user_templates.content_data.yjs` — the exact wire shape of
+ * `yjs_document_snapshots.snapshot_data`, so instantiation is a direct paste.
+ */
+
+import { gzipSync, gunzipSync } from 'node:zlib';
+
+import * as Y from 'yjs';
+
+import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('collaborativeTemplateService');
+
+export interface CollaborativeSnapshot {
+  yjs: string;
+  subtype: string;
+  title: string;
+}
+
+export interface InstantiateResult {
+  documentId: string;
+  subtype: string;
+}
+
+interface CollaborativeDocRow {
+  id: string;
+  title: string;
+  document_subtype: string | null;
+}
+
+interface SnapshotRow {
+  snapshot_data: Buffer;
+  created_at: string;
+}
+
+interface UpdateRow {
+  update_data: Buffer;
+}
+
+interface UserTemplateRow {
+  id: string;
+  user_id: string | null;
+  template_type: string;
+  title: string;
+  is_private: boolean;
+  status: string;
+  content_data: { yjs?: string; subtype?: string } | null;
+}
+
+const TEMPLATE_TYPE_TO_SUBTYPE: Record<string, string> = {
+  board: 'boards',
+  doc: 'docs',
+};
+
+const SUBTYPE_TO_TEMPLATE_TYPE: Record<string, string> = {
+  boards: 'board',
+  docs: 'doc',
+};
+
+export function subtypeToTemplateType(subtype: string | null | undefined): string {
+  if (!subtype) return 'doc';
+  return SUBTYPE_TO_TEMPLATE_TYPE[subtype] ?? 'doc';
+}
+
+/**
+ * Hydrate the current Y.Doc state from latest snapshot + subsequent updates,
+ * then return it as a single gzipped+base64 string suitable for storage in
+ * user_templates.content_data.yjs.
+ */
+export async function snapshotCollaborativeDoc(documentId: string): Promise<CollaborativeSnapshot> {
+  const db = getPostgresInstance();
+
+  const docRows = (await db.query(
+    `SELECT id, title, document_subtype
+     FROM collaborative_documents
+     WHERE id = $1 AND is_deleted = false`,
+    [documentId]
+  )) as CollaborativeDocRow[];
+
+  if (docRows.length === 0) {
+    throw new Error('Document not found');
+  }
+  const doc = docRows[0];
+
+  const snapshotRows = (await db.query(
+    `SELECT snapshot_data, created_at
+     FROM yjs_document_snapshots WHERE document_id = $1
+     ORDER BY version DESC LIMIT 1`,
+    [documentId]
+  )) as SnapshotRow[];
+
+  const ydoc = new Y.Doc();
+
+  if (snapshotRows.length > 0) {
+    Y.applyUpdate(ydoc, gunzipSync(snapshotRows[0].snapshot_data));
+
+    const updates = (await db.query(
+      `SELECT update_data FROM yjs_document_updates
+       WHERE document_id = $1 AND created_at > $2
+       ORDER BY created_at ASC`,
+      [documentId, snapshotRows[0].created_at]
+    )) as UpdateRow[];
+
+    for (const u of updates) {
+      try {
+        Y.applyUpdate(ydoc, gunzipSync(u.update_data));
+      } catch (err) {
+        log.warn(`[snapshot] failed to apply update for ${documentId}: ${(err as Error).message}`);
+      }
+    }
+  } else {
+    const updates = (await db.query(
+      `SELECT update_data FROM yjs_document_updates
+       WHERE document_id = $1 ORDER BY created_at ASC`,
+      [documentId]
+    )) as UpdateRow[];
+
+    for (const u of updates) {
+      try {
+        Y.applyUpdate(ydoc, gunzipSync(u.update_data));
+      } catch (err) {
+        log.warn(`[snapshot] failed to apply update for ${documentId}: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  const state = Y.encodeStateAsUpdate(ydoc);
+  const compressed = gzipSync(Buffer.from(state));
+
+  return {
+    yjs: compressed.toString('base64'),
+    subtype: doc.document_subtype ?? 'docs',
+    title: doc.title,
+  };
+}
+
+/**
+ * Create a fresh collaborative_document and seed its Yjs state from a saved
+ * template. Inserts a single snapshot at version 1 — Hocuspocus will pick it
+ * up on the next client connection.
+ */
+export async function createDocFromTemplate(
+  userId: string,
+  templateId: string,
+  title: string
+): Promise<InstantiateResult> {
+  const db = getPostgresInstance();
+
+  const templateRows = (await db.query(
+    `SELECT id, user_id, template_type, title, is_private, status, content_data
+     FROM user_templates
+     WHERE id = $1 AND type = 'template'`,
+    [templateId]
+  )) as UserTemplateRow[];
+
+  if (templateRows.length === 0) {
+    throw new Error('Template not found');
+  }
+  const template = templateRows[0];
+
+  const ownsTemplate = template.user_id === userId;
+  const isPublicPublished = !template.is_private && template.status === 'published';
+  if (!ownsTemplate && !isPublicPublished) {
+    throw new Error('Not authorized to use this template');
+  }
+
+  const yjsBase64 = template.content_data?.yjs;
+  if (!yjsBase64 || typeof yjsBase64 !== 'string') {
+    throw new Error('Template has no Yjs content');
+  }
+
+  const subtype =
+    template.content_data?.subtype ?? TEMPLATE_TYPE_TO_SUBTYPE[template.template_type] ?? 'docs';
+
+  const ownerPermissions = JSON.stringify({
+    [userId]: { level: 'owner', granted_at: new Date().toISOString() },
+  });
+
+  const newDocRows = (await db.query(
+    `INSERT INTO collaborative_documents
+      (title, created_by, last_edited_by, document_subtype, permissions, is_public)
+     VALUES ($1, $2, $2, $3, $4::jsonb, false)
+     RETURNING id`,
+    [title.trim() || template.title, userId, subtype, ownerPermissions]
+  )) as { id: string }[];
+
+  const newDocId = newDocRows[0].id;
+
+  const snapshotBuffer = Buffer.from(yjsBase64, 'base64');
+
+  await db.query(
+    `INSERT INTO yjs_document_snapshots
+      (document_id, snapshot_data, version, created_at, is_auto_save, label, created_by)
+     VALUES ($1, $2, 1, CURRENT_TIMESTAMP, false, $3, $4)`,
+    [newDocId, snapshotBuffer, `from-template:${templateId}`, userId]
+  );
+
+  log.info(`[instantiate] created ${subtype} doc ${newDocId} from template ${templateId}`);
+
+  return { documentId: newDocId, subtype };
+}

--- a/apps/web/src/features/boards/components/ShareBoardDialog.tsx
+++ b/apps/web/src/features/boards/components/ShareBoardDialog.tsx
@@ -1,3 +1,4 @@
+import { saveCollaborativeDocAsTemplate } from '@gruenerator/shared';
 import {
   Badge,
   Button,
@@ -40,6 +41,32 @@ export function ShareBoardDialog({ boardId, open, onOpenChange }: ShareBoardDial
   const [copied, setCopied] = useState(false);
   const [selectedGroupId, setSelectedGroupId] = useState('');
   const [groupPermission, setGroupPermission] = useState<'viewer' | 'editor'>('viewer');
+  const [templateMode, setTemplateMode] = useState<'idle' | 'editing' | 'saving' | 'saved'>('idle');
+  const [templateTitle, setTemplateTitle] = useState('');
+  const [templateError, setTemplateError] = useState<string | null>(null);
+
+  const handleSaveAsTemplate = useCallback(async () => {
+    const trimmed = templateTitle.trim();
+    if (!trimmed) {
+      setTemplateError('Bitte gib der Vorlage einen Titel.');
+      return;
+    }
+    try {
+      setTemplateMode('saving');
+      setTemplateError(null);
+      await saveCollaborativeDocAsTemplate({
+        documentId: boardId,
+        title: trimmed,
+        isPrivate: true,
+      });
+      setTemplateMode('saved');
+      setTimeout(() => setTemplateMode('idle'), 2500);
+    } catch (err) {
+      console.error('Failed to save board as template:', err);
+      setTemplateError('Vorlage konnte nicht gespeichert werden.');
+      setTemplateMode('editing');
+    }
+  }, [boardId, templateTitle]);
 
   const {
     collaborators,
@@ -256,6 +283,53 @@ export function ShareBoardDialog({ boardId, open, onOpenChange }: ShareBoardDial
             </div>
           </div>
         )}
+
+        {/* Save as template */}
+        <div className="border-t border-grey-200 dark:border-grey-700 pt-3">
+          {templateMode === 'idle' && (
+            <button
+              type="button"
+              onClick={() => {
+                setTemplateMode('editing');
+                setTemplateError(null);
+              }}
+              className="cursor-pointer bg-transparent border-none p-0 text-sm font-medium text-secondary-600 hover:underline"
+            >
+              Als Vorlage speichern
+            </button>
+          )}
+          {templateMode === 'editing' && (
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="text"
+                value={templateTitle}
+                onChange={(e) => setTemplateTitle(e.target.value)}
+                placeholder="Titel der Vorlage"
+                className="flex-1 min-w-[180px] h-8 rounded-md border border-grey-300 dark:border-grey-600 bg-background px-2 text-sm outline-none focus:border-primary-500"
+              />
+              <Button size="sm" onClick={handleSaveAsTemplate}>
+                Speichern
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setTemplateMode('idle');
+                  setTemplateError(null);
+                }}
+              >
+                Abbrechen
+              </Button>
+            </div>
+          )}
+          {templateMode === 'saving' && (
+            <p className="text-sm text-grey-500">Vorlage wird gespeichert…</p>
+          )}
+          {templateMode === 'saved' && (
+            <p className="text-sm text-green-600">✓ Vorlage gespeichert</p>
+          )}
+          {templateError && <p className="mt-1 text-xs text-red-600">{templateError}</p>}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/features/docs/DocsPage.tsx
+++ b/apps/web/src/features/docs/DocsPage.tsx
@@ -9,6 +9,7 @@ import {
   templates,
   type TemplateType,
 } from '@gruenerator/docs';
+import { instantiateUserTemplate, type UserTemplateSummary } from '@gruenerator/shared';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -313,6 +314,25 @@ function DocumentsContent() {
     [createBoard, navigate]
   );
 
+  const handleUserTemplateSelect = useCallback(
+    async (template: UserTemplateSummary) => {
+      try {
+        const result = await instantiateUserTemplate({
+          templateId: template.id,
+          title: template.title,
+        });
+        if (result.subtype === 'boards') {
+          void navigate(`/boards/${result.documentId}`);
+        } else {
+          adapter.navigateToDocument(result.documentId);
+        }
+      } catch (err) {
+        console.error('Failed to instantiate user template:', err);
+      }
+    },
+    [adapter, navigate]
+  );
+
   return (
     <>
       <div className="mb-md mt-md flex items-center gap-sm">
@@ -359,6 +379,7 @@ function DocumentsContent() {
           onShowGallery={() => setShowGallery(true)}
           onCreateBoardFromTemplate={handleCreateBoardFromTemplate}
           onCreateWhiteboard={() => handleCreateBoard('whiteboard')}
+          onUserTemplateSelect={handleUserTemplateSelect}
         />
 
         {isLoading ? (

--- a/apps/web/src/features/docs/TemplateCarousel.tsx
+++ b/apps/web/src/features/docs/TemplateCarousel.tsx
@@ -1,8 +1,10 @@
 import { templates, type TemplateType } from '@gruenerator/docs';
+import { listUserTemplates, type UserTemplateSummary } from '@gruenerator/shared';
 import { cn } from '@gruenerator/ui';
+import { useQuery } from '@tanstack/react-query';
 import { memo, useEffect, useRef, useState } from 'react';
 import { FiChevronDown, FiMoreVertical } from 'react-icons/fi';
-import { PiKanban, PiPencilLine } from 'react-icons/pi';
+import { PiBookmarkSimple, PiKanban, PiPencilLine } from 'react-icons/pi';
 
 import { boardTemplates } from '../boards/boardTemplates';
 
@@ -13,6 +15,7 @@ interface TemplateCarouselProps {
   onShowGallery: () => void;
   onCreateBoardFromTemplate: (templateId: string) => void;
   onCreateWhiteboard: () => void;
+  onUserTemplateSelect: (template: UserTemplateSummary) => void;
 }
 
 export const TemplateCarousel = memo(
@@ -21,7 +24,19 @@ export const TemplateCarousel = memo(
     onShowGallery,
     onCreateBoardFromTemplate,
     onCreateWhiteboard,
+    onUserTemplateSelect,
   }: TemplateCarouselProps) => {
+    const { data: userTemplates = [] } = useQuery<UserTemplateSummary[]>({
+      queryKey: ['user-templates', 'docs-and-boards'],
+      queryFn: async () => {
+        const [docs, boards] = await Promise.all([
+          listUserTemplates({ kind: 'doc' }),
+          listUserTemplates({ kind: 'board' }),
+        ]);
+        return [...docs, ...boards];
+      },
+      staleTime: 30_000,
+    });
     const [isHidden, setIsHidden] = useState(() => {
       try {
         return localStorage.getItem(STORAGE_KEY) === 'true';
@@ -174,6 +189,49 @@ export const TemplateCarousel = memo(
                 </span>
               </div>
             </button>
+
+            {userTemplates.length > 0 && (
+              <>
+                <div className="w-px self-stretch bg-grey-200 dark:bg-grey-600 shrink-0 my-1" />
+                {userTemplates.map((tpl) => {
+                  const isBoard = tpl.template_type === 'board';
+                  return (
+                    <button
+                      key={tpl.id}
+                      className="group/item shrink-0 w-[118px] cursor-pointer bg-transparent border-none p-0 text-left font-[inherit]"
+                      onClick={() => onUserTemplateSelect(tpl)}
+                      title={tpl.description ?? tpl.title}
+                    >
+                      <div
+                        className={cn(
+                          'w-[118px] h-[150px] border border-grey-200 dark:border-grey-600 rounded overflow-hidden flex items-center justify-center transition-[box-shadow,border-color] duration-150 ease-out group-hover/item:shadow-sm',
+                          isBoard
+                            ? 'bg-secondary-50 dark:bg-secondary-900/20 group-hover/item:border-secondary-300 dark:group-hover/item:border-secondary-500'
+                            : 'bg-background-pure dark:bg-grey-700 group-hover/item:border-grey-300 dark:group-hover/item:border-grey-500'
+                        )}
+                      >
+                        {isBoard ? (
+                          <PiKanban
+                            size={32}
+                            className="text-secondary-600 dark:text-secondary-400"
+                          />
+                        ) : (
+                          <PiBookmarkSimple size={32} className="text-grey-400" />
+                        )}
+                      </div>
+                      <div className="pt-1.5 px-1">
+                        <span className="block text-[0.8125rem] font-medium text-foreground truncate">
+                          {tpl.title}
+                        </span>
+                        <span className="block text-xs font-light text-grey-500 truncate">
+                          Eigene Vorlage
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </>
+            )}
           </div>
         )}
       </div>

--- a/packages/docs/src/components/permissions/ShareModal.tsx
+++ b/packages/docs/src/components/permissions/ShareModal.tsx
@@ -77,6 +77,32 @@ export const ShareModal = ({ documentId, documentTitle, onClose }: ShareModalPro
   const [directShareSuccess, setDirectShareSuccess] = useState(false);
   const [isChangingMode, setIsChangingMode] = useState(false);
 
+  const [templateMode, setTemplateMode] = useState<'idle' | 'editing' | 'saving' | 'saved'>('idle');
+  const [templateTitle, setTemplateTitle] = useState(documentTitle ?? '');
+  const [templateError, setTemplateError] = useState<string | null>(null);
+
+  const saveAsTemplate = async () => {
+    const trimmed = templateTitle.trim();
+    if (!trimmed) {
+      setTemplateError('Bitte gib der Vorlage einen Titel.');
+      return;
+    }
+    try {
+      setTemplateMode('saving');
+      setTemplateError(null);
+      await apiClient.post(`/docs/${documentId}/save-as-template`, {
+        title: trimmed,
+        is_private: true,
+      });
+      setTemplateMode('saved');
+      setTimeout(() => setTemplateMode('idle'), 2500);
+    } catch (err) {
+      console.error('Failed to save as template:', err);
+      setTemplateError('Vorlage konnte nicht gespeichert werden.');
+      setTemplateMode('editing');
+    }
+  };
+
   const fetchCollaborators = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -396,6 +422,49 @@ export const ShareModal = ({ documentId, documentTitle, onClose }: ShareModalPro
               </div>
             )}
           </div>
+        </div>
+
+        <div className="border-t border-grey-200 px-6 py-3 dark:border-grey-700">
+          {templateMode === 'idle' && (
+            <button
+              type="button"
+              onClick={() => setTemplateMode('editing')}
+              className="cursor-pointer bg-transparent border-none p-0 text-sm font-medium text-secondary-600 hover:underline"
+            >
+              Als Vorlage speichern
+            </button>
+          )}
+          {templateMode === 'editing' && (
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="text"
+                value={templateTitle}
+                onChange={(e) => setTemplateTitle(e.target.value)}
+                placeholder="Titel der Vorlage"
+                className="flex-1 min-w-[200px] h-8 rounded-md border border-grey-300 bg-background px-2 text-sm outline-none focus:border-primary-600 dark:border-grey-600"
+              />
+              <Button size="xs" onClick={saveAsTemplate}>
+                Speichern
+              </Button>
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() => {
+                  setTemplateMode('idle');
+                  setTemplateError(null);
+                }}
+              >
+                Abbrechen
+              </Button>
+            </div>
+          )}
+          {templateMode === 'saving' && (
+            <p className="text-sm text-grey-500">Vorlage wird gespeichert…</p>
+          )}
+          {templateMode === 'saved' && (
+            <p className="text-sm text-green-600">✓ Vorlage gespeichert</p>
+          )}
+          {templateError && <p className="mt-1 text-xs text-red-600">{templateError}</p>}
         </div>
 
         <div className="flex items-center border-t border-grey-200 p-4 px-6 dark:border-grey-700">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,9 @@ export * from './search/index.js';
 // Share
 export * from './share/index.js';
 
+// User Templates (boards/docs/canvas templates)
+export * from './templates/index.js';
+
 // Projects
 export * from './projects/index.js';
 

--- a/packages/shared/src/templates/index.ts
+++ b/packages/shared/src/templates/index.ts
@@ -1,0 +1,1 @@
+export * from './userTemplatesApi.js';

--- a/packages/shared/src/templates/userTemplatesApi.ts
+++ b/packages/shared/src/templates/userTemplatesApi.ts
@@ -1,0 +1,85 @@
+/**
+ * Client for user_templates that span multiple kinds (canvas/board/doc).
+ * Backend reads/writes share the user_templates table; the kind discriminator
+ * is `template_type` (`canvas` | `board` | `doc`).
+ */
+
+import { apiRequest } from '../api/client.js';
+
+export type TemplateKind = 'canvas' | 'board' | 'doc';
+
+export interface UserTemplateSummary {
+  id: string;
+  title: string;
+  description: string | null;
+  template_type: TemplateKind | string;
+  preview_image_url: string | null;
+  is_private: boolean;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  content_data: { yjs?: string; subtype?: string; preview?: Record<string, unknown> } | null;
+}
+
+interface ListResponse {
+  success: boolean;
+  data: UserTemplateSummary[];
+}
+
+interface SaveResponse {
+  success: boolean;
+  data: {
+    id: string;
+    title: string;
+    template_type: string;
+    is_private: boolean;
+    status: string;
+    created_at: string;
+  };
+  message?: string;
+}
+
+interface InstantiateResponse {
+  success: boolean;
+  data: { documentId: string; subtype: string };
+}
+
+export async function listUserTemplates(
+  params: { kind?: TemplateKind } = {}
+): Promise<UserTemplateSummary[]> {
+  const query = params.kind ? `?template_type=${encodeURIComponent(params.kind)}` : '';
+  const response = await apiRequest<ListResponse>('get', `/user-templates${query}`);
+  return response.data ?? [];
+}
+
+export async function saveCollaborativeDocAsTemplate(args: {
+  documentId: string;
+  title: string;
+  description?: string;
+  isPrivate?: boolean;
+  preview?: Record<string, unknown>;
+}): Promise<SaveResponse['data']> {
+  const response = await apiRequest<SaveResponse>(
+    'post',
+    `/docs/${args.documentId}/save-as-template`,
+    {
+      title: args.title,
+      description: args.description,
+      is_private: args.isPrivate ?? true,
+      preview: args.preview,
+    }
+  );
+  return response.data;
+}
+
+export async function instantiateUserTemplate(args: {
+  templateId: string;
+  title: string;
+}): Promise<InstantiateResponse['data']> {
+  const response = await apiRequest<InstantiateResponse>(
+    'post',
+    `/user-templates/${args.templateId}/instantiate`,
+    { title: args.title }
+  );
+  return response.data;
+}


### PR DESCRIPTION
## Summary

Lets users save a current board or doc as a Vorlage and create new ones from saved Vorlagen — reusing canvas-editor's existing `user_templates` table without a schema migration.

## Why

Boards and docs only had static, code-defined templates (`boardTemplates.ts`, `packages/docs/src/lib/templates.ts`); users couldn't save their own. The `user_templates` table was already kind-agnostic (`template_type` text, `content_data` JSONB), so the work was widening which kinds it accepts and adding the round-trip flow — not new infrastructure.

## How

- **Yjs serialization shortcut**: `content_data.yjs` stores the *exact wire format* of `yjs_document_snapshots.snapshot_data` (gzipped, base64). Instantiation pastes it back as a v1 snapshot — Hocuspocus picks it up on next connect with no transcoding.
- **One backend route covers boards + docs**: `POST /docs/:id/save-as-template` lives next to `/duplicate` in `documentController.ts`; the `template_type` (`'board'` | `'doc'`) is derived server-side from `document_subtype`. Authorization reuses `checkDocumentAccess`.
- **UI placement**: "Als Vorlage speichern" lives **inside the existing share dialog** (`ShareModal.tsx` for docs, `ShareBoardDialog.tsx` for boards), mirroring how canvas does it in `ShareDropdown`. Picking a saved Vorlage happens in the unified `TemplateCarousel` on `DocsPage`.

No DB migration. No new tables.

## Test plan

- [ ] Save a board with custom fields/rows/views → verify `user_templates` row with `template_type='board'` and `content_data.yjs` populated
- [ ] Pick the saved Vorlage from the docs page carousel → new board opens with same fields/rows/views (Yjs state preserved)
- [ ] Same round-trip for a doc with formatted BlockNote content
- [ ] `?template_type=board` filter returns only boards; doc carousel doesn't show board templates and vice versa
- [ ] Canvas save-as-template (existing `/share/:token/save-as-template` flow) unaffected
- [ ] Snapshotting a doc the user can't read → 403; instantiating another user's private template → 403