### PR TITLE
feat(agents): hidden Ricarda Lang notebook + collection-aware examples search

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -101,7 +101,7 @@ export async function executeDocumentSearchParallel(
     collectionsToSearch = notebookCollectionIds;
     log.info(`[Search] Using notebook-scoped collections: ${collectionsToSearch.join(', ')}`);
   } else if (agentConfig.toolRestrictions?.allowedCollections?.length) {
-    collectionsToSearch = agentConfig.toolRestrictions.allowedCollections;
+    collectionsToSearch = [...agentConfig.toolRestrictions.allowedCollections];
     log.info(`[Search] Using agent-allowed collections: ${collectionsToSearch.join(', ')}`);
   } else if (agentConfig.toolRestrictions?.defaultCollection) {
     const dc = agentConfig.toolRestrictions.defaultCollection;
@@ -783,7 +783,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
           collectionsToSearch = state.notebookCollectionIds;
           log.info(`[Search] Using notebook-scoped collections: ${collectionsToSearch.join(', ')}`);
         } else if (agentConfig.toolRestrictions?.allowedCollections?.length) {
-          collectionsToSearch = agentConfig.toolRestrictions.allowedCollections;
+          collectionsToSearch = [...agentConfig.toolRestrictions.allowedCollections];
           log.info(`[Search] Using agent-allowed collections: ${collectionsToSearch.join(', ')}`);
         } else if (agentConfig.toolRestrictions?.defaultCollection) {
           const dc = agentConfig.toolRestrictions.defaultCollection;
@@ -1026,8 +1026,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         // `toolRestrictions.examplesLvScope`; fall back to the per-agent
         // `defaultFilter.landesverband` (used by per-LV PR agents).
         const lvScope =
-          agentConfig.toolRestrictions?.examplesLvScope ??
-          agentConfig.defaultFilter?.landesverband;
+          agentConfig.toolRestrictions?.examplesLvScope ?? agentConfig.defaultFilter?.landesverband;
 
         // Composer paths want full bodies: PM bodies are reconstructed from
         // chunks inside searchExamples, social bodies skip the 500-char cut.

--- a/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.ts
@@ -160,7 +160,7 @@ export function createSearchDocumentsTool(deps: ToolDependencies): DynamicStruct
 
       let defaultCollections: string[];
       if (deps.agentConfig.toolRestrictions?.allowedCollections?.length) {
-        defaultCollections = deps.agentConfig.toolRestrictions.allowedCollections;
+        defaultCollections = [...deps.agentConfig.toolRestrictions.allowedCollections];
       } else if (deps.agentConfig.toolRestrictions?.defaultCollection) {
         const dc = deps.agentConfig.toolRestrictions.defaultCollection;
         defaultCollections = [dc, ...getSupplementaryCollectionsForLocale(deps.userLocale)];

--- a/apps/api/config/collectionMap.ts
+++ b/apps/api/config/collectionMap.ts
@@ -76,4 +76,10 @@ export const COLLECTION_MAP: Record<string, CollectionMapping> = {
     qdrantCollection: 'landesverbaende_documents',
     systemId: 'brandenburg-system',
   },
+  // Agent-only: reached via the `gruenerator-ricarda-lang` specialized agent.
+  // Not surfaced in @mention or notebook gallery.
+  'ricarda-lang-tweets': {
+    qdrantCollection: 'ricarda_lang_tweets',
+    systemId: 'ricarda-lang-tweets-system',
+  },
 };

--- a/apps/api/config/notebookCollectionMap.ts
+++ b/apps/api/config/notebookCollectionMap.ts
@@ -9,6 +9,9 @@
  */
 export const DISABLED_NOTEBOOK_IDS: ReadonlySet<string> = new Set<string>([
   'schleswig-holstein-notebook',
+  // Agent-only (by design, not broken): reachable only via the specialized
+  // `gruenerator-ricarda-lang` agent. End-user routes reject queries against it.
+  'ricarda-lang-notebook',
 ]);
 
 /**
@@ -36,6 +39,7 @@ export const NOTEBOOK_COLLECTION_MAP: Record<string, string[]> = {
   'kommunalwiki-notebook': ['kommunalwiki'],
   'boell-stiftung-notebook': ['boell-stiftung'],
   'gruenblog-notebook': ['gruenblog'],
+  'ricarda-lang-notebook': ['ricarda-lang-tweets'],
 };
 
 export function resolveNotebookCollections(notebookIds: string[]): string[] {

--- a/apps/api/config/qdrantCollectionsSchema.ts
+++ b/apps/api/config/qdrantCollectionsSchema.ts
@@ -209,6 +209,19 @@ export const COLLECTION_SCHEMAS: Record<string, CollectionSchema> = {
     ],
     handleRaceCondition: true,
   },
+  // Per-person tweet collection. Mirrors social_media_examples schema but lives
+  // in its own collection so the agent-only `ricarda-lang-notebook` stays isolated.
+  ricarda_lang_tweets: {
+    name: 'ricarda_lang_tweets',
+    optimizer: 'large',
+    hnsw: 'enhanced',
+    indexes: [
+      { field: 'platform', type: 'keyword' },
+      { field: 'source_account', type: 'keyword' },
+      { field: 'published_at', type: 'datetime' },
+    ],
+    handleRaceCondition: true,
+  },
   user_texts: {
     name: 'user_texts',
     optimizer: 'large',

--- a/apps/api/routes/chat/agents/types.ts
+++ b/apps/api/routes/chat/agents/types.ts
@@ -1,30 +1,13 @@
 /**
- * Agent configuration types for the AI chat service
+ * Agent configuration types for the AI chat service.
+ *
+ * `ToolRestrictions` is now sourced from `@gruenerator/shared/agents` so the
+ * API and the shared package can't drift. Re-exported here so existing
+ * `import { ToolRestrictions } from '.../routes/chat/agents/types'` callers
+ * keep compiling without touching their import paths.
  */
-
-/**
- * Tool restrictions allow per-agent customization of available search tools.
- * This enables country-specific agents (e.g., Austrian agent) to only access
- * relevant collections, enforced at the server level.
- */
-export interface ToolRestrictions {
-  /** Restrict gruenerator_search to specific collections */
-  allowedCollections?: string[] | undefined;
-  /** Default collection when not specified in query */
-  defaultCollection?: string | undefined;
-  /** Filter social media examples by country (DE = Germany, AT = Austria) */
-  examplesCountry?: 'DE' | 'AT' | undefined;
-  /**
-   * Per-Landesverband scope for press/social examples. Accepts a single short
-   * code (e.g. 'BE') or an array (e.g. ['BE', 'BE-F']) when the LV publishes
-   * under multiple codes (Berlin & Thüringen carry both Landesverband and
-   * Fraktion). Press filters via Qdrant `landesverband` field; social
-   * currently logs only (Apify follow-up will add the field to social_media_examples).
-   */
-  examplesLvScope?: string | readonly string[] | undefined;
-  /** Disable person search tool (e.g., no Austrian politician DB exists) */
-  personSearchEnabled?: boolean | undefined;
-}
+import type { ToolRestrictions } from '@gruenerator/shared/agents';
+export type { ToolRestrictions } from '@gruenerator/shared/agents';
 
 /**
  * Hard-pinned filters merged into tool calls (Qdrant / examples service).

--- a/apps/api/scripts/backfillRicardaLangTweets.ts
+++ b/apps/api/scripts/backfillRicardaLangTweets.ts
@@ -1,0 +1,57 @@
+/**
+ * Phase 2 one-off backfill: pulls the last ~12 months of @Ricarda_Lang tweets
+ * via X API v2 user-timeline and indexes them into the dedicated
+ * `ricarda_lang_tweets` Qdrant collection.
+ *
+ * Usage:
+ *   npx tsx apps/api/scripts/backfillRicardaLangTweets.ts
+ *
+ * Prerequisites:
+ *   - `X_BEARER_TOKEN` set in apps/api/.env
+ *   - `MISTRAL_API_KEY` set (used for embeddings)
+ *   - Backend has booted at least once so QdrantService.init() created the
+ *     `ricarda_lang_tweets` collection (registered in qdrantCollectionsSchema.ts)
+ *
+ * Caveats:
+ *   - X API access tier determines how far back `startTime` can reach. Free
+ *     tier: 7 days only. Basic/Pro/Enterprise: longer windows. The script
+ *     attempts a 12-month range and surfaces whatever X returns.
+ *   - User-timeline endpoint caps at 3200 recent tweets regardless of date.
+ *   - This is intentionally NOT wired into update-all-content.ts or the
+ *     content-sync GitHub Actions workflow. Future incremental sync (cron)
+ *     is deferred — the watermark gets updated at the end of this run so a
+ *     later cron entry will resume from the latest tweet seen here.
+ */
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const { xApiScraper } = await import('../services/scrapers/implementations/XApiScraper.js');
+
+const HANDLE = 'Ricarda_Lang';
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+// X API caps user-timeline at ~3200 tweets total; 5000 is a comfortable upper
+// bound to ensure pagination runs until the API stops returning a next_token.
+const MAX_TWEETS = 5000;
+
+async function main(): Promise<void> {
+  const startTime = new Date(Date.now() - ONE_YEAR_MS).toISOString();
+  console.log(`[backfill] @${HANDLE} since ${startTime}, cap ${MAX_TWEETS} tweets`);
+
+  await xApiScraper.init();
+  const result = await xApiScraper.scrape({
+    handles: [HANDLE],
+    maxTweetsPerRun: MAX_TWEETS,
+    ignoreWatermark: true,
+    paginate: true,
+    startTime,
+  });
+
+  console.log('[backfill] done');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error('[backfill] failed', error);
+  process.exit(1);
+});

