### PR TITLE
fix(web): remove dangling userDefaultsStore import that broke web build

### DIFF
--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -13,8 +13,6 @@ import {
 import { openDesktopLogin, type AuthSource } from '../utils/desktopAuth';
 import { isDesktopApp } from '../utils/platform';
 
-import { useUserDefaultsStore } from './userDefaultsStore';
-
 // =============================================================================
 // Type Definitions
 // =============================================================================
@@ -310,9 +308,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       win.queryClient.clear();
     }
 
-    // Legacy cleanup - no longer needed with new auth system
-
-    useUserDefaultsStore.getState().reset();
+    // user-defaults RQ cache is cleared via win.queryClient.clear() above
     useUserProfileStore.getState().reset();
 
     // Reset store to default state


### PR DESCRIPTION
The production web image has been failing to build on master ([run 25730436757](https://github.com/netzbegruenung/Gruenerator/actions/runs/25730436757)) with:

```
[UNRESOLVED_IMPORT] Could not resolve './userDefaultsStore' in src/stores/authStore.ts
```

## Why

Commit 29ab6864e deleted `apps/web/src/stores/userDefaultsStore.ts` when migrating user-defaults to React Query, and cleanly removed both the import and the `reset()` call from `authStore.ts`.

Commit 130af2f4 (login-loop fix, merged via #770) was resolved against a pre-migration base of `authStore.ts` and silently reintroduced the import + the `useUserDefaultsStore.getState().reset()` call on logout. Vite/Rolldown's static unresolved-import check rejects this at build time — local dev didn't surface it because the module graph never reached the dead branch through HMR.

The RQ cache that replaced the Zustand store is already wiped via `win.queryClient.clear()` two lines above the reintroduced call, so removing it preserves logout semantics.