### PR TITLE
fix(web): restore missing react-icons imports causing prod ReferenceError

### DIFF
--- a/apps/web/src/components/common/ExportDropdown.tsx
+++ b/apps/web/src/components/common/ExportDropdown.tsx
@@ -16,8 +16,9 @@ import {
 } from '@gruenerator/wolke';
 import { type JSX, useState, useEffect, type ReactNode } from 'react';
 import { CiMemoPad } from 'react-icons/ci';
+import { FaCloud } from 'react-icons/fa';
 import { FaFileWord, FaFilePdf, FaWordpress } from 'react-icons/fa6';
-import { HiRefresh, HiOutlineDocumentText } from 'react-icons/hi';
+import { HiRefresh, HiOutlineDocumentText, HiSave } from 'react-icons/hi';
 import {
   IoDownloadOutline,
   IoShareSocialSharp,

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   useIsMobile,
 } from '@gruenerator/ui';
 import { useEffect, useMemo, useCallback, useRef, useState, memo } from 'react';
-import { PiSun, PiMoon, PiSignIn, PiCaretRight, PiSparkle } from 'react-icons/pi';
+import { PiSun, PiMoon, PiSignIn, PiCaretRight, PiSparkle, PiStarFill } from 'react-icons/pi';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { getFavouriteItemsById } from '../../../config/sidebarFavouritesConfig';


### PR DESCRIPTION
## Why
Production crashes after login with `ReferenceError: PiStarFill is not defined`, caught by the BlockNote ErrorBoundary and surfaced to users as the global "Oops" screen.

Root cause: two files reference react-icons named exports that aren't in the import statement.

- `apps/web/src/components/layout/Sidebar/Sidebar.tsx` — `PiStarFill` used at line 414 (favourites remove button) but missing from the line 13 import.
- `apps/web/src/components/common/ExportDropdown.tsx` — `FaCloud` and `HiSave` used in export-target UI but never imported (`fa` + `hi`).

Likely introduced by an unused-imports codemod that pruned bindings whose usages live in conditionally-rendered branches.

## Test plan
- [ ] Verify the previously-crashing user flow (login → sidebar with favourites) no longer throws.
- [ ] Open ExportDropdown UI and confirm cloud/save icons render.