--- a/apps/api/scripts/exportRicardaLangTweets.ts
+++ b/apps/api/scripts/exportRicardaLangTweets.ts
@@ -1,0 +1,86 @@
+/**
+ * Phase 3 Step A: dump all Ricarda Lang tweets from the `ricarda_lang_tweets`
+ * Qdrant collection into a single JSONL file for offline style analysis.
+ *
+ * Usage: pnpm --filter @gruenerator/api exec tsx scripts/exportRicardaLangTweets.ts
+ *
+ * Output: apps/api/data/ricarda-lang-tweets.jsonl
+ *   Each line: { tweet_id, content, published_at, lang, url }
+ *   Sorted newest-first by `published_at`.
+ */
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const { getQdrantInstance } = await import('../database/services/QdrantService/index.js');
+
+interface TweetRecord {
+  tweet_id: string;
+  content: string;
+  published_at: string | null;
+  lang: string | null;
+  url: string;
+}
+
+const COLLECTION = 'ricarda_lang_tweets';
+const OUTPUT = 'data/ricarda-lang-tweets.jsonl';
+const SCROLL_BATCH = 100;
+
+async function main(): Promise<void> {
+  const qdrant = getQdrantInstance();
+  await qdrant.ensureConnected();
+  const client = qdrant.client;
+  if (!client) throw new Error('Qdrant client unavailable');
+
+  const tweets: TweetRecord[] = [];
+  let offset: string | number | null = null;
+  let pages = 0;
+
+  do {
+    const result = await client.scroll(COLLECTION, {
+      limit: SCROLL_BATCH,
+      ...(offset != null && { offset }),
+      with_payload: ['tweet_id', 'content', 'published_at', 'lang', 'example_id'],
+      with_vector: false,
+    });
+    pages++;
+
+    for (const point of result.points ?? []) {
+      const payload = (point.payload ?? {}) as Record<string, unknown>;
+      const tweet_id = String(payload.tweet_id ?? '');
+      const content = String(payload.content ?? '');
+      if (!tweet_id || !content) continue;
+      tweets.push({
+        tweet_id,
+        content,
+        published_at: (payload.published_at as string | null | undefined) ?? null,
+        lang: (payload.lang as string | null | undefined) ?? null,
+        url: String(payload.example_id ?? `https://x.com/Ricarda_Lang/status/${tweet_id}`),
+      });
+    }
+
+    const next = result.next_page_offset;
+    offset = typeof next === 'string' || typeof next === 'number' ? next : null;
+    console.log(
+      `[export] page ${pages}: ${result.points?.length ?? 0} points → ${tweets.length} total`
+    );
+  } while (offset != null);
+
+  tweets.sort((a, b) => {
+    const at = a.published_at ?? '';
+    const bt = b.published_at ?? '';
+    return bt.localeCompare(at);
+  });
+
+  mkdirSync(dirname(OUTPUT), { recursive: true });
+  writeFileSync(OUTPUT, tweets.map((t) => JSON.stringify(t)).join('\n') + '\n', 'utf8');
+  console.log(`[export] wrote ${tweets.length} tweets to ${OUTPUT}`);
+}
+
+main().catch((err) => {
+  console.error('[export] failed', err);
+  process.exit(1);
+});

