### PR TITLE
refactor(api): better-auth/minimal import + recommended indexes

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -1,6 +1,6 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { type UserProfile } from '@gruenerator/contracts';
-import { betterAuth } from 'better-auth';
+import { betterAuth } from 'better-auth/minimal';
 import { bearer } from 'better-auth/plugins/bearer';
 import { genericOAuth } from 'better-auth/plugins/generic-oauth';
 import { drizzle } from 'drizzle-orm/node-postgres';

--- a/apps/api/database/postgres/migrations/add_better_auth_recommended_indexes.sql
+++ b/apps/api/database/postgres/migrations/add_better_auth_recommended_indexes.sql
@@ -1,0 +1,9 @@
+-- Better Auth recommended indexes that were missing from the schema.
+-- See https://better-auth.com/docs/guides/optimizing-for-performance#database-indexes
+--
+-- Already present: idx_ba_sessions_user, idx_ba_sessions_token, idx_ba_accounts_user.
+-- Adding here: identifier lookup for verification flows (password reset, email verify),
+-- and email lookup for account-linking / admin support flows.
+
+CREATE INDEX IF NOT EXISTS idx_ba_verification_identifier ON ba_verification(identifier);
+CREATE INDEX IF NOT EXISTS idx_profiles_email ON profiles(email);

--- a/apps/api/database/schema/auth.ts
+++ b/apps/api/database/schema/auth.ts
@@ -67,14 +67,20 @@ export const ba_accounts = pgTable(
   })
 );
 
