### PR TITLE
fix(suche): atomic citation swap to prevent citation flinch

### DIFF
--- a/apps/api/agents/langgraph/SearchGraph/nodes/searchRespondNode.ts
+++ b/apps/api/agents/langgraph/SearchGraph/nodes/searchRespondNode.ts
@@ -69,7 +69,7 @@ function formatSearchContext(state: SearchGraphState): string {
     })
     .join('\n\n');
 
-  return `\n\n<suchergebnisse hinweis="Zitiere diese Quellen mit [Nummer]-Notation">\n${resultsXml}\n</suchergebnisse>`;
+  return `\n\n<suchergebnisse hinweis="Zitiere diese Quellen mit [cite:Nummer]-Notation">\n${resultsXml}\n</suchergebnisse>`;
 }
 
 function escapeXml(s: string): string {
@@ -111,13 +111,13 @@ Schreibe wie einen hochwertigen Artikel mit ansprechendem Erzählfluss.
 - Verwende Markdown: **fett** für Hervorhebungen, ## für Überschriften.
 
 ## ZITATIONSREGELN
-- Dir stehen GENAU ${sourceCount} Quellen zur Verfügung ([1] bis [${sourceCount}]).
-- Zitiere JEDE Aussage mit [Nummer]-Notation: "Aussage hier [1]."
+- Dir stehen GENAU ${sourceCount} Quellen zur Verfügung ([cite:1] bis [cite:${sourceCount}]).
+- Zitiere JEDE Aussage mit [cite:Nummer]-Notation: "Aussage hier [cite:1]."
 - Jeder Satz muss mindestens eine Zitation enthalten.
-- Verwende mehrere Quellen wenn möglich: "Fakt hier [1][3]."
-- Erfinde KEINE Quellen über [${sourceCount}] hinaus.
-- Nummer DIREKT nach dem Satz, VOR dem Punkt: "Text [1]."
-- NIEMALS "laut Quelle" oder "nach Angaben" — NUR [1], [2] etc.
+- Verwende mehrere Quellen wenn möglich: "Fakt hier [cite:1][cite:3]."
+- Erfinde KEINE Quellen über [cite:${sourceCount}] hinaus.
+- Nummer DIREKT nach dem Satz, VOR dem Punkt: "Text [cite:1]."
+- NIEMALS "laut Quelle" oder "nach Angaben" — NUR [cite:1], [cite:2] etc.
 
 ## WICHTIG: KEINE HALLUZINATIONEN
 - Zitiere NUR Informationen, die TATSÄCHLICH in den Quellen stehen.
@@ -164,13 +164,13 @@ Verwende Markdown: ## Überschriften, **fett**, zusammenhängende Absätze.
 Beginne direkt — keine meta-Einleitung.
 
 ## ZITATIONSREGELN
-- Dir stehen GENAU ${sourceCount} Quellen zur Verfügung ([1] bis [${sourceCount}]).
-- Zitiere JEDE Aussage mit [Nummer]-Notation.
+- Dir stehen GENAU ${sourceCount} Quellen zur Verfügung ([cite:1] bis [cite:${sourceCount}]).
+- Zitiere JEDE Aussage mit [cite:Nummer]-Notation.
 - Jeder Satz muss mindestens eine Zitation enthalten.
-- Verwende mehrere Quellen wenn möglich: "Fakt [1][3]."
-- Erfinde KEINE Quellen über [${sourceCount}] hinaus.
-- Nummer direkt nach dem Satz, vor dem Punkt: "Aussage [1]."
-- NIEMALS "laut Quelle" oder "nach Angaben" — NUR [1], [2] etc.
+- Verwende mehrere Quellen wenn möglich: "Fakt [cite:1][cite:3]."
+- Erfinde KEINE Quellen über [cite:${sourceCount}] hinaus.
+- Nummer direkt nach dem Satz, vor dem Punkt: "Aussage [cite:1]."
+- NIEMALS "laut Quelle" oder "nach Angaben" — NUR [cite:1], [cite:2] etc.
 
 ## WICHTIG: KEINE HALLUZINATIONEN
 - Zitiere NUR Informationen, die TATSÄCHLICH in den Quellen stehen.

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -175,10 +175,15 @@ export interface SSEEventPayloads {
     chart: ChartData;
   };
   completion: {
-    answer: string;
+    type?: 'completion';
+    // Notebook flow emits `answer`; SearchGraph reuses this event with `text`.
+    // Both are read by the frontend GrueneratorModelAdapter / NotebookModelAdapter
+    // as the canonical, citation-renumbered final answer.
+    answer?: string;
+    text?: string;
     citations: unknown[];
-    sources: unknown[];
-    allSources: unknown[];
+    sources?: unknown[];
+    allSources?: unknown[];
     sourcesByCollection?: Record<string, unknown>;
     metadata?: Record<string, unknown>;
   };

--- a/apps/api/routes/search/searchGraphController.ts
+++ b/apps/api/routes/search/searchGraphController.ts
@@ -360,6 +360,27 @@ router.post('/stream', async (req: AuthenticatedRequest, res: Response) => {
       });
     }
 
