### PR TITLE
fix(rate-limit): bucket per authenticated user, raise DDoS-only ceilings

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -113,13 +113,18 @@ import type { Application, Request, Response, NextFunction, Router } from 'expre
  */
 const isRateLimitDisabled = process.env.DISABLE_RATE_LIMITS === 'true';
 
+// Bucket key: authenticated user when known, else client IP. Without this,
+// users sharing an egress IP (office NAT, CGNAT, VPN) compete for one bucket.
+const perUserOrIpKey = (req: Request): string => req.user?.id ?? req.ip ?? 'anonymous';
+
 const aiGenerationLimiter = isRateLimitDisabled
   ? (_req: Request, _res: Response, next: NextFunction) => next()
   : rateLimit({
       windowMs: 15 * 60 * 1000, // 15 minutes
-      max: 200, // ~13 per minute average — protects against abuse, not normal use
+      max: 200, // AI cost control lives in rateLimitMiddleware.ts; this is a safety net only
       standardHeaders: true,
       legacyHeaders: false,
+      keyGenerator: perUserOrIpKey,
       message: { error: 'Too many AI generation requests, please try again later.' },
     });
 
@@ -127,9 +132,10 @@ const standardMutationLimiter = isRateLimitDisabled
   ? (_req: Request, _res: Response, next: NextFunction) => next()
   : rateLimit({
       windowMs: 15 * 60 * 1000,
-      max: 200,
+      max: 2000, // DDoS-only ceiling for writes — bulk ops can spike legitimately
       standardHeaders: true,
       legacyHeaders: false,
+      keyGenerator: perUserOrIpKey,
       // Skip GETs so polling endpoints (e.g. /api/subtitler/export-progress/:token,
       // fired every 2s during export) don't consume the mutation budget. The
       // limiter's purpose is abuse-prevention on writes; reads are covered by
@@ -142,9 +148,10 @@ const authenticatedReadLimiter = isRateLimitDisabled
   ? (_req: Request, _res: Response, next: NextFunction) => next()
   : rateLimit({
       windowMs: 15 * 60 * 1000, // 15 minutes
-      max: 1000, // ~66/min — generous for authenticated page loads with many parallel fetches
+      max: 10000, // DDoS-only — heavy users with many tabs + polling can hit 2–3k legitimately
       standardHeaders: true,
       legacyHeaders: false,
+      keyGenerator: perUserOrIpKey,
       message: { error: 'Too many requests, please try again later.' },
     });
 
@@ -152,9 +159,10 @@ const publicReadLimiter = isRateLimitDisabled
   ? (_req: Request, _res: Response, next: NextFunction) => next()
   : rateLimit({
       windowMs: 60 * 60 * 1000, // 1 hour
-      max: 500, // soft — prevents scraping, allows normal use
+      max: 2000, // allow embeds & site visitors without tripping legitimate traffic
       standardHeaders: true,
       legacyHeaders: false,
+      keyGenerator: perUserOrIpKey,
       message: { error: 'Too many requests, please try again later.' },
     });
 


### PR DESCRIPTION
## Why

GlitchTip [GRUENERATOR-8V](https://glitchtip/...) shows authenticated users getting `429 "Too many requests, please try again later."` on routine page loads — including the *first* request of a fresh session. That can't be the user exhausting their own budget; they're walking into a bucket their officemates have already filled.

Root cause: all four `express-rate-limit` instances in `apps/api/routes.ts` key on `req.ip` (no `keyGenerator`). `app.set('trust proxy', 1)` resolves `req.ip` correctly to the real client IP — but everyone behind the same egress NAT/CGNAT/VPN (Bundesgeschäftsstelle office, mobile carrier, corporate VPN) shares one bucket. A notebook page opens with ~12 parallel requests; a handful of colleagues blow through `1000 / 15min` in seconds.

Two-part fix:

1. **`keyGenerator: req.user?.id ?? req.ip`** — authenticated users get an isolated bucket; anonymous traffic keeps IP bucketing.
2. **Raise ceilings to DDoS-only thresholds** — a heavy user with multiple tabs + active polling can legitimately hit 2–3k/15min. The limiter is now a circuit breaker for runaway clients (infinite retry loops, scrapers), not a budget on real use. AI cost control stays in the Redis-backed per-user quotas in `rateLimitMiddleware.ts`, which are unaffected.

| Limiter | old `max` | new `max` |
|---|---|---|
| `authenticatedReadLimiter` (15min) | 1000 | 10000 |
| `standardMutationLimiter` (15min, GETs skipped) | 200 | 2000 |
| `publicReadLimiter` (1h, anonymous) | 500 | 2000 |
| `aiGenerationLimiter` (15min) | 200 | 200 (unchanged — safety net only) |

Follow-up worth a separate PR: add `rate-limit-redis` to share counters across cluster workers. Current per-worker `MemoryStore` is fine once the key is per-user and the ceilings are DDoS-only.