### PR TITLE
fix(chat): start a fresh thread when the user switches agents

### DIFF
--- a/packages/chat/src/runtime/AgentSwitchListener.tsx
+++ b/packages/chat/src/runtime/AgentSwitchListener.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAssistantRuntime } from '@assistant-ui/react';
+import { useAgentStore } from '../stores/chatStore';
+
+export function AgentSwitchListener() {
+  const assistantRuntime = useAssistantRuntime();
+  const selectedAgentId = useAgentStore((s) => s.selectedAgentId);
+  const prevRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (prevRef.current === undefined) {
+      prevRef.current = selectedAgentId;
+      return;
+    }
+    if (prevRef.current === selectedAgentId) return;
+    prevRef.current = selectedAgentId;
+
+    const store = useAgentStore.getState();
+    store.setThreadMode('chat');
+    store.setCustomSystemPrompt(null);
+    store.setCustomRoleName(null);
+    store.setCustomEnabledTools(null);
+    store.setCurrentThread(null);
+    void assistantRuntime.threads.switchToNewThread();
+  }, [selectedAgentId, assistantRuntime]);
+
+  return null;
+}

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -35,6 +35,7 @@ import {
   type GrueneratorAdapterConfig,
 } from './GrueneratorModelAdapter';
 import { GrueneratorAttachmentAdapter } from './GrueneratorAttachmentAdapter';
+import { AgentSwitchListener } from './AgentSwitchListener';
 import {
   createGrueneratorThreadListAdapter,
   type ExternalThreadEntry,
@@ -535,6 +536,7 @@ function GrueneratorChatRuntimeProvider({
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
       <ExternalThreadProvider value={externalCtx}>
         <ThreadTitleEffect />
+        <AgentSwitchListener />
         <ChatCollaborationBridge userId={userId} userName={userName}>
           {children}
         </ChatCollaborationBridge>


### PR DESCRIPTION
## Why

Clicking a sidebar agent link while a chat is active updates the URL but leaves the previous thread on screen — old messages stay, and the next send would post to the *old* thread with the *new* agent's config. The bug surfaces from every entry that funnels through `ChatPage`'s `?agent=` effect (sidebar pinned agents, AllAgentsDialog, SkillsPage, CustomGeneratorPage). Notebook pages use a separate runtime and are unaffected.

Root cause: `ChatPage` updated `selectedAgentId` but never cleared `currentThreadId` (persisted via `partialize`) and never asked assistant-ui to switch threads. The store and the runtime both retained the old thread.

## What this does

Adds an `AgentSwitchListener` mounted inside the `/chat` `AssistantRuntimeProvider`. On a real `selectedAgentId` change (initial mount excluded so direct deep-links don't blow away their freshly-loaded thread), it:

1. Resets agent-bound context — `threadMode → 'chat'`, clears `customSystemPrompt` / `customRoleName` / `customEnabledTools`, clears `currentThreadId`.
2. Calls `assistantRuntime.threads.switchToNewThread()` — the same canonical API already used by `ChatOverview` and `AutoMessageSender`. assistant-ui's history adapter re-runs and returns `{ messages: [] }`; `onThreadCreated` writes the fresh threadId once the user sends.

User-level prefs (model, provider, searchMode, default `enabledTools`) are intentionally preserved — switching agent ≠ factory reset.

Out of scope: in-composer toggles (notebook/role pickers via `ToolToggles`/`PlusMenu`) deliberately do not spawn new threads — those are mid-thread context tweaks.