--- a/apps/api/scripts/extractRicardaLangStyle.ts
+++ b/apps/api/scripts/extractRicardaLangStyle.ts
@@ -1,0 +1,122 @@
+/**
+ * Phase 3 Step B: read the exported Ricarda Lang tweet corpus and call an LLM
+ * with a meta-prompt to produce a structured German-language style guide
+ * suitable for embedding into the system agent's `systemRole`.
+ *
+ * Usage: pnpm --filter @gruenerator/api exec tsx scripts/extractRicardaLangStyle.ts
+ *
+ * Input:  apps/api/data/ricarda-lang-tweets.jsonl (from exportRicardaLangTweets.ts)
+ * Output: apps/api/data/ricarda-lang-style.md  (the style block to paste into systemRole)
+ *
+ * Model: Mistral Large (the codebase workhorse). The plan suggested Claude;
+ * we use Mistral here because the codebase has no direct Anthropic client —
+ * `anthropic` is only referenced as a regex pattern in provider routing.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const { generateText } = await import('ai');
+const { getModel } = await import('../services/ai/providers.js');
+
+interface TweetRecord {
+  tweet_id: string;
+  content: string;
+  published_at: string | null;
+  lang: string | null;
+  url: string;
+}
+
+const INPUT = 'data/ricarda-lang-tweets.jsonl';
+const OUTPUT = 'data/ricarda-lang-style.md';
+
+const META_PROMPT = `Du bist eine erfahrene Sprachanalystin und Stilforscherin. Deine Aufgabe ist es, den **Tweet-Stil von Ricarda Lang** anhand eines echten Tweet-Korpus zu rekonstruieren — so präzise, dass eine andere Person mit deiner Anleitung Tweets im selben Stil schreiben könnte.
+
+Du bekommst unten **alle** Originaltweets von @Ricarda_Lang aus den letzten zwölf Monaten (deutschsprachig, keine Retweets, keine Replies). Analysiere sie gründlich und produziere ein strukturiertes deutschsprachiges Stil-Handbuch im Markdown-Format.
+
+Das Stil-Handbuch MUSS folgende Abschnitte enthalten (in dieser Reihenfolge, mit den genauen Überschriften):
+
+## Stimme & Tonalität
+Beschreibe Register (Du-Form? Sie-Form? gemischt?), Genderstern-Konsistenz, emotionale Färbung (sachlich, kämpferisch, ironisch, warmherzig?), und 3–5 charakteristische Wendungen oder Lieblingswörter mit Zitatbeleg.
+
+## Aufbau eines typischen Tweets
+Erkläre den typischen Aufbau (z. B. Hook → Position → Forderung; oder rhetorische Frage → Pointe). Beschreibe 2–3 wiederkehrende Strukturen mit kurzen Beispielen.
+
+## Länge & Format
+Durchschnittliche Tweet-Länge in Zeichen, Spannweite, ob Threads vorkommen, ob Zeilenumbrüche genutzt werden.
+
+## Hashtag-, Mention- und Link-Muster
+Wie oft Hashtags? An welcher Position (Anfang, Ende, mitten im Satz)? Wiederkehrende Hashtags? Wie wird @-mentioned? Wie häufig sind Links/Bilder?
+
+## Emoji-Nutzung
+Häufigkeit (selten, gelegentlich, oft), typische Emojis, Position im Tweet.
+
+## Wiederkehrende Themen
+Top 5–8 inhaltliche Schwerpunkte mit je 1 Zitat aus dem Korpus als Beleg.
+
+## Rhetorische Mittel
+Anapher, rhetorische Frage, Du-Ansprache, "Es geht um …"-Frames, Zuspitzung, Pointen — welche werden wie häufig eingesetzt?
+
+## Was Ricarda NICHT tut
+Klare Negativliste: Was kommt im Korpus nicht vor? (z. B. Phrasen wie "Liebe Mitbürgerinnen und Mitbürger", übertriebene Floskeln, ChatGPT-Stil-Listen mit Bulletpoints, etc.)
+
+## 5 archetypische Beispiel-Tweets
+Wähle 5 Tweets aus dem Korpus, die zusammen ihre Bandbreite einfangen. Zitiere sie **wortwörtlich** und ergänze pro Tweet eine kurze Erklärung, welches Stil-Element er repräsentiert.
+
+WICHTIG:
+- Schreibe das Handbuch komplett auf Deutsch.
+- Sei konkret und beleg-basiert: jede Behauptung über den Stil muss mit einem Zitat aus dem Korpus untermauert sein.
+- Keine Plattitüden ("authentisch", "nahbar") ohne konkreten Beleg.
+- Keine Meta-Kommentare über deine Analyse-Methode — nur das fertige Handbuch.
+- Format: reines Markdown, beginnend mit "# Ricarda Lang — Tweet-Stil-Handbuch".
+
+Hier ist der Tweet-Korpus:
+
+`;
+
+async function main(): Promise<void> {
+  const raw = readFileSync(INPUT, 'utf8');
+  const tweets: TweetRecord[] = raw
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as TweetRecord)
+    .filter((t) => t.lang === 'de' || t.lang === null);
+
+  console.log(`[extract] loaded ${tweets.length} German tweets from ${INPUT}`);
+
+  const corpus = tweets
+    .map((t, i) => {
+      const date = t.published_at ? t.published_at.slice(0, 10) : 'unbekannt';
+      return `[${i + 1}] (${date}) ${t.content.replace(/\s+/g, ' ').trim()}`;
+    })
+    .join('\n');
+
+  const fullPrompt = META_PROMPT + corpus;
+  console.log(`[extract] prompt length: ${fullPrompt.length} chars`);
+
+  const model = getModel('mistral', 'mistral-large-latest');
+  const start = Date.now();
+  const result = await generateText({
+    model,
+    prompt: fullPrompt,
+    temperature: 0.3,
+    maxOutputTokens: 6000,
+  });
+  const duration = Date.now() - start;
+
+  console.log(
+    `[extract] done in ${(duration / 1000).toFixed(1)}s — output ${result.text.length} chars, usage: ${JSON.stringify(result.usage)}`
+  );
+
+  mkdirSync(dirname(OUTPUT), { recursive: true });
+  writeFileSync(OUTPUT, result.text, 'utf8');
+  console.log(`[extract] wrote style guide to ${OUTPUT}`);
+}
+
+main().catch((err) => {
+  console.error('[extract] failed', err);
+  process.exit(1);
+});

--- a/apps/api/scripts/seedRicardaLangTweets.ts
+++ b/apps/api/scripts/seedRicardaLangTweets.ts
@@ -1,0 +1,90 @@
+/**
+ * Phase 1 seed: inserts a handful of synthetic Ricarda Lang tweet documents
+ * into the `ricarda_lang_tweets` Qdrant collection so the
+ * `gruenerator-ricarda-lang` specialized agent can be smoke-tested end-to-end
+ * without depending on the X API.
+ *
+ * Usage: npx tsx apps/api/scripts/seedRicardaLangTweets.ts
+ *
+ * Prerequisites: backend has booted at least once so QdrantService.init()
+ * created the `ricarda_lang_tweets` collection (registered in
+ * qdrantCollectionsSchema.ts).
+ */
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const { getQdrantInstance } = await import('../database/services/QdrantService/index.js');
+const { indexSocialMediaExample } = await import('../database/services/QdrantService/indexing.js');
+const { mistralEmbeddingService } = await import('../services/mistral/index.js');
+
+interface SyntheticTweet {
+  id: string;
+  text: string;
+  publishedAt: string;
+}
+
+const TWEETS: SyntheticTweet[] = [
+  {
+    id: '1700000000000000001',
+    text: 'Klimaschutz ist die soziale Frage unserer Zeit. Wer jetzt nicht investiert, zahlt morgen drauf — besonders die Menschen mit kleinen Einkommen.',
+    publishedAt: '2025-09-12T10:14:00Z',
+  },
+  {
+    id: '1700000000000000002',
+    text: 'Die Kindergrundsicherung ist eine Frage des Anstands. Kein Kind in einem reichen Land darf in Armut aufwachsen.',
+    publishedAt: '2025-10-03T08:22:00Z',
+  },
+  {
+    id: '1700000000000000003',
+    text: 'Die Schuldenbremse in ihrer jetzigen Form ist eine Investitionsbremse. Wir brauchen Spielraum für Bildung, Bahn und Klimaschutz.',
+    publishedAt: '2025-11-21T17:48:00Z',
+  },
+  {
+    id: '1700000000000000004',
+    text: 'Tempo 30 in Innenstädten rettet Leben und macht Städte lebenswerter. Kommunen müssen selbst entscheiden dürfen.',
+    publishedAt: '2026-01-08T13:05:00Z',
+  },
+  {
+    id: '1700000000000000005',
+    text: 'Wärmewende heißt: faire Förderung statt Verbote-Debatten. Niemand wird im Stich gelassen.',
+    publishedAt: '2026-02-19T09:30:00Z',
+  },
+];
+
+const HANDLE = 'Ricarda_Lang';
+const COLLECTION = 'ricarda_lang_tweets';
+
+async function main(): Promise<void> {
+  await mistralEmbeddingService.init();
+  if (!mistralEmbeddingService.isReady()) {
+    throw new Error('Mistral embedding service did not initialize');
+  }
+
+  const qdrant = getQdrantInstance();
+  await qdrant.ensureConnected();
+  const client = qdrant.client;
+  if (!client) throw new Error('Qdrant client unavailable');
+
+  let inserted = 0;
+  for (const tweet of TWEETS) {
+    const exampleId = `https://x.com/${HANDLE}/status/${tweet.id}`;
+    const embedding = await mistralEmbeddingService.generateEmbedding(tweet.text);
+    await indexSocialMediaExample(client, COLLECTION, exampleId, embedding, tweet.text, 'x', {
+      country: 'DE',
+      source_account: HANDLE,
+      tweet_id: tweet.id,
+      published_at: tweet.publishedAt,
+      lang: 'de',
+    });
+    inserted++;
+    console.log(`[seed] indexed ${exampleId}`);
+  }
+
+  console.log(`[seed] done — ${inserted} synthetic tweets in ${COLLECTION}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -16,10 +16,31 @@ export interface FewShotExample {
 }
 
 export interface ToolRestrictions {
-  allowedCollections?: readonly string[];
-  defaultCollection?: string;
-  examplesCountry?: 'DE' | 'AT';
-  personSearchEnabled?: boolean;
+  /**
+   * Single canonical definition shared by `apps/api` (under
+   * `exactOptionalPropertyTypes: true`) and the web/shared callers. Each field
+   * is explicitly `T | undefined` so spread assignments from objects whose
+   * properties may be `undefined` type-check on both sides.
+   */
+  allowedCollections?: readonly string[] | undefined;
+  defaultCollection?: string | undefined;
+  examplesCountry?: 'DE' | 'AT' | undefined;
+  personSearchEnabled?: boolean | undefined;
+  /**
+   * Per-Landesverband scope for press/social examples. Accepts a single short
+   * code (e.g. 'BE') or an array (e.g. ['BE', 'BE-F']) when the LV publishes
+   * under multiple codes (Berlin & Thüringen carry both Landesverband and
+   * Fraktion). Press filters via Qdrant `landesverband` field; social
+   * currently logs only (Apify follow-up will add the field to social_media_examples).
+   */
+  examplesLvScope?: string | readonly string[] | undefined;
+  /**
+   * When set, `search_examples` queries this Qdrant collection name instead
+   * of the default `social_media_examples`. Used by per-person tweet-style
+   * agents (e.g. "Tweet wie Ricarda" → `ricarda_lang_tweets`) so the few-shot
+   * grounding comes from that person's tweets only.
+   */
+  examplesCollection?: string | undefined;
 }
 
 /**
@@ -106,4 +127,5 @@ export interface Skill {
   skillCategory?: SkillCategory;
   promptTemplate?: string;
   isSystemDefault?: boolean;
+  skillSystemPrompt?: string;
 }


### PR DESCRIPTION
## Summary

Foundation for a "Tweet wie Ricarda" persona agent and a generic mechanism so future per-person tweet-style agents (Cem, Habeck, …) can each reach a dedicated Qdrant collection.

- **Hidden notebook** `ricarda-lang-notebook` → Qdrant collection `ricarda_lang_tweets`, registered in `collectionMap` / `notebookCollectionMap` / `qdrantCollectionsSchema` and gated via `DISABLED_NOTEBOOK_IDS` so end-user routes reject it (frontend gallery + `@mention` autocomplete never see it).
- **`examplesCollection`** field on `ToolRestrictions` — generic per-agent override for the `search_examples` tool's target collection.
- **Type unification**: delete the API-local `ToolRestrictions` mirror in `routes/chat/agents/types.ts` and re-export from `@gruenerator/shared/agents`. Harden the shared definition with explicit `T | undefined` on every optional so `exactOptionalPropertyTypes: true` consumers stop drifting. Carries `examplesLvScope` (added on master) forward onto the unified shared type so per-LV Öffentlichkeitsarbeit agents keep working.
- **Drive-by readonly fix** in `searchNode` / `searchDocuments` — spread-copy `allowedCollections` into mutable locals, required by the readonly tightening above.
- **Field-selector** on the Qdrant scroll in `exportRicardaLangTweets` so only the 5 actually-used payload fields are fetched.
- **Offline scripts** under `apps/api/scripts/`: seed / backfill / export / extract style — the extractor produces the markdown persona prompt that gets embedded into the agent's `systemRole`.

## What this PR does NOT include

The Ricarda agent definition itself and the runtime `collection` threading (searchExamples tool → executor → service → QdrantService) live on a sibling WIP branch (`feat/skill-bibliothek-icons-and-page`) alongside the X/Bluesky scraper scaffolding they depend on. This PR is the cleanly-isolated shared-types + notebook-config foundation. `examplesCollection` is consumed by no one in this PR — that's intentional and safe.

The `backfillRicardaLangTweets` script references the X scraper via dynamic `await import(...)`; without the scraper scaffolding it won't run, but it doesn't break typecheck.

## Test plan

- [x] `pnpm --filter @gruenerator/api typecheck` — clean on master + this PR
- [x] `pnpm --filter @gruenerator/shared typecheck` — clean
- [ ] After merge: the umbrella branch's Ricarda agent definition can land on top with no contract changes needed here
- [ ] Existing Öffentlichkeitsarbeit agents (Berlin, Hamburg, Thüringen, etc.) still resolve `examplesLvScope` correctly — no consumers of the field were touched