### PR TITLE
fix(web): suspend rendering during auth bootstrap to stop Startseite flash

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import SuspenseWrapper from './components/common/SuspenseWrapper';
 import ErrorBoundary from './components/ErrorBoundary';
 import useAccessibility from './components/hooks/useAccessibility';
 import useDarkMode from './components/hooks/useDarkMode';
+import AuthBootstrap from './components/routing/AuthBootstrap';
 import AuthRoute from './components/routing/AuthRoute';
 import GuestRoute from './components/routing/GuestRoute';
 import LegacyGeneratorRedirect from './components/routing/LegacyGeneratorRedirect';
@@ -181,6 +182,7 @@ function App() {
         <UserProfileHydrationBridge />
         <Toaster richColors position="top-right" />
         <Router>
+          <AuthBootstrap />
           <ScrollToTop />
           <RouteLogger />
           <SuspenseWrapper>

--- a/apps/web/src/components/routing/AuthBootstrap.tsx
+++ b/apps/web/src/components/routing/AuthBootstrap.tsx
@@ -1,0 +1,25 @@
+import { useAuth } from '../../hooks/useAuth';
+
+/**
+ * Mounts the canonical `useAuth` query once at the App root so that
+ * `/auth/status` is fetched on every page load — regardless of which route
+ * the user lands on.
+ *
+ * Why this is needed: `useAuth` is otherwise called ad-hoc inside specific
+ * feature pages (workplace, profile, media-library, …). If the user lands
+ * directly on `/` (Startseite), no caller exists and the query never fires
+ * — which would leave `hasBootstrapped` permanently false and hang the
+ * AuthSplash forever.
+ *
+ * React Query dedupes by queryKey, so the in-page `useAuth` callers join
+ * this singleton query rather than firing duplicates.
+ *
+ * `instant: true` seeds the store synchronously from the instant-auth
+ * cache when present — keeping the splash invisible on the common path.
+ */
+const AuthBootstrap = () => {
+  useAuth({ instant: true });
+  return null;
+};
+
+export default AuthBootstrap;

--- a/apps/web/src/components/routing/AuthRoute.tsx
+++ b/apps/web/src/components/routing/AuthRoute.tsx
@@ -2,9 +2,27 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { useAuthStore } from '../../stores/authStore';
 
+import AuthSplash from './AuthSplash';
+
+/**
+ * Guards routes that require authentication.
+ *
+ *   - !hasBootstrapped → <AuthSplash />  (no premature redirect to /login)
+ *   - authenticated   → render Outlet
+ *   - guest           → /login?redirectTo=<current>
+ *
+ * Splash gating matters: without it, an authenticated user with an expired
+ * 15-min persist cache lands here, sees `isAuthenticated=false`, and gets
+ * redirected to /login — which then GuestRoute either renders or bounces
+ * once `/auth/status` confirms. The splash holds rendering until we know
+ * which way to go.
+ */
 const AuthRoute = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const hasBootstrapped = useAuthStore((s) => s.hasBootstrapped);
   const location = useLocation();
+
+  if (!hasBootstrapped) return <AuthSplash />;
 
   if (!isAuthenticated) {
     const currentPath = location.pathname + location.search;

--- a/apps/web/src/components/routing/AuthSplash.tsx
+++ b/apps/web/src/components/routing/AuthSplash.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from '@gruenerator/ui';
+
+/**
+ * Page skeleton shown while the auth-bootstrap window is open (before
+ * /auth/status has answered for the first time this page load).
+ *
+ * Deliberately content-agnostic — we don't yet know whether the user is
+ * logged in, so the skeleton must work for both the eventual Startseite
+ * AND the eventual /workplace. Showing a "Login" button would teach
+ * guests-who-are-actually-authenticated to click it unnecessarily, which
+ * is the exact bug this whole change is fixing.
+ */
+const AuthSplash = () => (
+  <div
+    className="fixed inset-0 z-50 flex flex-col bg-background"
+    role="status"
+    aria-live="polite"
+    aria-label="Wird geladen"
+  >
+    {/* Header bar */}
+    <div className="flex items-center justify-between border-b border-border px-md py-sm">
+      <Skeleton className="h-6 w-32" />
+      <Skeleton className="h-8 w-8 rounded-full" />
+    </div>
+
+    {/* Main content */}
+    <div className="mx-auto mt-xl w-full max-w-3xl px-md flex flex-col gap-md">
+      <Skeleton className="h-10 w-2/3" />
+      <Skeleton className="h-4 w-1/2" />
+      <Skeleton className="mt-lg h-32 w-full" />
+      <div className="mt-md grid grid-cols-1 gap-md md:grid-cols-3">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-24 w-full" />
+      </div>
+    </div>
+  </div>
+);
+
+export default AuthSplash;

--- a/apps/web/src/components/routing/GuestRoute.tsx
+++ b/apps/web/src/components/routing/GuestRoute.tsx
@@ -2,24 +2,34 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 import { useAuthStore } from '../../stores/authStore';
 
+import AuthSplash from './AuthSplash';
+
 /**
- * Guards "guest only" routes like /login.
+ * Guards "guest only" routes like /, /login, /register.
  *
- * Redirects away to /workplace ONLY when the server has confirmed the user
- * is authenticated in the current page load (`hasServerConfirmed: true`).
- * A merely cached/persisted `isAuthenticated: true` is not enough — the
- * Zustand persist layer and the instant-auth cache can both keep that flag
- * alive across a backend session expiry, which used to bounce the user
- * /login ↔ /workplace until the cache aged out. See storageKeys.ts and
- * authStore.ts hasServerConfirmed for the broader contract.
+ * Three-state truth table:
+ *   - !hasBootstrapped              → <AuthSplash />  (we don't know yet)
+ *   - guest (no server confirmation) → render Outlet  (show Startseite/login)
+ *   - authenticated & server-confirmed → /workplace
+ *
+ * Two failure modes this defends against:
+ *   1. Stale `isAuthenticated: true` from the 15-min persist cache surviving
+ *      a backend session expiry — `hasServerConfirmed` gates the redirect so
+ *      we don't bounce a real guest off /login.
+ *   2. Stale `isAuthenticated: false` from an expired persist cache while
+ *      the Keycloak cookie is still valid — `hasBootstrapped` suspends
+ *      rendering so we don't flash Startseite at an authenticated user.
  */
 const GuestRoute = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const hasServerConfirmed = useAuthStore((s) => s.hasServerConfirmed);
+  const hasBootstrapped = useAuthStore((s) => s.hasBootstrapped);
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
 
   // Don't redirect during logout — store may momentarily show authenticated from stale cache
   if (isLoggingOut) return <Outlet />;
+
+  if (!hasBootstrapped) return <AuthSplash />;
 
   return isAuthenticated && hasServerConfirmed ? (
     <Navigate to="/workplace" replace />

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -210,7 +210,7 @@ const standardRoutes: RouteConfig[] = [
   { path: '/startseite', component: Startseite, auth: 'guest', layoutMode: 'noChrome' as const },
   // Unified Text Generator route (wildcard for path-based tab navigation)
   { path: '/texte/*', component: GrueneratorenBundle.Texte, withForm: true },
-  { path: '/workplace', component: WorkplacePage },
+  { path: '/workplace', component: WorkplacePage, auth: 'required' as const },
   // Agent builder/editor. Dev-only until the feature ships — gated via the
   // existing `devOnly` filter at the bottom of this file (Vite tree-shakes the
   // routes in prod). The list/overview lives on the unified Library page at

--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -1,7 +1,6 @@
 import { SectionHeader } from '@gruenerator/ui';
 import { memo } from 'react';
 
-import withAuthRequired from '../../components/common/LoginRequired/withAuthRequired';
 import PageContainer from '../../components/common/PageContainer';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import { useFirstName } from '../../hooks/useFirstName';
@@ -276,6 +275,4 @@ const WorkplacePage = () => {
   );
 };
 
-export default withAuthRequired(WorkplacePage, {
-  title: 'Desk',
-});
+export default WorkplacePage;

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -71,6 +71,15 @@ export interface AuthStore {
   // redirect away from /login. Prevents the cache-driven redirect loop where
   // stale `isAuthenticated: true` survives a backend session expiry.
   hasServerConfirmed: boolean;
+  // True once the server (or the instant-auth cache, which mirrors the
+  // server's last word) has answered AT LEAST ONCE this page load — whether
+  // the answer was "authenticated" or "guest". Distinct from
+  // hasServerConfirmed, which is only true when the current answer is
+  // "authenticated". Route guards use this to suspend rendering during
+  // the bootstrap window, so guests don't flash Startseite at logged-in
+  // users (and vice versa) just because the cache expired but the cookie
+  // didn't.
+  hasBootstrapped: boolean;
   isLoading: boolean;
   error: string | null;
   isLoggingOut: boolean;
@@ -234,6 +243,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   isAuthenticated: persistedState?.isAuthenticated || false,
   // Intentionally always false on init — server must reconfirm every load.
   hasServerConfirmed: false,
+  // Always false on init — flips true the first time setAuthState (success
+  // or guest answer) or clearAuth fires. See type doc above.
+  hasBootstrapped: false,
   isLoading: persistedState ? false : true, // Don't start loading if we have persisted data
   error: null,
   isLoggingOut: false, // New state to track logout in progress
@@ -255,6 +267,8 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       // from /auth/status or the login flow). Promotes the cached optimistic
       // state to the "verified" tier that GuestRoute trusts for redirects.
       hasServerConfirmed: data.isAuthenticated,
+      // Either branch (authenticated or guest) constitutes a server answer.
+      hasBootstrapped: true,
       isLoading: false,
       error: null,
       // Extract color from canonical UserProfile field. The legacy
@@ -316,6 +330,9 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       user: null,
       isAuthenticated: false,
       hasServerConfirmed: false,
+      // clearAuth fires after a server answer ("not authenticated", explicit
+      // logout, or 401). The bootstrap window is over.
+      hasBootstrapped: true,
       isLoading: false,
       error: null,
       isLoggingOut: false,


### PR DESCRIPTION
## Why

The 15-minute persist-cache TTL in `authStore` is much shorter than the Keycloak session. On a cold reload after >15 min idle, `isAuthenticated` reads back `false` from the expired cache while the cookie is still valid. With only `auth: 'guest'` guarding `/`, the marketing Startseite flashed at logged-in users — training them to click the "Login" CTA and re-establish the session they already had. That's the "randomly sent to startpage, must click login again" experience.

The recent `hasServerConfirmed` fix in #(previous PR) closed the inverse failure mode (stale `true` bouncing real guests off `/login`), but did nothing for stale `false` after cache expiry.

## What changes

- New `hasBootstrapped` flag in `authStore` — flips `true` the first time `/auth/status` (or the instant-auth cache mirroring its last answer) resolves, regardless of outcome. Distinct from `hasServerConfirmed`, which is only true on a confirmed-authenticated answer.
- `GuestRoute` and `AuthRoute` now render a content-agnostic page skeleton (`AuthSplash`, built from `@gruenerator/ui`'s `Skeleton`) while `!hasBootstrapped`. No "Login" CTA on the splash — that's exactly what we don't want users to learn to click.
- New `AuthBootstrap` mounts `useAuth({ instant: true })` once at the App root so `/auth/status` actually fires on every page load. Previously `useAuth` was only called inside specific feature pages, so a direct hit on `/` never resolved bootstrap.
- `/workplace` moves to declarative `auth: 'required'` in `routes.ts`; `withAuthRequired` HOC dropped from `WorkplacePage.tsx`. Auth contract for `/` and `/workplace` now lives in one file.

## Truth table after this PR

| state | `/` (guest) | `/workplace` (required) |
|---|---|---|
| !hasBootstrapped | skeleton | skeleton |
| guest | Startseite | redirect to `/login?redirectTo=/workplace` |
| authenticated + confirmed | redirect to `/workplace` | render |

## Test plan

- [ ] Cold reload `/` while logged in after >15 min idle → skeleton → `/workplace`. No Startseite flash.
- [ ] Cold reload `/` while genuinely logged out → skeleton → Startseite.
- [ ] Hit `/workplace` while logged out → skeleton → `/login?redirectTo=/workplace` → after login → `/workplace`.
- [ ] Hit `/login` while logged in → `/workplace`.
- [ ] Click "Logout" → Startseite. No bounce.
- [ ] Existing 401 circuit-breaker in `apiClient` still fires on repeated bounces.