### PR TITLE
perf(web): trim first-load critical path (lazy editor + viewport-gated mocks + inline session probe)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -96,6 +96,17 @@
          while no longer parser-blocking on the critical path. -->
     <script defer src="/config.js"></script>
 
+    <!-- Kick the auth session probe from inline HTML so it runs in
+         parallel with bundle download rather than waiting for React to
+         mount AuthBootstrap. The response lands in the HTTP cache by the
+         time useAuth({ instant: true }) issues its actual fetch. Failure
+         is swallowed — this is a cache warmup, not a contract. -->
+    <script>
+      try {
+        fetch('/api/auth/v2/get-session', { credentials: 'include' }).catch(function () {});
+      } catch (e) {}
+    </script>
+
     <!-- Umami Analytics (GDPR-compliant with consent) -->
     <script>
       (function() {

--- a/apps/web/src/components/pages/Startseite/Home.tsx
+++ b/apps/web/src/components/pages/Startseite/Home.tsx
@@ -1,5 +1,6 @@
 import { TypingAnimation } from '@gruenerator/ui';
-import { lazy, memo, Suspense, type ReactNode } from 'react';
+import { useInView } from 'motion/react';
+import { lazy, memo, Suspense, useRef, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 import ReelMuster from '../../../assets/images/startseite/Reel_Muster.png';
@@ -10,6 +11,17 @@ const MockGenerator = lazy(() => import('./MockGenerator'));
 const DocumentsMock = lazy(() => import('./DocumentsMock'));
 const ImageComparisonMock = lazy(() => import('./ImageComparisonMock'));
 const NotebookMock = lazy(() => import('./NotebookMock'));
+
+// Gate below-fold lazy chunks on viewport visibility. React.lazy only
+// code-splits — the chunk still fetches as soon as Suspense mounts, which
+// happens on first paint regardless of scroll position. Wrapping defers
+// the fetch until the user scrolls close (200px margin so the chunk lands
+// before the placeholder enters the viewport).
+const LazyOnView = ({ children, fallback }: { children: ReactNode; fallback: ReactNode }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const inView = useInView(ref, { once: true, margin: '200px 0px' });
+  return <div ref={ref}>{inView ? children : fallback}</div>;
+};
 
 const NEWSLETTER_URL =
   'https://896ca129.sibforms.com/serve/MUIFAFnH3lov98jrw3d75u_DFByChA39XRS6JkBKqjTsN9gx0MxCvDn1FMnkvHLgzxEh1JBcEOiyHEkyzRC-XUO2DffKsVccZ4r7CCaYiugoiLf1a-yoTxDwoctxuzCsmDuodwrVwEwnofr7K42jQc-saIKeVuB_8UxrwS18QIaahZml1qMExNno2sEC7HyMy9Nz4f2f8-UJ4QmW';
@@ -121,9 +133,11 @@ const FEATURES: FeatureData[] = [
     description:
       'Optimiere deine Bilder mit Grünerator Imagine. Verbessere Qualität, entferne Hintergründe oder erstelle neue Varianten - alles KI-gestützt in Sekunden.',
     visual: (
-      <Suspense fallback={suspenseFallback}>
-        <ImageComparisonMock />
-      </Suspense>
+      <LazyOnView fallback={suspenseFallback}>
+        <Suspense fallback={suspenseFallback}>
+          <ImageComparisonMock />
+        </Suspense>
+      </LazyOnView>
     ),
   },
   {
@@ -132,9 +146,11 @@ const FEATURES: FeatureData[] = [
     description:
       'Stelle Fragen an Grundsatzprogramme, Bundestagsanträge und Kommunalwiki. Das Notebook liefert Antworten mit Quellenangaben.',
     visual: (
-      <Suspense fallback={suspenseFallback}>
-        <NotebookMock />
-      </Suspense>
+      <LazyOnView fallback={suspenseFallback}>
+        <Suspense fallback={suspenseFallback}>
+          <NotebookMock />
+        </Suspense>
+      </LazyOnView>
     ),
   },
   {

--- a/apps/web/src/features/image-studio/ImageStudioPage.tsx
+++ b/apps/web/src/features/image-studio/ImageStudioPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useMemo, useState, useRef } from 'react';
+import React, { useEffect, useCallback, useMemo, useState, useRef, lazy, Suspense } from 'react';
 import { HiArrowLeft } from 'react-icons/hi';
 import { useParams, useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 
@@ -36,7 +36,11 @@ import useImageStudioStore from '../../stores/imageStudioStore';
 
 import ImageStudioCategorySelector from './components/ImageStudioCategorySelector';
 import ImageStudioTypeSelector from './components/ImageStudioTypeSelector';
-import TemplateStudioFlow from './flows/TemplateStudioFlow';
+// Lazy-loaded: TemplateStudioFlow transitively imports @gruenerator/canvas-editor,
+// whose side-effect CSS (canvas-editor.css) would otherwise land in the entry
+// chunk and render-block the landing page even for guests who never open the
+// image studio.
+const TemplateStudioFlow = lazy(() => import('./flows/TemplateStudioFlow'));
 import { useImageGeneration } from './hooks/useImageGeneration';
 import { useTemplateClone } from './hooks/useTemplateClone';
 import { type FormErrors, type UrlTypeMapKey } from './types/componentTypes';
@@ -654,7 +658,11 @@ const ImageStudioPageContent: React.FC = () => {
   const renderCurrentStep = () => {
     // Route all types (KI, templates with text gen, and pure canvas templates) through unified TemplateStudioFlow
     if (typeConfig?.usesFluxApi || typeConfig?.hasTextGeneration || typeConfig?.endpoints?.canvas) {
-      return <TemplateStudioFlow onBack={handleBack} />;
+      return (
+        <Suspense fallback={<Spinner />}>
+          <TemplateStudioFlow onBack={handleBack} />
+        </Suspense>
+      );
     }
 
     // Fallback for unsupported types


### PR DESCRIPTION
## Why

Chrome DevTools trace of https://gruenerator.eu/ identified three independent issues on the first-load critical path. Each commit is a surgical fix for one of them; bundled here because they share the "what runs/loads on first paint of /" concern.

Builds on #814 (font preload + config.js defer).

## Three issues, three commits

### 1. Lazy-wrap `TemplateStudioFlow`

`ImageStudioPage` is route-lazy but statically imported `TemplateStudioFlow`, which transitively pulls `@gruenerator/canvas-editor` and its side-effect `import './canvas-editor.css'`.

**Verification caveat:** local build still emits `pkg-canvas-editor.css` as a render-blocking `<link>` in the entry HTML after this change. The lazy boundary at `TemplateStudioFlow` is the *correct* place to split image-studio internals (route-internal flows should not be statically pulled into their own chunk), but the entry-HTML CSS reduction needs Vite/Rolldown `advancedChunks` CSS-handling work that is deliberately out of scope here — the prod-crash history at `vite.config.ts:173-192` makes that a high-risk change for a separate, dedicated PR.

This commit therefore lands as a correctness improvement that *prepares* for the deeper fix without touching the chunk graph. No measured LCP win on its own; no regression either.

### 2. `LazyOnView` wrapper for below-fold Mocks

`React.lazy()` only code-splits — the chunk still fetches as soon as `<Suspense>` mounts. All four lazy Mock previews on `Home.tsx` were downloading on first paint, including the two below-fold ones.

Wraps `ImageComparisonMock` and `NotebookMock` in a small `LazyOnView` gate built on `motion/react`'s `useInView` (already a dep via `MockGenerator.tsx:1`). 200px prefetch margin so the chunk arrives before the placeholder enters the viewport. `MockGenerator` and `DocumentsMock` stay eager — they're above the fold and LCP-adjacent.

### 3. Inline session probe

`/api/auth/v2/get-session` fired only after `AuthBootstrap` mounted, i.e. after the entry chunk parsed (~2.9s in the trace).

A tiny inline `<script>` kicks the probe in parallel with bundle download. By the time `useAuth({instant:true})` runs, the response is in the HTTP cache. Same endpoint, same credentials, no new auth surface. Errors are swallowed because this is a cache warmup, not a contract — `useAuth` still does its own fetch on miss.

## Safety

- No new dependencies. `motion/react` already used in `MockGenerator.tsx:1`.
- Lazy-wrap adds one `<Suspense>` with the existing `Spinner` fallback — identical UX to the current loading state.
- Inline probe is failure-tolerant; if it throws or 5xxs, the real path is unaffected.

## Expected impact (post-deploy re-trace)

- ~200–400ms network contention recovered on `/` from gating below-fold mocks
- ~50–200ms wallclock on auth-gated routes from session-probe warmup
- Lazy-wrap: no immediate LCP impact (see verification caveat); paves the way for the dedicated CSS-chunking PR

## Out of scope (future PRs)

- **Brotli at the nginx layer** — `apps/web/Dockerfile:92-96` + `nginx.conf:14-17` configure gzip only; `ngx_brotli` not installed.
- **Raleway → woff2** — Raleway is `.woff` only today; PT Sans is dual-format.
- **Vite/Rolldown `advancedChunks` CSS-handling** — investigate why `pkg-canvas-editor.css`, `vendor-excalidraw.css`, `vendor-blocknote-export.css` show up as render-blocking `<link>` in entry HTML even though their JS chunks are correctly lazy and not modulepreloaded.