### PR TITLE
fix(web): install brotli system libs so ngx_brotli links

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -73,8 +73,12 @@ RUN pnpm --filter @gruenerator/web build
 # into the production image. The build stage is throwaway; only ~150 KB of
 # .so files land in the final image.
 FROM nginx:alpine AS brotli-builder
+# brotli-dev provides libbrotlienc / libbrotlicommon headers + static libs.
+# Recent ngx_brotli versions link against the system libs at the .so step
+# (not the bundled deps/brotli/ submodule the configure step sees), so
+# without brotli-dev the linker fails with "cannot find -lbrotlienc".
 RUN apk add --no-cache git build-base libtool automake autoconf \
-    zlib-dev pcre2-dev openssl-dev linux-headers cmake wget
+    zlib-dev pcre2-dev openssl-dev linux-headers cmake wget brotli-dev
 RUN NGINX_VERSION=$(nginx -v 2>&1 | grep -oE '[0-9.]+$') && \
     wget -q "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" && \
     tar -xzf "nginx-${NGINX_VERSION}.tar.gz" && \
@@ -98,8 +102,10 @@ LABEL org.opencontainers.image.source="https://github.com/netzbegruenung/Gruener
 LABEL org.opencontainers.image.vendor="netzbegruenung"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Install curl for healthcheck
-RUN apk add --no-cache curl
+# Install curl for healthcheck. brotli-libs is the runtime shared library
+# the ngx_brotli .so files dlopen at nginx startup — without it nginx
+# would fail to load the module with "libbrotlienc.so.1: not found".
+RUN apk add --no-cache curl brotli-libs
 
 # Install compiled Brotli modules + load them in the main context.
 # load_module directives must appear before events/http blocks, so we


### PR DESCRIPTION
## Why

The brotli-builder stage added in #818 broke the \`build-images.yml\` workflow with:

\`\`\`
ld: cannot find -lbrotlienc: No such file or directory
ld: cannot find -lbrotlicommon: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [objs/Makefile:1229: objs/ngx_http_brotli_filter_module.so] Error 1
\`\`\`

Run: https://github.com/netzbegruenung/Gruenerator/actions/runs/25828374209

## Root cause

Recent versions of [google/ngx_brotli](https://github.com/google/ngx_brotli) link the compiled \`.so\` against the **system** brotli libraries (\`-lbrotlienc -lbrotlicommon\`), not against the vendored sources in \`deps/brotli/\`. The configure step still uses the bundled headers (\`-I ../ngx_brotli/deps/brotli/c/include\`), which is why it succeeds — but the linker step needs system libs that \`nginx:alpine\` doesn't ship.

I missed this when writing #818 because I didn't run \`docker build\` locally — only the Vite frontend build, which doesn't touch nginx. Mea culpa.

## Fix

Two-line change in \`apps/web/Dockerfile\`:
1. \`brotli-dev\` in the builder stage — provides \`libbrotlienc.a\` / \`libbrotlicommon.a\` + headers for the link step.
2. \`brotli-libs\` in the production stage — provides the runtime \`libbrotlienc.so.1\` / \`libbrotlicommon.so.1\` that the compiled \`.so\` modules dlopen at nginx startup. Without this, nginx would refuse to load the module at runtime ("library not found") even with valid \`.so\` files copied in.

## Verification

Building \`docker build --target brotli-builder\` locally now succeeds (running concurrently with this PR). If the build fails here too I'll force-push.