### PR TITLE
fix(chat): declare SSE 200 as noBody so ts-rest stops resetting headers

### DIFF
--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -121,7 +121,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       if (!user?.id) {
         sse.send('error', { error: PROGRESS_MESSAGES.unauthorized });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       const userId = user.id;
@@ -130,13 +130,13 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       if (!aiWorkerPool) {
         sse.send('error', { error: PROGRESS_MESSAGES.aiUnavailable });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       if ((clientMessages as unknown[]).length === 0) {
         sse.send('error', { error: PROGRESS_MESSAGES.messagesRequired });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       const notebookIds = rawNotebookIds?.filter(isKnownNotebook) ?? [];
@@ -160,13 +160,13 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         log.error('[ChatGraph] Error converting messages:', convertError);
         sse.send('error', { error: 'Failed to process messages' });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       if (!modelMessages || !Array.isArray(modelMessages)) {
         sse.send('error', { error: 'Failed to process messages' });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       const validMessages = filterEmptyAssistantMessages(
@@ -200,8 +200,8 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         if (!isNewThread) {
           if (!(await canAccessThread(ThreadId(actualThreadId), UserId(userId)))) {
             sse.send('error', { error: 'Thread not found' });
-            res.end();
-            return { status: 200 as const, body: null };
+            sse.end();
+            return { status: 200 as const, body: undefined };
           }
         }
 
@@ -588,7 +588,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           },
         });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       // === Handle @board-erstellen tool ===
@@ -602,7 +602,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           ...(actualThreadId != null && { actualThreadId }),
           userId,
         });
-        if (created) return { status: 200 as const, body: null };
+        if (created) return { status: 200 as const, body: undefined };
       }
 
       // === Handle @dokument-erstellen tool ===
@@ -618,7 +618,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           userContent: lastUserText as string,
           intent: 'direct',
         });
-        if (created) return { status: 200 as const, body: null };
+        if (created) return { status: 200 as const, body: undefined };
       }
 
       // === Handle share_doc intent ===
@@ -632,7 +632,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           ...(rawDocMentionIds != null && { rawDocMentionIds }),
           ...(rawDocumentChatIds != null && { rawDocumentChatIds }),
         });
-        if (handled) return { status: 200 as const, body: null };
+        if (handled) return { status: 200 as const, body: undefined };
       }
 
       // === Stage 2: Search or Image Generation ===
@@ -718,7 +718,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         if (resolution.releaseSlot) await resolution.releaseSlot();
       }
 
-      if (fullText === null) return { status: 200 as const, body: null };
+      if (fullText === null) return { status: 200 as const, body: undefined };
 
       // === Stage 3b: Extract chart data from response (if chart intent) ===
       if (finalState.intent === 'chart') {
@@ -851,11 +851,15 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
 
       log.info(`[ChatGraph] Complete: ${fullText.length} chars in ${totalTimeMs}ms`);
       sse.end();
-      return { status: 200 as const, body: null };
+      return { status: 200 as const, body: undefined };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const errorStack = error instanceof Error ? error.stack : undefined;
-      log.error(`[ChatGraph] Controller error: ${errorMessage}`);
+      const { agentId, threadId, modelId } = args.body;
+      log.error(
+        `[ChatGraph] Controller error: ${errorMessage} ` +
+          `(agentId=${agentId ?? 'default'}, threadId=${threadId ?? 'new'}, modelId=${modelId ?? 'default'})`
+      );
       if (errorStack) log.error(`[ChatGraph] Stack: ${errorStack}`);
       if (!(error instanceof Error))
         log.error(`[ChatGraph] Raw error: ${JSON.stringify(error)?.slice(0, 500)}`);
@@ -863,7 +867,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         sse.send('error', { error: PROGRESS_MESSAGES.internalError });
         sse.end();
       }
-      return { status: 200 as const, body: null };
+      return { status: 200 as const, body: undefined };
     }
   },
 
@@ -880,7 +884,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       if (!user?.id) {
         sse.send('error', { error: PROGRESS_MESSAGES.unauthorized });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       const stored = await pipelineStateStore.get(threadId);
@@ -889,7 +893,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           error: 'Pipeline-Status abgelaufen. Bitte sende deine Nachricht erneut.',
         });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
       await pipelineStateStore.delete(threadId);
 
@@ -898,14 +902,14 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       if (requestContext.userId !== user.id) {
         sse.send('error', { error: PROGRESS_MESSAGES.unauthorized });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       const aiWorkerPool = getAIWorkerPool(req);
       if (!aiWorkerPool) {
         sse.send('error', { error: PROGRESS_MESSAGES.aiUnavailable });
         sse.end();
-        return { status: 200 as const, body: null };
+        return { status: 200 as const, body: undefined };
       }
 
       log.info(`[ChatGraph:Resume] Thread ${threadId}, answer: "${userAnswer.slice(0, 80)}"`);
@@ -1028,7 +1032,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         if (resolution2.releaseSlot) await resolution2.releaseSlot();
       }
 
