### PR TITLE
refactor(notebook): drop doc-count badge, show more description on cards

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -62,13 +62,6 @@ function hasFileDrag(e: DragEvent): boolean {
   return Array.from(e.dataTransfer.types).includes('Files');
 }
 
-function formatDocCount(c: NotebookCollection): string {
-  const n = c.document_count ?? c.documents?.length ?? 0;
-  if (n === 0) return 'Keine Dokumente';
-  if (n === 1) return '1 Dokument';
-  return `${n} Dokumente`;
-}
-
 const NotebookManagementCard = memo(function NotebookManagementCard({
   collection,
   isProcessing = false,
@@ -153,7 +146,7 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
               {collection.name}
             </div>
             {collection.description ? (
-              <div className="line-clamp-2 text-xs text-grey-500 dark:text-grey-400">
+              <div className="line-clamp-4 text-xs text-grey-500 dark:text-grey-400">
                 {collection.description}
               </div>
             ) : null}
@@ -192,22 +185,21 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
         </DropdownMenu>
       </div>
 
-      <div className="flex items-center gap-xs">
-        <Badge variant="secondary" className="text-xs">
-          {formatDocCount(collection)}
-        </Badge>
-        {collection.is_public ? (
-          <Badge variant="outline" className="text-xs">
-            Geteilt
-          </Badge>
-        ) : null}
-        {isProcessing ? (
-          <Badge variant="outline" className="gap-xs text-xs text-primary-600">
-            <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-            Wird verarbeitet…
-          </Badge>
-        ) : null}
-      </div>
+      {(collection.is_public || isProcessing) && (
+        <div className="flex items-center gap-xs">
+          {collection.is_public ? (
+            <Badge variant="outline" className="text-xs">
+              Geteilt
+            </Badge>
+          ) : null}
+          {isProcessing ? (
+            <Badge variant="outline" className="gap-xs text-xs text-primary-600">
+              <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+              Wird verarbeitet…
+            </Badge>
+          ) : null}
+        </div>
+      )}
       </div>
     </div>
   );


### PR DESCRIPTION
Cards on `/notebooks/meine` were truncating useful description text after 2 lines while spending the recovered space on a "X Dokumente" badge that duplicates info already inside the notebook.

- **Drop the doc-count Badge** — not needed at the card level
- **`line-clamp-2` → `line-clamp-4`** — descriptions like "Wahlprogramm & Koa-Vertrag zur Kreistagswahl 25 von Grüne Rhein-Sieg" now fit fully
- **Collapse the badges row when empty** — if a notebook isn't public and isn't indexing, no row at all (vs. an empty gap before)
- **Remove unused `formatDocCount` helper** — orphaned after the Badge drop

## Test plan
- [ ] Card with a long description shows up to 4 lines before truncating
- [ ] Card without description renders compactly (no empty description div)
- [ ] No "2 Dokumente" / "5 Dokumente" badge on any card
- [ ] "Geteilt" badge still shows on public collections
- [ ] "Wird verarbeitet…" badge still shows during indexing (and the badges row still renders for it)