### PR TITLE
feat(notebook): "Meine Notebooks" management page

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -133,6 +133,11 @@ const NotebookResolverPage = lazy(() =>
     default: m.NotebookResolver,
   }))
 );
+const MyNotebooksPage = lazy(() =>
+  import('../features/notebook/components/MyNotebooksPage').then((m) => ({
+    default: m.MyNotebooksPage,
+  }))
+);
 const DocumentViewPage = lazy(() => import('../features/documents/DocumentViewPage'));
 const Reel = lazy(() => import('../features/subtitler/components/SubtitlerPage'));
 const SubtitlerBetaPage = lazy(
@@ -194,6 +199,7 @@ export const GrueneratorenBundle = {
   Oparl: OparlPage,
   NotebookRoot: NotebookRootPage,
   NotebookResolver: NotebookResolverPage,
+  MyNotebooks: MyNotebooksPage,
   DocumentView: DocumentViewPage,
   VorlagenListe: VorlagenGallery,
   Reel: Reel,
@@ -257,6 +263,12 @@ const standardRoutes: RouteConfig[] = [
   {
     path: '/notebooks',
     component: GrueneratorenBundle.NotebookRoot,
+    withForm: true,
+    layoutMode: 'sidebarOnly',
+  },
+  {
+    path: '/notebooks/meine',
+    component: GrueneratorenBundle.MyNotebooks,
     withForm: true,
     layoutMode: 'sidebarOnly',
   },

--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -1,0 +1,441 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+} from '@gruenerator/ui';
+import { memo, useCallback, useMemo, useState } from 'react';
+import {
+  HiArrowLeft,
+  HiBookOpen,
+  HiDotsHorizontal,
+  HiExternalLink,
+  HiPencil,
+  HiPlus,
+  HiShare,
+  HiTrash,
+} from 'react-icons/hi';
+import { Link, useNavigate } from 'react-router-dom';
+
+import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
+import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+
+import NotebookEditor from './NotebookEditor';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+type DialogPhase =
+  | { kind: 'closed' }
+  | { kind: 'create' }
+  | { kind: 'edit'; collection: NotebookCollection }
+  | { kind: 'rename'; collection: NotebookCollection }
+  | { kind: 'delete'; collection: NotebookCollection };
+
+function formatDocCount(c: NotebookCollection): string {
+  const n = c.document_count ?? c.documents?.length ?? 0;
+  if (n === 0) return 'Keine Dokumente';
+  if (n === 1) return '1 Dokument';
+  return `${n} Dokumente`;
+}
+
+const NotebookManagementCard = memo(function NotebookManagementCard({
+  collection,
+  onOpen,
+  onRename,
+  onEdit,
+  onShare,
+  onDelete,
+}: {
+  collection: NotebookCollection;
+  onOpen: (c: NotebookCollection) => void;
+  onRename: (c: NotebookCollection) => void;
+  onEdit: (c: NotebookCollection) => void;
+  onShare: (c: NotebookCollection) => void;
+  onDelete: (c: NotebookCollection) => void;
+}) {
+  return (
+    <div className="group relative flex flex-col gap-sm rounded-md border border-grey-200 bg-background p-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700">
+      <div className="flex items-start justify-between gap-sm">
+        <button
+          type="button"
+          onClick={() => onOpen(collection)}
+          className="flex flex-1 cursor-pointer items-start gap-sm bg-transparent text-left"
+        >
+          <HiBookOpen className="mt-1 shrink-0 text-lg text-secondary-600" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold text-foreground-heading">
+              {collection.name}
+            </div>
+            {collection.description ? (
+              <div className="line-clamp-2 text-xs text-grey-500 dark:text-grey-400">
+                {collection.description}
+              </div>
+            ) : null}
+          </div>
+        </button>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              aria-label="Aktionen"
+              className="-mr-2 shrink-0 opacity-70 group-hover:opacity-100"
+            >
+              <HiDotsHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => onOpen(collection)}>
+              <HiExternalLink className="mr-2" /> Öffnen
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onRename(collection)}>
+              <HiPencil className="mr-2" /> Umbenennen
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onEdit(collection)}>
+              <HiPencil className="mr-2" /> Bearbeiten
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onShare(collection)}>
+              <HiShare className="mr-2" /> Link kopieren
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => onDelete(collection)} variant="destructive">
+              <HiTrash className="mr-2" /> Löschen
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="flex items-center gap-xs">
+        <Badge variant="secondary" className="text-xs">
+          {formatDocCount(collection)}
+        </Badge>
+        {collection.is_public ? (
+          <Badge variant="outline" className="text-xs">
+            Geteilt
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+function RenameDialog({
+  collection,
+  isUpdating,
+  onCancel,
+  onSubmit,
+}: {
+  collection: NotebookCollection;
+  isUpdating: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string, description: string) => void;
+}) {
+  const [name, setName] = useState(collection.name);
+  const [description, setDescription] = useState(collection.description ?? '');
+  const canSave = name.trim().length > 0 && !isUpdating;
+
+  return (
+    <DialogContent className="sm:max-w-[480px]">
+      <DialogHeader>
+        <DialogTitle>Notebook umbenennen</DialogTitle>
+        <DialogDescription>
+          Ändere den Namen und die Beschreibung deines Notebooks.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex flex-col gap-md py-sm">
+        <div className="flex flex-col gap-xs">
+          <label htmlFor="rename-name" className="text-sm font-medium">
+            Name
+          </label>
+          <Input
+            id="rename-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div className="flex flex-col gap-xs">
+          <label htmlFor="rename-description" className="text-sm font-medium">
+            Beschreibung
+          </label>
+          <Input
+            id="rename-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel} disabled={isUpdating}>
+          Abbrechen
+        </Button>
+        <Button onClick={() => onSubmit(name.trim(), description.trim())} disabled={!canSave}>
+          Speichern
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+function MyNotebooksPageInner() {
+  const navigate = useNavigate();
+  const {
+    query,
+    createQACollection,
+    updateQACollection,
+    deleteQACollection,
+    isCreating,
+    isUpdating,
+  } = useNotebookCollections({ isActive: true });
+  const [phase, setPhase] = useState<DialogPhase>({ kind: 'closed' });
+
+  const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
+
+  const handleOpen = useCallback(
+    (c: NotebookCollection) => {
+      void navigate(`/notebook/${c.id}`);
+    },
+    [navigate]
+  );
+
+  const handleShare = useCallback((c: NotebookCollection) => {
+    void navigator.clipboard.writeText(`${window.location.origin}/notebook/${c.id}`);
+  }, []);
+
+  const closeDialog = useCallback(() => setPhase({ kind: 'closed' }), []);
+
+  const handleRenameSubmit = useCallback(
+    async (collection: NotebookCollection, name: string, description: string) => {
+      if (!name) return;
+      await updateQACollection(collection.id, {
+        name,
+        description: description || undefined,
+        custom_prompt: collection.custom_prompt,
+        selectionMode: collection.selection_mode,
+        labels: collection.labels,
+      });
+      closeDialog();
+    },
+    [updateQACollection, closeDialog]
+  );
+
+  const handleEditSave = useCallback(
+    async (collection: NotebookCollection, data: unknown) => {
+      const d = data as {
+        name: string;
+        description?: string;
+        documents?: (string | number)[];
+        labels?: string[];
+      };
+      await updateQACollection(collection.id, {
+        name: d.name,
+        description: d.description,
+        documents: d.documents,
+        labels: d.labels,
+        selectionMode: collection.selection_mode,
+        custom_prompt: collection.custom_prompt,
+      });
+      closeDialog();
+    },
+    [updateQACollection, closeDialog]
+  );
+
+  const handleCreateSave = useCallback(
+    async (data: unknown) => {
+      const d = data as {
+        name: string;
+        description?: string;
+        documents?: (string | number)[];
+        labels?: string[];
+      };
+      await createQACollection({
+        name: d.name,
+        description: d.description,
+        documents: d.documents,
+        labels: d.labels,
+      });
+      closeDialog();
+    },
+    [createQACollection, closeDialog]
+  );
+
+  const handleDeleteConfirm = useCallback(
+    async (collection: NotebookCollection) => {
+      await deleteQACollection(collection.id);
+      closeDialog();
+    },
+    [deleteQACollection, closeDialog]
+  );
+
+  const isLoading = query.isLoading;
+  const isEmpty = !isLoading && collections.length === 0;
+
+  return (
+    <div className="mx-auto w-full max-w-6xl px-md py-lg">
+      <div className="mb-lg flex items-center justify-between gap-md">
+        <div className="flex items-center gap-sm">
+          <Link
+            to="/notebooks"
+            className="inline-flex items-center gap-xs text-sm text-grey-500 hover:text-foreground"
+          >
+            <HiArrowLeft /> Zurück
+          </Link>
+        </div>
+        <Button onClick={() => setPhase({ kind: 'create' })}>
+          <HiPlus className="mr-1" /> Neues Notebook
+        </Button>
+      </div>
+
+      <h1 className="mb-xs text-2xl font-semibold text-foreground-heading">Meine Notebooks</h1>
+      <p className="mb-lg text-sm text-grey-500 dark:text-grey-400">
+        Verwalte deine eigenen Notebooks: öffnen, umbenennen, bearbeiten oder löschen.
+      </p>
+
+      {isLoading ? (
+        <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-28 animate-pulse rounded-md border border-grey-200 bg-grey-50 dark:border-grey-700 dark:bg-grey-900"
+            />
+          ))}
+        </div>
+      ) : isEmpty ? (
+        <div className="flex flex-col items-center gap-md rounded-md border border-dashed border-grey-300 p-xl text-center dark:border-grey-700">
+          <HiBookOpen className="text-3xl text-grey-400" />
+          <div>
+            <div className="text-base font-medium text-foreground-heading">
+              Du hast noch keine eigenen Notebooks
+            </div>
+            <div className="mt-xs text-sm text-grey-500 dark:text-grey-400">
+              Erstelle dein erstes Notebook, um Dokumente und Quellen zu bündeln.
+            </div>
+          </div>
+          <Button onClick={() => setPhase({ kind: 'create' })}>
+            <HiPlus className="mr-1" /> Eigenes Notebook erstellen
+          </Button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+          {collections.map((c) => (
+            <NotebookManagementCard
+              key={c.id}
+              collection={c}
+              onOpen={handleOpen}
+              onRename={(col) => setPhase({ kind: 'rename', collection: col })}
+              onEdit={(col) => setPhase({ kind: 'edit', collection: col })}
+              onShare={handleShare}
+              onDelete={(col) => setPhase({ kind: 'delete', collection: col })}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Rename dialog */}
+      <Dialog
+        open={phase.kind === 'rename'}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+      >
+        {phase.kind === 'rename' ? (
+          <RenameDialog
+            collection={phase.collection}
+            isUpdating={isUpdating}
+            onCancel={closeDialog}
+            onSubmit={(name, description) =>
+              void handleRenameSubmit(phase.collection, name, description)
+            }
+          />
+        ) : null}
+      </Dialog>
+
+      {/* Full editor dialog (create or edit) */}
+      <Dialog
+        open={phase.kind === 'create' || phase.kind === 'edit'}
+        onOpenChange={(open) => {
+          if (!open && !isCreating && !isUpdating) closeDialog();
+        }}
+      >
+        <DialogContent
+          className="sm:max-w-[700px] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="sr-only">
+            {phase.kind === 'edit' ? 'Notebook bearbeiten' : 'Notebook erstellen'}
+          </DialogTitle>
+          {phase.kind === 'edit' ? (
+            <NotebookEditor
+              editingCollection={phase.collection}
+              loading={isUpdating}
+              onCancel={closeDialog}
+              onSave={(data) => handleEditSave(phase.collection, data)}
+            />
+          ) : phase.kind === 'create' ? (
+            <NotebookEditor
+              editingCollection={null}
+              loading={isCreating}
+              onCancel={closeDialog}
+              onSave={handleCreateSave}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={phase.kind === 'delete'}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Notebook löschen?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {phase.kind === 'delete'
+                ? `„${phase.collection.name}" wird unwiderruflich gelöscht. Die enthaltenen Dokumente bleiben in deiner Bibliothek erhalten.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                if (phase.kind === 'delete') void handleDeleteConfirm(phase.collection);
+              }}
+            >
+              Löschen
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+export const MyNotebooksPage = withAuthRequired(MyNotebooksPageInner, {
+  title: 'Meine Notebooks',
+});
+
+export default MyNotebooksPage;

--- a/apps/web/src/features/notebook/components/NotebookGallery.tsx
+++ b/apps/web/src/features/notebook/components/NotebookGallery.tsx
@@ -1,14 +1,19 @@
 import { memo, useMemo } from 'react';
+import { HiBookOpen, HiCog } from 'react-icons/hi';
 import { useNavigate } from 'react-router-dom';
 
 import { useAuthStore } from '../../../stores/authStore';
+import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 import {
   getAustrianNotebooks,
   getNotebooksByCategory,
   type NotebookConfigEntry,
 } from '../config/notebooksConfig';
 
+import type { NotebookCollection } from '../../../types/notebook';
+
 const HIDDEN_NOTEBOOK_IDS = ['gruenerator-notebook'];
+const MY_NOTEBOOKS_INLINE_LIMIT = 4;
 
 const NotebookCard = memo(({ notebook }: { notebook: NotebookConfigEntry }) => {
   const navigate = useNavigate();
@@ -48,6 +53,75 @@ function Section({ title, notebooks }: { title: string; notebooks: NotebookConfi
   );
 }
 
+const MyNotebookCard = memo(({ collection }: { collection: NotebookCollection }) => {
+  const navigate = useNavigate();
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="group flex min-h-[4rem] cursor-pointer items-center gap-sm rounded-md border border-grey-200 bg-background px-md py-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700"
+      onClick={() => navigate(`/notebook/${collection.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          void navigate(`/notebook/${collection.id}`);
+        }
+      }}
+    >
+      <HiBookOpen className="shrink-0 text-base text-secondary-600" />
+      <span className="flex-1 truncate text-sm font-medium text-foreground-heading">
+        {collection.name}
+      </span>
+    </div>
+  );
+});
+MyNotebookCard.displayName = 'GalleryMyNotebookCard';
+
+function ManageAllCard() {
+  const navigate = useNavigate();
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className="group flex min-h-[4rem] cursor-pointer items-center gap-sm rounded-md border border-dashed border-primary-400 bg-primary-50 px-md py-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-primary-700 dark:bg-primary-950/30"
+      onClick={() => navigate('/notebooks/meine')}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          void navigate('/notebooks/meine');
+        }
+      }}
+    >
+      <HiCog className="shrink-0 text-base text-primary-600 dark:text-primary-300" />
+      <span className="flex-1 text-sm font-medium text-primary-700 dark:text-primary-200">
+        Alle meine Notebooks verwalten
+      </span>
+    </div>
+  );
+}
+
+function MyNotebooksSection() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const { query } = useNotebookCollections({ isActive: isAuthenticated });
+  const collections = query.data ?? [];
+
+  if (!isAuthenticated) return null;
+
+  const inline = collections.slice(0, MY_NOTEBOOKS_INLINE_LIMIT);
+
+  return (
+    <>
+      <h2 className="mt-md mb-md text-xl font-semibold text-foreground-heading">Meine Notebooks</h2>
+      <div className="grid grid-cols-4 gap-sm max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+        {inline.map((c) => (
+          <MyNotebookCard key={c.id} collection={c} />
+        ))}
+        <ManageAllCard />
+      </div>
+    </>
+  );
+}
+
 export function NotebookGallery() {
   const locale = useAuthStore((state) => state.locale);
   const isAustrian = locale === 'de-AT';
@@ -65,6 +139,7 @@ export function NotebookGallery() {
 
   return (
     <section>
+      <MyNotebooksSection />
       {sections.map((s) => (
         <Section key={s.title} title={s.title} notebooks={s.notebooks} />
       ))}


### PR DESCRIPTION
## Summary

Users could create their own notebooks via the workplace flow but had no surface to **view, rename, edit, or delete** them afterwards. This adds a dedicated `/notebooks/meine` page and surfaces a "Meine Notebooks" section at the top of the public `/notebooks` gallery for discovery.

Pure frontend: the full CRUD contract (`notebookCollectionsContract`) already exists server-side; this wires it into a UX. Reuses `useNotebookCollections` (TanStack Query, with cache invalidation shared across the workplace section) and `NotebookEditor` (already supports edit mode via the `editingCollection` prop), so no new components or backend changes were required.

## Test plan
- [ ] `/notebooks/meine` renders empty state for a user with no collections
- [ ] Grid renders for a user with collections; cards show name, description, doc count, share badge
- [ ] Rename dialog updates the name in place (TanStack invalidates the workplace section too)
- [ ] "Bearbeiten" opens the full `NotebookEditor` and persists changes
- [ ] "Link kopieren" writes `${origin}/notebook/${id}` to clipboard
- [ ] Delete dialog removes the row after confirmation
- [ ] `/notebooks` shows a "Meine Notebooks" section at the top with up to 4 inline cards + "Alle meine Notebooks verwalten"
- [ ] Static `/notebooks/meine` route takes precedence over `/notebooks/:idOrSlug`