### PR TITLE
refactor(notebook): slim doc rows in Bearbeiten dialog

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -398,37 +398,43 @@ const NotebookEditor = ({
                             <div
                               key={doc.id}
                               className={cn(
-                                'flex items-center justify-between gap-sm px-sm py-xs bg-background-alt border rounded-lg min-w-0',
-                                isIndexing ? 'border-grey-300 dark:border-grey-600' : 'border-green-300'
+                                'group flex items-center gap-sm rounded-md px-sm py-[5px] min-w-0 transition-colors',
+                                isIndexing
+                                  ? 'bg-grey-50 dark:bg-grey-900/40'
+                                  : 'hover:bg-grey-100 dark:hover:bg-grey-800/50'
                               )}
                             >
-                              <div className="flex items-center gap-sm min-w-0 flex-1">
-                                {isIndexing ? (
-                                  <div className="size-[18px] shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                                ) : (
-                                  <HiCheckCircle size={18} className="text-green-600 shrink-0" />
-                                )}
-                                <span
-                                  className="font-medium text-sm text-foreground truncate"
-                                  title={doc.filename || doc.title}
-                                >
-                                  {doc.filename || doc.title}
+                              {isIndexing ? (
+                                <div className="size-[14px] shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                              ) : (
+                                <HiCheckCircle size={14} className="text-green-600 shrink-0" />
+                              )}
+                              <span
+                                className="text-sm text-foreground truncate flex-1"
+                                title={doc.filename || doc.title}
+                              >
+                                {doc.filename || doc.title}
+                              </span>
+                              {isIndexing && (
+                                <span className="text-xs text-grey-500 shrink-0">
+                                  verarbeitet…
                                 </span>
-                                {isIndexing && (
-                                  <span className="text-xs text-grey-500 shrink-0">
-                                    Wird verarbeitet…
-                                  </span>
-                                )}
-                              </div>
+                              )}
                               <Button
                                 type="button"
                                 variant="ghost"
-                                size="icon-sm"
+                                size="icon-xs"
+                                className={cn(
+                                  'shrink-0 transition-opacity',
+                                  isIndexing
+                                    ? 'opacity-60'
+                                    : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+                                )}
                                 onClick={() => handleRemoveDocument(doc.id)}
                                 disabled={loading}
                                 aria-label={`${doc.title} entfernen`}
                               >
-                                <HiX size={14} />
+                                <HiX size={12} />
                               </Button>
                             </div>
                           );


### PR DESCRIPTION
Follow-up to #806. Each doc row in the Bearbeiten modal was ~48px of full-width, green-bordered chrome — with even two long-titled docs the list dominated the modal (see screenshot in original feedback). The ✓ icon already signals state, so the green border was redundant visual weight.

Slim each row to ~32px: drop the border, shrink padding to `py-[5px]`, halve the status icons (18 → 14), and reveal the × button only on hover (with `focus-visible` for keyboard users). Bold filename → regular weight: the row reads as a list item, not a state badge.

Result: ~33% less vertical space per row. With 5 docs the list drops from ~240px → ~160px.

## Test plan
- [ ] Open Bearbeiten → existing docs render as slim, borderless rows
- [ ] Hover a row → × appears smoothly
- [ ] Tab to a row's × button → it appears via `focus-visible`
- [ ] Long filenames still truncate with `title` attr for full text on hover
- [ ] Indexing rows still show spinner + "verarbeitet…" label (with subtle bg-grey-50)