+    // ── Completion (atomic text+citations swap, prevents citation flinch) ──
+    // Mirrors the NotebookModelAdapter protocol: the frontend `completion`
+    // handler swaps accumulatedText with this canonical text (rewriting
+    // [cite:N] → [N]) and replaces citations in the same render pass, so chips
+    // appear simultaneously with the final markers — no plain "[1]" frame.
+    // Citations are remapped to the notebook citation shape that
+    // GrueneratorModelAdapter's `completion` case already understands.
+    sse.send('completion', {
+      type: 'completion',
+      text: fullText ?? '',
+      citations: state.citations.map((c) => ({
+        index: String(c.id),
+        cited_text: c.snippet,
+        document_title: c.title,
+        document_id: c.documentId,
+        source_url: c.url,
+        similarity_score: c.similarityScore,
+        collection_name: c.collectionName ?? c.source,
+      })),
+    });
+
     // ── Done ──
     const totalTimeMs = Date.now() - state.startTime;
     sse.send('done', {

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -200,7 +200,14 @@ async function* parseSSEStream(
       }
     }
 
-    content.push({ type: 'text' as const, text: accumulatedText });
+    // Normalize [cite:N] → [N] before emitting, so CitationMarkdownText's
+    // placeholder-badge layer (citationProcessing.ts:25) renders inline-reserved
+    // boxes during streaming. Mirrors NotebookModelAdapter's buildResult and
+    // prevents the SearchGraph "[cite:N]" markers from appearing as plain text.
+    content.push({
+      type: 'text' as const,
+      text: accumulatedText.replace(/\[cite:(\d+)\]/g, '[$1]'),
+    });
 
     const custom: GrueneratorMessageMetadata = {
       progress: { ...currentProgress, steps: [...progressSteps] },


### PR DESCRIPTION
## Why

The Suche agent (`gruenerator-suche`) showed visible citation flinch: during streaming the LLM emitted raw `[1]`, `[2]` markers that briefly rendered as plain text before resolving into citation chips once the terminal `done` event arrived. Notebook chat already solves this — citations attach atomically with the final answer in a single `completion` event. This PR brings the same protocol to the Suche path.

## How

The flinch-prevention machinery already existed in `packages/chat`:
- `processTextWithCitations` (citationProcessing.ts:25) renders an inline-reserved `CitationBadge` placeholder for any `[N]` marker even when the citation isn't loaded yet.
- `NotebookModelAdapter.buildResult()` exploits this by normalizing `[cite:N]` → `[N]` on every yield, then atomically swapping the canonical answer + citations at completion time.

This PR threads that same wire through the Suche path — no new types, no parallel renderer:

1. `searchRespondNode.ts` prompt now instructs `[cite:N]` markers instead of `[N]`.
2. `searchGraphController.ts` emits a `completion` SSE event (carrying the buffered final answer + citations remapped to notebook shape) right before `done`.
3. `GrueneratorModelAdapter.buildResult` normalizes `[cite:N]` → `[N]` in every yield, matching the notebook adapter.
4. `sseHelpers.ts` widens the `completion` event payload so the search path can reuse it (`text` alongside `answer`, optional `sources`).

The legacy `done` event is preserved as the lifecycle terminator and persistence trigger, so `ResearchArtifactCard` reload behavior is untouched.

## Test plan

- [ ] Open `/chat`, select the **gruenerator-suche** agent, send a multi-source query (e.g. "Was sind die aktuellen Forderungen der Grünen zur Mietpreisbremse?").
- [ ] Confirm in DevTools EventStream: `… → text_delta (with [cite:N]) → completion → done`.
- [ ] During streaming, `[N]` markers should render as placeholder badges (no plain `[1]` text). At completion, chips fill in without flicker.
- [ ] Reload the thread — persisted citations still render via `ResearchArtifactCard`.
- [ ] Notebook chat (separate path) still works unchanged — `completion.answer` field is still accepted.