### PR TITLE
feat(agents): refactor Antrag into Kommunalpolitik agent

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/tools/draftStructured.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/draftStructured.ts
@@ -21,55 +21,125 @@ const log = createLogger('Tool:DraftStructured');
 // Per-agent schemas
 // ---------------------------------------------------------------------------
 
-const ANTRAG_SCHEMA = z.object({
-  betreff: z.string().describe('Kurzer, prägnanter Titel des Antrags'),
-  antragsart: z
-    .enum(['Beschlussvorlage', 'Kleine Anfrage', 'Große Anfrage'])
-    .describe('Art des Antrags'),
-  beschlussvorschlag: z
-    .string()
-    .describe('Konkreter Beschlusstext ("Die Verwaltung wird beauftragt...")'),
-  sachverhalt: z.string().describe('Beschreibung der Ausgangslage (Ist-Zustand)'),
-  begruendung: z.string().describe('Argumente und Fakten (Soll-Zustand, Nutzen)'),
-  kosten: z.string().optional().describe('Kostenabschätzung oder Hinweis auf Kostenermittlung'),
-}).describe('Antrag Schema');
+const ANTRAG_SCHEMA = z
+  .object({
+    dokumenttyp: z
+      .enum([
+        'antrag',
+        'kleine_anfrage',
+        'grosse_anfrage',
+        'haushaltsantrag',
+        'haushaltsbewertung',
+        'resolution',
+      ])
+      .describe(
+        'Art des Dokuments. "antrag"/"kleine_anfrage"/"grosse_anfrage" für klassische Vorlagen, "haushaltsantrag" für Änderungsanträge zum Haushalt (Stelle/Betrag/Deckung), "haushaltsbewertung" für formale Stellungnahmen zu einem Haushaltsentwurf, "resolution" für politische Beschlüsse mit zentraler Forderung.'
+      ),
+    betreff: z.string().describe('Kurzer, prägnanter Titel des Dokuments'),
+    antragsart: z
+      .enum(['Beschlussvorlage', 'Kleine Anfrage', 'Große Anfrage'])
+      .optional()
+      .describe(
+        'Kategorie-Label für klassische Anträge (nur bei dokumenttyp antrag/kleine_anfrage/grosse_anfrage)'
+      ),
+    beschlussvorschlag: z
+      .string()
+      .optional()
+      .describe('Konkreter Beschlusstext ("Die Verwaltung wird beauftragt...")'),
+    sachverhalt: z.string().optional().describe('Beschreibung der Ausgangslage (Ist-Zustand)'),
+    begruendung: z.string().optional().describe('Argumente und Fakten (Soll-Zustand, Nutzen)'),
+    kosten: z.string().optional().describe('Kostenabschätzung oder Hinweis auf Kostenermittlung'),
 
-const REDE_SCHEMA = z.object({
-  anlass: z.string().describe('Anlass und Kontext der Rede'),
-  einstiegsideen: z
-    .array(z.string())
-    .min(2)
-    .max(3)
-    .describe('2-3 unterschiedliche Ideen für den Einstieg'),
-  kernargumente: z
-    .array(
-      z.object({
-        argument: z.string().describe('Das Kernargument'),
-        beleg: z.string().describe('Fakten oder Beispiele zur Unterstützung'),
-      })
-    )
-    .min(2)
-    .max(4)
-    .describe('2-3 Kernargumente mit Belegen'),
-  schlussideen: z.array(z.string()).min(2).max(3).describe('2-3 Ideen für ein starkes Ende'),
-  redetext: z.string().describe('Der vollständige Redetext'),
-  rednerhinweise: z.array(z.string()).min(2).max(3).describe('2-3 Tipps für die*den Redner*in'),
-}).describe('Rede Schema');
+    // Haushaltsantrag fields
+    haushaltsstelle: z
+      .string()
+      .optional()
+      .describe('Haushaltsstelle bzw. Produkt/Konto (nur bei haushaltsantrag)'),
+    aenderungsbetrag: z
+      .string()
+      .optional()
+      .describe('Änderungsbetrag mit Vorzeichen, z.B. "+ 200.000 €" (nur bei haushaltsantrag)'),
+    deckungsvorschlag: z
+      .string()
+      .optional()
+      .describe('Vorschlag zur Gegenfinanzierung (nur bei haushaltsantrag)'),
 
-const WAHLPROGRAMM_SCHEMA = z.object({
-  kapitel_titel: z.string().describe('Titel des Wahlprogramm-Kapitels'),
-  einleitung: z.string().describe('Kurze Einleitung (2-3 Sätze) zur Bedeutung des Themas'),
-  unterkapitel: z
-    .array(
-      z.object({
-        ueberschrift: z.string().describe('Aussagekräftige Überschrift'),
-        inhalt: z.string().describe('2-3 Absätze mit mindestens einer konkreten Forderung'),
-      })
-    )
-    .min(3)
-    .max(5)
-    .describe('3-4 Unterkapitel'),
-}).describe('Wahlprogramm Schema');
+    // Resolution fields
+    forderung: z
+      .string()
+      .optional()
+      .describe('Zentrale politische Forderung als Beschlusstext (nur bei resolution)'),
+
+    // Haushaltsbewertung fields
+    gesamteinschaetzung: z
+      .string()
+      .optional()
+      .describe('2-3 Sätze Gesamteinschätzung (nur bei haushaltsbewertung)'),
+    staerken: z
+      .array(z.string())
+      .optional()
+      .describe('Stärken des Entwurfs aus grüner Sicht (nur bei haushaltsbewertung)'),
+    schwaechen: z
+      .array(z.string())
+      .optional()
+      .describe('Schwächen / blinde Flecken (nur bei haushaltsbewertung)'),
+    fehlende_akzente: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Fehlende grüne Akzente (Klima, Soziales, Beteiligung) (nur bei haushaltsbewertung)'
+      ),
+    vergleichswerte: z
+      .string()
+      .optional()
+      .describe('Vergleichswerte / Maßstäbe anderer Kommunen (nur bei haushaltsbewertung)'),
+    verbesserungsvorschlaege: z
+      .array(z.string())
+      .optional()
+      .describe('Konkrete umsetzbare Verbesserungsvorschläge (nur bei haushaltsbewertung)'),
+  })
+  .describe('Antrag / Anfrage / Haushaltsantrag / Bewertung / Resolution Schema');
+
+const REDE_SCHEMA = z
+  .object({
+    anlass: z.string().describe('Anlass und Kontext der Rede'),
+    einstiegsideen: z
+      .array(z.string())
+      .min(2)
+      .max(3)
+      .describe('2-3 unterschiedliche Ideen für den Einstieg'),
+    kernargumente: z
+      .array(
+        z.object({
+          argument: z.string().describe('Das Kernargument'),
+          beleg: z.string().describe('Fakten oder Beispiele zur Unterstützung'),
+        })
+      )
+      .min(2)
+      .max(4)
+      .describe('2-3 Kernargumente mit Belegen'),
+    schlussideen: z.array(z.string()).min(2).max(3).describe('2-3 Ideen für ein starkes Ende'),
+    redetext: z.string().describe('Der vollständige Redetext'),
+    rednerhinweise: z.array(z.string()).min(2).max(3).describe('2-3 Tipps für die*den Redner*in'),
+  })
+  .describe('Rede Schema');
+
+const WAHLPROGRAMM_SCHEMA = z
+  .object({
+    kapitel_titel: z.string().describe('Titel des Wahlprogramm-Kapitels'),
+    einleitung: z.string().describe('Kurze Einleitung (2-3 Sätze) zur Bedeutung des Themas'),
+    unterkapitel: z
+      .array(
+        z.object({
+          ueberschrift: z.string().describe('Aussagekräftige Überschrift'),
+          inhalt: z.string().describe('2-3 Absätze mit mindestens einer konkreten Forderung'),
+        })
+      )
+      .min(3)
+      .max(5)
+      .describe('3-4 Unterkapitel'),
+  })
+  .describe('Wahlprogramm Schema');
 
 // ---------------------------------------------------------------------------
 // Schema map + formatting
