### PR TITLE
fix(api): repair vitest baseline (17 → 0 failures)

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/intentPipeline.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/intentPipeline.vitest.ts
@@ -41,9 +41,11 @@ import type {
  */
 const ALL_INTENTS: SearchIntent[] = [
   'research',
+  'compare',
   'search',
   'web',
   'examples',
+  'pressemitteilung_examples',
   'image',
   'image_edit',
   'sharepic',
@@ -278,9 +280,12 @@ describe('every SearchIntent has a handler path', () => {
     sharepic: 'handled via sharepic branch in controller (image generation variant)',
     direct: 'falls through to response generation',
     research: 'handled via search branch (intent !== direct)',
+    compare: 'handled via search branch — multi-document comparison, same path as research',
     search: 'handled via search branch (intent !== direct)',
     web: 'handled via search branch (intent !== direct)',
     examples: 'handled via search branch (intent !== direct)',
+    pressemitteilung_examples:
+      'handled via search branch — landesverbaende press release templates, same path as examples',
     summary: 'handled via summary branch in controller',
     chart: 'routes to respond, chart data handled by controller post-response',
     save_as_doc: 'routes to respond, then confirm_action SSE + pendingActionStore',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/defaultNotebook.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/defaultNotebook.vitest.ts
@@ -47,6 +47,7 @@ vi.mock('../../../../utils/logger.js', () => ({
 import {
   resolveNotebookCollections,
   isKnownNotebook,
+  isDisabledNotebook,
   NOTEBOOK_COLLECTION_MAP,
 } from '../../../../config/notebookCollectionMap.js';
 import {
@@ -182,7 +183,10 @@ describe('resolveNotebookCollections', () => {
 
 describe('isKnownNotebook', () => {
   it('returns true for all known notebook IDs', () => {
+    // DISABLED_NOTEBOOK_IDS entries stay in the map for admin tooling but
+    // isKnownNotebook returns false for them by design — filter them out.
     for (const id of Object.keys(NOTEBOOK_COLLECTION_MAP)) {
+      if (isDisabledNotebook(id)) continue;
       expect(isKnownNotebook(id)).toBe(true);
     }
   });

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.vitest.ts
@@ -21,6 +21,11 @@ vi.mock('../../../../config/vectorConfig.js', () => ({
       mergeOverfetch: 16,
       webScoreCeiling: 0.8,
     })),
+    // BaseSearchService's constructor calls this at module-load time via the
+    // exampleSearchService → DocumentSearchService import chain, so the mock
+    // has to satisfy the API even though no test here inspects the return.
+    getCacheConfig: vi.fn(() => ({ maxSize: 100, ttl: 60_000 })),
+    isVerboseMode: vi.fn(() => false),
   },
 }));
 

--- a/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchDocuments.vitest.ts
@@ -33,6 +33,21 @@ vi.mock('../../../../services/search/DiversityReranker.js', () => ({
   applyMMR: vi.fn((results: any[]) => results),
 }));
 
+// rerankResults() in searchDocuments.ts wraps its regoloRerankService call in
+// try/catch; if the service is unmocked it throws and the catch returns
+// early, which skips the filter + MMR step. Mock with an identity-style
+// passthrough so the rerank → filter → MMR pipeline actually runs.
+vi.mock('../../../../services/search/RegoloRerankService.js', () => ({
+  regoloRerankService: {
+    rerank: vi.fn(async ({ documents }: { documents: string[] }) =>
+      documents.map((_, originalIndex) => ({
+        originalIndex,
+        relevanceScore: 1 - originalIndex * 0.05,
+      }))
+    ),
+  },
+}));
+
 vi.mock('../../../../utils/logger.js', () => ({
   createLogger: () => ({
     info: vi.fn(),

--- a/apps/api/config/authRegressions.vitest.ts
+++ b/apps/api/config/authRegressions.vitest.ts
@@ -81,7 +81,18 @@
  */
 
 import pg from 'pg';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+// Better Auth refuses to construct when crossSubDomainCookies.enabled is true
+// without a baseURL. In real deploys BETTER_AUTH_URL is always set; in vitest
+// it isn't, so the module-load throws an unhandled rejection that the runner
+// reports as an error even though every test passes. Set a placeholder before
+// the betterAuth.ts import is evaluated.
+vi.hoisted(() => {
+  if (!process.env.BETTER_AUTH_URL) {
+    process.env.BETTER_AUTH_URL = 'http://localhost:3000';
+  }
+});
 
 import { auth } from './betterAuth.js';
 

--- a/apps/api/routes/docs/aiController.vitest.ts
+++ b/apps/api/routes/docs/aiController.vitest.ts
@@ -19,7 +19,13 @@ const mockToolDefinitionsToToolSet = vi.fn();
 vi.mock('@blocknote/xl-ai/server', () => ({
   injectDocumentStateMessages: mockInjectDocumentStateMessages,
   toolDefinitionsToToolSet: mockToolDefinitionsToToolSet,
-  aiDocumentFormats: { html: { systemPrompt: 'You are a document editor.' } },
+  // Mirror the format the controller actually reads: aiDocumentFormats._experimental_markdown.
+  // The earlier html shape is dead since the docs editor switched to markdown
+  // to dodge the "html diff" throw on color-span round-trips.
+  aiDocumentFormats: {
+    _experimental_markdown: { systemPrompt: 'You are a document editor.' },
+    html: { systemPrompt: 'You are a document editor.' },
+  },
 }));
 
 const mockGetModel = vi.fn();
@@ -327,7 +333,7 @@ describe('aiController – POST /api/docs/ai', () => {
       expect(opts.system).toContain('You are a document editor.');
       expect(opts.system).toContain('VALID SHAPES');
       expect(opts.toolChoice).toBe('auto');
-      expect(opts.maxOutputTokens).toBe(4096);
+      expect(opts.maxOutputTokens).toBe(32768);
       expect(opts.temperature).toBe(0.3);
     });
 

--- a/apps/api/services/document-services/TextChunker/langchainIntegration.ts
+++ b/apps/api/services/document-services/TextChunker/langchainIntegration.ts
@@ -35,44 +35,36 @@ export class LangChainChunker {
       separators: GERMAN_SEPARATORS,
     };
 
-    try {
-      // @ts-expect-error - LangChain is an optional dependency
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const { RecursiveCharacterTextSplitter } = await import('langchain/text_splitter');
-      const splitter: { splitText(text: string): Promise<string[]> } =
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        new RecursiveCharacterTextSplitter(opts) as { splitText(text: string): Promise<string[]> };
-      return splitter;
-    } catch (_err1) {
+    // LangChain text_splitter moved across packages over its 0.x → 0.3 history
+    // (`langchain/text_splitter` → `@langchain/core/text_splitter` →
+    // `@langchain/textsplitters`). The first two paths no longer exist in any
+    // installed version, but we keep the probe so a future `pnpm add` of the
+    // current package starts working without code changes. The paths are
+    // assembled at runtime via String(...) so vite's static-import analysis
+    // can't try to resolve them at test-collection time and crash on
+    // unresolvable specifiers.
+    const dynImport = (spec: string): Promise<unknown> => import(/* @vite-ignore */ String(spec));
+    const candidates = [
+      'langchain/text_splitter',
+      '@langchain/core/text_splitter',
+      '@langchain/textsplitters',
+    ];
+    for (const spec of candidates) {
       try {
-        // @ts-expect-error - LangChain is an optional dependency
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const { RecursiveCharacterTextSplitter } = await import('@langchain/core/text_splitter');
-        const splitter: { splitText(text: string): Promise<string[]> } =
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          new RecursiveCharacterTextSplitter(opts) as {
+        const mod = (await dynImport(spec)) as {
+          RecursiveCharacterTextSplitter: new (o: unknown) => {
             splitText(text: string): Promise<string[]>;
           };
-        return splitter;
-      } catch (_err2) {
-        try {
-          // @ts-expect-error - LangChain is an optional dependency
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          const { RecursiveCharacterTextSplitter } = await import('@langchain/textsplitters');
-          const splitter: { splitText(text: string): Promise<string[]> } =
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-            new RecursiveCharacterTextSplitter(opts) as {
-              splitText(text: string): Promise<string[]>;
-            };
-          return splitter;
-        } catch (_err3) {
-          if (vectorConfig.isVerboseMode()) {
-            console.warn('[LangChainChunker] LangChain not available; using fallback');
-          }
-          return null;
-        }
+        };
+        return new mod.RecursiveCharacterTextSplitter(opts);
+      } catch {
+        // try next candidate
       }
     }
+    if (vectorConfig.isVerboseMode()) {
+      console.warn('[LangChainChunker] LangChain not available; using fallback');
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Why

The api package's vitest suite had 17 failing tests on master, none of which represented a real production regression — every one was test-fixture or mock drift that had accumulated as production code moved on without the tests being updated. CI was reporting green because the failures were below the run-level threshold or were swallowed as module-load errors, but \`pnpm --filter @gruenerator/api test\` locally was a constant red wall.

This PR brings the suite to 845 passed / 0 failed / 0 errors.

## What broke (clusters, not a list)

- **Test fixtures lagging the source type**: \`ALL_INTENTS\` in intentPipeline.vitest.ts hadn't picked up \`compare\` or \`pressemitteilung_examples\`, even though both have been in \`SearchIntent\` and \`INTENT_MESSAGES\` for a while. The handler-path test failed for the same two intents — also added.
- **Mocks missing methods their target code now calls**: \`searchDocuments.vitest.ts\` didn't mock \`regoloRerankService\`, so the rerank threw and the try/catch returned before MMR could fire, making the diversity-applied assertion impossible. \`searchNode.vitest.ts\`'s vectorConfig mock was missing \`getCacheConfig\` and \`isVerboseMode\`, which BaseSearchService's constructor calls at module load. Both mocks extended.
- **Stale shape constants**: \`aiController.vitest.ts\` mocked \`aiDocumentFormats.html\` but the controller switched to \`._experimental_markdown\` (the migration that dodges the html-diff round-trip throw on color spans). The same file asserted \`maxOutputTokens: 4096\`; production raised it to 32768 after the old cap silently truncated mid-tool-call. Both updated to match.
- **Test invariant didn't model a later carve-out**: \`defaultNotebook.vitest.ts\` asserted every key in NOTEBOOK_COLLECTION_MAP is "known", but \`DISABLED_NOTEBOOK_IDS\` (schleswig-holstein, ricarda-lang) was added later — \`isKnownNotebook\` deliberately returns false for those. Filter via \`isDisabledNotebook\`.
- **Module-load throw treated as an error**: betterAuth.ts demands a baseURL whenever crossSubDomainCookies is enabled. In real deploys \`BETTER_AUTH_URL\` is always set; in vitest it isn't, so importing \`auth\` threw an unhandled rejection that vitest counted even though the 9 tests in authRegressions passed cleanly. Set a placeholder via \`vi.hoisted\` ahead of the import.
- **Vite resolution choking on a runtime fallback chain** (the one source-code change): the dynamic-import probe in \`langchainIntegration.ts\` tries three text-splitter package paths, the first two of which no longer exist. Runtime is fine (try/catch each), but vitest's vite-resolve plugin tries to statically resolve every \`import()\` spec at test-collection time and crashed on the dead paths — taking out 4 unrelated test files (compoundPipeline, defaultNotebook, searchNode, toolSchemas). Assembled the specifier via \`String(...)\` so the resolver can't pre-bind it. Behaviour unchanged.

## Risk

Six of seven changes are in \`*.vitest.ts\` files — they have no production effect. The one source-code change (\`langchainIntegration.ts\`) only changes how vite sees the import specifier; the actual runtime probe order and fallback are byte-identical.