### PR TITLE
fix(api): revert better-auth/minimal — breaks Keycloak OAuth callback

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -1,6 +1,6 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter';
 import { type UserProfile } from '@gruenerator/contracts';
-import { betterAuth } from 'better-auth/minimal';
+import { betterAuth } from 'better-auth';
 import { bearer } from 'better-auth/plugins/bearer';
 import { genericOAuth } from 'better-auth/plugins/generic-oauth';
 import { drizzle } from 'drizzle-orm/node-postgres';


### PR DESCRIPTION
## Why

Production observed after PR #789 deploy:
> Es ist ein Fehler aufgetreten. Unerwarteter Fehler während der Bearbeitung der Anfrage an den Identity Provider.

Keycloak OAuth callback fails. `better-auth/minimal` is documented as dropping internal database-adapter plumbing; turns out it also drops something needed by the generic-oauth callback path in our setup. The bundle-size win was nice but secondary to "users can log in."

The other half of #789 (the two recommended DB indexes, `idx_ba_verification_identifier` + `idx_profiles_email`) applied cleanly and is independent — leaving it in place.

**Recommend merging asap** (login is broken in test/prod until then).

## Follow-up

Once login is back, investigate which specific Better Auth internal is missing from the minimal export under our config (Drizzle adapter + genericOAuth + bearer + Redis secondary storage). Likely either the OAuth state-cookie handling or the Drizzle account-linking path. If we can isolate it, we may be able to re-introduce the minimal import with a targeted addition.