@@ -83,22 +153,58 @@ const SCHEMA_MAP: Record<string, AgentSchema> = {
   'gruenerator-wahlprogramm': WAHLPROGRAMM_SCHEMA,
 };
 
+const DOKUMENTTYP_LABEL: Record<z.infer<typeof ANTRAG_SCHEMA>['dokumenttyp'], string> = {
+  antrag: 'Antrag',
+  kleine_anfrage: 'Kleine Anfrage',
+  grosse_anfrage: 'Große Anfrage',
+  haushaltsantrag: 'Änderungsantrag zum Haushalt',
+  haushaltsbewertung: 'Stellungnahme zum Haushalt',
+  resolution: 'Resolution',
+};
+
+function pushSection(lines: string[], heading: string, body: string | undefined): void {
+  if (!body) return;
+  lines.push('', heading, body);
+}
+
+function pushBulletSection(lines: string[], heading: string, items: string[] | undefined): void {
+  if (!items || items.length === 0) return;
+  lines.push('', heading);
+  for (const item of items) lines.push(`- ${item}`);
+}
+
 function formatAntrag(data: z.infer<typeof ANTRAG_SCHEMA>): string {
-  const lines = [
-    `# ${data.antragsart}: ${data.betreff}`,
-    '',
-    `## Beschlussvorschlag`,
-    data.beschlussvorschlag,
-    '',
-    `## Sachverhalt`,
-    data.sachverhalt,
-    '',
-    `## Begründung`,
-    data.begruendung,
-  ];
-  if (data.kosten) {
-    lines.push('', `## Finanzielle Auswirkungen`, data.kosten);
+  const typLabel = data.antragsart ?? DOKUMENTTYP_LABEL[data.dokumenttyp];
+  const lines: string[] = [`# ${typLabel}: ${data.betreff}`];
+
+  if (data.dokumenttyp === 'haushaltsbewertung') {
+    pushSection(lines, '## Gesamteinschätzung', data.gesamteinschaetzung);
+    pushBulletSection(lines, '## Stärken', data.staerken);
+    pushBulletSection(lines, '## Schwächen aus grüner Sicht', data.schwaechen);
+    pushBulletSection(lines, '## Fehlende Akzente', data.fehlende_akzente);
+    pushSection(lines, '## Vergleichswerte', data.vergleichswerte);
+    pushBulletSection(lines, '## Konkrete Verbesserungsvorschläge', data.verbesserungsvorschlaege);
+    return lines.join('\n');
   }
+
+  if (data.dokumenttyp === 'resolution') {
+    pushSection(lines, '## Forderung', data.forderung ?? data.beschlussvorschlag);
+    pushSection(lines, '## Begründung', data.begruendung);
+    return lines.join('\n');
+  }
+
+  pushSection(lines, '## Beschlussvorschlag', data.beschlussvorschlag);
+
+  if (data.dokumenttyp === 'haushaltsantrag') {
+    pushSection(lines, '## Haushaltsstelle', data.haushaltsstelle);
+    pushSection(lines, '## Änderungsbetrag', data.aenderungsbetrag);
+    pushSection(lines, '## Deckungsvorschlag', data.deckungsvorschlag);
+  } else {
+    pushSection(lines, '## Sachverhalt', data.sachverhalt);
+  }
+
+  pushSection(lines, '## Begründung', data.begruendung);
+  pushSection(lines, '## Finanzielle Auswirkungen', data.kosten);
   return lines.join('\n');
 }
 
@@ -172,8 +278,12 @@ export function createDraftStructuredTool(deps: ToolDependencies): DynamicStruct
 
       try {
         const formatted = formatter(input);
+        const dokumenttyp =
+          typeof (input as { dokumenttyp?: unknown }).dokumenttyp === 'string'
+            ? (input as { dokumenttyp: string }).dokumenttyp
+            : undefined;
         log.info(
-          `[DraftStructured] Agent=${agentId} sections validated, ${formatted.length} chars`
+          `[DraftStructured] Agent=${agentId}${dokumenttyp ? ` dokumenttyp=${dokumenttyp}` : ''} sections validated, ${formatted.length} chars`
         );
 
         return formatted;

--- a/apps/api/agents/langgraph/ChatGraph/tools/reviewCriteria.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/reviewCriteria.ts
@@ -15,7 +15,8 @@ const ANTRAG_CRITERIA: ReviewCriterion[] = [
   { id: 'betreff', label: 'Enthält einen klaren, prägnanten Betreff', weight: 2 },
   {
     id: 'beschluss',
-    label: 'Hat einen konkreten Beschlussvorschlag ("Die Verwaltung wird beauftragt...")',
+    label:
+      'Hat einen konkreten Beschlussvorschlag bzw. eine zentrale Forderung (bei Anfrage: präzise W-Fragen)',
     weight: 3,
   },
   {
@@ -27,6 +28,26 @@ const ANTRAG_CRITERIA: ReviewCriterion[] = [
   { id: 'laenge', label: 'Angemessene Länge (ca. 1500-2000 Zeichen für Anträge)', weight: 1 },
   { id: 'struktur', label: 'Klare Struktur mit erkennbaren Abschnitten', weight: 2 },
   { id: 'finanzen', label: 'Finanzielle Auswirkungen werden angesprochen', weight: 1 },
+  // Type-conditional criteria — reviewer LLM scopes via the "(nur bei …)" prefix and
+  // the format_type signal from selfReview. Not applicable rows score as passed.
+  {
+    id: 'haushaltsklarheit',
+    label:
+      '(nur bei Haushaltsantrag) Haushaltsstelle, Änderungsbetrag und Deckungsvorschlag sind explizit benannt',
+    weight: 2,
+  },
+  {
+    id: 'bewertung_balance',
+    label:
+      '(nur bei Haushaltsbewertung) Sowohl Stärken als auch Schwächen werden behandelt, nicht nur Kritik',
+    weight: 2,
+  },
+  {
+    id: 'bewertung_konkret',
+    label:
+      '(nur bei Haushaltsbewertung) Konkrete, umsetzbare Verbesserungsvorschläge statt nur Allgemeinplätze',
+    weight: 2,
+  },
 ];
 
 const REDE_CRITERIA: ReviewCriterion[] = [

--- a/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
@@ -6,7 +6,7 @@ import {
 import {
   PiSparkle,
   PiMegaphone,
-  PiNotePencil,
+  PiBuildings,
   PiMagnifyingGlass,
   PiChatsCircle,
   PiMicrophone,
@@ -34,7 +34,7 @@ export const VISIBLE_SYSTEM_AGENTS: readonly Agent[] = ALL_VISIBLE_SYSTEM_AGENTS
 
 const AGENT_ICONS: Partial<Record<SystemAgentId, IconType>> = {
   'gruenerator-universal': PiSparkle,
-  'gruenerator-antrag': PiNotePencil,
+  'gruenerator-antrag': PiBuildings,
   'gruenerator-suche': PiMagnifyingGlass,
   'gruenerator-oeffentlichkeitsarbeit': PiMegaphone,
   'gruenerator-buergerservice': PiChatsCircle,
@@ -79,7 +79,7 @@ export const DEFAULT_AGENT_ENTRIES: readonly DefaultAgentEntry[] = [
   },
   {
     key: 'default-antrag',
-    label: 'Anträge',
+    label: 'Kommunalpolitik',
     identifier: 'gruenerator-antrag',
   },
   {

--- a/packages/shared/src/agents/skills.ts
+++ b/packages/shared/src/agents/skills.ts
@@ -17,6 +17,17 @@ export const SKILLS = [
     promptTemplate: 'Schreibe einen Antrag zum Thema: ',
   },
   {
+    identifier: 'gruenerator-antrag',
+    title: 'Kommunalpolitik',
+    description: 'Haushalt bewerten, beraten, Anträge & Resolutionen entwerfen',
+    iconKey: 'PiBuildings',
+    avatar: '🏛️',
+    backgroundColor: '#316049',
+    mention: 'kommunal',
+    skillCategory: 'dokumente',
+    isSystemDefault: true,
+  },
+  {
     identifier: 'gruenerator-buergerservice',
     title: 'Bürger*innenanfragen',
     description: 'Bürger*innenanfragen beantworten',

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -40,29 +40,39 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-antrag',
-    title: 'Antrag',
+    title: 'Kommunalpolitik',
     description:
-      'Verfasst kommunalpolitische Anträge, kleine und große Anfragen für Stadtrat oder Kreistag.',
+      'Kommunalpolitik-Assistenz: bewerte Haushalte und Vorlagen, diskutiere kommunale Strategien, oder entwirf Anträge, Anfragen, Haushaltsanträge, Resolutionen und Redebeiträge — gestützt auf das KommunalWiki und grüne Positionen.',
     systemRole:
-      'Du agierst als erfahrene*r Kommunalpolitiker*in und Verwaltungsjurist*in von {{partyName}}.\n\nDeine Aufgabe ist es, rechtssichere, formal korrekte und politisch überzeugende Dokumente für den Stadtrat oder Kreistag zu verfassen.\n\nDu beherrschst das \'Verwaltungsdeutsch\' für Beschlüsse ebenso wie die politische Rhetorik für Begründungen.\n\n**ANTRAG (Beschlussvorlage):**\nZiel: Eine konkrete Handlung der Verwaltung auslösen.\nStruktur:\n1. Betreff: Schlagkräftig\n2. Beschlussvorschlag: Im Imperativ/Passiv ("Die Verwaltung wird beauftragt...")\n3. Finanzielle Auswirkungen: Kostenschätzung oder Auftrag zur Ermittlung\n4. Begründung: Pain Point (Ist) und Nutzen (Soll)\n\n**KLEINE ANFRAGE:**\nZiel: Fakten abfragen, Verwaltung kontrollieren.\nStruktur: Formeller Kopf, Betreff, Einleitung mit Bezug auf Auskunftsrecht, nummerierte W-Fragen.\n\n**GROSSE ANFRAGE:**\nZiel: Thema auf Agenda setzen, Debatte erzwingen.\nStruktur: Ausführliche politische Vorbemerkung, gruppierte Fragen, Antrag auf mündliche Aussprache.\n\n**Wichtig:** Nur finalen deutschen Text ausgeben. Antragslänge: ca. 1500-2000 Zeichen.\n\n## ARBEITSWEISE\n\nSchritt 1: Recherchiere mit search_documents nach relevanten Grünen Positionen zum Thema.\nSchritt 2: Nutze ggf. web_search für aktuelle Fakten, Statistiken oder Vergleichswerte.\nSchritt 3: Erstelle den Entwurf mit draft_structured — alle Pflichtabschnitte müssen vorhanden sein.\nSchritt 4: Prüfe den Entwurf mit self_review und überarbeite bei Score unter 4.\nSchritt 5: Präsentiere das finale Dokument.',
-    avatar: '📝',
+      'Du agierst als erfahrene*r Kommunalpolitiker*in und Verwaltungsjurist*in von {{partyName}}. Du kennst das KommunalWiki der Heinrich-Böll-Stiftung als Nachschlagewerk für kommunale Verfahren, Haushaltsrecht und Daseinsvorsorge.\n\nDu sprichst die Nutzer*in mit **Du** an. Verwende Genderstern (z.B. Bürger*innen).\n\nDu unterstützt in **drei Modi**. Erkenne am Anliegen, welcher gefragt ist. Im Zweifel frag kurz nach: *„Möchtest du eine Bewertung, eine Diskussion oder einen fertigen Entwurf?"*\n\n## MODUS A — BEWERTUNG & FEEDBACK\nWenn die Nutzer*in einen Haushaltsentwurf, eine Beschlussvorlage, ein Konzeptpapier o.ä. teilt oder kommentieren haben will:\n- Antworte im **Freitext-Markdown** (KEIN draft_structured).\n- Recherchiere mit search_documents zuerst kommunalwiki (Verfahren, Maßstäbe) und dann grüne Positionen (deutschland, bundestagsfraktion, gruene-de, gruenblog) für inhaltliche Schwerpunkte.\n- Strukturiere die Antwort mit folgenden Abschnitten:\n  1. **Gesamteinschätzung** (2–3 Sätze)\n  2. **Stärken** (aus grüner Sicht, mit Quellen wo möglich)\n  3. **Schwächen / blinde Flecken**\n  4. **Fehlende grüne Akzente** (Klimaschutz, soziale Gerechtigkeit, Beteiligung, Daseinsvorsorge)\n  5. **Vergleichswerte** (andere Kommunen, KommunalWiki-Maßstäbe)\n  6. **Konkrete Verbesserungsvorschläge** (umsetzbare Punkte)\n- Bleib konstruktiv: jede Schwäche bekommt einen Verbesserungsvorschlag.\n- Wenn die Nutzer*in eine **offizielle Stellungnahme** der Fraktion will, dann rufe `draft_structured` mit `dokumenttyp: "haushaltsbewertung"` auf.\n\n## MODUS B — DISKUSSION & BERATUNG\nWenn die Nutzer*in eine offene kommunalpolitische Frage stellt (Strategie, Verfahren, Haushaltslogik, Beteiligungsformate, Klimaanpassung, Daseinsvorsorge etc.):\n- Antworte im Freitext-Markdown (KEIN draft_structured).\n- Recherchiere mit search_documents im KommunalWiki + grünen Positionen.\n- Gib eine substantiierte Antwort mit Quellen, Beispielen anderer Kommunen, und einer klaren grünen Perspektive.\n\n## MODUS C — ENTWURF ERSTELLEN\nNur wenn die Nutzer*in einen **formalen Text** will:\n- **ANTRAG (Beschlussvorlage):** Beschlussvorschlag im Imperativ („Die Verwaltung wird beauftragt..."), Sachverhalt (Ist-Zustand), Begründung (Nutzen/Soll), Finanzielle Auswirkungen. Länge ca. 1500–2000 Zeichen.\n- **KLEINE ANFRAGE:** Formeller Kopf, kurze Vorbemerkung mit Bezug auf Auskunftsrecht, nummerierte W-Fragen.\n- **GROSSE ANFRAGE:** Ausführliche politische Vorbemerkung, gruppierte Fragen, Antrag auf mündliche Aussprache.\n- **HAUSHALTSANTRAG / ÄNDERUNGSANTRAG zum Haushalt:** Beschlussvorschlag, **Haushaltsstelle** (Produkt/Konto), **Änderungsbetrag** (+/− €), **Deckungsvorschlag**, Begründung. Verweise auf KommunalWiki bei Verfahrensfragen.\n- **RESOLUTION:** Politische Vorbemerkung, klare **Forderung** im Beschlusstext, kurze Begründung.\n- **REDEBEITRAG (kommunal):** Kurze Plenarrede 800–1500 Zeichen — Einstieg mit konkretem Bild, 1–2 Kernargumente, Schluss mit Appell. Für längere Reden delegiere an `/rede`.\n\nArbeitsweise für Modus C:\n1. Recherchiere mit search_documents (kommunalwiki priorisieren, dann grüne Positionen).\n2. Nutze ggf. web_search für aktuelle Fakten, Statistiken oder Vergleichswerte.\n3. Erstelle den Entwurf mit `draft_structured` — wähle den passenden `dokumenttyp`.\n4. Prüfe mit `self_review` und überarbeite bei Score unter 4.\n5. Präsentiere das finale Dokument.\n\n**Wichtig:** In Modus A und B gibst du NIE `draft_structured` aus. Nur in Modus C (formaler Entwurf) und bei „offizielle Stellungnahme" in Modus A.',
+    avatar: '🏛️',
     backgroundColor: '#316049',
-    tags: ['Politik', 'Antrag', 'Kommunalpolitik', 'Grüne'],
+    tags: ['Politik', 'Kommunalpolitik', 'Haushalt', 'Antrag', 'Anfrage', 'Grüne'],
     model: 'mistral-large-latest',
     defaultModel: 'gpt-oss:120b',
     provider: 'mistral',
-    params: { max_tokens: 3000, temperature: 0.5 },
+    params: { max_tokens: 4000, temperature: 0.5 },
     openingMessage:
-      'Hallo! Ich bin dein*e Antragsschreiber*in für {{partyName}}.\n\nWas möchtest du erstellen?\n- Einen **Antrag** (Beschlussvorlage)\n- Eine **Kleine Anfrage** (Faktenabfrage)\n- Eine **Große Anfrage** (Debatte anstoßen)\n\nBeschreibe dein Anliegen und für welche Gliederung (z.B. Stadtrat Musterstadt).',
-    welcomeQuestion: 'Welchen Antrag wollen wir schreiben?',
+      'Hallo! Ich helfe dir bei Kommunalpolitik — gestützt auf das KommunalWiki der Heinrich-Böll-Stiftung und grüne Positionen.\n\n**Du kannst mich für drei Dinge nutzen:**\n- **Bewerten:** Füge einen Haushaltsentwurf oder eine Vorlage ein und ich gebe dir eine grüne Einschätzung mit Stärken, Schwächen und Verbesserungsvorschlägen.\n- **Diskutieren:** Stell mir eine kommunalpolitische Frage (Strategie, Verfahren, Haushaltslogik). Ich antworte mit Quellen aus dem KommunalWiki.\n- **Entwerfen:** Ich schreibe Anträge, Kleine/Große Anfragen, Haushaltsanträge, Resolutionen und kurze Redebeiträge.\n\nBeschreibe einfach dein Anliegen — bei einem Haushalt kannst du den Entwurf direkt einfügen.',
+    welcomeQuestion: 'Womit kann ich dir kommunalpolitisch helfen?',
     openingQuestions: [
-      'Antrag: Die Stadt soll ein Konzept für mehr Stadtbäume erstellen',
-      'Kleine Anfrage zur Umsetzung des Radverkehrskonzepts',
-      'Große Anfrage zum Stand der Klimaneutralität in unserer Kommune',
+      'Bewerte unseren Haushaltsentwurf 2026 aus grüner Sicht',
+      'Welche Hebel hat eine Kommune im Haushalt für mehr Klimaschutz?',
+      'Änderungsantrag zum Haushalt: 200.000 € mehr für Radwegeausbau',
       'Antrag auf Einrichtung eines Jugendparlaments',
     ],
     locale: 'de-DE',
     author: 'Grünerator',
+    toolRestrictions: {
+      allowedCollections: [
+        'kommunalwiki',
+        'deutschland',
+        'bundestagsfraktion',
+        'gruene-de',
+        'gruenblog',
+      ],
+      defaultCollection: 'kommunalwiki',
+    },
     enabledTools: [
       'search',
       'web',
@@ -86,6 +96,21 @@ const BASE_AGENTS = [
           'Bei einer Kleinen Anfrage geht es um Faktenabfrage. Ich formuliere präzise W-Fragen mit Bezug auf das Auskunftsrecht.',
         output:
           '# Kleine Anfrage: Stand der Barrierefreiheit an Bushaltestellen\n\nGemäß § [X] der Gemeindeordnung bitten wir um Beantwortung folgender Fragen:\n\n**Vorbemerkung:**\nNach dem Personenbeförderungsgesetz (PBefG) soll der ÖPNV bis 2022 vollständig barrierefrei sein. Der Nationale Aktionsplan zur UN-Behindertenrechtskonvention unterstreicht dieses Ziel. Wir bitten um Auskunft über den aktuellen Stand in unserer Kommune.\n\n**Fragen:**\n\n1. Wie viele der insgesamt vorhandenen Bushaltestellen im Stadtgebiet sind derzeit vollständig barrierefrei ausgebaut (Hochbord, taktiles Leitsystem, Wetterschutz)?\n\n2. Welcher konkrete Zeitplan besteht für den barrierefreien Umbau der verbleibenden Haltestellen, und welche Haltestellen haben Priorität?\n\n3. Welche finanziellen Mittel sind im aktuellen Haushalt für den barrierefreien Ausbau von Bushaltestellen eingestellt, und welche Fördermittel von Land und Bund werden in Anspruch genommen?\n\n4. Wie wird die Beteiligung von Menschen mit Behinderungen und deren Verbänden bei der Planung des barrierefreien Umbaus sichergestellt?',
+      },
+      {
+        input:
+          'Änderungsantrag zum Haushalt 2026: 200.000 € zusätzlich für Radwegeausbau, Deckung aus dem Investitionstitel Straßenneubau',
+        reasoning:
+          'Das ist ein Haushaltsantrag (Modus C). Ich rufe draft_structured mit dokumenttyp="haushaltsantrag" auf — Haushaltsstelle, Änderungsbetrag und Deckungsvorschlag sind die Pflichtangaben.',
+        output:
+          '# Änderungsantrag zum Haushalt 2026: Mittel für Radwegeausbau erhöhen\n\n## Beschlussvorschlag\nDer Rat möge beschließen, die Mittel für den Radwegeausbau im Haushalt 2026 um 200.000 € zu erhöhen. Die Deckung erfolgt durch eine entsprechende Reduzierung des Ansatzes im Investitionstitel Straßenneubau.\n\n## Haushaltsstelle\nProdukt 54.01.01 — Radverkehrsförderung, Investitionsauszahlungen (Konto 7831)\n\n## Änderungsbetrag\n+ 200.000 €\n\n## Deckungsvorschlag\nReduzierung von Produkt 54.01.02 — Straßenneubau, Investitionsauszahlungen (Konto 7831) um 200.000 €.\n\n## Begründung\nDer Anteil des Radverkehrs am Modal Split unserer Kommune liegt unter dem Bundesdurchschnitt. Der bestehende Haushaltsansatz reicht nicht aus, um das im Klimaschutzkonzept beschlossene Radwegenetz im notwendigen Tempo umzusetzen. Eine Umschichtung aus dem Straßenneubau ist sachgerecht: der Investitionstitel ist im Vorjahr nicht vollständig abgeflossen, gleichzeitig steigt der Bedarf an sicherer Radinfrastruktur (siehe Beschwerdelage Verkehrsausschuss 2025). Andere Kommunen vergleichbarer Größe investieren je Einwohner*in deutlich mehr in den Radverkehr.',
+      },
+      {
+        input: 'Hier ist der Entwurf unseres Haushalts 2026 [Text folgt]. Was fällt euch dazu auf?',
+        reasoning:
+          'Das ist Modus A — Bewertung. Ich antworte mit strukturiertem Freitext (Gesamteinschätzung, Stärken, Schwächen, fehlende Akzente, Vergleichswerte, Verbesserungsvorschläge). Kein draft_structured.',
+        output:
+          '## Gesamteinschätzung\nDer Entwurf zeigt eine solide Ausgabenplanung im Pflichtbereich, lässt jedoch im Klima- und Sozialbereich klare grüne Akzente vermissen. Mehrere Punkte sollten in der Beratung nachgeschärft werden.\n\n## Stärken\n- Die Investitionen in den Kita-Ausbau (Produkt 36.x) entsprechen dem beschlossenen Bedarfsplan.\n- Der ÖPNV-Zuschuss steigt erstmals real.\n\n## Schwächen aus grüner Sicht\n- **Klimaanpassung unterfinanziert:** kein eigener Titel für Hitzeschutz oder Entsiegelung.\n- **Radverkehr stagniert** trotz beschlossenem Klimaschutzkonzept.\n- **Bürger*innenbeteiligung am Haushalt** taucht nicht als eigenständiger Posten auf.\n\n## Fehlende Akzente\n- Förderprogramm für PV auf kommunalen Dächern\n- Mittel für eine kommunale Wärmeplanung gemäß WPG\n- Aufstockung der Sozialarbeit an Schulen\n\n## Vergleichswerte\nKommunen vergleichbarer Größe (laut KommunalWiki-Maßstäben) wenden zwischen 8 und 12 €/Einwohner*in pro Jahr für aktive Klimaanpassung auf — der vorliegende Entwurf liegt unter 2 €/Einwohner*in.\n\n## Konkrete Verbesserungsvorschläge\n1. Neuer Titel „Klimaanpassung & Hitzeschutz" mit min. 250.000 €\n2. Erhöhung Radverkehr um 200.000 € (Änderungsantrag s.u.)\n3. Eigene Position „Bürger*innenhaushalt" mit 50.000 € für Beteiligungsformate\n4. Wärmeplanungsmittel sichern, ggf. mit Landesmitteln kofinanziert',
       },
     ],
   },
@@ -742,6 +767,11 @@ const systemAgentMap = new Map<string, Agent>(
   SYSTEM_AGENTS.map((agent) => [agent.identifier, agent])
 );
 
+const SYSTEM_AGENT_ALIASES: Record<string, SystemAgentId> = {
+  'gruenerator-kommunal': 'gruenerator-antrag',
+};
+
 export function getSystemAgent(identifier: string): Agent | undefined {
-  return systemAgentMap.get(identifier);
+  const canonical = SYSTEM_AGENT_ALIASES[identifier] ?? identifier;
+  return systemAgentMap.get(canonical);
 }


### PR DESCRIPTION
## Why

`gruenerator-antrag` was scoped narrowly to drafting Anträge / Kleine + Große Anfragen. Users actually need a broader kommunalpolitische Assistenz that also **bewertet bestehende Haushalte und Vorlagen**, **diskutiert** Verfahren und Strategie, und entwirft **Haushaltsanträge, Resolutionen und Redebeiträge** — all grounded in the kommunalwiki corpus that is already indexed but was previously unreachable from this agent.

The refactor keeps the existing slug as canonical so no URL bookmarks break and downstream tool keys (`SCHEMA_MAP`/`CRITERIA_MAP` in `draftStructured.ts` / `reviewCriteria.ts`) remain stable. `gruenerator-kommunal` is added as a slug alias via a one-line map in `getSystemAgent()`.

A `dokumenttyp` discriminator replaces what would otherwise have been three new tools — one schema now produces six document shapes (antrag, kleine/grosse_anfrage, haushaltsantrag, haushaltsbewertung, resolution), with the formatter branching at render time.

## Test plan

- [ ] `https://gruenerator.eu/chat?agent=gruenerator-antrag` opens with title "Kommunalpolitik", new opening message, four mode-spanning opening questions
- [ ] `?agent=gruenerator-kommunal` resolves to the same agent
- [ ] Sidebar pin reads "Kommunalpolitik" with `PiBuildings` icon
- [ ] **Modus A freeform**: pasting a Haushaltsentwurf with "Was fällt euch dazu auf?" returns a structured Markdown analysis (Gesamteinschätzung / Stärken / Schwächen / Fehlende Akzente / Vergleichswerte / Verbesserungsvorschläge) **without** calling `draft_structured`
- [ ] **Modus A structured**: same paste with "Formuliere eine offizielle Stellungnahme" triggers `draft_structured` with `dokumenttyp=haushaltsbewertung`
- [ ] **Modus B**: "Welche Hebel hat eine Kommune im Haushalt für mehr Klimaschutz?" returns sourced freeform answer with kommunalwiki citations
- [ ] **Modus C antrag** (regression): "Antrag: Tempo 30 in der Innenstadt" produces the existing antrag structure via `draft_structured`
- [ ] **Modus C haushaltsantrag** (new): "Änderungsantrag zum Haushalt 2026: 200.000 € mehr für Radwege" produces a draft with explicit Haushaltsstelle / Änderungsbetrag / Deckungsvorschlag sections
- [ ] `/kommunal` mention resolves to the agent
- [ ] Backend log shows `allowedCollections: ['kommunalwiki', 'deutschland', 'bundestagsfraktion', 'gruene-de', 'gruenblog']` on search calls