### PR TITLE
refactor(notebooks): bring back chat composer + 3-dot menu cards

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -1,3 +1,5 @@
+import { SlNotebook } from 'react-icons/sl';
+
 import { getIcon, getIconById as getIconFromRegistry } from '../../../config/icons';
 
 import type { BadgeType } from '../../common/StatusBadge';
@@ -63,7 +65,7 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
     path: '/notebooks',
     title: 'Notebooks',
     description: 'Suche, Wissensmanagement & Dokumentenrecherche',
-    icon: getIcon('navigation', 'notebooks'),
+    icon: SlNotebook,
     activePaths: ['/notebooks', '/notebook'],
   };
 

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -265,6 +265,8 @@ const standardRoutes: RouteConfig[] = [
   {
     path: '/notebooks',
     component: GrueneratorenBundle.NotebookRoot,
+    withForm: true,
+    layoutMode: 'sidebarOnly',
   },
   {
     path: '/notebooks/meine',

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -10,12 +10,12 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-  Separator,
   Skeleton,
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { memo, useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
+  HiCog,
   HiDotsVertical,
   HiOutlineTrash,
   HiPencil,
@@ -23,15 +23,12 @@ import {
   HiShare,
   HiUserGroup,
 } from 'react-icons/hi';
-import { PiMagnifyingGlass, PiStar, PiStarFill } from 'react-icons/pi';
+import { PiStar, PiStarFill } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
-import PageContainer from '../../../components/common/PageContainer';
-import ToolGrid from '../../../components/common/ToolGrid';
-import ErrorBoundary from '../../../components/ErrorBoundary';
 import apiClient from '../../../components/utils/apiClient';
-import { getIcon, NotebookIcon } from '../../../config/icons';
+import { NotebookIcon } from '../../../config/icons';
 import { useGroups, type GroupSummary } from '../../groups/hooks/useGroups';
 import { useAuthStore } from '../../../stores/authStore';
 import { useDocumentsStore } from '../../../stores/documentsStore';
@@ -40,20 +37,16 @@ import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 import {
   getAustrianNotebooks,
   getNotebooksByCategory,
-  SYSTEM_NOTEBOOKS,
   type NotebookConfigEntry,
 } from '../config/notebooksConfig';
 import { getNotebookConfig } from '../config/notebookPagesConfig';
 
 import { LastAddedSection } from './LastAddedSection';
 import NotebookEditor from './NotebookEditor';
-import NotebookList from './NotebookList';
+import { NotebookPageContent } from './NotebookPage';
 import { StatisticsSection } from './StatisticsSection';
 
-import type { ToolEntry } from '../../../components/common/ToolGrid';
 import type { NotebookCollection } from '../../../types/notebook';
-
-import { cn } from '@/utils/cn';
 
 interface EditorSaveData {
   id?: string;
@@ -65,34 +58,6 @@ interface EditorSaveData {
   labels?: string[];
 }
 
-const tools: ToolEntry[] = [
-  {
-    id: 'suche',
-    title: 'Suche',
-    description: 'Webrecherche für aktuelle Informationen mit KI-Unterstützung.',
-    path: '/suche',
-    icon: getIcon('navigation', 'suche'),
-    tags: ['Web', 'Recherche'],
-  },
-  {
-    id: 'research',
-    title: 'Manuell',
-    description: 'Manuelle Suche über alle gescrapten Dokumente und Programme.',
-    path: '/research',
-    icon: getIcon('navigation', 'research'),
-    tags: ['Dokumente', 'Qdrant'],
-  },
-  {
-    id: 'monitor',
-    title: 'Monitor',
-    description: 'Medienbeobachtung mit Themen, Stimmung, Umfragen und Risiko-Analyse.',
-    path: '/monitor',
-    icon: getIcon('navigation', 'monitor'),
-    tags: ['Medien', 'Trends'],
-  },
-];
-
-const EMPTY_NOTEBOOKS: NotebookConfigEntry[] = [];
 const EMPTY_COLLECTIONS: NotebookCollection[] = [];
 
 const HIDDEN_NOTEBOOK_IDS = [
@@ -108,7 +73,7 @@ const NotebookCard = memo(
     const toggleFavourite = useSidebarFavouritesStore((s) => s.toggleFavourite);
     const isFull = useSidebarFavouritesStore((s) => s.isFull);
     const starred = isFavourite(notebook.id);
-    const showStar = starred || !isFull();
+    const canStar = starred || !isFull();
     const [sharedGroupId, setSharedGroupId] = useState<string | null>(null);
 
     const handleShareToGroup = async (groupId: string) => {
@@ -140,75 +105,65 @@ const NotebookCard = memo(
       >
         <notebook.icon className="text-base text-secondary-600 shrink-0" />
         <span className="text-sm font-medium text-foreground-heading flex-1">{notebook.title}</span>
-        {groups.length > 0 && (
-          <div
-            className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="flex items-center justify-center w-6 h-6 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
-                  aria-label="Teilen"
-                >
-                  <HiShare size={14} />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {groups.map((group) => (
-                  <DropdownMenuItem key={group.id} onClick={() => handleShareToGroup(group.id)}>
-                    <HiUserGroup />
-                    {sharedGroupId === group.id ? 'Geteilt!' : group.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        )}
-        {showStar && (
-          <button
-            type="button"
-            className={cn(
-              'shrink-0 flex items-center justify-center w-6 h-6 rounded-full transition-all duration-300',
-              starred
-                ? 'text-primary-600 hover:text-primary-700'
-                : 'text-grey-400 opacity-0 group-hover:opacity-100 hover:text-primary-600'
-            )}
-            onClick={(e) => {
-              e.stopPropagation();
-              toggleFavourite(notebook.id);
-            }}
-            aria-label={starred ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
-          >
-            {starred ? <PiStarFill size={14} /> : <PiStar size={14} />}
-          </button>
-        )}
+        <div
+          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center justify-center w-6 h-6 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
+                aria-label="Aktionen"
+              >
+                <HiDotsVertical size={14} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {canStar && (
+                <DropdownMenuItem onClick={() => toggleFavourite(notebook.id)}>
+                  {starred ? <PiStarFill /> : <PiStar />}
+                  {starred ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+                </DropdownMenuItem>
+              )}
+              {groups.length > 0 && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <HiShare />
+                    Teilen
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {groups.map((group) => (
+                      <DropdownMenuItem key={group.id} onClick={() => handleShareToGroup(group.id)}>
+                        <HiUserGroup />
+                        {sharedGroupId === group.id ? 'Geteilt!' : group.name}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     );
   }
 );
 NotebookCard.displayName = 'NotebookCard';
 
-const COLLAPSE_THRESHOLD = 3;
-
 const NotebookSection = memo(
   ({
     title,
     notebooks,
-    search,
     columns = 1,
     groups = [],
   }: {
     title: string;
     notebooks: NotebookConfigEntry[];
-    search?: string;
     columns?: 1 | 2;
     groups?: GroupSummary[];
   }) => {
-    const filtered = notebooks
-      .filter((nb) => !HIDDEN_NOTEBOOK_IDS.includes(nb.id))
-      .filter((nb) => !search || nb.title.toLowerCase().includes(search.toLowerCase()));
+    const filtered = notebooks.filter((nb) => !HIDDEN_NOTEBOOK_IDS.includes(nb.id));
     if (filtered.length === 0) return null;
 
     return (
@@ -230,6 +185,8 @@ const NotebookSection = memo(
   }
 );
 NotebookSection.displayName = 'NotebookSection';
+
+const COLLAPSE_THRESHOLD = 3;
 
 interface EigeneNotebooksProps {
   qaCollections: { id: string; name: string }[];
@@ -253,6 +210,7 @@ const EigeneNotebooks = memo(
     loading,
     copiedId,
   }: EigeneNotebooksProps) => {
+    const navigate = useNavigate();
     const [expanded, setExpanded] = useState(false);
     const [deletingId, setDeletingId] = useState<string | null>(null);
     const [sharedInfo, setSharedInfo] = useState<string | null>(null);
@@ -303,6 +261,15 @@ const EigeneNotebooks = memo(
             aria-label="Notebook erstellen"
           >
             <HiPlus size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={() => void navigate('/notebooks/meine')}
+            className="flex items-center justify-center w-7 h-7 rounded-full text-grey-500 hover:text-foreground hover:bg-grey-200/40 dark:hover:bg-grey-700/40 transition-colors cursor-pointer"
+            aria-label="Meine Notebooks verwalten"
+            title="Meine Notebooks verwalten"
+          >
+            <HiCog size={16} />
           </button>
         </div>
         {loading ? (
@@ -426,7 +393,7 @@ EigeneNotebooks.displayName = 'EigeneNotebooks';
 
 const EMPTY_GROUPS: GroupSummary[] = [];
 
-const NotebooksIndexPage = () => {
+function NotebooksIndexFooter() {
   const navigate = useNavigate();
   const locale = useAuthStore((state) => state.locale);
   const isAustrian = locale === 'de-AT';
@@ -447,9 +414,7 @@ const NotebooksIndexPage = () => {
 
   const systemCollectionIds = useMemo(() => {
     const config = getNotebookConfig('gruenerator');
-    return config.collections
-      .filter((c) => !c.locale || c.locale === locale)
-      .map((c) => c.id);
+    return config.collections.filter((c) => !c.locale || c.locale === locale).map((c) => c.id);
   }, [locale]);
 
   const queryClient = useQueryClient();
@@ -465,40 +430,8 @@ const NotebooksIndexPage = () => {
 
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const deferredQuery = useDeferredValue(searchQuery);
-
-  const filteredTools = useMemo(
-    () =>
-      deferredQuery
-        ? tools.filter(
-            (t) =>
-              t.title.toLowerCase().includes(deferredQuery.toLowerCase()) ||
-              t.description.toLowerCase().includes(deferredQuery.toLowerCase())
-          )
-        : tools,
-    [deferredQuery]
-  );
-
-  const filteredQaCollections = useMemo(
-    () =>
-      deferredQuery
-        ? qaCollections.filter((c) => c.name.toLowerCase().includes(deferredQuery.toLowerCase()))
-        : qaCollections,
-    [deferredQuery, qaCollections]
-  );
-
-  const searchResultNotebooks = useMemo(() => {
-    if (!deferredQuery) return EMPTY_NOTEBOOKS;
-    const q = deferredQuery.toLowerCase();
-    return SYSTEM_NOTEBOOKS.filter((nb) => !HIDDEN_NOTEBOOK_IDS.includes(nb.id)).filter(
-      (nb) => nb.title.toLowerCase().includes(q) || nb.description.toLowerCase().includes(q)
-    );
-  }, [deferredQuery]);
-
   const [showEditor, setShowEditor] = useState(false);
   const [editingCollection, setEditingCollection] = useState<NotebookCollection | null>(null);
-  const [processingCollectionIds, setProcessingCollectionIds] = useState<Set<string>>(new Set());
   const pollingRef = useRef<Set<string>>(new Set());
 
   const handleCreate = useCallback(() => {
@@ -545,25 +478,13 @@ const NotebooksIndexPage = () => {
       if (pollingRef.current.has(collectionId)) return;
       pollingRef.current.add(collectionId);
 
-      setProcessingCollectionIds((prev) => new Set([...prev, collectionId]));
-
       Promise.all(documentIds.map((docId) => pollDocumentStatus(docId)))
         .then(() => {
           pollingRef.current.delete(collectionId);
-          setProcessingCollectionIds((prev) => {
-            const next = new Set(prev);
-            next.delete(collectionId);
-            return next;
-          });
           void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
         })
         .catch(() => {
           pollingRef.current.delete(collectionId);
-          setProcessingCollectionIds((prev) => {
-            const next = new Set(prev);
-            next.delete(collectionId);
-            return next;
-          });
         });
     },
     [pollDocumentStatus, queryClient]
@@ -607,129 +528,64 @@ const NotebooksIndexPage = () => {
   }, []);
 
   return (
-    <ErrorBoundary>
-      <PageContainer
-        title="Notebooks"
-        subtitle="Suche, Wissensmanagement und Dokumentenrecherche."
-      >
-        <div className="relative max-w-[500px] mx-auto mb-lg">
-          <PiMagnifyingGlass className="absolute left-md top-1/2 -translate-y-1/2 text-grey-400 text-lg" />
-          <input
-            type="text"
-            placeholder="Suchen..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-2xl pr-md py-sm bg-background border border-grey-200 dark:border-grey-700 rounded-lg text-base text-foreground placeholder:text-grey-400 focus:outline-none focus:border-primary-500 transition-colors"
+    <section className="mt-xl">
+      <div className="flex flex-wrap gap-xl max-md:flex-col">
+        <div className="flex-1 min-w-0">
+          <NotebookSection
+            title="Notebooks"
+            notebooks={allNotebooks}
+            columns={2}
+            groups={stableGroups}
           />
         </div>
-
-        {/* Search results — visible when searching */}
-        <div className={deferredQuery ? undefined : 'hidden'}>
-          {searchResultNotebooks.length > 0 && (
-            <>
-              <h2 className="text-xl font-semibold text-foreground-heading mb-md">Notebooks</h2>
-              <div className="grid grid-cols-5 max-lg:grid-cols-4 max-md:grid-cols-3 max-sm:grid-cols-2 gap-sm">
-                {searchResultNotebooks.map((notebook) => (
-                  <NotebookCard key={notebook.id} notebook={notebook} groups={stableGroups} />
-                ))}
-              </div>
-            </>
-          )}
-
-          {filteredQaCollections.length > 0 && (
-            <>
-              <h2 className="text-xl font-semibold text-foreground-heading mt-xl mb-md">
-                Meine Notebooks
-              </h2>
-              <NotebookList
-                qaCollections={filteredQaCollections}
-                onView={handleView}
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-                onShare={handleShare}
-                loading={collectionsLoading}
-                processingCollectionIds={processingCollectionIds}
-                compact
-              />
-            </>
-          )}
-
-          {filteredTools.length > 0 && (
-            <>
-              <h2 className="text-xl font-semibold text-foreground-heading mt-xl mb-md">Tools</h2>
-              <ToolGrid tools={filteredTools} columns={3} />
-            </>
-          )}
-
-          {deferredQuery &&
-            searchResultNotebooks.length === 0 &&
-            filteredQaCollections.length === 0 &&
-            filteredTools.length === 0 && (
-              <p className="text-center text-foreground py-xl">
-                Keine Ergebnisse für &ldquo;{searchQuery}&rdquo;
-              </p>
-            )}
+        <div>
+          <EigeneNotebooks
+            qaCollections={qaCollections}
+            onView={handleView}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
+            onShare={handleShare}
+            onCreate={handleCreate}
+            loading={collectionsLoading}
+            copiedId={copiedId}
+          />
         </div>
+      </div>
 
-        {/* Default view — visible when not searching */}
-        <div className={deferredQuery ? 'hidden' : undefined}>
-          <div className="flex flex-wrap gap-xl max-md:flex-col">
-            <div className="flex-1 min-w-0">
-              <NotebookSection
-                title="Notebooks"
-                notebooks={allNotebooks}
-                columns={2}
-                groups={stableGroups}
-              />
-            </div>
-            <div>
-              <EigeneNotebooks
-                qaCollections={qaCollections}
-                onView={handleView}
-                onEdit={handleEdit}
-                onDelete={handleDelete}
-                onShare={handleShare}
-                onCreate={handleCreate}
-                loading={collectionsLoading}
-                copiedId={copiedId}
-              />
-            </div>
-          </div>
+      {systemCollectionIds.length > 0 && (
+        <LastAddedSection collectionIds={systemCollectionIds} showSourceLabel />
+      )}
 
-          {systemCollectionIds.length > 0 && (
-            <LastAddedSection collectionIds={systemCollectionIds} showSourceLabel />
-          )}
+      {systemCollectionIds.length > 0 && (
+        <StatisticsSection collectionIds={systemCollectionIds} />
+      )}
 
-          {systemCollectionIds.length > 0 && (
-            <StatisticsSection collectionIds={systemCollectionIds} />
-          )}
+      {/* Tools section commented out per request — chat composer at the top covers Suche. */}
 
-          <Separator className="mt-xl" />
-
-          <h2 className="text-xl font-semibold text-foreground-heading mt-xl mb-md">Tools</h2>
-          <ToolGrid tools={tools} columns={3} />
-        </div>
-
-        <Dialog open={showEditor} onOpenChange={(open) => !open && handleCancel()}>
-          <DialogContent
-            className="sm:max-w-[700px] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
-            aria-describedby={undefined}
-          >
-            <DialogTitle className="sr-only">
-              {editingCollection ? 'Notebook bearbeiten' : 'Notebook erstellen'}
-            </DialogTitle>
-            <NotebookEditor
-              onSave={handleSave}
-              onCancel={handleCancel}
-              editingCollection={editingCollection}
-              loading={collectionsLoading}
-            />
-          </DialogContent>
-        </Dialog>
-      </PageContainer>
-    </ErrorBoundary>
+      <Dialog open={showEditor} onOpenChange={(open) => !open && handleCancel()}>
+        <DialogContent
+          className="sm:max-w-[700px] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="sr-only">
+            {editingCollection ? 'Notebook bearbeiten' : 'Notebook erstellen'}
+          </DialogTitle>
+          <NotebookEditor
+            onSave={handleSave}
+            onCancel={handleCancel}
+            editingCollection={editingCollection}
+            loading={collectionsLoading}
+          />
+        </DialogContent>
+      </Dialog>
+    </section>
   );
-};
+}
+
+function NotebooksIndexPage() {
+  const config = useMemo(() => getNotebookConfig('gruenerator'), []);
+  return <NotebookPageContent config={config} startpageFooter={<NotebooksIndexFooter />} />;
+}
 
 export default withAuthRequired(NotebooksIndexPage, {
   title: 'Notebooks',


### PR DESCRIPTION
## Summary

Follow-up to #809. Restores the chat composer on `/notebooks` and tightens the system-notebook cards.

- Wrap `/notebooks` in `NotebookPageContent` (gruenerator config) so the chat composer + KI / Manuelle Recherche / Chat pills return at the top; the recherche-style grid, Eigene column, Zuletzt hinzugefügt and Statistiken render in the `startpageFooter` slot.
- `NotebookCard`: replace the two hover icons (share + star) with a single `@gruenerator/ui` `DropdownMenu` (3-dot trigger) containing the Favoriten toggle and the Teilen submenu.
- `Eigene` header: settings icon next to the `+` button opens `/notebooks/meine`.
- Drop the Tools section — the composer covers the Suche entry.
- Sidebar Notebooks entry switched to `SlNotebook` from `react-icons/sl`.
- Restore `withForm: true, layoutMode: 'sidebarOnly'` on the route so the chat runtime mounts.

## Test plan

- [ ] `/notebooks` shows composer + tabs at top, grid + Eigene + Zuletzt + Statistiken below
- [ ] 3-dot menu opens on card hover; Favoriten toggle + Teilen submenu work
- [ ] Settings icon in Eigene navigates to `/notebooks/meine`
- [ ] Sidebar shows the SlNotebook icon