### PR TITLE
chore(canvas-editor): drop AutoSave debug console.logs

### DIFF
--- a/packages/canvas-editor/src/stores/AutoSaveStoreProvider.tsx
+++ b/packages/canvas-editor/src/stores/AutoSaveStoreProvider.tsx
@@ -27,10 +27,6 @@ export function AutoSaveStoreProvider({
 }) {
   const storeRef = useRef<AutoSaveStoreApi | null>(null);
   if (!storeRef.current) {
-    console.log('[AutoSave][Provider] mount', {
-      initialShareTokenProp: initialShareToken,
-      seededWith: initialShareToken ?? null,
-    });
     storeRef.current = createAutoSaveStore({ initialShareToken });
   }
   return (

--- a/packages/canvas-editor/src/stores/createAutoSaveStore.ts
+++ b/packages/canvas-editor/src/stores/createAutoSaveStore.ts
@@ -36,34 +36,20 @@ export interface CreateAutoSaveStoreOptions {
 
 export function createAutoSaveStore(options: CreateAutoSaveStoreOptions = {}) {
   const initialShareToken = options.initialShareToken ?? null;
-  const instanceId = Math.random().toString(36).slice(2, 7);
-  console.log('[AutoSave][createStore]', {
-    instanceId,
-    initialShareToken,
-    seeded: initialShareToken !== null,
-  });
   return createStore<AutoSaveStore>()((set) => ({
     autoSaveStatus: 'idle',
     autoSavedShareToken: initialShareToken,
     lastAutoSavedImageSrc: null,
 
-    setAutoSaveStatus: (status) => {
-      console.log('[AutoSave][setStatus]', { instanceId, status });
-      set({ autoSaveStatus: status });
-    },
-    setAutoSavedShareToken: (token) => {
-      console.log('[AutoSave][setShareToken]', { instanceId, token });
-      set({ autoSavedShareToken: token });
-    },
+    setAutoSaveStatus: (status) => set({ autoSaveStatus: status }),
+    setAutoSavedShareToken: (token) => set({ autoSavedShareToken: token }),
     setLastAutoSavedImageSrc: (src) => set({ lastAutoSavedImageSrc: src }),
-    clearAutoSaveState: () => {
-      console.log('[AutoSave][clearAutoSaveState]', { instanceId });
+    clearAutoSaveState: () =>
       set({
         autoSaveStatus: 'idle',
         autoSavedShareToken: null,
         lastAutoSavedImageSrc: null,
-      });
-    },
+      }),
   }));
 }
 


### PR DESCRIPTION
The `[AutoSave][createStore]`, `[setStatus]`, `[setShareToken]`, `[clearAutoSaveState]`, and `[Provider] mount` logs were dev-time instrumentation from the per-instance AutoSaveStore work and shipped to prod. They fire on every canvas mount and every status change, cluttering the production console with no diagnostic value remaining.

Pure deletion — no behavior change.