### PR TITLE
feat(chat): show streaming errors as assistant messages in-thread

### DIFF
--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -21,6 +21,7 @@ import { parseAllMentions } from '../lib/mentionParser';
 import { parseSSELine } from '../lib/sseParser';
 import { INTENT_TO_TOOL, DEEP_TOOL_MAP } from '../lib/toolMappings';
 import { useDocumentChatStore } from '../stores/documentChatStore';
+import { streamErrorMessage } from './streamErrorMessage';
 import type { ConfirmActionData, DocumentCreatedData } from '../types/messageMetadata';
 
 export type GrueneratorMessageMetadata = {
@@ -998,16 +999,23 @@ export function createGrueneratorModelAdapter(
         };
       }
 
-      const response = await configFetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
-        signal: abortSignal,
-      });
+      let response: Response;
+      try {
+        response = await configFetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(requestBody),
+          signal: abortSignal,
+        });
+      } catch (fetchError) {
+        if (abortSignal?.aborted) return;
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(fetchError) }] };
+        return;
+      }
 
       if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error((errorData as { error?: string }).error || `HTTP error ${response.status}`);
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(null, response) }] };
+        return;
       }
 
       const streamOutcome: StreamOutcome = { interrupted: false, indexedDocumentIds: [] };
@@ -1030,7 +1038,12 @@ export function createGrueneratorModelAdapter(
         ) {
           return;
         }
-        throw err;
+        // Other mid-stream errors (e.g. backend SSE `error` event) — surface
+        // as an assistant message so the user sees what went wrong in-thread,
+        // not just in the dev console.
+        if (abortSignal?.aborted) return;
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(err) }] };
+        return;
       }
 
       // Persist server-indexed document IDs to thread for follow-up messages

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -11,6 +11,7 @@ import {
 import { parseSSELine } from '../lib/sseParser';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore } from '../stores/chatConfigStore';
+import { streamErrorMessage } from './streamErrorMessage';
 
 function normalizeCiteMarkers(text: string): string {
   return text.replace(/\[cite:(\d+)\]/g, '[$1]');
@@ -204,31 +205,31 @@ export function createNotebookModelAdapter(
       const endpoint = config.endpoint || '/api/chat-service/notebook/stream';
       const c0 = performance.now();
       console.debug('[Notebook] ⏱ Request sent to %s', endpoint);
-      const response = await configFetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-        signal: abortSignal,
-      });
+      let response: Response;
+      try {
+        response = await configFetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: abortSignal,
+        });
+      } catch (fetchError) {
+        if (abortSignal?.aborted) return;
+        // Network failure before any response — surface as an assistant message
+        // so the user sees what happened in the conversation, not just in console.
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(fetchError) }] };
+        return;
+      }
 
       if (!response.ok) {
-        const errorData = (await response.json().catch(() => ({}))) as {
-          error?: string;
-          message?: string;
-        };
-        if (response.status === 429) {
-          throw new Error(
-            errorData.message ||
-              errorData.error ||
-              'Tageslimit erreicht. Bitte morgen erneut versuchen.'
-          );
-        }
-        throw new Error(errorData.error || `HTTP error ${response.status}`);
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(null, response) }] };
+        return;
       }
 
       const reader = response.body?.getReader();
       if (!reader) {
-        throw new Error('No response body');
+        yield { content: [{ type: 'text' as const, text: streamErrorMessage(new Error('Keine Antwort vom Server erhalten.')) }] };
+        return;
       }
 
       const decoder = new TextDecoder();
@@ -277,6 +278,7 @@ export function createNotebookModelAdapter(
         };
       }
 
