### PR TITLE
fix(web): respect VITE_API_BASE_URL in authClient

### DIFF
--- a/apps/web/src/lib/authClient.ts
+++ b/apps/web/src/lib/authClient.ts
@@ -12,9 +12,11 @@ import { createAuthClient } from 'better-auth/react';
  *
  * **`baseURL` must be absolute.** `createAuthClient` runs `new URL(baseURL)`
  * at construction time, which throws on a bare path like `/api/auth/v2`.
- * We derive the origin from `window.location` (same-origin pattern, mirrors
- * the WS scheme rule) so dev (`http://localhost:3000`), test, and prod
- * (`https://gruenerator.eu`) all work without env wiring.
+ * Compose against the same `VITE_API_BASE_URL` the rest of the app uses
+ * (Salt sets it to `https://{domain}/api` in test/prod); fall back to
+ * `'/api'` in dev where it's unset. `new URL(input, base)` resolves the
+ * relative dev case against `window.location.origin` and respects the
+ * already-absolute prod value — same trick the browser uses for `<a href>`.
  *
  * Shape note: the response shape from `authClient.getSession()` is
  * Better Auth's native `Session` (camelCase `name`/`image`/`emailVerified`
@@ -25,6 +27,8 @@ import { createAuthClient } from 'better-auth/react';
  * `./sessionUserToProfile.ts`) which mirrors the server's
  * `toBetterAuthUser()` null-strip + Zod-parse boundary.
  */
+const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '/api';
+
 export const authClient = createAuthClient({
-  baseURL: `${window.location.origin}/api/auth/v2`,
+  baseURL: new URL(`${apiBase}/auth/v2`, window.location.origin).toString(),
 });


### PR DESCRIPTION
## Why

Refinement on top of #793. Salt already provisions `VITE_API_BASE_URL=https://{domain}/api` for test and prod (see `Salt/states/gruenerator-docker/files/backend.env.j2:77`), and ~15 other consumers across `apps/web` already read it. Pulling the same variable into the Better Auth client keeps the API surface consistent — one canonical base, one place to change it.

`new URL(input, base)` resolves both modes:
- **prod/test** — `VITE_API_BASE_URL` is already absolute, so `window.location.origin` is ignored.
- **dev** — variable unset → `'/api'` fallback resolves against `window.location.origin`.

**Stacking note:** Builds on #790 (the file added) and #793 (the absolute-URL fix). Until those merge, this PR's diff shows all three commits; afterwards it collapses to the single refinement.