### PR TITLE
fix(web): restore SidebarAgents imports + cleanup unused thread props

### DIFF
--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,9 @@
 import { useAgentStore } from '@gruenerator/chat';
-import { getSystemAgent } from '@gruenerator/shared/agents';
+import {
+  getSystemAgent,
+  type Agent,
+  type SystemAgentId,
+} from '@gruenerator/shared/agents';
 import {
   Sheet,
   SheetContent,
@@ -30,7 +34,7 @@ import {
 
 import { AllAgentsDialog } from './AllAgentsDialog';
 import NewItemDropdown from './NewItemDropdown';
-import { DEFAULT_AGENT_ENTRIES, getAgentIcon } from './sidebarAgentConfig';
+import { DEFAULT_AGENT_ENTRIES, HIDDEN_INVENTORY_AGENT_IDS, getAgentIcon } from './sidebarAgentConfig';
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
 import { cn } from '@/utils/cn';

--- a/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
@@ -22,7 +22,7 @@ import type { IconType } from 'react-icons';
  * DEFAULT_AGENT_ENTRIES — excluded from the main system-agent list below
  * to avoid duplicate rows.
  */
-const HIDDEN_INVENTORY_AGENT_IDS = new Set<SystemAgentId>([
+export const HIDDEN_INVENTORY_AGENT_IDS = new Set<SystemAgentId>([
   'gruenerator-oeffentlichkeitsarbeit',
   'gruenerator-antrag',
   'gruenerator-suche',

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -105,11 +105,7 @@ function ChatPage() {
             requireProfileHydration
           />
         ) : (
-          <GrueneratorThread
-            onNavigate={handleNavigate}
-            firstName={firstName}
-            requireProfileHydration
-          />
+          <GrueneratorThread onNavigate={handleNavigate} firstName={firstName} />
         )}
       </main>
     </div>

--- a/apps/web/src/features/search/components/SearchPage.tsx
+++ b/apps/web/src/features/search/components/SearchPage.tsx
@@ -109,7 +109,7 @@ function SearchPage() {
 
   if (isThreadView) {
     return (
-      <GrueneratorThread onNavigate={navigate} firstName={firstName} requireProfileHydration />
+      <GrueneratorThread onNavigate={navigate} firstName={firstName} />
     );
   }
 

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -63,6 +63,12 @@ export interface Agent {
   routeTo?: 'chat' | 'search';
   defaultFilter?: AgentDefaultFilter;
   /**
+   * Auto-pair this agent with a specific notebook on selection — used by
+   * per-LV PR agents so RAG and @notebook lookups align with the agent's
+   * regional identity. Consumed in ChatPage on agent change.
+   */
+  defaultNotebookId?: string;
+  /**
    * Hide this agent from agent-picker / inventory UIs. The identifier stays
    * live in the registry (so backend fallbacks and existing chat threads
    * keep resolving), but no UI surface offers it to the user. Used for


### PR DESCRIPTION
## Why
Follow-up to #773 (icon imports). Typechecking apps/web on master surfaced three more issues with the same root cause class — codemod-pruned imports left dangling JSX/identifier references:

- `SidebarAgents` references `Agent`, `SystemAgentId`, `HIDDEN_INVENTORY_AGENT_IDS` without importing them. Same crash pattern as `PiStarFill`: would throw `ReferenceError` as soon as a user has any favourited agent. `HIDDEN_INVENTORY_AGENT_IDS` was declared `const` (not exported) — promoted to `export`.
- `ChatPage` / `SearchPage` pass `requireProfileHydration` to `GrueneratorThread`, which doesn't declare it. Harmless at runtime (React drops the prop) but a TS error; removed the prop at the call sites since `GrueneratorThread` already passes profile state through `GrueneratorComposer` differently.
- `Agent.defaultNotebookId` is read in `ChatPage`'s agent-change effect but wasn't on the shared `Agent` type. Declared it as optional.

apps/web typechecks clean after these changes.