### PR TITLE
fix(notebooks): suppress duplicate Zuletzt/Statistiken on index page

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -84,6 +84,8 @@ interface NotebookPageContentProps {
   startpageFooter?: ReactNode;
   /** Disable the Statistiken section (e.g. for small dynamic user notebooks). Defaults to true. */
   showStats?: boolean;
+  /** Disable the built-in "Zuletzt hinzugefügt" section (caller renders its own). Defaults to true. */
+  showLastAdded?: boolean;
   /** Disable the manual research tab (dynamic user notebooks have no system collection scope). Defaults to true. */
   showManualSearch?: boolean;
 }
@@ -128,6 +130,7 @@ export const NotebookPageContent = ({
   threadId: threadIdProp,
   startpageFooter,
   showStats = true,
+  showLastAdded = true,
   showManualSearch = true,
 }: NotebookPageContentProps): React.ReactElement => {
   const isMulti = config.collectionType === 'multi';
@@ -344,6 +347,7 @@ export const NotebookPageContent = ({
                   recentCollectionIds={recentCollectionIds}
                   showRecentSourceLabel={isMulti}
                   showStats={showStats}
+                  showLastAdded={showLastAdded}
                   showManualSearch={showManualSearch}
                   notebookMention={notebookMention}
                   footer={startpageFooter}

--- a/apps/web/src/features/notebook/components/NotebookStartpage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookStartpage.tsx
@@ -37,6 +37,7 @@ interface NotebookStartpageProps {
   recentCollectionIds: string[];
   showRecentSourceLabel?: boolean;
   showStats?: boolean;
+  showLastAdded?: boolean;
   showManualSearch?: boolean;
   /** Mention slug for the global-chat tab (e.g. 'berlin'). Null hides the tab. */
   notebookMention?: string | null;
@@ -77,6 +78,7 @@ export function NotebookStartpage({
   recentCollectionIds,
   showRecentSourceLabel,
   showStats = true,
+  showLastAdded = true,
   showManualSearch = true,
   notebookMention,
   footer,
@@ -167,7 +169,7 @@ export function NotebookStartpage({
             )}
           </div>
 
-          {recentCollectionIds.length > 0 && (
+          {showLastAdded && recentCollectionIds.length > 0 && (
             <LastAddedSection
               collectionIds={recentCollectionIds}
               showSourceLabel={showRecentSourceLabel}

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -584,7 +584,14 @@ function NotebooksIndexFooter() {
 
 function NotebooksIndexPage() {
   const config = useMemo(() => getNotebookConfig('gruenerator'), []);
-  return <NotebookPageContent config={config} startpageFooter={<NotebooksIndexFooter />} />;
+  return (
+    <NotebookPageContent
+      config={config}
+      startpageFooter={<NotebooksIndexFooter />}
+      showLastAdded={false}
+      showStats={false}
+    />
+  );
 }
 
 export default withAuthRequired(NotebooksIndexPage, {


### PR DESCRIPTION
## Summary

Follow-up to #812. On `/notebooks`, **Zuletzt hinzugefügt** and **Statistiken** were rendering twice: once from `NotebookStartpage`'s built-in slots (above the footer) and once from our footer (below the grid).

- Add a `showLastAdded` prop to `NotebookStartpage` next to the existing `showStats`, default `true`.
- Thread it through `NotebookPageContent`.
- Disable both built-ins from `NotebooksIndexPage` so only the footer copy renders, keeping the visible order grid → Eigene → Zuletzt → Statistiken.

Every other caller (e.g. `/notebooks/:idOrSlug`, the `/gruene-*` redirects) is unaffected because the defaults stay `true`.

## Test plan

- [ ] `/notebooks` shows Zuletzt + Statistiken exactly once, below the grid
- [ ] An individual notebook page (e.g. `/notebooks/grundsatz`) still shows both sections as before