### PR TITLE
fix(docs): add mobile close button for AI chat panel

### DIFF
--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -751,6 +751,13 @@ function EditorContent() {
                 isOpen={effectivePanel === 'chat'}
               />
             </Suspense>
+            <button
+              onClick={() => setActiveSidebar(null)}
+              className="hidden max-md:flex absolute top-2 right-2 z-10 h-9 w-9 items-center justify-center rounded-lg bg-background/90 dark:bg-grey-900/90 text-grey-600 hover:bg-grey-100 hover:text-foreground dark:text-grey-300 dark:hover:bg-grey-700 shadow-sm border border-grey-200 dark:border-grey-700"
+              aria-label="KI-Chat schließen"
+            >
+              <FiX size={18} />
+            </button>
           </aside>
         )}
 


### PR DESCRIPTION
On mobile, opening the AI chat in the docs editor leaves users stuck — the chat aside becomes a fullscreen overlay (`fixed inset-0 z-[200]`) that covers the top app bar, hiding the chat-toggle button that would normally close it. Unlike the comments/versions sidebars, the chat aside has no header of its own, so there was no way to return to the document without reloading.

Adds a mobile-only floating close button (`hidden max-md:flex`) inside the chat aside.