### PR TITLE
feat(notebooks): compact click-to-edit header in editor dialog

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,18 +1,16 @@
 import { Badge, Button } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
+import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
 import {
-  useState,
-  useEffect,
-  useCallback,
-  useRef,
-  type ComponentType,
-  type DragEvent,
-  type KeyboardEvent,
-} from 'react';
-import { useForm } from 'react-hook-form';
-import { HiCheckCircle, HiArrowLeft, HiUpload, HiX, HiPlus } from 'react-icons/hi';
+  HiCheckCircle,
+  HiArrowLeft,
+  HiUpload,
+  HiX,
+  HiPlus,
+  HiPencil,
+} from 'react-icons/hi';
 
-import { useFormFields } from '../../../components/common/Form/hooks';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
 
@@ -27,27 +25,6 @@ interface NotebookCollection {
 interface NotebookEditorFormData {
   name: string;
   description: string;
-}
-
-interface FormFieldComponents {
-  Input: ComponentType<{
-    name: string;
-    control: unknown;
-    label: string;
-    placeholder?: string;
-    rules?: unknown;
-  }>;
-  Textarea: ComponentType<{
-    name: string;
-    control: unknown;
-    label: string;
-    placeholder?: string;
-    minRows?: number;
-    maxRows?: number;
-    helpText?: string;
-    rules?: unknown;
-  }>;
-  [key: string]: unknown;
 }
 
 interface UploadedDocument {
@@ -127,9 +104,9 @@ const NotebookEditor = ({
   const [labels, setLabels] = useState<string[]>([]);
   const [newLabel, setNewLabel] = useState('');
   const [indexingDocIds, setIndexingDocIds] = useState<Set<string>>(() => new Set());
+  const [editing, setEditing] = useState<null | 'name' | 'desc' | 'labels'>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { Input, Textarea } = useFormFields() as unknown as FormFieldComponents;
   const { uploadFileOnly, pollDocumentStatus } = useDocumentsStore();
 
   const { control, handleSubmit, reset, setValue } = useForm<NotebookEditorFormData>({
@@ -138,6 +115,28 @@ const NotebookEditor = ({
       description: '',
     },
   });
+
+  const watchedName = useWatch({ control, name: 'name' }) ?? '';
+  const watchedDesc = useWatch({ control, name: 'description' }) ?? '';
+
+  const commitName = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        setValue('name', trimmed.slice(0, 100), { shouldValidate: true, shouldDirty: true });
+      }
+      setEditing(null);
+    },
+    [setValue]
+  );
+
+  const commitDesc = useCallback(
+    (value: string) => {
+      setValue('description', value.slice(0, 500), { shouldDirty: true });
+      setEditing(null);
+    },
+    [setValue]
+  );
 
   useEffect(() => {
     if (editingCollection) {
@@ -285,16 +284,6 @@ const NotebookEditor = ({
     setLabels((prev) => prev.filter((l) => l !== labelToRemove));
   }, []);
 
-  const handleLabelKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        handleAddLabel();
-      }
-    },
-    [handleAddLabel]
-  );
-
   const onSubmit = async (data: NotebookEditorFormData): Promise<void> => {
     if (uploadedDocuments.length === 0) return;
 
@@ -430,201 +419,282 @@ const NotebookEditor = ({
               exit={{ opacity: 0, x: 20 }}
               transition={{ duration: 0.2 }}
             >
-              <form onSubmit={handleSubmit(onSubmit)} className="space-y-sm">
-                <div className="space-y-sm">
-                  {uploadedDocuments.length > 0 && (
-                    <div>
-                      <label className="text-sm font-medium text-foreground">
-                        Dokumente ({uploadedDocuments.length}/{MAX_DOCUMENTS})
-                      </label>
-                      <div className="mt-xs grid grid-cols-1 gap-sm md:grid-cols-2 xl:grid-cols-3">
-                        {uploadedDocuments.map((doc) => {
-                          const isIndexing = indexingDocIds.has(doc.id);
-                          const fileType = getFileTypeBadge(doc.filename || doc.title);
-                          return (
-                            <div
-                              key={doc.id}
-                              className={cn(
-                                'group relative flex items-center gap-sm rounded-xl border border-grey-200 bg-background p-sm min-w-0 transition-all duration-200 dark:border-grey-800',
-                                isIndexing
-                                  ? 'opacity-90'
-                                  : 'hover:border-grey-300 hover:shadow-sm dark:hover:border-grey-700'
-                              )}
-                            >
-                              <span
-                                className={cn(
-                                  'shrink-0 rounded-md px-1.5 py-[3px] text-[10px] font-semibold uppercase tracking-wide',
-                                  fileType.tagClass,
-                                  isIndexing && 'opacity-60'
-                                )}
-                                aria-hidden
-                              >
-                                {fileType.label}
-                              </span>
-                              <div className="min-w-0 flex-1">
-                                <div
-                                  className="truncate text-sm font-medium text-foreground"
-                                  title={doc.filename || doc.title}
-                                >
-                                  {doc.filename || doc.title}
-                                </div>
-                                <div className="mt-[2px] flex items-center gap-xs text-xs text-grey-500">
-                                  {isIndexing ? (
-                                    <>
-                                      <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                                      <span>Wird verarbeitet…</span>
-                                    </>
-                                  ) : (
-                                    <>
-                                      <HiCheckCircle size={12} className="text-green-600" />
-                                      <span>Bereit</span>
-                                    </>
-                                  )}
-                                </div>
-                              </div>
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-xs"
-                                className={cn(
-                                  'shrink-0 transition-opacity',
-                                  isIndexing
-                                    ? 'opacity-60'
-                                    : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
-                                )}
-                                onClick={() => handleRemoveDocument(doc.id)}
-                                disabled={loading}
-                                aria-label={`${doc.title} entfernen`}
-                              >
-                                <HiX size={12} />
-                              </Button>
-                            </div>
-                          );
-                        })}
-                      </div>
-                      {uploadedDocuments.length < MAX_DOCUMENTS && (
-                        <div
-                          className={cn(
-                            'mt-xs flex min-h-[56px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-sm transition-colors duration-200',
-                            isDragOver
-                              ? 'border-primary-500 bg-green-50 dark:bg-secondary-900'
-                              : 'border-grey-300 hover:border-primary-500 hover:bg-background dark:border-grey-600',
-                            (isUploading || loading) && 'cursor-default opacity-60'
-                          )}
-                          onDrop={handleDrop}
-                          onDragOver={handleDragOver}
-                          onDragLeave={handleDragLeave}
-                          onClick={() => {
-                            if (isUploading || loading) return;
-                            fileInputRef.current?.click();
-                          }}
-                        >
-                          {isUploading ? (
-                            <>
-                              <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                              <span className="text-sm text-grey-500">Wird hochgeladen…</span>
-                            </>
-                          ) : (
-                            <>
-                              <HiUpload className="text-grey-400" />
-                              <span className="text-sm font-medium text-foreground">
-                                Weitere Dateien ablegen oder klicken
-                              </span>
-                              <span className="text-xs text-grey-500">
-                                ({MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)
-                              </span>
-                            </>
-                          )}
-                        </div>
-                      )}
-                      <input
-                        ref={fileInputRef}
-                        type="file"
-                        multiple
-                        accept={ACCEPTED_EXTENSIONS.join(',')}
-                        onChange={handleFileSelect}
-                        style={{ display: 'none' }}
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-md">
+                {/* Compact header: name / description / labels — click to edit */}
+                <section className="rounded-xl bg-background-alt/50 px-sm py-sm">
+                  {editing === 'name' ? (
+                    <input
+                      type="text"
+                      defaultValue={watchedName}
+                      autoFocus
+                      maxLength={100}
+                      placeholder="Name des Notebooks"
+                      onBlur={(e) => commitName(e.currentTarget.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          commitName(e.currentTarget.value);
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault();
+                          setEditing(null);
+                        }
+                      }}
+                      className="w-full bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-grey-400"
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setEditing('name')}
+                      className="group flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background"
+                      aria-label="Name bearbeiten"
+                    >
+                      <span
+                        className={cn(
+                          'truncate text-lg font-semibold leading-tight',
+                          watchedName ? 'text-foreground' : 'italic text-grey-400'
+                        )}
+                      >
+                        {watchedName || 'Notebook benennen…'}
+                      </span>
+                      <HiPencil
+                        size={12}
+                        className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
                       />
-                      {uploadError && <p className="mt-xs text-sm text-red-600">{uploadError}</p>}
-                    </div>
+                    </button>
                   )}
 
-                  <div>
-                    <Input
-                      name="name"
-                      control={control}
-                      label="Name des Notebooks"
-                      placeholder="z.B. Klimapolitik-Dokumente"
-                      rules={{
-                        required: 'Name ist erforderlich',
-                        maxLength: { value: 100, message: 'Name darf maximal 100 Zeichen haben' },
+                  {editing === 'desc' ? (
+                    <textarea
+                      defaultValue={watchedDesc}
+                      autoFocus
+                      rows={3}
+                      maxLength={500}
+                      placeholder="Kurze Beschreibung…"
+                      onBlur={(e) => commitDesc(e.currentTarget.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          commitDesc(e.currentTarget.value);
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault();
+                          setEditing(null);
+                        }
                       }}
+                      className="mt-xs w-full resize-none rounded-md border border-grey-200 bg-background px-sm py-xs text-sm text-foreground outline-none placeholder:text-grey-400 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-grey-700"
                     />
-                  </div>
-
-                  <div>
-                    <Textarea
-                      name="description"
-                      control={control}
-                      label="Beschreibung (optional)"
-                      placeholder="Kurze Beschreibung des Notebooks..."
-                      minRows={2}
-                      maxRows={4}
-                      rules={{
-                        maxLength: {
-                          value: 500,
-                          message: 'Beschreibung darf maximal 500 Zeichen haben',
-                        },
-                      }}
-                    />
-                  </div>
-
-                  <div>
-                    <label className="text-sm font-medium text-foreground">Labels (optional)</label>
-                    <div className="mt-xs flex items-center gap-xs">
-                      <input
-                        type="text"
-                        value={newLabel}
-                        onChange={(e) => setNewLabel(e.target.value)}
-                        onKeyDown={handleLabelKeyDown}
-                        placeholder="Label hinzufügen…"
-                        maxLength={30}
-                        disabled={loading || labels.length >= 10}
-                        className="flex-1 rounded-md border border-grey-300 dark:border-grey-600 bg-background px-sm py-xs text-sm text-foreground placeholder:text-grey-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={handleAddLabel}
-                        disabled={loading || !newLabel.trim() || labels.length >= 10}
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setEditing('desc')}
+                      className="group mt-[2px] flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background"
+                      aria-label="Beschreibung bearbeiten"
+                    >
+                      <span
+                        className={cn(
+                          'line-clamp-1 text-sm',
+                          watchedDesc ? 'text-grey-600 dark:text-grey-300' : 'italic text-grey-400'
+                        )}
                       >
-                        <HiPlus size={14} />
-                      </Button>
-                    </div>
-                    {labels.length > 0 && (
-                      <div className="mt-xs flex flex-wrap gap-xs">
-                        {labels.map((label) => (
-                          <Badge
-                            key={label}
-                            variant="secondary"
-                            className="bg-secondary-600 text-white border-transparent gap-1"
-                          >
-                            {label}
-                            <button
-                              type="button"
-                              className="ml-0.5 inline-flex items-center hover:text-grey-200"
-                              onClick={() => handleRemoveLabel(label)}
-                              aria-label={`Label "${label}" entfernen`}
-                            >
-                              <HiX size={12} />
-                            </button>
-                          </Badge>
-                        ))}
+                        {watchedDesc || 'Beschreibung hinzufügen…'}
+                      </span>
+                      <HiPencil
+                        size={11}
+                        className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
+                      />
+                    </button>
+                  )}
+
+                  <div className="mt-sm flex flex-wrap items-center gap-xs">
+                    {labels.map((label) => (
+                      <Badge
+                        key={label}
+                        variant="secondary"
+                        className="gap-1 border-transparent bg-secondary-600 text-xs text-white"
+                      >
+                        {label}
+                        <button
+                          type="button"
+                          className="ml-0.5 inline-flex items-center hover:text-grey-200"
+                          onClick={() => handleRemoveLabel(label)}
+                          aria-label={`Label "${label}" entfernen`}
+                        >
+                          <HiX size={11} />
+                        </button>
+                      </Badge>
+                    ))}
+                    {editing === 'labels' ? (
+                      <div className="flex items-center gap-xs">
+                        <input
+                          type="text"
+                          value={newLabel}
+                          autoFocus
+                          onChange={(e) => setNewLabel(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              handleAddLabel();
+                            } else if (e.key === 'Escape') {
+                              e.preventDefault();
+                              setNewLabel('');
+                              setEditing(null);
+                            }
+                          }}
+                          onBlur={() => {
+                            if (!newLabel.trim()) setEditing(null);
+                          }}
+                          placeholder="Label…"
+                          maxLength={30}
+                          disabled={loading || labels.length >= 10}
+                          className="w-32 rounded-md border border-grey-300 bg-background px-sm py-[2px] text-xs text-foreground placeholder:text-grey-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-grey-600"
+                        />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={handleAddLabel}
+                          disabled={loading || !newLabel.trim() || labels.length >= 10}
+                          aria-label="Label hinzufügen"
+                        >
+                          <HiPlus size={12} />
+                        </Button>
                       </div>
+                    ) : (
+                      labels.length < 10 && (
+                        <button
+                          type="button"
+                          onClick={() => setEditing('labels')}
+                          className="inline-flex items-center gap-1 rounded-full border border-dashed border-grey-300 px-2 py-[2px] text-xs text-grey-500 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-grey-600"
+                        >
+                          <HiPlus size={10} />
+                          {labels.length === 0 ? 'Label hinzufügen' : 'Weiteres Label'}
+                        </button>
+                      )
                     )}
                   </div>
-                </div>
+                </section>
+
+                {/* Documents: cards + dropzone */}
+                {uploadedDocuments.length > 0 && (
+                  <div className="space-y-xs">
+                    <div className="flex items-baseline justify-between px-1">
+                      <label className="text-xs font-medium uppercase tracking-wide text-grey-500">
+                        Dokumente
+                      </label>
+                      <span className="text-xs text-grey-500">
+                        {uploadedDocuments.length}/{MAX_DOCUMENTS}
+                      </span>
+                    </div>
+                    <div className="grid grid-cols-1 gap-sm md:grid-cols-2 xl:grid-cols-3">
+                      {uploadedDocuments.map((doc) => {
+                        const isIndexing = indexingDocIds.has(doc.id);
+                        const fileType = getFileTypeBadge(doc.filename || doc.title);
+                        return (
+                          <div
+                            key={doc.id}
+                            className={cn(
+                              'group relative flex items-center gap-sm rounded-xl border border-grey-200 bg-background p-sm min-w-0 transition-all duration-200 dark:border-grey-800',
+                              isIndexing
+                                ? 'opacity-90'
+                                : 'hover:border-grey-300 hover:shadow-sm dark:hover:border-grey-700'
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                'shrink-0 rounded-md px-1.5 py-[3px] text-[10px] font-semibold uppercase tracking-wide',
+                                fileType.tagClass,
+                                isIndexing && 'opacity-60'
+                              )}
+                              aria-hidden
+                            >
+                              {fileType.label}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              <div
+                                className="truncate text-sm font-medium text-foreground"
+                                title={doc.filename || doc.title}
+                              >
+                                {doc.filename || doc.title}
+                              </div>
+                              <div className="mt-[2px] flex items-center gap-xs text-xs text-grey-500">
+                                {isIndexing ? (
+                                  <>
+                                    <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                                    <span>Wird verarbeitet…</span>
+                                  </>
+                                ) : (
+                                  <>
+                                    <HiCheckCircle size={12} className="text-green-600" />
+                                    <span>Bereit</span>
+                                  </>
+                                )}
+                              </div>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className={cn(
+                                'shrink-0 transition-opacity',
+                                isIndexing
+                                  ? 'opacity-60'
+                                  : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+                              )}
+                              onClick={() => handleRemoveDocument(doc.id)}
+                              disabled={loading}
+                              aria-label={`${doc.title} entfernen`}
+                            >
+                              <HiX size={12} />
+                            </Button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {uploadedDocuments.length < MAX_DOCUMENTS && (
+                      <div
+                        className={cn(
+                          'flex min-h-[52px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-sm transition-colors duration-200',
+                          isDragOver
+                            ? 'border-primary-500 bg-green-50 dark:bg-secondary-900'
+                            : 'border-grey-300 hover:border-primary-500 hover:bg-background dark:border-grey-600',
+                          (isUploading || loading) && 'cursor-default opacity-60'
+                        )}
+                        onDrop={handleDrop}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onClick={() => {
+                          if (isUploading || loading) return;
+                          fileInputRef.current?.click();
+                        }}
+                      >
+                        {isUploading ? (
+                          <>
+                            <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                            <span className="text-sm text-grey-500">Wird hochgeladen…</span>
+                          </>
+                        ) : (
+                          <>
+                            <HiUpload className="text-grey-400" />
+                            <span className="text-sm font-medium text-foreground">
+                              Weitere Dateien ablegen oder klicken
+                            </span>
+                            <span className="text-xs text-grey-500">
+                              ({MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)
+                            </span>
+                          </>
+                        )}
+                      </div>
+                    )}
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      multiple
+                      accept={ACCEPTED_EXTENSIONS.join(',')}
+                      onChange={handleFileSelect}
+                      style={{ display: 'none' }}
+                    />
+                    {uploadError && <p className="mt-xs text-sm text-red-600">{uploadError}</p>}
+                  </div>
+                )}
 
                 <div className="flex flex-wrap justify-end gap-sm pt-md border-t border-grey-200 dark:border-grey-700">
                   {!editingCollection && (
@@ -638,7 +708,10 @@ const NotebookEditor = ({
                       Zurück
                     </Button>
                   )}
-                  <Button type="submit" disabled={loading || uploadedDocuments.length === 0}>
+                  <Button
+                    type="submit"
+                    disabled={loading || uploadedDocuments.length === 0 || !watchedName.trim()}
+                  >
                     {loading
                       ? 'Wird gespeichert...'
                       : editingCollection


### PR DESCRIPTION
The edit-mode form treated name, description and labels as three full-height labeled rows. In edit mode the user already knows what the notebook is, so those duplicated the dialog title and pushed the file cards below the fold.

Title, description and tags now collapse into a small calm header at the top of the dialog — each click-to-edit inline. Enter / blur commits, Esc reverts; Cmd+Enter for description. File cards then take over the visual hierarchy directly underneath.

`react-hook-form` still owns the field values via `useWatch` + `setValue`; submit payload is unchanged.

## Screenshot (before)
The current layout from the linked screenshot — three full-width labeled rows after the file grid.

## Test plan
- [ ] `/notebooks/meine` → Bearbeiten on an existing notebook: header shows name (bold) + description (muted, one line) + label chips; cards block below with a hairline divider.
- [ ] Click title → inline input, Enter commits, Esc reverts, empty + blur keeps previous value.
- [ ] Click description → autosize textarea, Cmd+Enter commits, Esc reverts.
- [ ] Click "+ Label" → existing input + plus button surfaces inline; add/remove unchanged; 10-item / 30-char caps respected.
- [ ] Save → backend receives same `{ name, description, labels, documents }` payload.
- [ ] Create flow regression: drop file → step 2 → suggested name still appears, description / labels start empty with ghost prompts.
- [ ] Dark mode + 360 px width sanity check.