### PR TITLE
feat(notebook): show per-document progress when creating a notebook

### DIFF
--- a/apps/api/routes/documents/documentsContractRouter.ts
+++ b/apps/api/routes/documents/documentsContractRouter.ts
@@ -21,6 +21,7 @@ import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { COLLECTION_MAP } from '../../config/collectionMap.js';
 import { applyDefaultFilter } from '../../config/systemCollectionsConfig.js';
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import { DocumentSearchService } from '../../services/document-services/DocumentSearchService/index.js';
 import { getPostgresDocumentService } from '../../services/document-services/PostgresDocumentService/index.js';
 import { getWolkeSyncService } from '../../services/sync/index.js';
@@ -155,6 +156,44 @@ export const documentsContractRouter = s.router(documentsContract, {
         body: {
           success: false,
           message: (error as Error).message || 'Failed to get sync status',
+        },
+      };
+    }
+  },
+
+  getDocumentStatuses: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const { ids } = args.body;
+
+      const postgres = getPostgresInstance();
+      const rows = (await postgres.query(
+        `SELECT id, status FROM documents WHERE id = ANY($1) AND user_id = $2`,
+        [ids, userId]
+      )) as Array<{ id: string; status: string }>;
+
+      // IDs not owned by the caller are silently omitted (don't leak existence).
+      // Unknown status strings get normalized to 'pending' — defensive against
+      // legacy rows or future statuses that haven't been added to the enum yet.
+      const allowed = new Set(['pending', 'uploaded', 'processing', 'completed', 'failed']);
+      const statuses = rows.map((r) => ({
+        id: r.id,
+        status: (allowed.has(r.status) ? r.status : 'pending') as
+          | 'pending'
+          | 'uploaded'
+          | 'processing'
+          | 'completed'
+          | 'failed',
+      }));
+
+      return { status: 200 as const, body: { success: true, statuses } };
+    } catch (error) {
+      log.error('[documentsContract.getDocumentStatuses] Error:', error);
+      return {
+        status: 500 as const,
+        body: {
+          success: false,
+          message: (error as Error).message || 'Failed to get document statuses',
         },
       };
     }

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -135,7 +135,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
           let documents: DocumentRecord[] = [];
           if (documentIds.length > 0) {
             documents = await postgres.query<DocumentRecord>(
-              'SELECT id, title, page_count, created_at, source_type, wolke_share_link_id, status FROM documents WHERE id = ANY($1)',
+              'SELECT id, title, page_count, created_at, source_type, wolke_share_link_id FROM documents WHERE id = ANY($1)',
               [documentIds]
             );
           }
@@ -306,7 +306,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
           for (const doc of pendingDocs) {
             processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
               log.error(
-                `[notebookCollectionsContract.createCollection] Background processing failed for doc ${doc.id}:`,
+                `[notebookCollectionsContract.createCollection] Background processing failed for doc ${doc.id} in collection ${collectionId}:`,
                 err
               );
             });

