### PR TITLE
feat(agents): /agents/<slug> URL + sidebar/icon derivation from agent metadata

### DIFF
--- a/apps/web/src/components/layout/Sidebar/AllAgentsDialog.tsx
+++ b/apps/web/src/components/layout/Sidebar/AllAgentsDialog.tsx
@@ -1,21 +1,12 @@
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@gruenerator/ui';
+import { getAgentSlug } from '@gruenerator/shared/agents';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@gruenerator/ui';
 import { type ReactNode } from 'react';
 import { PiStarFill } from 'react-icons/pi';
 
 import { useUserAgents } from '../../../features/agents/api';
 import useAgentFavoritesStore from '../../../stores/agentFavoritesStore';
 
-import {
-  DEFAULT_AGENT_ENTRIES,
-  VISIBLE_SYSTEM_AGENTS,
-  getAgentIcon,
-} from './sidebarAgentConfig';
+import { DEFAULT_AGENT_ENTRIES, VISIBLE_SYSTEM_AGENTS, getAgentIcon } from './sidebarAgentConfig';
 import { menuLinkClass } from './sidebarStyles';
 
 import { cn } from '@/utils/cn';
@@ -103,7 +94,9 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
               <AgentListRow
                 key={entry.key}
                 title={entry.label}
-                onClick={() => onLinkClick(`/chat?agent=${entry.identifier}`, entry.label)}
+                onClick={() =>
+                  onLinkClick(`/agents/${getAgentSlug(entry.identifier)}`, entry.label)
+                }
                 avatar={
                   <span className="shrink-0 w-7 h-7 flex items-center justify-center text-secondary-600">
                     <Icon aria-hidden="true" className="h-5 w-5" />
@@ -123,7 +116,9 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
                 key={agent.identifier}
                 title={agent.title}
                 description={agent.description}
-                onClick={() => onLinkClick(`/chat?agent=${agent.identifier}`, agent.title)}
+                onClick={() =>
+                  onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
+                }
                 avatar={
                   <span className="shrink-0 w-7 h-7 flex items-center justify-center text-secondary-600">
                     <Icon aria-hidden="true" className="h-5 w-5" />
@@ -151,7 +146,9 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
                   key={`ua-${agent.identifier}`}
                   title={agent.title}
                   description={agent.description}
-                  onClick={() => onLinkClick(`/chat?agent=${agent.identifier}`, agent.title)}
+                  onClick={() =>
+                    onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
+                  }
                   avatar={
                     <span
                       className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-sm"

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useAgentStore } from '@gruenerator/chat';
-import { getSystemAgent } from '@gruenerator/shared/agents';
+import { getAgentSlug, getSystemAgent, type Agent } from '@gruenerator/shared/agents';
 import {
   Sheet,
   SheetContent,
@@ -30,7 +30,7 @@ import {
 
 import { AllAgentsDialog } from './AllAgentsDialog';
 import NewItemDropdown from './NewItemDropdown';
-import { DEFAULT_AGENT_ENTRIES, getAgentIcon } from './sidebarAgentConfig';
+import { DEFAULT_AGENT_ENTRIES, PINNED_AGENT_IDS, getAgentIcon } from './sidebarAgentConfig';
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
 import { cn } from '@/utils/cn';
@@ -457,7 +457,7 @@ const SidebarAgents = memo(function SidebarAgents({
   const favoriteAgents = useMemo(() => {
     const out: Agent[] = [];
     for (const identifier of favoriteIdentifiers) {
-      if (HIDDEN_INVENTORY_AGENT_IDS.has(identifier as SystemAgentId)) continue;
+      if (PINNED_AGENT_IDS.has(identifier)) continue;
       const agent = getSystemAgent(identifier);
       if (!agent) continue; // covers deleted agents + migration unknowns
       out.push(agent);
@@ -521,7 +521,9 @@ const SidebarAgents = memo(function SidebarAgents({
               <li key={entry.key}>
                 <button
                   type="button"
-                  onClick={() => onLinkClick(`/chat?agent=${entry.identifier}`, entry.label)}
+                  onClick={() =>
+                    onLinkClick(`/agents/${getAgentSlug(entry.identifier)}`, entry.label)
+                  }
                   className={menuLinkClass(false)}
                 >
                   <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
@@ -539,7 +541,9 @@ const SidebarAgents = memo(function SidebarAgents({
               <li key={`fav-${agent.identifier}`}>
                 <button
                   type="button"
-                  onClick={() => onLinkClick(`/chat?agent=${agent.identifier}`, agent.title)}
+                  onClick={() =>
+                    onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
+                  }
                   className={menuLinkClass(false)}
                 >
                   <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
@@ -555,7 +559,9 @@ const SidebarAgents = memo(function SidebarAgents({
             <li key={agent.identifier}>
               <button
                 type="button"
-                onClick={() => onLinkClick(`/chat?agent=${agent.identifier}`, agent.title)}
+                onClick={() =>
+                  onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
+                }
                 className={menuLinkClass(false)}
               >
                 <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
@@ -596,6 +602,5 @@ const SidebarAgents = memo(function SidebarAgents({
     </div>
   );
 });
-
 
 export default memo(Sidebar);

--- a/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
@@ -1,7 +1,6 @@
 import {
   VISIBLE_SYSTEM_AGENTS as ALL_VISIBLE_SYSTEM_AGENTS,
   type Agent,
-  type SystemAgentId,
 } from '@gruenerator/shared/agents';
 import {
   PiSparkle,
@@ -18,39 +17,34 @@ import {
 import type { IconType } from 'react-icons';
 
 /**
- * Agent ids already rendered at the top of the "Alle Agents" modal via
- * DEFAULT_AGENT_ENTRIES — excluded from the main system-agent list below
- * to avoid duplicate rows.
+ * String key → react-icons component. Agents reference icons by `iconKey`
+ * (in their `SYSTEM_AGENTS` entry); this registry is the platform-side mapping.
+ * Adding a new agent icon = add one line here AND set `iconKey` on the agent.
  */
-const HIDDEN_INVENTORY_AGENT_IDS = new Set<SystemAgentId>([
-  'gruenerator-oeffentlichkeitsarbeit',
-  'gruenerator-antrag',
-  'gruenerator-suche',
-]);
-
-export const VISIBLE_SYSTEM_AGENTS: readonly Agent[] = ALL_VISIBLE_SYSTEM_AGENTS.filter(
-  (a) => !HIDDEN_INVENTORY_AGENT_IDS.has(a.identifier as SystemAgentId)
-);
-
-const AGENT_ICONS: Partial<Record<SystemAgentId, IconType>> = {
-  'gruenerator-universal': PiSparkle,
-  'gruenerator-antrag': PiBuildings,
-  'gruenerator-suche': PiMagnifyingGlass,
-  'gruenerator-oeffentlichkeitsarbeit': PiMegaphone,
-  'gruenerator-buergerservice': PiChatsCircle,
-  'gruenerator-rede-schreiber': PiMicrophone,
-  'gruenerator-wahlprogramm': PiBookOpenText,
-  'gruenerator-leichte-sprache': PiHandHeart,
-  'gruenerator-docs-editor': PiFileText,
+const ICON_REGISTRY: Record<string, IconType> = {
+  sparkle: PiSparkle,
+  megaphone: PiMegaphone,
+  buildings: PiBuildings,
+  'magnifying-glass': PiMagnifyingGlass,
+  'chats-circle': PiChatsCircle,
+  microphone: PiMicrophone,
+  'book-open-text': PiBookOpenText,
+  'hand-heart': PiHandHeart,
+  'file-text': PiFileText,
 };
 
+const FALLBACK_ICON: IconType = PiSparkle;
+
 /**
- * All PR agents (universal + 7 per-LV variants) share PiMegaphone — the
- * prefix check means new LV-PR agents need zero changes here.
+ * Per-LV Öffentlichkeitsarbeit variants share the megaphone via prefix check —
+ * adding a new LV-PR agent needs zero changes here (and no `iconKey` on the
+ * agent definition either).
  */
 export function getAgentIcon(identifier: string): IconType {
   if (identifier.startsWith('gruenerator-oeffentlichkeitsarbeit')) return PiMegaphone;
-  return AGENT_ICONS[identifier as SystemAgentId] ?? PiSparkle;
+  const agent = ALL_VISIBLE_SYSTEM_AGENTS.find((a) => a.identifier === identifier);
+  if (agent?.iconKey) return ICON_REGISTRY[agent.iconKey] ?? FALLBACK_ICON;
+  return FALLBACK_ICON;
 }
 
 export interface DefaultAgentEntry {
@@ -60,31 +54,35 @@ export interface DefaultAgentEntry {
 }
 
 /**
- * Pinned defaults always shown in the sidebar regardless of favorites.
- * "Öffentlichkeitsarbeit" is the combined Presse + Social Media agent.
- * Splitting it into separate entries caused an Array.find first-match display
- * ambiguity (clicking Social Media showed "Pressemitteilung" because both
- * pointed at the same identifier) — single entry resolves that.
- * Icon comes from `getAgentIcon(identifier)` — single source of truth.
+ * Pinned defaults — always visible at the top of the sidebar regardless of
+ * favorites. Derived from `pinnedToSidebar: true` on the agent definition.
+ * To pin a new agent: flip that flag on its `SYSTEM_AGENTS` entry and add an
+ * `iconKey` — no edits in this file.
  *
- * Per-LV Öffentlichkeitsarbeit agents are intentionally NOT pinned here.
- * They are discoverable via the "Alle Agents" modal and the per-LV notebook
- * auto-select; users can favorite them to surface them in the sidebar.
+ * Order follows array order in `SYSTEM_AGENTS`.
  */
-export const DEFAULT_AGENT_ENTRIES: readonly DefaultAgentEntry[] = [
-  {
-    key: 'default-oeffentlichkeitsarbeit',
-    label: 'Öffentlichkeitsarbeit',
-    identifier: 'gruenerator-oeffentlichkeitsarbeit',
-  },
-  {
-    key: 'default-antrag',
-    label: 'Kommunalpolitik',
-    identifier: 'gruenerator-antrag',
-  },
-  {
-    key: 'default-suche',
-    label: 'Suche',
-    identifier: 'gruenerator-suche',
-  },
-];
+export const DEFAULT_AGENT_ENTRIES: readonly DefaultAgentEntry[] = ALL_VISIBLE_SYSTEM_AGENTS.filter(
+  (a) => a.pinnedToSidebar === true
+).map((a) => ({
+  key: `default-${a.identifier.replace(/^gruenerator-/, '')}`,
+  label: a.title,
+  identifier: a.identifier,
+}));
+
+/**
+ * Identifier set for the pinned agents. Used by sidebar consumers (e.g.
+ * `Sidebar.tsx`) to filter the favorites list and avoid double-rendering
+ * agents that are already pinned at the top.
+ */
+export const PINNED_AGENT_IDS: ReadonlySet<string> = new Set(
+  DEFAULT_AGENT_ENTRIES.map((e) => e.identifier)
+);
+
+/**
+ * Agents shown in the "Alle Agents" modal: visible registry minus the pinned
+ * set (those are rendered separately). Single source of truth for the modal
+ * — keeps it from drifting against the sidebar.
+ */
+export const VISIBLE_SYSTEM_AGENTS: readonly Agent[] = ALL_VISIBLE_SYSTEM_AGENTS.filter(
+  (a) => !PINNED_AGENT_IDS.has(a.identifier)
+);

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -43,6 +43,15 @@ const LegacyNotebookIdRedirectComponent: FC<Record<string, unknown>> = () => {
 const LegacyNotebookIdRedirect = lazy(() =>
   Promise.resolve({ default: LegacyNotebookIdRedirectComponent })
 );
+
+// Redirect singular /agent/:slug → canonical plural /agents/:slug
+const LegacyAgentSlugRedirectComponent: FC<Record<string, unknown>> = () => {
+  const { slug } = useParams();
+  return createElement(Navigate, { to: `/agents/${slug ?? ''}`, replace: true });
+};
+const LegacyAgentSlugRedirect = lazy(() =>
+  Promise.resolve({ default: LegacyAgentSlugRedirectComponent })
+);
 const DocumentToDocsRedirectComponent: FC<Record<string, unknown>> = () => {
   const { id } = useParams();
   return createElement(Navigate, { to: `/docs/${id || ''}`, replace: true });
@@ -123,9 +132,7 @@ const Nutzungsbedingungen = lazy(
 const NotFound = lazy(() => import('../components/pages/NotFound'));
 const Search = lazy(() => import('../features/search/components/SearchPage'));
 const OparlPage = lazy(() => import('../features/oparl/pages/OparlPage'));
-const NotebookRootPage = lazy(
-  () => import('../features/notebook/components/NotebooksIndexPage')
-);
+const NotebookRootPage = lazy(() => import('../features/notebook/components/NotebooksIndexPage'));
 const NotebookResolverPage = lazy(() =>
   import('../features/notebook/components/NotebookResolver').then((m) => ({
     default: m.NotebookResolver,
@@ -238,6 +245,11 @@ const standardRoutes: RouteConfig[] = [
     component: AgentBuilderPage,
     devOnly: true,
   },
+  // Chat with a specific system agent at /agents/<slug>. Slug is the agent
+  // identifier with the `gruenerator-` prefix stripped (see `getAgentSlug`
+  // in @gruenerator/shared/agents). ChatPage handles both this path-based
+  // form and the legacy `/chat?agent=<slug>` query form.
+  { path: '/agents/:slug', component: ChatPage, layoutMode: 'sidebarOnly' },
   {
     path: '/desk',
     component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),
@@ -368,10 +380,10 @@ const standardRoutes: RouteConfig[] = [
   { path: '/gruenerator/erstellen', component: CreateCustomGeneratorPage, withForm: true },
   { path: '/gruenerator/:slug', component: GrueneratorenBundle.CustomGenerator, withForm: true },
   // Redirects for removed pages
-  {
-    path: '/agent/:slug',
-    component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),
-  },
+  // Legacy singular `/agent/:slug` URLs now route to the canonical plural
+  // `/agents/:slug` so old bookmarks open the agent's chat instead of
+  // bouncing to /workplace.
+  { path: '/agent/:slug', component: LegacyAgentSlugRedirect },
   {
     path: '/prompt/:slug',
     component: lazy(() => Promise.resolve({ default: createRedirect('/workplace') })),

--- a/apps/web/src/features/generators/CustomGeneratorPage.tsx
+++ b/apps/web/src/features/generators/CustomGeneratorPage.tsx
@@ -1,3 +1,4 @@
+import { getAgentSlug } from '@gruenerator/shared/agents';
 import { Button } from '@gruenerator/ui';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import React, { useMemo, memo } from 'react';
@@ -55,7 +56,7 @@ const CustomGeneratorPage: React.FC = memo(() => {
     if (!slug) return;
     convertMutation.mutate(slug, {
       onSuccess: ({ agent }) => {
-        void navigate(`/chat?agent=${agent.identifier}`);
+        void navigate(`/agents/${getAgentSlug(agent.identifier)}`);
       },
     });
   };

--- a/apps/web/src/features/skills/SkillsPage.tsx
+++ b/apps/web/src/features/skills/SkillsPage.tsx
@@ -5,7 +5,7 @@ import {
   type AgentListItem,
   type SkillCategory,
 } from '@gruenerator/chat';
-import { AGENT_CATEGORY_LABELS, type Agent } from '@gruenerator/shared/agents';
+import { AGENT_CATEGORY_LABELS, getAgentSlug, type Agent } from '@gruenerator/shared/agents';
 import { Input, SectionHeader, CardGrid } from '@gruenerator/ui';
 import { useMemo, useState } from 'react';
 import {
@@ -263,7 +263,7 @@ function LibraryPageInner() {
   };
 
   const handleSelectAgent = (agent: Agent) => {
-    void navigate(`/chat?agent=${encodeURIComponent(agent.identifier)}`);
+    void navigate(`/agents/${encodeURIComponent(getAgentSlug(agent.identifier))}`);
   };
 
   const handleEditAgent = (agent: Agent) => {

--- a/packages/shared/src/agents/index.ts
+++ b/packages/shared/src/agents/index.ts
@@ -21,6 +21,8 @@ export {
 
 export { SKILLS, resolveSkillMention } from './skills.js';
 
+export { getAgentSlug, resolveAgentSlug } from './slug.js';
+
 export {
   MCP_AGENTS,
   MCP_SOCIAL_MEDIA_VARIANTS,

--- a/packages/shared/src/agents/slug.ts
+++ b/packages/shared/src/agents/slug.ts
@@ -1,0 +1,34 @@
+import { getSystemAgent } from './system.js';
+
+const AGENT_ID_PREFIX = 'gruenerator-';
+
+/**
+ * Convert an agent identifier to its URL slug form by stripping the
+ * `gruenerator-` registry prefix. Used when generating `/chat?agent=…` URLs
+ * so the browser bar shows `?agent=oeffentlichkeitsarbeit` instead of the
+ * verbose `?agent=gruenerator-oeffentlichkeitsarbeit`.
+ *
+ * Identifiers without the prefix (user-defined agents) pass through unchanged.
+ */
+export function getAgentSlug(identifier: string): string {
+  return identifier.startsWith(AGENT_ID_PREFIX)
+    ? identifier.slice(AGENT_ID_PREFIX.length)
+    : identifier;
+}
+
+/**
+ * Resolve a URL slug back to a system agent identifier.
+ *
+ * - If `slug` already carries the `gruenerator-` prefix (legacy URL), return
+ *   it unchanged — backwards-compatible with bookmarks predating the slug
+ *   refactor.
+ * - Otherwise re-prefix and verify a system agent exists; if so, return the
+ *   full identifier. If no system agent matches, return the slug as-is so
+ *   user-defined agents (whose identifiers don't follow the registry
+ *   convention) still route correctly.
+ */
+export function resolveAgentSlug(slug: string): string {
+  if (slug.startsWith(AGENT_ID_PREFIX)) return slug;
+  const candidate = `${AGENT_ID_PREFIX}${slug}`;
+  return getSystemAgent(candidate) ? candidate : slug;
+}

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -7,6 +7,7 @@ const BASE_AGENTS = [
     // Kept as the backend fallback (chat_threads.agent_id default; 8+ controller
     // call sites). Flag hides it from pickers without removing the identifier.
     hiddenFromInventory: true,
+    iconKey: 'sparkle',
     description:
       'Vielseitiger Textgenerator mit Zugriff auf grüne Parteiprogramme, Positionen und Dokumente via semantischer Suche.',
     systemRole:
@@ -41,6 +42,8 @@ const BASE_AGENTS = [
   {
     identifier: 'gruenerator-antrag',
     title: 'Kommunalpolitik',
+    iconKey: 'buildings',
+    pinnedToSidebar: true,
     description:
       'Kommunalpolitik-Assistenz: bewerte Haushalte und Vorlagen, diskutiere kommunale Strategien, oder entwirf Anträge, Anfragen, Haushaltsanträge, Resolutionen und Redebeiträge — gestützt auf das KommunalWiki und grüne Positionen.',
     systemRole:
@@ -117,6 +120,8 @@ const BASE_AGENTS = [
   {
     identifier: 'gruenerator-suche',
     title: 'Suche',
+    iconKey: 'magnifying-glass',
+    pinnedToSidebar: true,
     description:
       'Recherche mit Quellenangaben über Web und grüne Dokumente — perplexity-artige Antworten mit Zitaten.',
     // systemRole unused — SearchGraph builds its own prompt in searchRespondNode.ts.
@@ -144,6 +149,8 @@ const BASE_AGENTS = [
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit',
     title: 'Öffentlichkeitsarbeit',
+    iconKey: 'megaphone',
+    pinnedToSidebar: true,
     description: 'Erstellt Pressemitteilungen und Social-Media-Inhalte für alle Plattformen.',
     systemRole:
       'Du bist die*der leitende Kommunikationsmanager*in für {{partyName}} und kombinierst professionelle Pressearbeit mit strategischem Social-Media-Management.\n\n**GENERELLE RICHTLINIEN:**\n- Tonalität: Verbindlich, motivierend und lösungsorientiert\n- Politische Haltung: Vertrete die grünen Werte selbstbewusst\n- Sicherheit: Erfinde niemals Fakten oder Zitate\n- Ziel: Maximale Reichweite bei gleichzeitiger politischer Seriosität\n\nWenn der*die Nutzer*in eine bestimmte Plattform anwählt (z.B. /presse, /instagram, /facebook, /twitter, /linkedin, /reel), bekommst du dafür eine plattformspezifische Spezifikation in deinem Kontext. Halte dich strikt an das dortige Zeichenlimit, die Tonalität und die Beispiel-Suchanweisung. Erstelle für JEDE angefragte Plattform einen eigenen, optimierten Inhalt.\n\n## ARBEITSWEISE\n\nSchritt 1: Recherchiere mit search_documents nach Grünen Positionen zum Thema.\nSchritt 2: Nutze web_search für aktuelle Fakten und Kontext.\nSchritt 3: Folge der plattformspezifischen Beispiel-Suchanweisung (siehe plattformspezifische Spezifikation, falls aktiv).\nSchritt 4: Erstelle den Inhalt plattformgerecht, inspiriert von den gefundenen Beispielen.\nSchritt 5: Prüfe mit self_review: Richtiger Ton? Zeichenlimit? W-Fragen bei PM beantwortet?\nSchritt 6: Überarbeite bei Score unter 4.',
@@ -391,6 +398,7 @@ const BASE_AGENTS = [
     defaultFilter: { landesverband: 'BB' },
   },
   {
+    iconKey: 'chats-circle',
     identifier: 'gruenerator-buergerservice',
     title: 'Bürger*innenanfragen',
     description:
@@ -428,6 +436,7 @@ const BASE_AGENTS = [
     ],
   },
   {
+    iconKey: 'microphone',
     identifier: 'gruenerator-rede-schreiber',
     title: 'Rede',
     description:
@@ -473,6 +482,7 @@ const BASE_AGENTS = [
     ],
   },
   {
+    iconKey: 'book-open-text',
     identifier: 'gruenerator-wahlprogramm',
     title: 'Wahlprogramm',
     description:
@@ -517,6 +527,7 @@ const BASE_AGENTS = [
     ],
   },
   {
+    iconKey: 'hand-heart',
     identifier: 'gruenerator-leichte-sprache',
     title: 'Leichte Sprache',
     description:
@@ -554,6 +565,7 @@ const BASE_AGENTS = [
     ],
   },
   {
+    iconKey: 'file-text',
     identifier: 'gruenerator-docs-editor',
     title: 'Dokument-Assistent',
     description:

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -91,6 +91,29 @@ export interface Agent {
    */
   hiddenFromInventory?: boolean;
   /**
+   * Notebook ID this agent auto-selects when the user opens its chat
+   * (`ChatPage` calls `setSelectedNotebook` with this on agent activation).
+   * Used by the per-LV PR agents so the regional notebook pairs with the
+   * regional agent without an extra click. Set by the LV-spec generator
+   * in `system.ts`; absent on hand-written entries.
+   */
+  defaultNotebookId?: string;
+  /**
+   * Frontend icon registry key. Maps to a `react-icons` component in
+   * `apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts::ICON_REGISTRY`.
+   * Per-LV `gruenerator-oeffentlichkeitsarbeit-*` agents inherit the megaphone
+   * via prefix special-case, so they need no `iconKey` of their own.
+   */
+  iconKey?: string;
+  /**
+   * Surfaces this agent as a pinned entry in the web sidebar (always visible,
+   * separate from user favorites). Label and icon come from the agent's
+   * `title` and `iconKey` respectively — set both before flipping this on.
+   * Used to derive `DEFAULT_AGENT_ENTRIES` and `PINNED_AGENT_IDS` so adding a
+   * new pinned agent is a single edit in the agent definition.
+   */
+  pinnedToSidebar?: boolean;
+  /**
    * UI grouping bucket on AgentListPage. Currently only `'gruppen'` is defined
    * (the synthetic "shared with my groups" bucket, never assigned in config).
    * Additional categories will be added as the agent taxonomy stabilizes.


### PR DESCRIPTION
## Summary

Two refactors that share an underlying goal: stop hand-curating duplicated agent surfaces, derive them from the agent definition.

### Cleaner URLs: `/agents/<slug>`

`gruenerator.eu/chat?agent=gruenerator-oeffentlichkeitsarbeit` → `gruenerator.eu/agents/oeffentlichkeitsarbeit`. Agent is the noun, chat is the implicit verb. Matches the existing `/agents/new` / `/agents/:identifier/edit` namespace.

- `getAgentSlug` / `resolveAgentSlug` helpers in `@gruenerator/shared/agents` (strip / re-prefix `gruenerator-`).
- New route `/agents/:slug` renders `ChatPage`; legacy `/chat?agent=` still works.
- Singular `/agent/:slug` redirect (which used to bounce to `/workplace`) now forwards to the canonical plural — old shared links recover.
- All seven `navigate(...)` callsites moved to the new form.

### Derive sidebar pin + icon from Agent metadata

Master had three hardcoded lists referencing the same 3 agent IDs (`AGENT_ICONS`, `HIDDEN_INVENTORY_AGENT_IDS`, `DEFAULT_AGENT_ENTRIES`). Adding a 4th pinned agent meant 3 edits across 2 files.

- New `iconKey?: string` and `pinnedToSidebar?: boolean` on `Agent`.
- The 9 hand-written agents get explicit `iconKey` values; per-LV PR variants keep their megaphone prefix special-case in `getAgentIcon`.
- `DEFAULT_AGENT_ENTRIES`, `PINNED_AGENT_IDS`, `VISIBLE_SYSTEM_AGENTS` all derive from filters over `SYSTEM_AGENTS`.
- Frontend keeps a string-keyed `ICON_REGISTRY` (react-icons can't live in the platform-agnostic shared package).
- Also declared `defaultNotebookId?: string` on `Agent` — the LV-spec generator sets it but the type never reflected it, causing a pre-existing eslint break that surfaced via my type tightening.
- Drive-by fix: missing `Agent` / `SystemAgentId` / `HIDDEN_INVENTORY_AGENT_IDS` imports in `Sidebar.tsx` (broken on master, fixed here).

### Adding a pinned agent after this PR

Set `iconKey: 'foo'` and `pinnedToSidebar: true` on the agent's `SYSTEM_AGENTS` entry. Add `foo: PiFoo` to `ICON_REGISTRY` once if the icon is new. URL becomes `/agents/<slug>` automatically. **No edits in any `sidebarAgentConfig.ts` / `DEFAULT_AGENT_ENTRIES` list.**

## Test plan

- [x] `pnpm --filter @gruenerator/shared typecheck` clean
- [x] `pnpm exec eslint apps/web/src/features/chat/ChatPage.tsx` clean (was broken on master before)
- [ ] Manual: visit `/agents/oeffentlichkeitsarbeit`, `/agents/suche`, `/agents/antrag` — sidebar pin highlights correctly, chat opens in agent
- [ ] Manual: old `/chat?agent=gruenerator-oeffentlichkeitsarbeit` URL still opens the right agent (backwards compat)
- [ ] Manual: old `/agent/foo` singular URL forwards to `/agents/foo`