### PR TITLE
fix(docs): isolate comments sidebar crash from editor

### DIFF
--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -442,7 +442,17 @@ const BlockNoteEditorInner = ({
           {commentsPortalTarget &&
             showComments &&
             threadStore &&
-            createPortal(<ThreadsSidebar filter="all" />, commentsPortalTarget)}
+            createPortal(
+              <ErrorBoundary
+                fallback={null}
+                onError={(err) =>
+                  console.warn('[Comments] sidebar render failed:', err)
+                }
+              >
+                <ThreadsSidebar filter="all" />
+              </ErrorBoundary>,
+              commentsPortalTarget
+            )}
         </BlockNoteView>
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
## Why

Opening the comments panel on a doc could tear down the entire BlockNote editor with a red `ErrorBoundary` fallback. The throw originates inside `@blocknote/react`'s `FloatingThreadController`:

> `User <uuid> resolved thread <uuid>, but their data could not be found.`

For any resolved thread, BlockNote does `userStore.get(thread.resolvedBy)` and throws synchronously when the entry is missing. Our `resolveUsers` (`packages/docs/src/hooks/useResolveUsers.ts`) calls `POST /users/batch` → `SELECT … FROM profiles WHERE id = ANY(…)`; if a UUID isn't in `profiles`, that slot in the returned array stays `undefined` and BlockNote throws.

We can't guarantee the invariant on the backend — accounts get deleted, Better Auth users may not have a `profiles` row yet, system actors aren't profiles. So we contain the blast radius: the comments sidebar can fail to empty, but the editor must stay alive.

## How

Wrap the portaled `<ThreadsSidebar />` in its own `ErrorBoundary` with `fallback={null}`. React portals bubble errors through the React parent tree, so a boundary at the portal call site catches the throw before it reaches the outer editor boundary. Toggling the comments panel off/on remounts the boundary, giving a natural retry when the data becomes valid.