### PR TITLE
fix(web): drop synth-guest cooldown — post-login no longer bounces to /login

### DIFF
--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -448,12 +448,6 @@ export const useAuth = (options: AuthOptions = {}) => {
     lazy || (instant && hasCachedData)
   );
 
-  // Always allow auth on login page (conscious user action). Used inside
-  // `queryFn` to decide whether to short-circuit the cooldown.
-  const isOnLoginPage =
-    typeof window !== 'undefined' &&
-    (window.location.pathname === '/login' || window.location.pathname === '/auth/login');
-
   const {
     data: authData,
     isLoading: isQueryLoading,
@@ -462,22 +456,6 @@ export const useAuth = (options: AuthOptions = {}) => {
   } = useQuery<AuthData>({
     queryKey: ['authStatus'],
     queryFn: async (): Promise<AuthData> => {
-      // Recently-logged-out cooldown: synthesise a guest answer instead of
-      // hitting the server. Side effects still run, so the bootstrap signal
-      // resolves and guards stop holding the splash. Replaces the old
-      // `enabled` gate, which left the query in `pending` forever and hung
-      // the splash.
-      if (isRecentlyLoggedOut() && !isOnLoginPage) {
-        try {
-          localStorage.removeItem(LOGOUT_TIMESTAMP);
-        } catch {
-          // Ignore localStorage errors
-        }
-        const guestAnswer: AuthData = { isAuthenticated: false };
-        applyAuthAnswer(guestAnswer, queryClient);
-        return guestAnswer;
-      }
-
       if (import.meta.env.VITE_E2E_AUTH_BYPASS === 'true') {
         const data = buildE2EBypassAuthData();
         applyAuthAnswer(data, queryClient);


### PR DESCRIPTION
## Why

PR #784 replaced the old \`enabled\` cooldown gate with a synthesised guest answer inside \`queryFn\`. That turned the original splash-hang into a redirect-loop: after a successful Keycloak login that lands on \`/workplace\`, \`RequireAuth\` sees the synthesised \`{isAuthenticated: false}\`, bounces to \`/login?redirectTo=/workplace\`, and the user has to log in a second time.

The cooldown was guarding against an "immediate re-auth race" that does not exist in our stack — \`authStore.logout\` awaits the backend \`/auth/logout\` (which destroys the \`ba_sessions\` row) before clearing local state, so \`/auth/status\` returns guest immediately after logout regardless of how recently \`LOGOUT_TIMESTAMP\` was written.

The \`LOGIN_INTENT\` bypass that was supposed to handle intentional re-logins is fragile (Safari ITP, private browsing, slow OAuth, non-\`LoginPage\` entry points). The fix isn't to harden the bypass — it's to trust the server.

## Verification

- [ ] Log out from \`/workplace\` → immediately click Login → complete Keycloak → lands on \`/workplace\` (today: bounces to \`/login\`).
- [ ] Logout still redirects cleanly to \`/\` with no re-auth flash.
- [ ] Cold guest still sees splash → Startseite (PR #784 regression check).
- [ ] Stale tab: leave 6+ min, return focus → \`refetchOnWindowFocus\` fires \`/auth/status\` and reflects whatever the server says.

## Scope

12-line deletion in one file. \`isRecentlyLoggedOut\` helper kept (it's still used by \`loadPersistedAuthState\`'s separate concern of suppressing optimistic-state hydration in the immediate post-logout window).