### PR TITLE
fix(chat): surface attachment validation errors to user

### DIFF
--- a/packages/chat/src/lib/attachmentErrorHandler.ts
+++ b/packages/chat/src/lib/attachmentErrorHandler.ts
@@ -1,0 +1,12 @@
+export function handleAttachmentError(error: unknown): void {
+  const message =
+    error instanceof Error ? error.message : 'Datei konnte nicht hinzugefügt werden.';
+  console.warn('[Attachment]', error);
+  void import('sonner')
+    .then(({ toast }) => {
+      toast.error('Anhang nicht möglich', { description: message });
+    })
+    .catch(() => {
+      // sonner not installed in host app — fall back to console only
+    });
+}

--- a/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
@@ -10,6 +10,7 @@ import {
   fileToBase64,
   getAcceptedFileTypes,
 } from '../lib/fileUtils';
+import { handleAttachmentError } from '../lib/attachmentErrorHandler';
 
 // Synthetic content types used by @docs / @datei mention chips. These never
 // correspond to real File uploads — they flow through AUI's CreateAttachment
@@ -26,7 +27,12 @@ export class GrueneratorAttachmentAdapter implements AttachmentAdapter {
   accept = [getAcceptedFileTypes(), ...SYNTHETIC_MENTION_TYPES].join(',');
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
-    validateFile(file);
+    try {
+      validateFile(file);
+    } catch (error) {
+      handleAttachmentError(error);
+      throw error;
+    }
 
     return {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Why

GlitchTip `GRUENERATOR-97` (Firefox 150 / Windows 10, production) shows a user dropped a 79.6MB PDF (`KLAK Haltern_Endbericht_März25.pdf`) into the chat composer. `validateFile` threw `Datei zu groß: … Maximum: 25.0MB`, the error bubbled into assistant-ui's `addAttachment`, Sentry received it — but the user saw nothing. The file just silently failed to appear. Same gap covered unsupported MIME types and the multi-file caps.

## Approach

Mirror the existing `dictationErrorHandler.ts` pattern: a tiny helper that lazy-imports `sonner` (so mobile / non-sonner hosts stay buildable) and surfaces the validator's already-user-grade German message as `toast.error('Anhang nicht möglich', { description })`. The adapter wraps `validateFile` in try/catch, toasts, then re-throws — the re-throw is load-bearing because assistant-ui treats a rejection as "do not add to composer state."

## Test plan

- [ ] `pnpm dev:web` → `/chat` → drop a >25MB file → red toast with size message, no attachment chip.
- [ ] Drop an unsupported type (e.g. `.exe`) → `Dateityp nicht unterstützt: …` toast, no attachment chip.
- [ ] Sentry still receives the event (re-throw preserves it).