### PR TITLE
fix(hocuspocus): scope preview writes to doc subtypes only

### DIFF
--- a/apps/api/database/postgres/migrations/repair_boards_corrupted_content.sql
+++ b/apps/api/database/postgres/migrations/repair_boards_corrupted_content.sql
@@ -1,0 +1,20 @@
+-- Repair board rows whose `content` column was overwritten by the Hocuspocus
+-- preview pipeline with BlockNote XHTML (e.g. "<blockgroup>...") instead of
+-- JSON metadata. Pre-fix (see services/hocuspocus/src/persistence.ts), the
+-- preview UPDATEs had no subtype filter, so any board ID that ever flowed
+-- through the docs editor got its metadata clobbered. The frontend then
+-- crashed in `parseContent` (apps/web/src/features/boards/types.ts) when
+-- JSON.parse hit the HTML.
+--
+-- Only rows that are *definitively* malformed are touched: subtype is
+-- 'boards', content is non-null, and content does not start with '{'.
+-- Healthy rows (NULL content or valid JSON object) are left alone.
+-- The repair value matches the default a fresh kanban board produces; we
+-- can't recover the original board_type because the only source of truth
+-- for that bit was the now-overwritten `content` column.
+
+UPDATE collaborative_documents
+SET content = '{"board_type":"kanban"}'
+WHERE document_subtype = 'boards'
+  AND content IS NOT NULL
+  AND content NOT LIKE '{%';

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -25,6 +25,29 @@ const DEFAULT_TITLES = new Set([
   'Untitled Document',
 ]);
 
+// Subtypes whose `content` column stores a BlockNote HTML preview written by
+// this service. Boards (and any future polymorphic subtype) share the same
+// `collaborative_documents` table but store JSON metadata in `content` and
+// must never be overwritten by the preview pipeline. Kept as a readonly tuple
+// so adding/removing a subtype is a single-source change; the derived union
+// catches accidental string drift at compile time.
+//
+// Mirrors `DOCS_SUBTYPES` in apps/api/routes/workplace/recentActivityController.ts.
+// Per CLAUDE.md, the Hocuspocus service has zero cross-package deps, so the
+// constant is duplicated here intentionally rather than imported.
+const DOC_SUBTYPES = [
+  'blank',
+  'antrag',
+  'pressemitteilung',
+  'protokoll',
+  'notizen',
+  'redaktionsplan',
+  'checkliste',
+  'einladung',
+] as const;
+type DocSubtype = (typeof DOC_SUBTYPES)[number];
+const DOC_SUBTYPES_PARAM: readonly DocSubtype[] = DOC_SUBTYPES;
+
 /**
  * Extract a title from the first heading or paragraph in HTML output.
  * Returns null if no usable text is found.
@@ -351,8 +374,10 @@ export class PostgresPersistence {
 
       if (preview) {
         await this.db(
-          'UPDATE collaborative_documents SET content = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $1',
-          [documentId, preview]
+          `UPDATE collaborative_documents
+           SET content = $2, updated_at = CURRENT_TIMESTAMP
+           WHERE id = $1 AND document_subtype = ANY($3::text[])`,
+          [documentId, preview, DOC_SUBTYPES_PARAM]
         );
         log.debug(`[Preview] Updated preview for ${documentId} (${preview.length} chars)`);
 
@@ -397,10 +422,12 @@ export class PostgresPersistence {
       }
 
       if (preview) {
-        await this.db('UPDATE collaborative_documents SET content = $2 WHERE id = $1', [
-          documentId,
-          preview,
-        ]);
+        await this.db(
+          `UPDATE collaborative_documents
+           SET content = $2
+           WHERE id = $1 AND document_subtype = ANY($3::text[])`,
+          [documentId, preview, DOC_SUBTYPES_PARAM]
+        );
         log.debug(`[Backfill] Extracted preview for ${documentId} (${preview.length} chars)`);
       }
 


### PR DESCRIPTION
## Summary

Follow-up to #775, which fixed the render-side crash from boards with non-JSON `content`. This PR closes the data-corruption source: Hocuspocus's preview pipeline (`updateContentPreview`, `extractContentPreview`) was writing BlockNote XHTML into `collaborative_documents.content` keyed only on `id`, with no subtype filter. Any board ID that ever flowed through the docs editor had its JSON metadata clobbered.

The fix locks both UPDATEs to known doc subtypes (`document_subtype = ANY($3::text[])`), mirroring the read-side filter in `apps/api/routes/workplace/recentActivityController.ts`. The subtype list is a typed readonly tuple in `persistence.ts`, so a future drift surfaces as a TS error at the inclusion site rather than a silent denial. The constant is duplicated rather than imported because per `CLAUDE.md`, the Hocuspocus service has zero cross-package deps.

A one-shot repair migration is included to fix already-corrupted board rows — the original `board_type` cannot be recovered (the only source of truth was the now-overwritten `content`), so all repaired rows default to kanban. The migration only touches rows where `content NOT LIKE '{%'`, so healthy rows are untouched and re-running is a no-op.

## Test plan

- [ ] After deploy, query `SELECT count(*) FROM collaborative_documents WHERE document_subtype = 'boards' AND content IS NOT NULL AND content NOT LIKE '{%'` — must be 0.
- [ ] Edit a normal doc — preview still updates on the doc row.
- [ ] Open a board's UUID via `/docs/:id` (simulating the leak) — Hocuspocus preview write no-ops on that row; the board's metadata stays intact.