### PR TITLE
perf(web): preload critical fonts and defer config.js

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -91,8 +91,10 @@
       }
     </script>
 
-    <!-- Konfigurationsdatei -->
-    <script src="/config.js"></script>
+    <!-- Konfigurationsdatei. defer keeps document order with the module
+         entry below, so window.API_BASE_URL is still set before React boots,
+         while no longer parser-blocking on the critical path. -->
+    <script defer src="/config.js"></script>
 
     <!-- Umami Analytics (GDPR-compliant with consent) -->
     <script>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -28,6 +28,41 @@ const tauriPackages = [
   '@tauri-apps/plugin-store',
 ];
 
+// Build-only plugin: inject <link rel="preload"> for the fonts on the
+// LCP critical path so the browser starts fetching them in parallel with
+// CSS parsing instead of after it. Chrome DevTools traces showed
+// Raleway-Regular (heading font, where the LCP text element renders) was
+// the last node in the critical chain at ~3.3s. Asset filenames are
+// content-hashed, so the plugin resolves the actual emitted filename from
+// the build bundle at HTML-emit time rather than hardcoding a hash.
+function preloadFontsPlugin(): Plugin {
+  const TARGETS = [
+    { pattern: /^assets\/fonts\/Raleway-Regular\..+\.woff$/, type: 'font/woff' },
+    { pattern: /^assets\/fonts\/PTSans-Regular\..+\.woff2$/, type: 'font/woff2' },
+  ];
+  return {
+    name: 'preload-critical-fonts',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler(html, ctx) {
+        const bundle = ctx.bundle;
+        if (!bundle) return html;
+        const tags: string[] = [];
+        for (const { pattern, type } of TARGETS) {
+          const match = Object.keys(bundle).find((name) => pattern.test(name));
+          if (!match) continue;
+          tags.push(
+            `<link rel="preload" as="font" type="${type}" href="/${match}" crossorigin>`
+          );
+        }
+        if (tags.length === 0) return html;
+        return html.replace('</head>', `    ${tags.join('\n    ')}\n  </head>`);
+      },
+    },
+  };
+}
+
 // Plugin to provide stub modules for Tauri packages in web context
 function tauriStubPlugin(): Plugin {
   return {
@@ -62,6 +97,7 @@ export default defineConfig(({ command }) => ({
   plugins: [
     // Only use Tauri stub plugin when NOT in Tauri context
     ...(!isTauri ? [tauriStubPlugin()] : []),
+    preloadFontsPlugin(),
     react({ jsxRuntime: 'automatic' }),
     ...(command === 'build' ? [babel({ presets: [reactCompilerPreset()] })] : []),
     tailwindcss(),


### PR DESCRIPTION
## Why

Chrome DevTools performance trace of https://gruenerator.eu/ identified the text-LCP as the dominant first-load bottleneck:

| Metric | Value |
|---|---|
| TTFB | 41 ms ✅ |
| LCP (lab) | **3,298 ms** |
| LCP (field p75, CrUX) | **2,468 ms** — Needs Improvement |
| Render delay | **3,257 ms** (98.8% of LCP) |
| CLS / INP | 0.07 / 88 ms ✅ |

The critical-request chain bottoms out at `Raleway-Regular.woff` at 3,282 ms — the font request only starts after CSS parses. Separately, `/config.js` sits parser-blocking on the critical path with no `defer`.

This PR is the surgical, low-risk slice of a larger perf plan: just preloading + defer, no bundle-graph or font-format changes.

## Expected impact

- **~1 s LCP improvement** on cold loads: Raleway-Regular and PT Sans-Regular start fetching in parallel with CSS instead of after it.
- **~170 ms render-blocking time recovered** from deferring `config.js`.
- Net field LCP target: drop from 2.47 s → ~1.5–1.8 s (well inside "Good").

## Safety

- `config.js` only sets `window.API_BASE_URL`. Module scripts are implicitly deferred by spec, so adding `defer` keeps document-order execution intact — `window.API_BASE_URL` is still set before React boots.
- The Vite plugin runs **build-only** (`apply: 'build'`) and resolves hashed asset filenames from the bundle at HTML-emit time. If a target font is renamed or absent, it skips silently — no build failure.
- No app code, no CSS, no font binaries, no chunk graph changes.

## Follow-up PRs (deferred, not in this PR)

1. Generate `.woff2` for the Raleway family (no woff2 files exist today; needs `wawoff2`/`fonttools`).
2. Investigate why `vendor-excalidraw.css`, `vendor-blocknote-export.css`, `pkg-canvas-editor.css` land in the entry chunk on `/` and add ~700 ms render-blocking time.
3. Gate the four below-fold Mock previews on `Home.tsx` behind an IntersectionObserver so their lazy chunks don't fetch on first paint.

## Verification

Post-deploy: re-run a Chrome DevTools performance trace on https://gruenerator.eu/ and confirm `Raleway-Regular` request begins at ~0 ms (initiated by `<link rel=preload>` in the HTML head) instead of after the CSS request.