### PR TITLE
fix(web): stop caching guest answers; refetch auth on mount

### DIFF
--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -360,11 +360,20 @@ const buildE2EBypassAuthData = (): AuthData => {
  * per fetch in the queryFn body has no equivalent silent-skip path.
  */
 const applyAuthAnswer = (data: AuthData, queryClient: ReturnType<typeof useQueryClient>) => {
-  setCachedAuthState(data);
-
   const { isAuthenticated: currentIsAuthenticated, user: currentUser } = useAuthStore.getState();
 
   if (data.isAuthenticated && data.user) {
+    // Cache ONLY positive answers. A guest answer in INSTANT_AUTH_CACHE acts
+    // as `initialData` for React Query on the next page load (e.g. the
+    // post-Keycloak-callback `/workplace` mount), which puts the query into
+    // `success` state with `{isAuthenticated: false}` before any network call
+    // — and with `refetchOnMount: false` the queryFn never fires to correct it.
+    // RequireAuth then bounces synchronously to `/login?redirectTo=/workplace`,
+    // trapping the user in a redirect loop after a successful OAuth callback.
+    // The cost of one-way caching is a stale-positive flash after cross-device
+    // logout; `refetchOnMount: 'always'` on the query handles that.
+    setCachedAuthState(data);
+
     notifyAuthConfirmed();
     try {
       localStorage.removeItem(LOGIN_INTENT);
@@ -398,14 +407,18 @@ const applyAuthAnswer = (data: AuthData, queryClient: ReturnType<typeof useQuery
         });
     }
   } else {
-    // Server says guest. If we were authenticated, run the full clearAuth
-    // teardown (wipes persisted state, profile store, etc.). If we were
-    // already guest, skip — no cleanup needed.
+    // Server says guest. Wipe any positive entry from the instant-auth cache
+    // so the next page load does not seed React Query with a false positive
+    // (and, more importantly, leaves no false negative behind for the
+    // post-login `/workplace` mount to read).
+    clearCachedAuthState();
+
     if (currentIsAuthenticated) {
+      // Full teardown: clears persisted state, profile store, etc.
       useAuthStore.getState().clearAuth();
     } else {
-      // Still need to reflect the server answer into the store so
-      // `hasServerConfirmed` is freshly accurate.
+      // Reflect the server answer into the store so `hasServerConfirmed` is
+      // freshly accurate.
       useAuthStore.getState().setAuthState({ user: null, isAuthenticated: false });
     }
   }
@@ -487,7 +500,13 @@ export const useAuth = (options: AuthOptions = {}) => {
     // we want the UI to learn about it immediately, rather than waiting for
     // the next user-triggered API call to 401 and trip the redirect path.
     refetchOnWindowFocus: true,
-    refetchOnMount: false,
+    // 'always' so a fresh page load (Cmd+R, Keycloak callback redirect,
+    // cross-device logout) revalidates against the backend even when the
+    // 5-minute persisted positive cache seeds React Query via `initialData`.
+    // The combination of cache-positive-only + refetchOnMount:'always' gives
+    // us instant /workplace render on the warm path AND prompt correction
+    // when the cached state has gone stale.
+    refetchOnMount: 'always',
     refetchOnReconnect: true,
   });
 


### PR DESCRIPTION
## Why

After PR #786, users still get bounced to \`/login?redirectTo=%2Fworkplace\` after a successful Keycloak login (confirmed by backend logs showing 4 \`session-created\` entries for the same user in 14 min — Better Auth IS creating sessions; the frontend just won't believe them).

Root cause: \`applyAuthAnswer\` writes \`INSTANT_AUTH_CACHE\` for **every** answer — including \`{isAuthenticated: false}\`. Combined with \`refetchOnMount: false\`, a recent guest cache becomes self-fulfilling:

1. Guest visit → \`/auth/status\` returns guest → **cache stores guest**.
2. User clicks Login → Keycloak → callback redirects to \`/workplace\` (fresh page load).
3. \`getCachedAuthEntry()\` reads recent guest cache.
4. React Query starts with \`initialData: {isAuthenticated: false}\`, \`status: 'success'\`, no splash, no fetch.
5. \`useAuthBootstrapped\` returns \`true\` (status !== pending).
6. Zustand \`isAuthenticated\` is \`false\` (logged-out state).
7. \`RequireAuth\` synchronously \`Navigate\`s to \`/login\`. The user is now on \`/login\`. \`queryFn\` never runs.

PR #782 had deliberately switched to \"cache guest answers too\" to fix a *different* bug (stale \`true\` cache outliving a guest response). That fix traded one false-positive for the false-negative this PR removes.

## Fix

- \`applyAuthAnswer\`: cache **only** positive answers. Guest answers \`clearCachedAuthState()\` so the next page load reads no initialData → React Query starts pending → splash → \`queryFn\` fires → truth wins.
- \`refetchOnMount: 'always'\` so a stale-positive cache (cross-device logout: this device thinks auth, session destroyed elsewhere) revalidates against the backend on every fresh page load.

## Verification

- [ ] Log out from \`/workplace\` → click Login → complete Keycloak → lands on \`/workplace\` immediately, no bounce.
- [ ] Cold guest hits \`/\` → splash → Startseite.
- [ ] Warm authenticated reload of \`/workplace\` → instant render (cache hit), background refetch validates.
- [ ] Window-focus refetch after idle still corrects an expired session.

## Scope

One file, 35 lines (mostly comments + the explicit auth/guest branch split). No backend touch.