-      if (fullText === null) return { status: 200 as const, body: null };
+      if (fullText === null) return { status: 200 as const, body: undefined };
 
       // === Persist & complete ===
       await persistResumedResponse({
@@ -1055,7 +1059,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
 
       log.info(`[ChatGraph:Resume] Complete: ${fullText.length} chars in ${totalTimeMs}ms`);
       sse.end();
-      return { status: 200 as const, body: null };
+      return { status: 200 as const, body: undefined };
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const errorStack = error instanceof Error ? error.stack : undefined;
@@ -1065,7 +1069,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         sse.send('error', { error: PROGRESS_MESSAGES.internalError });
         sse.end();
       }
-      return { status: 200 as const, body: null };
+      return { status: 200 as const, body: undefined };
     }
   },
 });

--- a/packages/chat/src/lib/toolMappings.ts
+++ b/packages/chat/src/lib/toolMappings.ts
@@ -23,4 +23,6 @@ export const DEEP_TOOL_MAP: Record<string, string> = {
   recall_memory: 'recall_memory',
   save_memory: 'save_memory',
   search_user_content: 'search_user_content',
+  draft_structured: 'draft_structured',
+  self_review: 'self_review',
 };

--- a/packages/contracts/src/contracts/chatGraphContract.ts
+++ b/packages/contracts/src/contracts/chatGraphContract.ts
@@ -14,12 +14,16 @@ import { initContract } from '@ts-rest/core';
 import {
   chatStreamBodySchema,
   chatResumeBodySchema,
-  sseAcceptedResponseSchema,
   chatGraphErrorResponseSchema,
 } from '../schemas/chatGraph.js';
 
 const c = initContract();
 
+// SSE endpoints: the response body is streamed manually via res.write(). We
+// declare 200 as c.noBody() so ts-rest calls res.status(200).end() instead of
+// res.json() after the handler returns — otherwise res.json sets headers on an
+// already-ended SSE response and Express logs "Cannot set headers after they
+// are sent to the client".
 export const chatGraphContract = c.router(
   {
     /**
@@ -31,7 +35,7 @@ export const chatGraphContract = c.router(
       path: '/api/chat-graph/stream',
       body: chatStreamBodySchema,
       responses: {
-        200: sseAcceptedResponseSchema,
+        200: c.noBody(),
         400: chatGraphErrorResponseSchema,
         401: chatGraphErrorResponseSchema,
         500: chatGraphErrorResponseSchema,
@@ -49,7 +53,7 @@ export const chatGraphContract = c.router(
       path: '/api/chat-graph/resume',
       body: chatResumeBodySchema,
       responses: {
-        200: sseAcceptedResponseSchema,
+        200: c.noBody(),
         400: chatGraphErrorResponseSchema,
         401: chatGraphErrorResponseSchema,
         500: chatGraphErrorResponseSchema,

--- a/packages/contracts/src/schemas/chatGraph.ts
+++ b/packages/contracts/src/schemas/chatGraph.ts
@@ -59,13 +59,8 @@ export const chatResumeBodySchema = z.object({
 
 // ── Response schemas ────────────────────────────────────────────────────────
 
-/**
- * SSE endpoints don't return a structured JSON body on success —
- * they stream events. We model the accepted response as an opaque object
- * so ts-rest is satisfied. Actual SSE events are not validated here.
- */
-export const sseAcceptedResponseSchema = z.unknown();
-
+// SSE success responses are declared as c.noBody() in chatGraphContract.ts —
+// see that file for why. Only the error shape needs a schema.
 export const chatGraphErrorResponseSchema = z.object({
   error: z.string(),
 });


### PR DESCRIPTION
## Why

Every chat-graph request was logging `Error after headers sent: Cannot set headers after they are sent to the client` from ts-rest's `mainReqHandler`. The handler streams SSE, calls `sse.end()`, then returns `{ status: 200, body: null }`. ts-rest then calls `res.status(200).json(null)` which tries to set Content-Type on a response whose headers were already on the wire — Express raises the warning unconditionally.

That noise made the Antrag agent's user-facing `⚠️ Es ist ein Fehler aufgetreten` hard to diagnose: the catch-block error was lost in the framework warning, and we couldn't tell from logs which agent/thread/model was in play.

Declaring the 200 response as `c.noBody()` flips ts-rest into calling `res.status(200).end()` instead — idempotent on an already-ended SSE response. Same trick for `resume`.

Also enriches the catch-block log with `agentId/threadId/modelId` so the next time the Antrag flow surfaces an error we can read the controller log directly. And adds `draft_structured` + `self_review` to `DEEP_TOOL_MAP` so Antrag/Rede/Wahlprogramm tool calls render a UI tool card during streaming.

## Test plan

- [ ] Backend log after a successful chat round-trip on each main agent (Suche, Öffentlichkeitsarbeit, Anträge) — `docker logs api-1 | grep "Cannot set headers"` is empty.
- [ ] Fresh chat with `gruenerator-antrag` → tool card displays with proper label during draft_structured/self_review streaming.
- [ ] If an Antrag chat does error, controller log includes `(agentId=…, threadId=…, modelId=…)` for triage.