### PR TITLE
fix(chat): allow doc collaborators to access doc-linked chat threads

### DIFF
--- a/apps/api/database/schema/chat.ts
+++ b/apps/api/database/schema/chat.ts
@@ -28,6 +28,7 @@ export const chatThreads = pgTable('chat_threads', {
   custom_enabled_tools: jsonb('custom_enabled_tools').$type<Record<string, unknown>>(),
   notebook_collection_id: varchar('notebook_collection_id', { length: 255 }),
   notebook_collection_ids: jsonb('notebook_collection_ids').$type<string[]>(),
+  doc_id: uuid('doc_id'),
 });
 
 export const chatMessages = pgTable('chat_messages', {

--- a/apps/api/routes/chat/services/threadAccessService.ts
+++ b/apps/api/routes/chat/services/threadAccessService.ts
@@ -8,7 +8,8 @@ import { type ThreadId, type UserId } from '../../../utils/types/branded.js';
  * arguments at a call site is a compile error — both are UUIDs at runtime
  * and plain string parameters would hide the bug. Access is granted if
  * the user is the owner, is listed in `permissions`, the thread is public,
- * or a group the user is a member of has the thread shared to it.
+ * a group the user is a member of has the thread shared to it, or — for
+ * doc-linked chat threads — the user can access the linked document.
  *
  * Uses separate queries to avoid PostgreSQL type ambiguity
  * (chat_threads.user_id is varchar, group_memberships.user_id is uuid).
@@ -26,7 +27,27 @@ export async function canAccessThread(threadId: ThreadId, userId: UserId): Promi
   );
   if (directAccess.length > 0) return true;
 
-  // Check group access separately to avoid type conflicts
+  // Doc-linked chat threads: defer to the linked document's access rules so
+  // any user who can access the document can use its chat. Mirrors
+  // checkDirectAccess() in routes/docs/documentAccess.ts.
+  const docDirectAccess = await db.query(
+    `SELECT 1
+     FROM chat_threads ct
+     INNER JOIN collaborative_documents d ON d.id = ct.doc_id
+     WHERE ct.id = $1
+       AND ct.doc_id IS NOT NULL
+       AND (
+         d.created_by = $2
+         OR d.is_public = true
+         OR d.share_mode = 'authenticated'
+         OR d.permissions ? $2::text
+       )
+     LIMIT 1`,
+    [threadId, userId]
+  );
+  if (docDirectAccess.length > 0) return true;
+
+  // Group access on the chat thread itself
   const groupAccess = await db.query(
     `SELECT 1 FROM group_content_shares gcs
      INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id
@@ -36,5 +57,25 @@ export async function canAccessThread(threadId: ThreadId, userId: UserId): Promi
      LIMIT 1`,
     [threadId, userId]
   );
-  return groupAccess.length > 0;
+  if (groupAccess.length > 0) return true;
+
+  // Group access on the linked document (mirrors checkGroupAccess() in
+  // routes/docs/documentAccess.ts, scoped to the thread's doc_id).
+  const docGroupAccess = await db.query(
+    `SELECT 1
+     FROM chat_threads ct
+     INNER JOIN group_content_shares gcs
+       ON gcs.content_type IN ('collaborative_documents', 'canvas_template')
+      AND gcs.content_id = ct.doc_id::text
+     INNER JOIN group_memberships gm
+       ON gm.group_id = gcs.group_id
+      AND gm.user_id = $2::uuid
+      AND gm.is_active = TRUE
+     WHERE ct.id = $1
+       AND ct.doc_id IS NOT NULL
+       AND COALESCE((gcs.permissions->>'read')::boolean, true) = true
+     LIMIT 1`,
+    [threadId, userId]
+  );
+  return docGroupAccess.length > 0;
 }


### PR DESCRIPTION
## Summary

Document chats failed with `Thread not found` for everyone except the document creator. The doc-chat thread is created with `user_id = doc.created_by`, but `canAccessThread` only consulted thread-level ownership/permissions/public + thread group shares — it ignored the linked `doc_id`, so collaborators who could read the document (and had already been granted a `threadId` by `getChatThread`) were blocked at message send.

The two access paths around doc-chat were asymmetric: `getChatThread` correctly defers to `checkDocumentAccess`, but the streaming endpoint did not. This patch makes `canAccessThread` defer to the linked document's access rules when `chat_threads.doc_id` is set, mirroring `checkDirectAccess` / `checkGroupAccess` in `routes/docs/documentAccess.ts`. Live derivation keeps chat access in lockstep with doc permission changes without a backfill or per-collaborator write into `chat_threads.permissions`.

Also adds the long-missing `doc_id` field to the Drizzle `chatThreads` schema so `InferSelectModel` matches the column added by `add_chat_threads_doc_id.sql` (4-layer audit gap).

## Test plan
- [ ] User A creates a doc, sends a chat → still works (owner path unchanged)
- [ ] User A shares the doc with User B (direct permission); User B sends a chat → no longer errors
- [ ] User C with no doc access cannot use the threadId
- [ ] Doc shared to a group: a group member sends a chat → works via `docGroupAccess` branch