### PR TITLE
fix(api): forward Set-Cookie from auth.api.signOut on logout

### DIFF
--- a/apps/api/routes/auth/authCore.ts
+++ b/apps/api/routes/auth/authCore.ts
@@ -7,7 +7,7 @@
 
 import { fromNodeHeaders } from 'better-auth/node';
 import { and, eq, like } from 'drizzle-orm';
-import express, { type Router, type Response } from 'express';
+import express, { type Router, type Request, type Response } from 'express';
 
 import { auth } from '../../config/betterAuth.js';
 import { env } from '../../config/env.js';
@@ -23,6 +23,37 @@ const log = createLogger('authCore');
 const { requireAuth: ensureAuthenticated } = authMiddlewareModule;
 
 const router: Router = express.Router();
+
+/**
+ * Sign the user out of Better Auth AND forward the cookie-clearing headers to
+ * the Express response. `auth.api.signOut({ headers, asResponse: true })`
+ * returns a Response carrying `Set-Cookie: ba.session_token=; Max-Age=0`
+ * (plus the same for `ba.session_data`, the 300s cookie cache). Without this
+ * forwarding step those headers are discarded by the Express handler, so the
+ * browser keeps both cookies — and because the cookie cache stores a signed
+ * copy of the session, subsequent `auth.api.getSession()` calls return the
+ * cached user for up to 300s even though the DB row has been deleted. That's
+ * the "logs me back in immediately after logout" bug.
+ *
+ * Pattern straight from Better Auth issue #7034 (Express/NestJS context).
+ * Multiple Set-Cookie headers must be forwarded — `res.setHeader('Set-Cookie',
+ * cookies)` with an array does this correctly.
+ */
+async function signOutAndForwardCookies(req: Request, res: Response): Promise<void> {
+  try {
+    const betterAuthResponse = await auth.api.signOut({
+      headers: fromNodeHeaders(req.headers),
+      asResponse: true,
+    });
+    const cookies: string[] = [];
+    betterAuthResponse.headers.forEach((value, key) => {
+      if (key.toLowerCase() === 'set-cookie') cookies.push(value);
+    });
+    if (cookies.length) res.setHeader('Set-Cookie', cookies);
+  } catch (err) {
+    log.warn('[Auth Logout] auth.api.signOut threw: %s', (err as Error).message);
+  }
+}
 
 // ============================================================================
 // Health & Test Routes
@@ -103,11 +134,7 @@ router.get('/logout', async (req: AuthRequest, res: Response): Promise<void> => 
     }
   }
 
-  try {
-    await auth.api.signOut({ headers: fromNodeHeaders(req.headers) });
-  } catch {
-    // Sign-out may fail if no session — that's fine
-  }
+  await signOutAndForwardCookies(req, res);
 
   res.status(200).json({ success: true, message: 'Logout completed', sessionCleared: true });
 });
@@ -154,12 +181,7 @@ router.post('/logout', async (req: AuthRequest, res: Response): Promise<void> =>
     }
   }
 
-  try {
-    await auth.api.signOut({ headers: fromNodeHeaders(req.headers) });
-  } catch (err) {
-    // Sign-out may fail if no session — log so we know it happened
-    log.warn('[Auth Logout] auth.api.signOut threw: %s', (err as Error).message);
-  }
+  await signOutAndForwardCookies(req, res);
 
   res.json({
     success: true,


### PR DESCRIPTION
## Why

After PR #790 swapped the frontend session probe to Better Auth's native handler, logout-then-immediate-redirect-to-/workplace started reproducing reliably. Root cause: a long-standing backend bug that the new code path exposed.

`auth.api.signOut({ headers })` returns a Response carrying the Set-Cookie headers that clear both `ba.session_token` and `ba.session_data` (the **signed 300s cookie cache**). The Express handler was awaiting the promise but never forwarding the Response's headers to `res`. So:

1. DB session row → deleted ✓
2. Browser session cookie → stays
3. Browser cookie cache → stays, containing a signed snapshot of the user

Next `getSession()` call: server reads the cache cookie, validates the signature, returns the cached user without touching the DB. For up to 300s the user appears logged in, even though the row is gone.

The fix is the Express/NestJS pattern straight from Better Auth issue #7034 — call `signOut` with `asResponse: true`, collect the Set-Cookie headers from the returned `Response`, set them on `res` via `res.setHeader('Set-Cookie', cookies)` (which handles the multi-value array correctly). Applied to both GET and POST `/api/auth/logout` handlers via a shared helper.

## Why this didn't surface before #790

The old `/auth/status` wrapper used the same `auth.api.getSession()` under the hood, so the same cache cookie was honored there too. Best guess: timing/cache-eviction quirks in the wrapper path, or queryFn error branches masking the cached answer. The native endpoint is a more direct path — it consistently returns the cached user, so the bug becomes deterministic.

## Verify after deploy

- Login → land on /workplace
- Logout → land on /, **stay there**
- DevTools → after logout, the `ba.session_*` cookies should be absent