--- a/apps/web/src/features/notebook/components/NotebookCreationProgress.tsx
+++ b/apps/web/src/features/notebook/components/NotebookCreationProgress.tsx
@@ -1,0 +1,126 @@
+import { Button } from '@gruenerator/ui';
+import { HiCheckCircle, HiOutlineClock, HiX } from 'react-icons/hi';
+
+import { cn } from '../../../utils/cn';
+
+import { useDocumentStatusPolling } from '../hooks/useDocumentStatusPolling';
+
+import type { DocumentStatusValue } from '@gruenerator/contracts';
+
+interface DocumentMeta {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  notebookName: string;
+  documents: DocumentMeta[];
+  onClose: () => void;
+}
+
+const ROW_LABEL: Record<DocumentStatusValue, string> = {
+  pending: 'Wartet',
+  uploaded: 'Wartet',
+  processing: 'Wird verarbeitet…',
+  completed: 'Fertig',
+  failed: 'Fehler',
+};
+
+const TERMINAL: ReadonlySet<DocumentStatusValue> = new Set(['completed', 'failed']);
+
+const StatusIcon = ({ status }: { status: DocumentStatusValue }) => {
+  if (status === 'completed') {
+    return <HiCheckCircle className="w-5 h-5 text-emerald-500 shrink-0" aria-hidden />;
+  }
+  if (status === 'failed') {
+    return <HiX className="w-5 h-5 text-red-500 shrink-0" aria-hidden />;
+  }
+  if (status === 'processing') {
+    return (
+      <span
+        className="w-5 h-5 shrink-0 inline-block rounded-full border-2 border-primary-500 border-t-transparent animate-spin"
+        aria-hidden
+      />
+    );
+  }
+  return <HiOutlineClock className="w-5 h-5 text-neutral-400 shrink-0" aria-hidden />;
+};
+
+const NotebookCreationProgress = ({ notebookName, documents, onClose }: Props) => {
+  const ids = documents.map((d) => d.id);
+  const { statuses, allDone } = useDocumentStatusPolling(ids, { enabled: ids.length > 0 });
+
+  const doneCount = documents.filter((d) =>
+    TERMINAL.has(statuses[d.id] ?? 'pending')
+  ).length;
+  const total = documents.length;
+  const percent = total === 0 ? 100 : Math.round((doneCount / total) * 100);
+
+  return (
+    <div className="p-6 flex flex-col gap-4">
+      <div>
+        <h2 className="text-lg font-semibold">{notebookName || 'Notebook'} wird erstellt…</h2>
+        <p className="text-sm text-neutral-500 mt-1">
+          Deine Dokumente werden verarbeitet. Das kann je nach Größe einige Sekunden dauern.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {documents.map((doc) => {
+          const status = statuses[doc.id] ?? 'pending';
+          const isFailed = status === 'failed';
+          return (
+            <li
+              key={doc.id}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2 rounded-md bg-neutral-50 dark:bg-neutral-900',
+                isFailed && 'bg-red-50 dark:bg-red-950/30'
+              )}
+            >
+              <StatusIcon status={status} />
+              <span className="flex-1 truncate text-sm">{doc.title}</span>
+              <span
+                className={cn(
+                  'text-xs text-neutral-500',
+                  status === 'completed' && 'text-emerald-600',
+                  isFailed && 'text-red-600'
+                )}
+              >
+                {ROW_LABEL[status]}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="flex flex-col gap-1">
+        <div className="flex justify-between text-xs text-neutral-500">
+          <span>
+            {doneCount} von {total} abgeschlossen
+          </span>
+          <span>{percent}%</span>
+        </div>
+        <div
+          className="h-2 rounded-full bg-neutral-200 dark:bg-neutral-800 overflow-hidden"
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="h-full bg-primary-500 transition-[width] duration-300 ease-out"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <Button onClick={onClose} disabled={!allDone}>
+          {allDone ? 'Schließen' : 'Bitte warten…'}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default NotebookCreationProgress;

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -240,6 +240,7 @@ const NotebookEditor = ({
       ...data,
       selectionMode: 'documents',
       documents: uploadedDocuments.map((doc) => doc.id),
+      documentMeta: uploadedDocuments.map((doc) => ({ id: doc.id, title: doc.title })),
       id: editingCollection?.id,
       labels,
     };

--- a/apps/web/src/features/notebook/hooks/useDocumentStatusPolling.ts
+++ b/apps/web/src/features/notebook/hooks/useDocumentStatusPolling.ts
@@ -1,0 +1,51 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useQuery } from '@tanstack/react-query';
+
+import type { DocumentStatusValue } from '@gruenerator/contracts';
+
+export type DocumentStatusMap = Record<string, DocumentStatusValue>;
+
+const TERMINAL: ReadonlySet<DocumentStatusValue> = new Set(['completed', 'failed']);
+
+const allTerminal = (ids: string[], statuses: DocumentStatusMap): boolean =>
+  ids.length > 0 && ids.every((id) => TERMINAL.has(statuses[id] ?? 'pending'));
+
+/**
+ * Poll the status of one or more uploaded documents at a fixed interval.
+ *
+ * Stops polling automatically when every requested ID has reached a terminal
+ * state (`completed` or `failed`). Unknown IDs (e.g. not yet visible to the
+ * caller's user_id) are treated as `pending` and will keep polling.
+ */
+export function useDocumentStatusPolling(
+  ids: string[],
+  options: { enabled?: boolean; intervalMs?: number } = {}
+): { statuses: DocumentStatusMap; allDone: boolean } {
+  const { enabled = true, intervalMs = 1000 } = options;
+
+  const query = useQuery({
+    queryKey: ['documentStatuses', [...ids].sort()],
+    enabled: enabled && ids.length > 0,
+    queryFn: async (): Promise<DocumentStatusMap> => {
+      const client = getContractsClient();
+      const result = await client.documents.getDocumentStatuses({ body: { ids } });
+      if (result.status !== 200) return {};
+      const map: DocumentStatusMap = {};
+      for (const row of result.body.statuses) {
+        map[row.id] = row.status;
+      }
+      return map;
+    },
+    refetchInterval: (q) => {
+      const data = q.state.data as DocumentStatusMap | undefined;
+      if (!data) return intervalMs;
+      return allTerminal(ids, data) ? false : intervalMs;
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 0,
+    gcTime: 0,
+  });
+
+  const statuses = query.data ?? {};
+  return { statuses, allDone: allTerminal(ids, statuses) };
+}

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -4,6 +4,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import ToolGrid from '../../../components/common/ToolGrid';
 import { useAuthStore } from '../../../stores/authStore';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+import NotebookCreationProgress from '../../notebook/components/NotebookCreationProgress';
 import NotebookEditor from '../../notebook/components/NotebookEditor';
 import {
   getAustrianNotebooks,
@@ -16,13 +17,18 @@ import type { NotebookCollection } from '../../../types/notebook';
 
 const INITIAL_COUNT = 5;
 
+type CreationPhase =
+  | { kind: 'closed' }
+  | { kind: 'editing' }
+  | { kind: 'processing'; name: string; documents: Array<{ id: string; title: string }> };
+
 const NotebooksSection: React.FC = memo(() => {
-  const [showEditor, setShowEditor] = useState(false);
+  const [phase, setPhase] = useState<CreationPhase>({ kind: 'closed' });
   const [showAll, setShowAll] = useState(false);
   const locale = useAuthStore((state) => state.locale);
   const isAustrian = locale === 'de-AT';
 
-  const { query, createQACollection, deleteQACollection } = useNotebookCollections({
+  const { query, createQACollection, deleteQACollection, isCreating } = useNotebookCollections({
     isActive: true,
   });
   const qaCollections = query.data ?? [];
@@ -61,8 +67,8 @@ const NotebooksSection: React.FC = memo(() => {
 
   const allTools = useMemo(() => [...userTools, ...systemTools], [userTools, systemTools]);
 
-  const handleCreate = useCallback(() => setShowEditor(true), []);
-  const handleCancel = useCallback(() => setShowEditor(false), []);
+  const handleCreate = useCallback(() => setPhase({ kind: 'editing' }), []);
+  const handleClose = useCallback(() => setPhase({ kind: 'closed' }), []);
 
   const handleShare = useCallback((id: string) => {
     void navigator.clipboard.writeText(`${window.location.origin}/notebook/${id}`);
@@ -83,16 +89,25 @@ const NotebooksSection: React.FC = memo(() => {
         name: string;
         description?: string;
         documents?: (string | number)[];
+        documentMeta?: Array<{ id: string; title: string }>;
       };
       await createQACollection({
         name: saveData.name,
         description: saveData.description,
         documents: saveData.documents,
       });
-      setShowEditor(false);
+      // Hand off to the progress view, which polls per-document status until terminal.
+      // documentMeta carries the upload titles for the progress rows; the IDs from
+      // saveData.documents are authoritative for the polling query.
+      const docs = (saveData.documentMeta ?? []).filter(
+        (d): d is { id: string; title: string } => typeof d.id === 'string'
+      );
+      setPhase({ kind: 'processing', name: saveData.name, documents: docs });
     },
     [createQACollection]
   );
+
+  const dialogOpen = phase.kind !== 'closed';
 
   return (
     <section className="mb-xl">
@@ -119,18 +134,37 @@ const NotebooksSection: React.FC = memo(() => {
         </button>
       )}
 
-      <Dialog open={showEditor} onOpenChange={(open) => !open && handleCancel()}>
+      <Dialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          if (open) return;
+          // Block dismiss while the create request is in flight or documents are
+          // still being processed in the background. Once everything is terminal
+          // the user closes via the explicit "Schließen" button inside the progress view.
+          if (phase.kind === 'editing' && !isCreating) handleClose();
+        }}
+      >
         <DialogContent
           className="sm:max-w-[700px] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
           aria-describedby={undefined}
         >
-          <DialogTitle className="sr-only">Notebook erstellen</DialogTitle>
-          <NotebookEditor
-            onSave={handleSave}
-            onCancel={handleCancel}
-            editingCollection={null}
-            loading={false}
-          />
+          <DialogTitle className="sr-only">
+            {phase.kind === 'processing' ? 'Notebook wird erstellt' : 'Notebook erstellen'}
+          </DialogTitle>
+          {phase.kind === 'processing' ? (
+            <NotebookCreationProgress
+              notebookName={phase.name}
+              documents={phase.documents}
+              onClose={handleClose}
+            />
+          ) : (
+            <NotebookEditor
+              onSave={handleSave}
+              onCancel={handleClose}
+              editingCollection={null}
+              loading={isCreating}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </section>

--- a/packages/contracts/src/contracts/documentsContract.ts
+++ b/packages/contracts/src/contracts/documentsContract.ts
@@ -21,6 +21,8 @@ import {
   syncStatusErrorSchema,
   documentsAuthErrorSchema,
   documentsValidationErrorSchema,
+  documentStatusesRequestSchema,
+  documentStatusesResponseSchema,
 } from '../schemas/documents.js';
 
 const c = initContract();
@@ -74,6 +76,26 @@ export const documentsContract = c.router(
         500: syncStatusErrorSchema,
       },
       summary: 'Get Wolke sync status for the current user',
+    },
+
+    /**
+     * POST /api/documents/statuses
+     * Look up the current `status` of multiple documents in one call.
+     * Used by the notebook-creation dialog to poll progress while the
+     * backend processes uploads in the background. POST (not GET) because
+     * the IDs list can be long and Zod-validating a body is simpler than
+     * a comma-separated querystring.
+     */
+    getDocumentStatuses: {
+      method: 'POST',
+      path: '/api/documents/statuses',
+      body: documentStatusesRequestSchema,
+      responses: {
+        200: documentStatusesResponseSchema,
+        401: documentsAuthErrorSchema,
+        500: documentsValidationErrorSchema,
+      },
+      summary: 'Get status of multiple documents for progress polling',
     },
   },
   { pathPrefix: '' }

--- a/packages/contracts/src/schemas/documents.ts
+++ b/packages/contracts/src/schemas/documents.ts
@@ -71,6 +71,42 @@ export const syncStatusErrorSchema = z.object({
   message: z.unknown(),
 });
 
+// ── document statuses (used during notebook creation progress polling) ─────
+
+/**
+ * Five-state lifecycle observed across the codebase:
+ *   - 'pending'    DB default for newly-inserted rows
+ *   - 'uploaded'   manualController sets this after the file is on disk
+ *   - 'processing' processUploadedDocument flips this while extracting + embedding
+ *   - 'completed'  final success state
+ *   - 'failed'     final error state (actual error stays in server logs; no error_message column)
+ */
+export const documentStatusValueSchema = z.enum([
+  'pending',
+  'uploaded',
+  'processing',
+  'completed',
+  'failed',
+]);
+
+export const documentStatusesRequestSchema = z.object({
+  ids: z.array(z.string().uuid()).min(1).max(50),
+});
+
+export const documentStatusesResponseSchema = z.object({
+  success: z.boolean(),
+  statuses: z.array(
+    z.object({
+      id: z.string(),
+      status: documentStatusValueSchema,
+    })
+  ),
+});
+
+export type DocumentStatusValue = z.infer<typeof documentStatusValueSchema>;
+export type DocumentStatusesRequest = z.infer<typeof documentStatusesRequestSchema>;
+export type DocumentStatusesResponse = z.infer<typeof documentStatusesResponseSchema>;
+
 // ── Shared error schema ──────────────────────────────────────────────────────
 
 export const documentsAuthErrorSchema = z.object({ error: z.string() });

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -29,7 +29,9 @@ import {
   emailContract,
   modelPreferencesContract,
   adminVorlagenContract,
+  authStatusContract,
   docsContract,
+  documentsContract,
 } from '@gruenerator/contracts';
 import { initClient } from '@ts-rest/core';
 
@@ -136,7 +138,9 @@ const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS
 const _emailClient = () => initClient(emailContract, CLIENT_OPTS);
 const _modelPreferencesClient = () => initClient(modelPreferencesContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
+const _authStatusClient = () => initClient(authStatusContract, CLIENT_OPTS);
 const _docsClient = () => initClient(docsContract, CLIENT_OPTS);
+const _documentsClient = () => initClient(documentsContract, CLIENT_OPTS);
 
 export interface ContractsClient {
   threads: ReturnType<typeof _threadsClient>;
@@ -151,7 +155,9 @@ export interface ContractsClient {
   email: ReturnType<typeof _emailClient>;
   modelPreferences: ReturnType<typeof _modelPreferencesClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
+  authStatus: ReturnType<typeof _authStatusClient>;
   docs: ReturnType<typeof _docsClient>;
+  documents: ReturnType<typeof _documentsClient>;
 }
 
 // ── Lazy singleton ────────────────────────────────────────────────────────────
@@ -183,7 +189,9 @@ export function getContractsClient(): ContractsClient {
     email: _emailClient(),
     modelPreferences: _modelPreferencesClient(),
     adminVorlagen: _adminVorlagenClient(),
+    authStatus: _authStatusClient(),
     docs: _docsClient(),
+    documents: _documentsClient(),
   };
 
   return _client;


### PR DESCRIPTION
## Why

Creating an own notebook felt instant in the UI but the backend's document
processing (text extract → chunk → embed → Qdrant write) ran fire-and-forget
after the 201. Clicking into a fresh notebook could surface an empty,
non-queryable collection for many seconds, with no indication anything was
still happening.

The fix replaces the editor with a precise progress view inside the same
dialog: each uploaded document gets a live row that flips
`Wartet → Wird verarbeitet… → Fertig / Fehler`, plus an `X von Y abgeschlossen`
bar. The dialog can't be dismissed until every document is terminal.

## Approach

Honest visibility, not artificial blocking. Transport is plain client polling
against a new `POST /api/documents/statuses` endpoint — keeps the ts-rest
contract surface clean (no SSE bridge for one screen). The backend keeps the
intentional fire-and-forget so the creation HTTP call stays short.

The new `documents` namespace was missing from `ContractsClient`; added it
generically (not as a one-off) so future document endpoints don't have to
re-discover this.

## Test plan

- [ ] Workplace → "Eigenes Notebook erstellen" → upload 3 PDFs → submit; rows progress live, bar fills, "Schließen" enables only when all done.
- [ ] Try ESC / backdrop click during processing — must be blocked.
- [ ] Force a failure (e.g. corrupt file) — that row goes red `Fehler`, other rows still complete, notebook still exists.
- [ ] Network tab: `POST /api/auth/notebook-collections` finishes <500ms, `POST /api/documents/statuses` polls at ~1 Hz and stops at terminal.
- [ ] CI: typecheck + lint across `contracts`, `shared`, `api`, `web` (local: all green).