### PR TITLE
fix(chat): stop duplicating thread rows when creating a new chat

### DIFF
--- a/packages/chat/src/runtime/GrueneratorThreadListAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorThreadListAdapter.ts
@@ -128,31 +128,18 @@ export function createGrueneratorThreadListAdapter(
     async initialize(_localId: string) {
       if (pendingInit) return pendingInit;
       pendingInit = (async (): Promise<{ remoteId: string; externalId: undefined }> => {
+        // assistant-ui contracts initialize() to mint a NEW remoteId per local thread.
+        // Returning an existing thread's id makes its `then:` reducer overwrite
+        // threadIdMap[remoteId] = mappingId(localId), aliasing two threadIds entries
+        // to the same threadData slot and rendering the same thread twice in the sidebar.
+        // Stale empty drafts are reaped by the auto-cleanup in list() below.
         const threadMode = useAgentStore.getState().threadMode;
-        const emptyThread = cachedThreads.find(
-          (t) => t.agentId === agentId && !t.lastMessage && t.status !== 'archived'
-        );
-        if (emptyThread) {
-          threadTypeCache.set(emptyThread.id, emptyThread.threadType || threadMode);
-          useAgentStore.getState().setCurrentThread(emptyThread.id);
-          return { remoteId: emptyThread.id, externalId: undefined };
-        }
         const result = await apiClient.post<{ id: string }>('/api/chat-service/threads', {
           agentId,
           threadType: threadMode,
         });
         threadTypeCache.set(result.id, threadMode);
         useAgentStore.getState().setCurrentThread(result.id);
-        cachedThreads.push({
-          id: result.id,
-          userId: '',
-          agentId,
-          title: null,
-          threadType: threadMode,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-          lastMessage: null,
-        });
         return { remoteId: result.id, externalId: undefined };
       })().finally(() => {
         pendingInit = null;


### PR DESCRIPTION
## Summary

Clicking "+ Neu" sometimes rendered the just-created thread twice in the sidebar (screenshot in the linked issue: two identical "Schreibe einen Instagram-Post …" rows with a stray "Neue Unterhaltung" between them).

Root cause: `GrueneratorThreadListAdapter.initialize()` reused an existing empty thread's `remoteId` instead of POSTing a fresh one. assistant-ui's `RemoteThreadListThreadListRuntimeCore` assumes every `initialize()` returns a brand-new `remoteId` — its `then:` reducer unconditionally writes `threadIdMap[remoteId] = mappingId(localId)`, which silently aliases the existing entry's slot to the new local thread. The result: two `threadIds` entries point at the same `threadData` slot, and the list refresh's merge into `threadIdMap` doesn't undo the alias.

Fix: always POST a new thread in `initialize()`. The list-time auto-cleanup at `list()` already deletes stale empty drafts on the next refresh, so rapid "+ Neu" clicks don't leak threads server-side.

## Test plan
- [ ] Open `/chat`, click "+ Neu" repeatedly without sending — only the newest empty draft should remain after the next list refresh.
- [ ] Send a first message in a brand-new thread; the title appears on exactly one sidebar row.
- [ ] No regression in notebook-thread routing (the `threadTypeCache.set(result.id, threadMode)` line is preserved, which `ThreadListItem.handleSwitch` reads via `getThreadType`).