### PR TITLE
feat(notebook): drag-to-card + dropzone-in-modal for adding docs

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -21,9 +21,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
+  toast,
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState, type DragEvent } from 'react';
 import {
   HiBookOpen,
   HiDotsHorizontal,
@@ -32,6 +33,7 @@ import {
   HiPlus,
   HiShare,
   HiTrash,
+  HiUpload,
 } from 'react-icons/hi';
 import { useNavigate } from 'react-router-dom';
 
@@ -39,6 +41,7 @@ import withAuthRequired from '../../../components/common/LoginRequired/withAuthR
 import PageContainer from '../../../components/common/PageContainer';
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useDocumentsStore } from '../../../stores/documentsStore';
+import { cn } from '../../../utils/cn';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
@@ -51,6 +54,13 @@ type DialogPhase =
   | { kind: 'edit'; collection: NotebookCollection }
   | { kind: 'rename'; collection: NotebookCollection }
   | { kind: 'delete'; collection: NotebookCollection };
+
+const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.odt', '.rtf'];
+const MAX_DOCUMENTS_PER_NOTEBOOK = 20;
+
+function hasFileDrag(e: DragEvent): boolean {
+  return Array.from(e.dataTransfer.types).includes('Files');
+}
 
 function formatDocCount(c: NotebookCollection): string {
   const n = c.document_count ?? c.documents?.length ?? 0;
@@ -67,6 +77,7 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
   onEdit,
   onShare,
   onDelete,
+  onAddFiles,
 }: {
   collection: NotebookCollection;
   isProcessing?: boolean;
@@ -75,9 +86,61 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
   onEdit: (c: NotebookCollection) => void;
   onShare: (c: NotebookCollection) => void;
   onDelete: (c: NotebookCollection) => void;
+  onAddFiles: (c: NotebookCollection, files: File[]) => void;
 }) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const docCount = collection.document_count ?? collection.documents?.length ?? 0;
+  const isFull = docCount >= MAX_DOCUMENTS_PER_NOTEBOOK;
+
+  const handleDragEnter = (e: DragEvent<HTMLDivElement>) => {
+    if (!hasFileDrag(e)) return;
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    if (!hasFileDrag(e)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = isFull ? 'none' : 'copy';
+  };
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    setIsDragOver(false);
+  };
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    if (!hasFileDrag(e)) return;
+    e.preventDefault();
+    setIsDragOver(false);
+    if (isProcessing) return;
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length > 0) onAddFiles(collection, files);
+  };
+
   return (
-    <div className="group relative flex flex-col gap-sm rounded-md border border-grey-200 bg-background p-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700">
+    <div
+      className={cn(
+        'group relative flex flex-col gap-sm rounded-md border border-grey-200 bg-background p-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700',
+        isDragOver && !isFull && 'border-primary-500 ring-2 ring-primary-500/30',
+        isDragOver && isFull && 'border-red-400 ring-2 ring-red-400/20'
+      )}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {isDragOver ? (
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-xs rounded-md text-sm font-medium backdrop-blur-[1px]',
+            isFull
+              ? 'bg-red-50/85 text-red-700 dark:bg-red-900/40 dark:text-red-200'
+              : 'bg-primary-500/10 text-primary-700 dark:text-primary-200'
+          )}
+        >
+          <HiUpload />
+          {isFull ? `Notebook ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK})` : `Hier ablegen, um zu „${collection.name}" hinzuzufügen`}
+        </div>
+      ) : null}
+      <div className={cn(isDragOver && 'pointer-events-none')}>
       <div className="flex items-start justify-between gap-sm">
         <button
           type="button"
@@ -145,6 +208,7 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
           </Badge>
         ) : null}
       </div>
+      </div>
     </div>
   );
 });
