### PR TITLE
feat(web): surface API errors as toasts (Phase 2 of rate-limit fix)

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -24,8 +24,11 @@ const FirstRunWizard = lazy(() =>
   }))
 );
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Toaster } from '@gruenerator/ui';
+
+import { toastApiError } from './components/utils/toastError';
 const PopupNutzungsbedingungen = lazy(
   () => import('./components/Popups/popup_nutzungsbedingungen')
 );
@@ -35,6 +38,22 @@ const PopupWartung = lazy(() => import('./components/Popups/popup_wartung'));
 
 // QueryClient Instanz erstellen
 const queryClient = new QueryClient({
+  // Global error surfacing: every failed query/mutation toasts via the shared
+  // German error-message dictionary, unless the caller sets `meta: { silent: true }`.
+  // Background prefetches with working fallbacks should opt out; user-initiated
+  // queries and all mutations should let the toast fire.
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      if (query.meta?.silent === true) return;
+      toastApiError(error);
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _variables, _context, mutation) => {
+      if (mutation.meta?.silent === true) return;
+      toastApiError(error);
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 5 * 60 * 1000, // 5 Minuten Cache
@@ -163,6 +182,7 @@ function App() {
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
+        <Toaster richColors position="top-right" />
         <Router>
           <ScrollToTop />
           <RouteLogger />

--- a/apps/web/src/components/utils/toastError.ts
+++ b/apps/web/src/components/utils/toastError.ts
@@ -1,0 +1,62 @@
+import { toast } from '@gruenerator/ui';
+import type { AxiosError } from 'axios';
+
+import { getErrorMessage } from './errorMessages';
+
+/**
+ * Stable toast IDs for dedup — 12 parallel failed requests collapse into 1 toast.
+ */
+const TOAST_IDS = {
+  rateLimited: 'api-error-429',
+  network: 'api-error-network',
+  serverError: 'api-error-5xx',
+  generic: 'api-error-generic',
+} as const;
+
+function readRetryAfterSeconds(error: unknown): number | null {
+  const headers = (error as AxiosError | undefined)?.response?.headers;
+  if (!headers) return null;
+  const raw = headers['retry-after'] ?? headers['Retry-After'];
+  if (!raw) return null;
+  const asNumber = Number(raw);
+  if (Number.isFinite(asNumber) && asNumber > 0) return Math.ceil(asNumber);
+  const asDate = Date.parse(String(raw));
+  if (Number.isFinite(asDate)) {
+    const seconds = Math.ceil((asDate - Date.now()) / 1000);
+    return seconds > 0 ? seconds : null;
+  }
+  return null;
+}
+
+function pickToastId(status: number | undefined): string {
+  if (status === 429) return TOAST_IDS.rateLimited;
+  if (status === undefined) return TOAST_IDS.network;
+  if (status >= 500) return TOAST_IDS.serverError;
+  return TOAST_IDS.generic;
+}
+
+/**
+ * Surface an API error as a user-visible toast, using the shared German
+ * error-message dictionary. Multiple concurrent failures with the same
+ * category collapse into a single toast via sonner's id-based dedup.
+ */
+export function toastApiError(error: unknown): void {
+  const status = (error as AxiosError | undefined)?.response?.status;
+
+  // 401 is handled by the auth-redirect layer (apiClient interceptor + AuthRoute).
+  // Toasting "Authentifizierungsfehler" on every logged-out page load is noise.
+  // 404 typically reflects a stale or wrong URL — callers show inline empty states.
+  if (status === 401 || status === 404) return;
+
+  const { title, message } = getErrorMessage(error);
+  const retryAfter = status === 429 ? readRetryAfterSeconds(error) : null;
+  const description =
+    retryAfter !== null
+      ? `Bitte versuche es in ${retryAfter} Sekunden erneut.`
+      : message;
+
+  toast.error(title, {
+    id: pickToastId(status),
+    description,
+  });
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -210,6 +210,7 @@ export { SelectCard, type SelectCardProps } from './components/select-card';
 export { SmartInput, type SmartInputOption, type SmartInputProps } from './components/smart-input';
 export { LiteTooltip, type LiteTooltipProps } from './components/lite-tooltip';
 export { Toaster } from './components/sonner';
+export { toast } from 'sonner';
 export {
   NotificationBell,
   type NotificationBellProps,


### PR DESCRIPTION
## Why

Phase 1 (#767) stopped users from getting bogus 429s. Phase 2 makes sure that when an API call *does* fail — for any reason — the user sees it instead of staring at stale state.

GlitchTip GRUENERATOR-8V showed the exact problem: a dozen requests 429'd in parallel and the UI logged `console.warn` only. The user had no idea what was happening. Same shape applies to any 5xx, network blip, or true rate-limit case.

## What changed

- **Mount `<Toaster />` at app root.** Sonner was already in `@gruenerator/ui` but no `<Toaster />` was rendered, so `toast.*` calls vanished. Also re-export `toast` from `@gruenerator/ui` so apps don't need a direct `sonner` dep (strict pnpm).
- **Global React Query error handlers.** `QueryCache.onError` and `MutationCache.onError` both call `toastApiError(error)`. One change covers every React Query consumer in the app — dozens of silent catches now surface for free.
- **Dedup via stable sonner IDs.** 12 parallel 429s collapse into one rate-limit toast. Same for 5xx and network errors.
- **`Retry-After` parsing.** `express-rate-limit` sends `Retry-After` automatically (`standardHeaders: true` is already set). The toast now reads it and shows *"Bitte versuche es in N Sekunden erneut."* instead of a generic "Anfragelimit erreicht".
- **Opt-out for graceful prefetches.** Set `meta: { silent: true }` on queries that have working fallbacks (auth init prefetch, userDefaults hydration) so they stay quiet — toasting on a graceful degradation is noise, not signal.
- **Skip 401/404 at the toast layer.** Those reach the user via other channels (auth redirect, inline "nicht gefunden" pages). Toasting on top would duplicate.

Copy comes from the existing `errorMessages.ts` German dictionary, including the already-defined 429 entry — no new translations needed.

## Test plan

- [ ] Trigger a 5xx (kill backend mid-request, or hit a broken endpoint) → toast appears with the German 5xx copy.
- [ ] Set `DISABLE_RATE_LIMITS=false` and burst-call an endpoint until 429 → one toast appears (not many), with "Bitte versuche es in N Sekunden" if Retry-After is present.
- [ ] Log out and reload `/` → no 401 toast appears (logged-out auth probes are silent by design).
- [ ] Navigate to a non-existent doc → inline 404 UI shows, no toast.