### PR TITLE
refactor(notebook): Meine Notebooks shell + add-docs-in-edit

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -22,6 +22,7 @@ import {
   DropdownMenuTrigger,
   Input,
 } from '@gruenerator/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { memo, useCallback, useMemo, useState } from 'react';
 import {
   HiBookOpen,
@@ -37,6 +38,7 @@ import { useNavigate } from 'react-router-dom';
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import PageContainer from '../../../components/common/PageContainer';
 import ErrorBoundary from '../../../components/ErrorBoundary';
+import { useDocumentsStore } from '../../../stores/documentsStore';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
@@ -199,6 +201,8 @@ function RenameDialog({
 
 function MyNotebooksPageInner() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
   const {
     query,
     createQACollection,
@@ -247,6 +251,11 @@ function MyNotebooksPageInner() {
         documents?: (string | number)[];
         labels?: string[];
       };
+      const originalIds = new Set((collection.documents ?? []).map((doc) => String(doc.id)));
+      const addedIds = (d.documents ?? [])
+        .map((id) => String(id))
+        .filter((id) => !originalIds.has(id));
+
       await updateQACollection(collection.id, {
         name: d.name,
         description: d.description,
@@ -256,8 +265,14 @@ function MyNotebooksPageInner() {
         custom_prompt: collection.custom_prompt,
       });
       closeDialog();
+
+      if (addedIds.length > 0) {
+        void Promise.all(addedIds.map((id) => pollDocumentStatus(id))).finally(() => {
+          void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+        });
+      }
     },
-    [updateQACollection, closeDialog]
+    [updateQACollection, closeDialog, pollDocumentStatus, queryClient]
   );
 
   const handleCreateSave = useCallback(

--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -24,7 +24,6 @@ import {
 } from '@gruenerator/ui';
 import { memo, useCallback, useMemo, useState } from 'react';
 import {
-  HiArrowLeft,
   HiBookOpen,
   HiDotsHorizontal,
   HiExternalLink,
@@ -33,9 +32,11 @@ import {
   HiShare,
   HiTrash,
 } from 'react-icons/hi';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
+import PageContainer from '../../../components/common/PageContainer';
+import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
@@ -290,27 +291,18 @@ function MyNotebooksPageInner() {
   const isEmpty = !isLoading && collections.length === 0;
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-md py-lg">
-      <div className="mb-lg flex items-center justify-between gap-md">
-        <div className="flex items-center gap-sm">
-          <Link
-            to="/notebooks"
-            className="inline-flex items-center gap-xs text-sm text-grey-500 hover:text-foreground"
-          >
-            <HiArrowLeft /> Zurück
-          </Link>
+    <ErrorBoundary>
+      <PageContainer
+        title="Meine Notebooks"
+        subtitle="Verwalte deine eigenen Notebooks: öffnen, umbenennen, bearbeiten oder löschen."
+      >
+        <div className="mb-lg flex justify-end">
+          <Button onClick={() => setPhase({ kind: 'create' })}>
+            <HiPlus className="mr-1" /> Neues Notebook
+          </Button>
         </div>
-        <Button onClick={() => setPhase({ kind: 'create' })}>
-          <HiPlus className="mr-1" /> Neues Notebook
-        </Button>
-      </div>
 
-      <h1 className="mb-xs text-2xl font-semibold text-foreground-heading">Meine Notebooks</h1>
-      <p className="mb-lg text-sm text-grey-500 dark:text-grey-400">
-        Verwalte deine eigenen Notebooks: öffnen, umbenennen, bearbeiten oder löschen.
-      </p>
-
-      {isLoading ? (
+        {isLoading ? (
         <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
           {Array.from({ length: 4 }).map((_, i) => (
             <div
@@ -430,7 +422,8 @@ function MyNotebooksPageInner() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+      </PageContainer>
+    </ErrorBoundary>
   );
 }
 

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -390,22 +390,20 @@ const NotebookEditor = ({
                                 {doc.filename || doc.title}
                               </span>
                             </div>
-                            {!editingCollection && (
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                onClick={() => handleRemoveDocument(doc.id)}
-                                disabled={loading}
-                                aria-label={`${doc.title} entfernen`}
-                              >
-                                <HiX size={14} />
-                              </Button>
-                            )}
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              onClick={() => handleRemoveDocument(doc.id)}
+                              disabled={loading}
+                              aria-label={`${doc.title} entfernen`}
+                            >
+                              <HiX size={14} />
+                            </Button>
                           </div>
                         ))}
                       </div>
-                      {!editingCollection && uploadedDocuments.length < MAX_DOCUMENTS && (
+                      {uploadedDocuments.length < MAX_DOCUMENTS && (
                         <button
                           type="button"
                           className="mt-xs text-sm text-primary-600 hover:underline disabled:opacity-50"
@@ -417,16 +415,14 @@ const NotebookEditor = ({
                             : `+ Weitere Datei hinzufügen (${MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)`}
                         </button>
                       )}
-                      {!editingCollection && (
-                        <input
-                          ref={fileInputRef}
-                          type="file"
-                          multiple
-                          accept={ACCEPTED_EXTENSIONS.join(',')}
-                          onChange={handleFileSelect}
-                          style={{ display: 'none' }}
-                        />
-                      )}
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        multiple
+                        accept={ACCEPTED_EXTENSIONS.join(',')}
+                        onChange={handleFileSelect}
+                        style={{ display: 'none' }}
+                      />
                       {uploadError && <p className="mt-xs text-sm text-red-600">{uploadError}</p>}
                     </div>
                   )}


### PR DESCRIPTION
Two small changes to the recently-added /notebooks/meine page:

1. **Structure** — adopt the shared `<ErrorBoundary><PageContainer title subtitle>` shell so the page reads visually the same as Workplace and Recherche. The bespoke `max-w-6xl` shell, inline `<h1>`, and `← Zurück` link were the only deltas; the sidebar already covers navigation.
2. **Feature** — let users add documents while editing an existing notebook. The component already had the upload UI; three `!editingCollection` guards in `NotebookEditor` were the only gate. After save, `MyNotebooksPage` polls newly-added document IDs and invalidates the collections query when indexing finishes — same fire-and-forget pattern `RecherchePage` uses in its create flow.

No backend or contract changes — the PATCH endpoint already replaces the document set.

## Test plan
- [ ] `/notebooks/meine` renders inside the shared PageContainer chrome
- [ ] Open a notebook → **Bearbeiten** → `+ Weitere Datei hinzufügen (N verbleibend)` is visible
- [ ] Upload a PDF, save → dialog closes; card `document_count` updates within a few seconds
- [ ] Click `×` on an existing doc, save → re-open shows the doc removed
- [ ] 20-doc cap still surfaces the "übersprungen" message on overflow