+      let streamErrorEncountered: unknown = null;
       try {
         while (true) {
           const { done, value } = await reader.read();
@@ -407,6 +409,7 @@ export function createNotebookModelAdapter(
         if (abortSignal?.aborted) {
           return;
         }
+        streamErrorEncountered = readError;
         console.warn(
           '[Notebook] Stream read error after %d chars: %s',
           accumulatedText.length,
@@ -476,6 +479,13 @@ export function createNotebookModelAdapter(
         console.debug(`[Notebook] ⏱ Total: ${Math.round(performance.now() - c0)}ms`);
       } else if (accumulatedText) {
         yield buildResult();
+      } else if (streamErrorEncountered) {
+        // Stream errored before any answer arrived — surface the real cause
+        // (e.g. backend `error` SSE event) instead of the misleading
+        // "keine passende Antwort" fallback.
+        yield {
+          content: [{ type: 'text' as const, text: streamErrorMessage(streamErrorEncountered) }],
+        };
       } else {
         accumulatedText =
           'Leider konnte ich keine passende Antwort finden. Bitte versuche es mit einer anderen Frage.';

--- a/packages/chat/src/runtime/streamErrorMessage.ts
+++ b/packages/chat/src/runtime/streamErrorMessage.ts
@@ -1,0 +1,50 @@
+/**
+ * Build a user-facing markdown error message to inject as the assistant's
+ * final turn when a chat streaming request fails. Yielding this from the
+ * adapter (instead of throwing) makes the failure visible in the conversation
+ * with the user's question still right above it.
+ */
+export function streamErrorMessage(error: unknown, response?: Response): string {
+  const status = response?.status;
+
+  if (status === 429) {
+    const retryAfterRaw = response?.headers.get('retry-after');
+    const retryAfter = parseRetryAfter(retryAfterRaw);
+    if (retryAfter !== null) {
+      return `⚠️ **Anfragelimit erreicht.** Bitte versuche es in ${retryAfter} Sekunden erneut.`;
+    }
+    return '⚠️ **Anfragelimit erreicht.** Bitte warte einen Moment und versuche es dann erneut.';
+  }
+
+  if (status === 401 || status === 403) {
+    return '⚠️ **Sitzung abgelaufen.** Bitte melde dich erneut an.';
+  }
+
+  if (status && status >= 500) {
+    return `⚠️ **Der Server konnte deine Anfrage nicht beantworten** (HTTP ${status}). Bitte versuche es in einem Moment erneut.`;
+  }
+
+  if (isNetworkError(error)) {
+    return '⚠️ **Verbindung unterbrochen.** Bitte prüfe deine Internetverbindung und versuche es erneut.';
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? 'Unbekannter Fehler');
+  return `⚠️ **Es ist ein Fehler aufgetreten.**\n\n${message}`;
+}
+
+function parseRetryAfter(raw: string | null | undefined): number | null {
+  if (!raw) return null;
+  const asNumber = Number(raw);
+  if (Number.isFinite(asNumber) && asNumber > 0) return Math.ceil(asNumber);
+  const asDate = Date.parse(raw);
+  if (Number.isFinite(asDate)) {
+    const seconds = Math.ceil((asDate - Date.now()) / 1000);
+    return seconds > 0 ? seconds : null;
+  }
+  return null;
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
+  return /network error|failed to fetch|load failed|error in input stream/i.test(error.message);
+}


### PR DESCRIPTION
## Why

Phase 3 of the rate-limit / error-visibility series (after #767 and #768). Toasts work for sidebar fetches, but a chat error needs to live *inside the conversation* — the user wants to see what they asked, followed by why it failed. A toast that disappears after 4 seconds, or worse a generic "Leider konnte ich keine passende Antwort finden" fallback that hides the real cause, both leave the user confused.

The breadcrumb in GRUENERATOR-8V shows `/api/chat-service/notebook/stream` returning 429 with no in-chat feedback at all — the request just vanishes.

## What changed

Both streaming adapters (`NotebookModelAdapter`, `GrueneratorModelAdapter`) previously `throw`ed on non-OK responses, mid-stream connection drops, and backend SSE `error` events. Assistant-ui then either dropped the turn or, in the Notebook case, fell through to a misleading "keine passende Antwort" message.

Replace the throws with `yield + return` — emit a final `ChatModelRunResult` containing a German markdown error string so the failure renders as the assistant's reply:

> ⚠️ **Anfragelimit erreicht.** Bitte versuche es in 12 Sekunden erneut.

Shared helper `packages/chat/src/runtime/streamErrorMessage.ts`:
- Maps HTTP status → user-facing copy (429 with `Retry-After` parsing, 5xx, 401/403, network errors).
- Re-uses the same `Retry-After` parsing approach as the toast helper (Phase 2). Cross-package import would have meant pulling apps/web utils into packages/chat — ~25 LOC of intentional duplication is cheaper.

Side-effect: fixed the "no completionData" fallthrough in `NotebookModelAdapter` that was hiding real SSE `error` events behind the generic fallback message.

## Test plan

- [ ] Burst-call the notebook chat until backend 429 → assistant message appears with "Anfragelimit erreicht" + retry-after seconds.
- [ ] Kill the backend mid-stream → assistant message ends with "Verbindung unterbrochen" (or "Server konnte deine Anfrage nicht beantworten" for clean 5xx).
- [ ] Normal happy path still works — no error message appears when streaming completes successfully.
- [ ] Pressing the stop button mid-stream still aborts cleanly without showing an error message (abort path preserved).