### PR TITLE
fix(ci): route content-sync tsx invocations through pnpm scripts

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -108,8 +108,8 @@ jobs:
           ARGS="--landesverband ${{ matrix.lv }}"
           if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
-          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
-          npx tsx apps/api/update-all-content.ts $ARGS
+          echo "Running: pnpm --filter @gruenerator/api run update:all -- $ARGS"
+          pnpm --filter @gruenerator/api run update:all -- $ARGS
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
@@ -167,8 +167,8 @@ jobs:
           ARGS="--source ${{ matrix.source }} --no-email"
           if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
-          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
-          npx tsx apps/api/update-all-content.ts $ARGS
+          echo "Running: pnpm --filter @gruenerator/api run update:all -- $ARGS"
+          pnpm --filter @gruenerator/api run update:all -- $ARGS
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
@@ -220,7 +220,7 @@ jobs:
           merge-multiple: true
 
       - name: Aggregate summaries
-        run: npx tsx apps/api/aggregate-sync-summaries.ts --dir summaries/
+        run: pnpm --filter @gruenerator/api run sync:aggregate -- --dir summaries/
         env:
           BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
           BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Update content stats page
         if: always()
-        run: npx tsx apps/api/generate-content-stats.ts
+        run: pnpm --filter @gruenerator/api run stats:content
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
@@ -378,8 +378,8 @@ jobs:
           ARGS="$FLAG $VAL"
           if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
-          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
-          npx tsx apps/api/update-all-content.ts $ARGS
+          echo "Running: pnpm --filter @gruenerator/api run update:all -- $ARGS"
+          pnpm --filter @gruenerator/api run update:all -- $ARGS
 
       - name: Generate job summary
         if: always()
@@ -412,7 +412,7 @@ jobs:
 
       - name: Update content stats page
         if: always()
-        run: npx tsx apps/api/generate-content-stats.ts
+        run: pnpm --filter @gruenerator/api run stats:content
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}

--- a/.github/workflows/social-media-sync.yml
+++ b/.github/workflows/social-media-sync.yml
@@ -43,8 +43,8 @@ jobs:
           ARGS="--source social-media"
           if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
           if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
-          echo "Running: npx tsx apps/api/update-all-content.ts $ARGS"
-          npx tsx apps/api/update-all-content.ts $ARGS
+          echo "Running: pnpm --filter @gruenerator/api run update:all -- $ARGS"
+          pnpm --filter @gruenerator/api run update:all -- $ARGS
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Update content stats page
         if: always()
-        run: npx tsx apps/api/generate-content-stats.ts
+        run: pnpm --filter @gruenerator/api run stats:content
         env:
           QDRANT_URL: ${{ secrets.QDRANT_URL }}
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,8 @@
     "scrape:satzungen:stats": "node scripts/scrape-satzungen.js --stats",
     "update:all": "cross-env NODE_OPTIONS=--conditions=development npx tsx update-all-content.ts",
     "update:all:dry-run": "cross-env NODE_OPTIONS=--conditions=development npx tsx update-all-content.ts --dry-run",
+    "sync:aggregate": "cross-env NODE_OPTIONS=--conditions=development npx tsx aggregate-sync-summaries.ts",
+    "stats:content": "cross-env NODE_OPTIONS=--conditions=development npx tsx generate-content-stats.ts",
     "export:finetuning": "cross-env NODE_OPTIONS=--conditions=development npx tsx scripts/exportFineTuningData.ts",
     "export:finetuning:dry-run": "cross-env NODE_OPTIONS=--conditions=development npx tsx scripts/exportFineTuningData.ts --dry-run",
     "export:finetuning:test": "cross-env NODE_OPTIONS=--conditions=development npx tsx scripts/exportFineTuningData.ts --limit 10",


### PR DESCRIPTION
## Why

Content Sync runs have been failing with `ERR_MODULE_NOT_FOUND: …@gruenerator/shared/dist/utils/index.js` ([example run](https://github.com/netzbegruenung/Gruenerator/actions/runs/25760183944)).

The regression dates back to `289da3f` ("migrate workspace packages to development conditional exports"). After that commit, `@gruenerator/shared` resolves to `./dist/*.js` unless the runner is launched with `NODE_OPTIONS=--conditions=development`. The same commit updated `apps/api`'s `package.json` scripts to set that env var, but the GitHub Actions workflows kept calling `npx tsx apps/api/<entry>.ts` directly — so they fall through to `dist/`, which is never built in CI.

It went undetected for a while because the email/notification module didn't transitively import `@gruenerator/shared`. Recent additions (notification dispatcher, email templates) brought it into the import graph via `landesverbaendeConfig` → `@gruenerator/shared/search`, and every scheduled run since has been failing.

## The fix

Encode the "how to launch tsx in this repo" convention in **one** place — `apps/api/package.json` — and have CI go through it. Adds `sync:aggregate` and `stats:content` scripts mirroring the existing `update:all` pattern, and switches `content-sync.yml` + `social-media-sync.yml` to call them via `pnpm --filter @gruenerator/api run …`.

New workflows can't drift from dev resolution behavior, and we don't need a CI-only build step that exists solely to produce `dist/` artifacts.

`aggregate-test.yml` and `email-test.yml` are left as a follow-up — they invoke one-off test scripts that aren't on the scheduled production path.