@@ -211,6 +275,7 @@ function MyNotebooksPageInner() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
+  const uploadFileOnly = useDocumentsStore((s) => s.uploadFileOnly);
   const {
     query,
     createQACollection,
@@ -320,6 +385,69 @@ function MyNotebooksPageInner() {
     [deleteQACollection, closeDialog]
   );
 
+  const handleAddFilesToCard = useCallback(
+    async (collection: NotebookCollection, rawFiles: File[]) => {
+      const accepted = rawFiles.filter((f) =>
+        ACCEPTED_EXTENSIONS.some((ext) => f.name.toLowerCase().endsWith(ext))
+      );
+      const rejectedCount = rawFiles.length - accepted.length;
+      if (rejectedCount > 0) {
+        toast.error(
+          `${rejectedCount} Datei${rejectedCount === 1 ? '' : 'en'} übersprungen — Format nicht unterstützt`
+        );
+      }
+      if (accepted.length === 0) return;
+
+      const existingIds = (collection.documents ?? []).map((d) => String(d.id));
+      const remainingSlots = MAX_DOCUMENTS_PER_NOTEBOOK - existingIds.length;
+      if (remainingSlots <= 0) {
+        toast.error(`„${collection.name}" ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK} Dokumente)`);
+        return;
+      }
+      const filesToUpload = accepted.slice(0, remainingSlots);
+      const overCap = accepted.length - filesToUpload.length;
+
+      setProcessingCollectionIds((prev) => new Set(prev).add(collection.id));
+
+      try {
+        const uploaded = await Promise.all(
+          filesToUpload.map((f) => uploadFileOnly(f, f.name))
+        );
+        const newIds = uploaded.map((d) => String(d.id));
+
+        await updateQACollection(collection.id, {
+          name: collection.name,
+          description: collection.description,
+          documents: [...existingIds, ...newIds],
+          labels: collection.labels,
+          selectionMode: collection.selection_mode,
+          custom_prompt: collection.custom_prompt,
+        });
+        void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+
+        const successLabel = `${filesToUpload.length} Datei${filesToUpload.length === 1 ? '' : 'en'} zu „${collection.name}" hinzugefügt`;
+        toast.success(
+          overCap > 0
+            ? `${successLabel} (${overCap} übersprungen — max ${MAX_DOCUMENTS_PER_NOTEBOOK})`
+            : successLabel
+        );
+
+        await Promise.all(newIds.map((id) => pollDocumentStatus(id)));
+        void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Fehler beim Hochladen');
+      } finally {
+        setProcessingCollectionIds((prev) => {
+          if (!prev.has(collection.id)) return prev;
+          const next = new Set(prev);
+          next.delete(collection.id);
+          return next;
+        });
+      }
+    },
+    [uploadFileOnly, updateQACollection, queryClient, pollDocumentStatus]
+  );
+
   const isLoading = query.isLoading;
   const isEmpty = !isLoading && collections.length === 0;
 
@@ -327,7 +455,7 @@ function MyNotebooksPageInner() {
     <ErrorBoundary>
       <PageContainer
         title="Meine Notebooks"
-        subtitle="Verwalte deine eigenen Notebooks: öffnen, umbenennen, bearbeiten oder löschen."
+        subtitle="Verwalte deine eigenen Notebooks. Ziehe Dateien direkt auf eine Karte, um sie hinzuzufügen."
       >
         <div className="mb-lg flex justify-end">
           <Button onClick={() => setPhase({ kind: 'create' })}>
@@ -371,6 +499,7 @@ function MyNotebooksPageInner() {
               onEdit={(col) => setPhase({ kind: 'edit', collection: col })}
               onShare={handleShare}
               onDelete={(col) => setPhase({ kind: 'delete', collection: col })}
+              onAddFiles={handleAddFilesToCard}
             />
           ))}
         </div>

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -80,10 +80,11 @@ const NotebookEditor = ({
   const [isDragOver, setIsDragOver] = useState(false);
   const [labels, setLabels] = useState<string[]>([]);
   const [newLabel, setNewLabel] = useState('');
+  const [indexingDocIds, setIndexingDocIds] = useState<Set<string>>(() => new Set());
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { Input, Textarea } = useFormFields() as unknown as FormFieldComponents;
-  const { uploadFileOnly } = useDocumentsStore();
+  const { uploadFileOnly, pollDocumentStatus } = useDocumentsStore();
 
   const { control, handleSubmit, reset, setValue } = useForm<NotebookEditorFormData>({
     defaultValues: {
@@ -136,6 +137,21 @@ const NotebookEditor = ({
         }
         if (newDocs.length > 0) {
           setUploadedDocuments((prev) => [...prev, ...newDocs]);
+          setIndexingDocIds((prev) => {
+            const next = new Set(prev);
+            newDocs.forEach((d) => next.add(d.id));
+            return next;
+          });
+          newDocs.forEach((d) => {
+            void pollDocumentStatus(d.id).finally(() => {
+              setIndexingDocIds((prev) => {
+                if (!prev.has(d.id)) return prev;
+                const next = new Set(prev);
+                next.delete(d.id);
+                return next;
+              });
+            });
+          });
           if (wasEmpty) {
             const firstTitle = newDocs[0].title.replace(/\.[^/.]+$/, '');
             const suggestedName =
@@ -155,7 +171,7 @@ const NotebookEditor = ({
         setIsUploading(false);
       }
     },
-    [uploadFileOnly, setValue, uploadedDocuments.length]
+    [uploadFileOnly, pollDocumentStatus, setValue, uploadedDocuments.length]
   );
 
   const handleFileSelect = useCallback(
@@ -376,44 +392,82 @@ const NotebookEditor = ({
                         Dokumente ({uploadedDocuments.length}/{MAX_DOCUMENTS})
                       </label>
                       <div className="mt-xs flex flex-col gap-xs">
-                        {uploadedDocuments.map((doc) => (
-                          <div
-                            key={doc.id}
-                            className="flex items-center justify-between gap-sm px-sm py-xs bg-background-alt border border-green-300 rounded-lg min-w-0"
-                          >
-                            <div className="flex items-center gap-sm min-w-0 flex-1">
-                              <HiCheckCircle size={18} className="text-green-600 shrink-0" />
-                              <span
-                                className="font-medium text-sm text-foreground truncate"
-                                title={doc.filename || doc.title}
-                              >
-                                {doc.filename || doc.title}
-                              </span>
-                            </div>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-sm"
-                              onClick={() => handleRemoveDocument(doc.id)}
-                              disabled={loading}
-                              aria-label={`${doc.title} entfernen`}
+                        {uploadedDocuments.map((doc) => {
+                          const isIndexing = indexingDocIds.has(doc.id);
+                          return (
+                            <div
+                              key={doc.id}
+                              className={cn(
+                                'flex items-center justify-between gap-sm px-sm py-xs bg-background-alt border rounded-lg min-w-0',
+                                isIndexing ? 'border-grey-300 dark:border-grey-600' : 'border-green-300'
+                              )}
                             >
-                              <HiX size={14} />
-                            </Button>
-                          </div>
-                        ))}
+                              <div className="flex items-center gap-sm min-w-0 flex-1">
+                                {isIndexing ? (
+                                  <div className="size-[18px] shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                                ) : (
+                                  <HiCheckCircle size={18} className="text-green-600 shrink-0" />
+                                )}
+                                <span
+                                  className="font-medium text-sm text-foreground truncate"
+                                  title={doc.filename || doc.title}
+                                >
+                                  {doc.filename || doc.title}
+                                </span>
+                                {isIndexing && (
+                                  <span className="text-xs text-grey-500 shrink-0">
+                                    Wird verarbeitet…
+                                  </span>
+                                )}
+                              </div>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                onClick={() => handleRemoveDocument(doc.id)}
+                                disabled={loading}
+                                aria-label={`${doc.title} entfernen`}
+                              >
+                                <HiX size={14} />
+                              </Button>
+                            </div>
+                          );
+                        })}
                       </div>
                       {uploadedDocuments.length < MAX_DOCUMENTS && (
-                        <button
-                          type="button"
-                          className="mt-xs text-sm text-primary-600 hover:underline disabled:opacity-50"
-                          onClick={() => fileInputRef.current?.click()}
-                          disabled={isUploading || loading}
+                        <div
+                          className={cn(
+                            'mt-xs flex min-h-[56px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-sm transition-colors duration-200',
+                            isDragOver
+                              ? 'border-primary-500 bg-green-50 dark:bg-secondary-900'
+                              : 'border-grey-300 hover:border-primary-500 hover:bg-background dark:border-grey-600',
+                            (isUploading || loading) && 'cursor-default opacity-60'
+                          )}
+                          onDrop={handleDrop}
+                          onDragOver={handleDragOver}
+                          onDragLeave={handleDragLeave}
+                          onClick={() => {
+                            if (isUploading || loading) return;
+                            fileInputRef.current?.click();
+                          }}
                         >
-                          {isUploading
-                            ? 'Wird hochgeladen…'
-                            : `+ Weitere Datei hinzufügen (${MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)`}
-                        </button>
+                          {isUploading ? (
+                            <>
+                              <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                              <span className="text-sm text-grey-500">Wird hochgeladen…</span>
+                            </>
+                          ) : (
+                            <>
+                              <HiUpload className="text-grey-400" />
+                              <span className="text-sm font-medium text-foreground">
+                                Weitere Dateien ablegen oder klicken
+                              </span>
+                              <span className="text-xs text-grey-500">
+                                ({MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)
+                              </span>
+                            </>
+                          )}
+                        </div>
                       )}
                       <input
                         ref={fileInputRef}


### PR DESCRIPTION
The current way to add a document to an existing user notebook is the **Bearbeiten** modal's tiny green text link — three clicks deep, no drag-and-drop, no per-file feedback. This PR makes the common case (\"I have a PDF, add it to this notebook\") a single drag, and brings the modal up to the same level for everything else.

## Two changes

### 1. Drag onto a card on `/notebooks/meine`
Each card is now a drop target. Drag one or more files from the desktop, drop on a card, and they upload into that notebook directly — no modal. The existing per-card \"Wird verarbeitet…\" badge from #805 surfaces indexing state. Toasts confirm success / reject unsupported formats / surface the 20-doc cap.

### 2. Compact dropzone inside the Bearbeiten modal
Replaces the tiny `+ Weitere Datei hinzufügen` text link with a ~56px-tall dropzone that accepts drag and click. Each newly added doc row also gets a spinner + \"Wird verarbeitet…\" indicator until `pollDocumentStatus` resolves — so users see what's happening inside the modal too.

## Why this approach

I considered 8 options (modal-only polish, full-page edit route, editable detail-page sidebar, tabs in the modal, separate \"Dokumente verwalten\" modal, auto-save on drop, …) and picked drag-to-card + modal dropzone (E+A) because:

- The 80% case (\"add this PDF\") becomes one drag, matching Notion/Dropbox/Drive ergonomics.
- The modal stays as a focused fallback for everything that *isn't* a quick file add (rename, remove, label management, recovery).
- Doesn't change save semantics — Aktualisieren still commits everything, Abbrechen still discards. Drag-to-card is its own atomic action that auto-PATCHes.

## Test plan
- [ ] `/notebooks/meine`: drag a PDF onto a card → success toast, badge appears, doc count updates after indexing
- [ ] Drag a `.exe` → \"Format nicht unterstützt\" toast, nothing uploaded
- [ ] Drag onto a card with 20/20 docs → red overlay + \"voll\" toast
- [ ] Drag onto a card mid-processing → drop is no-op (gated on isProcessing)
- [ ] Drag multiple files at once → all upload, single batched success toast
- [ ] Open Bearbeiten → the compact dropzone is visible, drag onto it works, click opens file picker
- [ ] New file rows show spinner + \"Wird verarbeitet…\" until indexing completes