### PR TITLE
fix(web): cookie banner uses --background-color (was --background)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -140,7 +140,7 @@
     <style>
       .terms-banner {
         position: fixed; bottom: 0; left: 0; width: 100%;
-        background: var(--background, #ffffff);
+        background: var(--background-color, #ffffff);
         color: var(--font-color, #1a1a1a);
         padding: 10px 20px;
         box-shadow: 0 -2px 5px rgba(0, 0, 0, 0.15);
@@ -155,7 +155,7 @@
       .terms-banner__actions { display: flex; gap: 12px; align-items: center; }
       .terms-banner button {
         background: var(--font-color-h, #1a1a1a);
-        color: var(--background, #ffffff);
+        color: var(--background-color, #ffffff);
         border: none; border-radius: 50px;
         padding: 10px 20px;
         font: inherit; cursor: pointer;
@@ -192,30 +192,34 @@
       </div>
     </div>
     <script>
+      // Mirrors the 'termsAccepted' key tracked by usePopupDismiss.ts
+      // (POPUP_KEYS registry). The inline write below bypasses the
+      // server-side cross-device sync that the React hook performed for
+      // authenticated users — acceptable because the banner is shown once
+      // on signed-out landing and the vast majority of dismissals happen
+      // before sign-in.
       (function () {
-        try {
-          var banner = document.getElementById('terms-banner');
-          if (!banner) return;
-          var dismissed = false;
-          try { dismissed = localStorage.getItem('termsAccepted') === 'true'; } catch (e) {}
-          var noChrome = /-no-header-footer/.test(location.pathname);
-          if (dismissed || noChrome) {
-            banner.parentNode.removeChild(banner);
+        var banner = document.getElementById('terms-banner');
+        if (!banner) return;
+        var dismissed = false;
+        try { dismissed = localStorage.getItem('termsAccepted') === 'true'; } catch (e) {}
+        var noChrome = /-no-header-footer/.test(location.pathname);
+        if (dismissed || noChrome) {
+          banner.remove();
+          return;
+        }
+        function accept(grantAnalytics) {
+          try { localStorage.setItem('termsAccepted', 'true'); } catch (e) {}
+          if (grantAnalytics && typeof window.grantAnalyticsConsent === 'function') {
+            window.grantAnalyticsConsent(); // reloads the page to load Umami
             return;
           }
-          function accept(grantAnalytics) {
-            try { localStorage.setItem('termsAccepted', 'true'); } catch (e) {}
-            if (grantAnalytics && typeof window.grantAnalyticsConsent === 'function') {
-              window.grantAnalyticsConsent(); // reloads the page to load Umami
-              return;
-            }
-            if (banner.parentNode) banner.parentNode.removeChild(banner);
-          }
-          var btnNecessary = document.getElementById('terms-banner-necessary');
-          var btnAccept = document.getElementById('terms-banner-accept-all');
-          if (btnNecessary) btnNecessary.addEventListener('click', function () { accept(false); });
-          if (btnAccept) btnAccept.addEventListener('click', function () { accept(true); });
-        } catch (e) {}
+          banner.remove();
+        }
+        var btnNecessary = document.getElementById('terms-banner-necessary');
+        var btnAccept = document.getElementById('terms-banner-accept-all');
+        if (btnNecessary) btnNecessary.addEventListener('click', function () { accept(false); });
+        if (btnAccept) btnAccept.addEventListener('click', function () { accept(true); });
       })();
     </script>
 


### PR DESCRIPTION
## Why

Follow-up to #828 (which merged before a \`/simplify\` review could be folded back in). Three findings from that review — one real bug, two cleanups:

### 1. CSS variable typo (real visual bug)

The inline banner in #828 used \`var(--background, #ffffff)\` in two places. The actual theme variable in \`apps/web/src/assets/styles/common/variables.css:71,292,430\` is \`--background-color\` — \`--background\` is undefined, so the \`#ffffff\` fallback always wins.

**Effect**: dark-mode visitors see a permanent **white** banner over the dark page, plus button colors flipped the same way (\`color: var(--background, #ffffff)\` on the buttons). Not caught by any tooling because CSS variable names aren't validated by typecheck, lint, or trace.

### 2. \`Element.remove()\` instead of \`parentNode.removeChild\`

Codebase targets ES2022 (\`vite.config.ts:125\`); the longer form is just legacy muscle memory.

### 3. Drop the outer \`try/catch\` wrapping the IIFE

The only realistic throw sites are \`localStorage.getItem\` and \`localStorage.setItem\` in incognito/storage-disabled contexts. Both are already wrapped individually. The outer wrapper was belt-and-braces over no-throw DOM calls.

## Also: maintainer-facing comment

Added a 5-line comment near the inline \`localStorage\` read pointing future maintainers at \`POPUP_KEYS\` in \`apps/web/src/hooks/usePopupDismiss.ts\` and noting that the inline write skips the server cross-device sync that the deleted React hook performed for authenticated users (acceptable trade-off; the banner is dismissed pre-signin in the overwhelming majority of cases — already disclosed in #828's body).

## Safety

HTML-only change. No app code paths touched. The CSS variable fix only changes which color is read at runtime — falls back gracefully on browsers without the variable defined, same as before.