### PR TITLE
refactor(notebook): wider editor dialog + Notion-style doc cards

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -532,7 +532,7 @@ function MyNotebooksPageInner() {
         }}
       >
         <DialogContent
-          className="sm:max-w-[700px] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
+          className="sm:max-w-[min(1200px,calc(100%-2rem))] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
           aria-describedby={undefined}
         >
           <DialogTitle className="sr-only">

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -60,25 +60,49 @@ interface UploadedDocument {
 const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.odt', '.rtf'];
 const MAX_DOCUMENTS = 20;
 
-function getFileTypeBadge(filename: string): { label: string; bgClass: string } {
+function getFileTypeBadge(filename: string): { label: string; tagClass: string } {
   const ext = filename.toLowerCase().split('.').pop() ?? '';
   switch (ext) {
     case 'pdf':
-      return { label: 'PDF', bgClass: 'bg-red-500' };
+      return {
+        label: 'PDF',
+        tagClass: 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300',
+      };
     case 'docx':
-      return { label: 'DOCX', bgClass: 'bg-blue-500' };
+      return {
+        label: 'DOCX',
+        tagClass: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
+      };
     case 'doc':
-      return { label: 'DOC', bgClass: 'bg-blue-500' };
+      return {
+        label: 'DOC',
+        tagClass: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
+      };
     case 'odt':
-      return { label: 'ODT', bgClass: 'bg-emerald-500' };
+      return {
+        label: 'ODT',
+        tagClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
+      };
     case 'rtf':
-      return { label: 'RTF', bgClass: 'bg-orange-500' };
+      return {
+        label: 'RTF',
+        tagClass: 'bg-orange-100 text-orange-700 dark:bg-orange-950/40 dark:text-orange-300',
+      };
     case 'md':
-      return { label: 'MD', bgClass: 'bg-slate-500' };
+      return {
+        label: 'MD',
+        tagClass: 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+      };
     case 'txt':
-      return { label: 'TXT', bgClass: 'bg-slate-500' };
+      return {
+        label: 'TXT',
+        tagClass: 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+      };
     default:
-      return { label: ext.slice(0, 4).toUpperCase() || 'FILE', bgClass: 'bg-grey-500' };
+      return {
+        label: ext.slice(0, 4).toUpperCase() || 'FILE',
+        tagClass: 'bg-grey-200 text-grey-700 dark:bg-grey-800 dark:text-grey-300',
+      };
   }
 }
 
@@ -413,7 +437,7 @@ const NotebookEditor = ({
                       <label className="text-sm font-medium text-foreground">
                         Dokumente ({uploadedDocuments.length}/{MAX_DOCUMENTS})
                       </label>
-                      <div className="mt-xs grid grid-cols-2 gap-xs max-sm:grid-cols-1">
+                      <div className="mt-xs grid grid-cols-1 gap-sm md:grid-cols-2 xl:grid-cols-3">
                         {uploadedDocuments.map((doc) => {
                           const isIndexing = indexingDocIds.has(doc.id);
                           const fileType = getFileTypeBadge(doc.filename || doc.title);
@@ -421,22 +445,22 @@ const NotebookEditor = ({
                             <div
                               key={doc.id}
                               className={cn(
-                                'group relative flex items-center gap-sm rounded-md bg-background-alt p-sm min-w-0 transition-all duration-200',
+                                'group relative flex items-center gap-sm rounded-xl border border-grey-200 bg-background p-sm min-w-0 transition-all duration-200 dark:border-grey-800',
                                 isIndexing
                                   ? 'opacity-90'
-                                  : 'hover:bg-grey-100 hover:shadow-sm dark:hover:bg-grey-800/60'
+                                  : 'hover:border-grey-300 hover:shadow-sm dark:hover:border-grey-700'
                               )}
                             >
-                              <div
+                              <span
                                 className={cn(
-                                  'flex h-[26px] w-[34px] shrink-0 items-center justify-center rounded-sm text-[10px] font-bold uppercase tracking-wide text-white',
-                                  fileType.bgClass,
+                                  'shrink-0 rounded-md px-1.5 py-[3px] text-[10px] font-semibold uppercase tracking-wide',
+                                  fileType.tagClass,
                                   isIndexing && 'opacity-60'
                                 )}
                                 aria-hidden
                               >
                                 {fileType.label}
-                              </div>
+                              </span>
                               <div className="min-w-0 flex-1">
                                 <div
                                   className="truncate text-sm font-medium text-foreground"
@@ -444,7 +468,7 @@ const NotebookEditor = ({
                                 >
                                   {doc.filename || doc.title}
                                 </div>
-                                <div className="mt-[1px] flex items-center gap-xs text-xs text-grey-500">
+                                <div className="mt-[2px] flex items-center gap-xs text-xs text-grey-500">
                                   {isIndexing ? (
                                     <>
                                       <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />


### PR DESCRIPTION
Follow-up to #813. Two tweaks based on usability feedback:

1. **Wider dialog on desktop**: the editor was capped at 700px, which felt cramped for managing multiple docs. Bump to `min(1200px, calc(100%-2rem))` — full available width on smaller monitors, 1200px cap on 4K so it doesn't get absurd. Mobile and tablet are unaffected (existing `w-[calc(100%-1rem)]` still applies).

2. **Notion-style doc cards**: replace the solid colored type chips (e.g. `bg-red-500 text-white` "PDF") with soft tinted tags (e.g. `bg-red-100 text-red-700` "PDF") — the GitHub/Linear label idiom. Bump card corner radius `rounded-md` → `rounded-xl`, add a 1px `border-grey-200` resting state, and a subtle `border-grey-300 + shadow-sm` lift on hover. The grid now responds `1 / md:2 / xl:3` so it can use the new horizontal space.

Result: cards feel like proper objects (border + radius + hover shadow) rather than just colored rows, and the soft tags read as metadata rather than alerts.

## Test plan
- [ ] Open Bearbeiten on desktop → dialog spans up to ~1200px
- [ ] Cards have subtle border, slightly larger corner radius
- [ ] Hover a card → border darkens slightly, soft shadow appears, × fades in
- [ ] Type tags read as soft pills (e.g. desaturated red for PDF), not bright solid badges
- [ ] On `md` (640px+) screens, 2-column grid; on `xl` (1280px+), 3-column; mobile 1-column
- [ ] Indexing state still shows spinner + "Wird verarbeitet…"