### PR TITLE
fix(notebooks): hide example prompts on overview index

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookRoot.tsx
+++ b/apps/web/src/features/notebook/components/NotebookRoot.tsx
@@ -5,7 +5,7 @@ import { NotebookGallery } from './NotebookGallery';
 import { NotebookPageContent } from './NotebookPage';
 
 function NotebookRootPage() {
-  const config = getNotebookConfig('gruenerator');
+  const config = { ...getNotebookConfig('gruenerator'), exampleQuestions: [] };
   return <NotebookPageContent config={config} startpageFooter={<NotebookGallery />} />;
 }
 


### PR DESCRIPTION
The `/notebooks` overview already surfaces the gallery, recent notebooks and stats sections as the primary entry points. The inherited example-question chips from `NotebookPageContent` duplicated that affordance and pushed the real navigation content below the fold.

`NotebookStartpage` already conditionally renders the block based on `exampleQuestions.length > 0`, so passing an empty array from `NotebookRoot` cleanly hides it without touching the shared component or other notebook pages.