### PR TITLE
fix(notebook): reset agent when entering a user notebook

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -424,6 +424,15 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
   const id = idProp ?? idFromParams;
   const user = useAuthStore((s) => s.user);
   const { initDocumentSelection, getSelectedDocumentIds } = useNotebookStore();
+
+  // Reset agent to the default (universal). NotebookPage warms a system
+  // notebook's agent into the persisted store; without a counterpart here,
+  // a stale öffentlichkeitsarbeit-* selection bleeds into user notebooks.
+  const setSelectedAgent = useAgentStore((s) => s.setSelectedAgent);
+  useEffect(() => {
+    setSelectedAgent(null);
+  }, [id, setSelectedAgent]);
+
   const { query, getQACollection } = useNotebookCollections({ isActive: true });
   const collection = id ? getQACollection(id) : undefined;
   const { isLoading, isError, data: qaCollections } = query;


### PR DESCRIPTION
## Summary

A user reported that chatting in their personal (user-created) notebook about Klimaschutz produced a press-release-styled answer with a 📰 *Pressemitteilung* `SkillBadge`, even though they never picked that skill.

Root cause: `NotebookPage` warms a system notebook's `defaultAgent` into the persisted `selectedAgentId` (Zustand `persist`, localStorage). `DynamicNotebookPage` had no counterpart, so the selection stuck across navigation. The classifier wasn't at fault — the agent's `systemRole` was simply still being sent to the model on every request.

Mirrors the warmup in `NotebookPage.tsx:397-403` by resetting to `null` (universal) on `id` change. Same hook, opposite direction.

Follow-up worth considering (out of scope here): `selectedAgentId` is global + persisted, but conceptually belongs to a thread / notebook context. Scoping it would remove the need for these defensive resets entirely.