### PR TITLE
fix(shared): drop dangling authStatusContract refs breaking hocuspocus build

### DIFF
--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -29,7 +29,6 @@ import {
   emailContract,
   modelPreferencesContract,
   adminVorlagenContract,
-  authStatusContract,
   docsContract,
   documentsContract,
 } from '@gruenerator/contracts';
@@ -138,7 +137,6 @@ const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS
 const _emailClient = () => initClient(emailContract, CLIENT_OPTS);
 const _modelPreferencesClient = () => initClient(modelPreferencesContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
-const _authStatusClient = () => initClient(authStatusContract, CLIENT_OPTS);
 const _docsClient = () => initClient(docsContract, CLIENT_OPTS);
 const _documentsClient = () => initClient(documentsContract, CLIENT_OPTS);
 
@@ -155,7 +153,6 @@ export interface ContractsClient {
   email: ReturnType<typeof _emailClient>;
   modelPreferences: ReturnType<typeof _modelPreferencesClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
-  authStatus: ReturnType<typeof _authStatusClient>;
   docs: ReturnType<typeof _docsClient>;
   documents: ReturnType<typeof _documentsClient>;
 }
@@ -189,7 +186,6 @@ export function getContractsClient(): ContractsClient {
     email: _emailClient(),
     modelPreferences: _modelPreferencesClient(),
     adminVorlagen: _adminVorlagenClient(),
-    authStatus: _authStatusClient(),
     docs: _docsClient(),
     documents: _documentsClient(),
   };


### PR DESCRIPTION
## Why

The master Docker build at run [25818658219](https://github.com/netzbegruenung/Gruenerator/actions/runs/25818658219) fails in `build-hocuspocus`:

```
src/api/contractsClient.ts(32,3): error TS2305:
Module '"@gruenerator/contracts"' has no exported member 'authStatusContract'.
```

`authStatusContract` was deleted in 2eebfe330 (refactor to `authClient.getSession()`), but PR #802 (commit 7bcd81609) was rebased/merged from a stale base and reintroduced the import, the factory, the interface field, and the assignment in `packages/shared/src/api/contractsClient.ts` — alongside the unrelated `documentsContract` additions it actually wanted to add.

The hocuspocus Dockerfile is the only image build that compiles `packages/shared` directly, so the rest of the build matrix didn't catch it.

## Fix

Remove the four dangling `authStatus*` lines. No other code in the repo references `authStatus` on the contracts client, so this is purely cleanup of the unmerged-half.