### PR TITLE
fix(hocuspocus): bump updated_at on every store, decoupled from preview equality

### DIFF
--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -356,6 +356,18 @@ export class PostgresPersistence {
     }
   }
 
+  async touchUpdatedAt(documentId: string): Promise<void> {
+    try {
+      await this.db(
+        'UPDATE collaborative_documents SET updated_at = CURRENT_TIMESTAMP WHERE id = $1',
+        [documentId]
+      );
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.debug(`[Touch] Failed to touch updated_at for ${documentId}: ${err.message}`);
+    }
+  }
+
   async updateContentPreview(documentId: string, ydoc: Y.Doc): Promise<void> {
     try {
       const fragment = ydoc.getXmlFragment(DOCUMENT_FRAGMENT_NAME);

--- a/services/hocuspocus/src/server.ts
+++ b/services/hocuspocus/src/server.ts
@@ -136,6 +136,7 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
         );
       }
 
+      void persistence.touchUpdatedAt(documentName);
       void persistence.updateContentPreview(documentName, document);
     },
 


### PR DESCRIPTION
## Why

PR #799 stopped the restart-backfill from clobbering `updated_at`, but introduced a subtler regression: real edits no longer advance `updated_at` for long docs.

The IS DISTINCT FROM guard compares the *truncated* preview (`slice(0, 2000)`) against the stored preview. For docs longer than 2000 characters, edits anywhere past that boundary leave the truncated preview byte-identical to what's already stored — so the guard skips the UPDATE and the trigger never fires. Stellenausschreibung is one such doc: 18+ hours of real edits with `updated_at` frozen.

Fix: decouple "did the user edit" from "did the rendered preview change". `onStoreDocument` is the authoritative signal for the former — Hocuspocus only fires it after a debounced Yjs change. Add a dedicated `touchUpdatedAt()` call alongside the preview write, so `updated_at` advances on every store regardless of preview equality.

The preview write keeps its `IS DISTINCT FROM` guard — that's still needed to prevent the boot-time `backfillAllPreviews` from churning `updated_at` on every restart.

## Test plan

- [ ] `pnpm --filter @gruenerator/hocuspocus typecheck` (verified locally, exit 0)
- [ ] Edit a doc whose content is longer than 2000 chars
- [ ] `SELECT updated_at FROM collaborative_documents WHERE id = '<doc>';` advances to the current minute
- [ ] Restart hocuspocus; `[Backfill] Completed: 0/N` (or close to 0) — backfill remains a no-op
- [ ] Dashboard "Zuletzt erstellt" reflects real edit times across long and short docs