-export const ba_verification = pgTable('ba_verification', {
-  id: text('id').primaryKey(),
-  identifier: text('identifier').notNull(),
-  value: text('value').notNull(),
-  expires_at: timestamp('expires_at', { withTimezone: true }).notNull(),
-  created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
-  updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow(),
-});
+export const ba_verification = pgTable(
+  'ba_verification',
+  {
+    id: text('id').primaryKey(),
+    identifier: text('identifier').notNull(),
+    value: text('value').notNull(),
+    expires_at: timestamp('expires_at', { withTimezone: true }).notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    identifierIdx: index('idx_ba_verification_identifier').on(table.identifier),
+  })
+);
 
 /**
  * Drizzle relations for joins. Better Auth's `findOAuthUser` issues a query

--- a/apps/api/database/schema/core.ts
+++ b/apps/api/database/schema/core.ts
@@ -1,5 +1,6 @@
 import {
   boolean,
+  index,
   integer,
   jsonb,
   pgTable,
@@ -8,66 +9,72 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 
-export const profiles = pgTable('profiles', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
-  updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow(),
-  first_name: text('first_name'),
-  last_name: text('last_name'),
-  display_name: text('display_name'),
-  avatar_url: text('avatar_url'),
-  deutschlandmodus: boolean('deutschlandmodus').notNull().default(false),
-  is_admin: boolean('is_admin').notNull().default(false),
-  profile_image: integer('profile_image').notNull().default(1),
-  avatar_robot_id: integer('avatar_robot_id').notNull().default(1),
-  keycloak_id: text('keycloak_id'),
-  username: text('username'),
-  last_login: timestamp('last_login', { withTimezone: true }),
-  email: text('email'),
-  email_verified: boolean('email_verified').notNull().default(false),
-  custom_prompt: text('custom_prompt'),
-  beta_features: jsonb('beta_features').$type<Record<string, boolean>>().notNull().default({}),
-  presseabbinder: text('presseabbinder'),
-  custom_antrag_gliederung: text('custom_antrag_gliederung'),
-  auth_source: text('auth_source'),
-  locale: text('locale').notNull().default('de-DE'),
-  groups_enabled: boolean('groups_enabled').notNull().default(false),
-  groups: boolean('groups').notNull().default(false),
-  custom_generators: boolean('custom_generators').notNull().default(false),
-  database_access: boolean('database_access').notNull().default(false),
-  collab: boolean('collab').notNull().default(false),
-  notebook: boolean('notebook').notNull().default(false),
-  sharepic: boolean('sharepic').notNull().default(false),
-  anweisungen: boolean('anweisungen').notNull().default(false),
-  chat_color: text('chat_color'),
-  content_management: boolean('content_management').notNull().default(false),
-  labor_enabled: boolean('labor_enabled').notNull().default(false),
-  sites: boolean('sites').notNull().default(false),
-  sites_enabled: boolean('sites_enabled').notNull().default(true),
-  chat: boolean('chat').notNull().default(false),
-  website: boolean('website').notNull().default(false),
-  ai_sharepic: boolean('ai_sharepic').notNull().default(false),
-  vorlagen: boolean('vorlagen').notNull().default(false),
-  video_editor: boolean('video_editor').notNull().default(false),
-  scanner: boolean('scanner').notNull().default(false),
-  prompts: boolean('prompts').notNull().default(false),
-  interactive_antrag_enabled: boolean('interactive_antrag_enabled').notNull().default(true),
-  nextcloud_share_links: jsonb('nextcloud_share_links')
-    .$type<Record<string, unknown>[]>()
-    .notNull()
-    .default([]),
-  wordpress_sites: jsonb('wordpress_sites')
-    .$type<Record<string, unknown>[]>()
-    .notNull()
-    .default([]),
-  wordpress_enabled: boolean('wordpress_enabled').notNull().default(false),
-  document_mode: text('document_mode').notNull().default('manual'),
-  user_defaults: jsonb('user_defaults')
-    .$type<Record<string, Record<string, unknown>>>()
-    .notNull()
-    .default({}),
-  docs: boolean('docs').notNull().default(false),
-  boards: boolean('boards').notNull().default(false),
-  bundestag_api_enabled: boolean('bundestag_api_enabled').notNull().default(false),
-  memory_enabled: boolean('memory_enabled').notNull().default(false),
-});
+export const profiles = pgTable(
+  'profiles',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+    first_name: text('first_name'),
+    last_name: text('last_name'),
+    display_name: text('display_name'),
+    avatar_url: text('avatar_url'),
+    deutschlandmodus: boolean('deutschlandmodus').notNull().default(false),
+    is_admin: boolean('is_admin').notNull().default(false),
+    profile_image: integer('profile_image').notNull().default(1),
+    avatar_robot_id: integer('avatar_robot_id').notNull().default(1),
+    keycloak_id: text('keycloak_id'),
+    username: text('username'),
+    last_login: timestamp('last_login', { withTimezone: true }),
+    email: text('email'),
+    email_verified: boolean('email_verified').notNull().default(false),
+    custom_prompt: text('custom_prompt'),
+    beta_features: jsonb('beta_features').$type<Record<string, boolean>>().notNull().default({}),
+    presseabbinder: text('presseabbinder'),
+    custom_antrag_gliederung: text('custom_antrag_gliederung'),
+    auth_source: text('auth_source'),
+    locale: text('locale').notNull().default('de-DE'),
+    groups_enabled: boolean('groups_enabled').notNull().default(false),
+    groups: boolean('groups').notNull().default(false),
+    custom_generators: boolean('custom_generators').notNull().default(false),
+    database_access: boolean('database_access').notNull().default(false),
+    collab: boolean('collab').notNull().default(false),
+    notebook: boolean('notebook').notNull().default(false),
+    sharepic: boolean('sharepic').notNull().default(false),
+    anweisungen: boolean('anweisungen').notNull().default(false),
+    chat_color: text('chat_color'),
+    content_management: boolean('content_management').notNull().default(false),
+    labor_enabled: boolean('labor_enabled').notNull().default(false),
+    sites: boolean('sites').notNull().default(false),
+    sites_enabled: boolean('sites_enabled').notNull().default(true),
+    chat: boolean('chat').notNull().default(false),
+    website: boolean('website').notNull().default(false),
+    ai_sharepic: boolean('ai_sharepic').notNull().default(false),
+    vorlagen: boolean('vorlagen').notNull().default(false),
+    video_editor: boolean('video_editor').notNull().default(false),
+    scanner: boolean('scanner').notNull().default(false),
+    prompts: boolean('prompts').notNull().default(false),
+    interactive_antrag_enabled: boolean('interactive_antrag_enabled').notNull().default(true),
+    nextcloud_share_links: jsonb('nextcloud_share_links')
+      .$type<Record<string, unknown>[]>()
+      .notNull()
+      .default([]),
+    wordpress_sites: jsonb('wordpress_sites')
+      .$type<Record<string, unknown>[]>()
+      .notNull()
+      .default([]),
+    wordpress_enabled: boolean('wordpress_enabled').notNull().default(false),
+    document_mode: text('document_mode').notNull().default('manual'),
+    user_defaults: jsonb('user_defaults')
+      .$type<Record<string, Record<string, unknown>>>()
+      .notNull()
+      .default({}),
+    docs: boolean('docs').notNull().default(false),
+    boards: boolean('boards').notNull().default(false),
+    bundestag_api_enabled: boolean('bundestag_api_enabled').notNull().default(false),
+    memory_enabled: boolean('memory_enabled').notNull().default(false),
+  },
+  (table) => ({
+    emailIdx: index('idx_profiles_email').on(table.email),
+  })
+);


### PR DESCRIPTION
## Why

Two small, orthogonal Better Auth improvements stacked into one PR.

**`better-auth/minimal`** — drops Kysely (and transitive deps) from the API server bundle. Safe to swap because we use the Drizzle adapter and run raw SQL migrations through `PostgresService.init()`, so the "no built-in migration CLI" caveat doesn't apply to us. See <https://better-auth.com/docs/guides/optimizing-for-performance#removing-unnecessary-dependencies>.

**Missing indexes** — closes the last two gaps in Better Auth's [recommended index set](https://better-auth.com/docs/guides/optimizing-for-performance#database-indexes):

- `idx_ba_verification_identifier` — every password-reset / email-verification flow looks up by this column.
- `idx_profiles_email` — account-linking and admin/support lookups.

(`idx_ba_sessions_user`, `idx_ba_sessions_token`, `idx_ba_accounts_user` already exist.)

Migration is `CREATE INDEX IF NOT EXISTS` — idempotent. Drizzle schemas updated to keep the schema files in sync with the runtime DDL (per `feedback_type_safety_4_layer_audit`).