### PR TITLE
fix(boards): tolerate non-JSON content in parseContent

### DIFF
--- a/apps/web/src/features/boards/types.ts
+++ b/apps/web/src/features/boards/types.ts
@@ -12,9 +12,16 @@ export interface Board {
 
 function parseContent(board: Board): { is_archived?: boolean; board_type?: BoardType } {
   if (!board.content) return {};
-  return typeof board.content === 'string'
-    ? (JSON.parse(board.content) as { is_archived?: boolean; board_type?: BoardType })
-    : board.content;
+  if (typeof board.content !== 'string') return board.content;
+  try {
+    return JSON.parse(board.content) as { is_archived?: boolean; board_type?: BoardType };
+  } catch {
+    // Rows in `collaborative_documents` with subtype='boards' occasionally carry
+    // non-JSON content (e.g. BlockNote XHTML "<blockgroup>…") when the docs
+    // editor wrote to a row that was previously a board. Treat malformed
+    // metadata as absent rather than crashing every consumer in render.
+    return {};
+  }
 }
 
 export function getBoardType(board: Board): BoardType {


### PR DESCRIPTION
## Summary

A single board row whose `content` column holds BlockNote XHTML (`<blockgroup>...`) instead of JSON crashed every render that ran through `useBoardsTyped` — `JSON.parse` threw synchronously inside `parseContent`, propagated past TanStack Query (the throw site is in a synchronously-derived value, not a query callback), and tripped the `ErrorBoundary` on both **WorkplacePage** and **DocsPage**. Reported from production on mobile, but the bug is data-shaped, not device-shaped.

Wrapping the parse so malformed metadata degrades to the brand-new-board default (kanban, not archived) makes the UI resilient regardless of how the cross-write happened.

## Follow-up (not in this PR)

The underlying data drift — rows in `collaborative_documents` with `document_subtype='boards'` whose `content` was written by the docs editor — still needs investigating. Suggested triage query:

```sql
SELECT id, title, updated_at
FROM collaborative_documents
WHERE document_subtype = 'boards'
  AND content IS NOT NULL
  AND content NOT LIKE '{%';
```

## Test plan

- [ ] Load `/workplace` for a user whose board list contains a row with non-JSON content — page renders instead of falling into `ErrorBoundary`.
- [ ] Load `/docs` for the same user — same.
- [ ] Healthy boards still classify correctly (kanban vs. whiteboard, archived vs. active).