### PR TITLE
fix(hocuspocus): skip preview UPDATE when content unchanged

### DIFF
--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -376,7 +376,9 @@ export class PostgresPersistence {
         await this.db(
           `UPDATE collaborative_documents
            SET content = $2, updated_at = CURRENT_TIMESTAMP
-           WHERE id = $1 AND document_subtype = ANY($3::text[])`,
+           WHERE id = $1
+             AND document_subtype = ANY($3::text[])
+             AND content IS DISTINCT FROM $2`,
           [documentId, preview, DOC_SUBTYPES_PARAM]
         );
         log.debug(`[Preview] Updated preview for ${documentId} (${preview.length} chars)`);
@@ -425,7 +427,9 @@ export class PostgresPersistence {
         await this.db(
           `UPDATE collaborative_documents
            SET content = $2
-           WHERE id = $1 AND document_subtype = ANY($3::text[])`,
+           WHERE id = $1
+             AND document_subtype = ANY($3::text[])
+             AND content IS DISTINCT FROM $2`,
           [documentId, preview, DOC_SUBTYPES_PARAM]
         );
         log.debug(`[Backfill] Extracted preview for ${documentId} (${preview.length} chars)`);


### PR DESCRIPTION
## Why

The "Zuletzt erstellt" dashboard collapsed all items to the same relative time (e.g. "Vor 43 Minuten") after every Hocuspocus container restart.

Root cause: `backfillAllPreviews()` runs on every boot and writes a `content` UPDATE for every non-deleted row in `collaborative_documents`. The `BEFORE UPDATE` trigger `update_collaborative_documents_updated_at` then sets `updated_at = NOW()` on every doc — destroying the sort order used by `/api/recent-activity`.

The two preview-writing SQL statements now guard the UPDATE with `AND content IS DISTINCT FROM $2`. When the preview is unchanged, no row matches, the trigger never fires, and `updated_at` is preserved. Real edits with a changed preview still bump `updated_at` as before.

`IS DISTINCT FROM` (instead of `<>`) is deliberate — it returns true when one side is NULL, so first-ever preview writes for rows where `content` is still NULL still go through.

## Recovery

Existing rows already have corrupted `updated_at`. After this is deployed and Hocuspocus is restarted (no-op backfill confirmed by `[Backfill] Completed: 0/N` in logs), run the one-time SQL in `/home/morit/.claude/plans/smooth-wondering-leaf.md` to restore each doc's `updated_at` from `MAX(yjs_document_updates.created_at)`.

## Test plan

- [ ] `pnpm --filter @gruenerator/hocuspocus typecheck` (verified locally, exit 0)
- [ ] Restart Hocuspocus container; backfill logs show `Completed: 0/N` (or close to 0)
- [ ] `SELECT id, updated_at FROM collaborative_documents ORDER BY updated_at DESC LIMIT 10;` — timestamps unchanged across restart
- [ ] Edit a doc in the editor; only that doc's `updated_at` advances and it jumps to the top of the dashboard