### PR TITLE
refactor(notebooks): type NotebookEditor save payload via Zod schema

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -1,3 +1,4 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -130,76 +131,78 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
           )}
         >
           <HiUpload />
-          {isFull ? `Notebook ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK})` : `Hier ablegen, um zu „${collection.name}" hinzuzufügen`}
+          {isFull
+            ? `Notebook ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK})`
+            : `Hier ablegen, um zu „${collection.name}" hinzuzufügen`}
         </div>
       ) : null}
       <div className={cn(isDragOver && 'pointer-events-none')}>
-      <div className="flex items-start justify-between gap-sm">
-        <button
-          type="button"
-          onClick={() => onOpen(collection)}
-          className="flex flex-1 cursor-pointer items-start gap-sm bg-transparent text-left"
-        >
-          <HiBookOpen className="mt-1 shrink-0 text-lg text-secondary-600" />
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold text-foreground-heading">
-              {collection.name}
-            </div>
-            {collection.description ? (
-              <div className="line-clamp-4 text-xs text-grey-500 dark:text-grey-400">
-                {collection.description}
+        <div className="flex items-start justify-between gap-sm">
+          <button
+            type="button"
+            onClick={() => onOpen(collection)}
+            className="flex flex-1 cursor-pointer items-start gap-sm bg-transparent text-left"
+          >
+            <HiBookOpen className="mt-1 shrink-0 text-lg text-secondary-600" />
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-sm font-semibold text-foreground-heading">
+                {collection.name}
               </div>
+              {collection.description ? (
+                <div className="line-clamp-4 text-xs text-grey-500 dark:text-grey-400">
+                  {collection.description}
+                </div>
+              ) : null}
+            </div>
+          </button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                aria-label="Aktionen"
+                className="-mr-2 shrink-0 opacity-70 group-hover:opacity-100"
+              >
+                <HiDotsHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onSelect={() => onOpen(collection)}>
+                <HiExternalLink className="mr-2" /> Öffnen
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onRename(collection)}>
+                <HiPencil className="mr-2" /> Umbenennen
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onEdit(collection)}>
+                <HiPencil className="mr-2" /> Bearbeiten
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => onShare(collection)}>
+                <HiShare className="mr-2" /> Link kopieren
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => onDelete(collection)} variant="destructive">
+                <HiTrash className="mr-2" /> Löschen
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {(collection.is_public || isProcessing) && (
+          <div className="flex items-center gap-xs">
+            {collection.is_public ? (
+              <Badge variant="outline" className="text-xs">
+                Geteilt
+              </Badge>
+            ) : null}
+            {isProcessing ? (
+              <Badge variant="outline" className="gap-xs text-xs text-primary-600">
+                <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                Wird verarbeitet…
+              </Badge>
             ) : null}
           </div>
-        </button>
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="icon"
-              variant="ghost"
-              aria-label="Aktionen"
-              className="-mr-2 shrink-0 opacity-70 group-hover:opacity-100"
-            >
-              <HiDotsHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={() => onOpen(collection)}>
-              <HiExternalLink className="mr-2" /> Öffnen
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onRename(collection)}>
-              <HiPencil className="mr-2" /> Umbenennen
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onEdit(collection)}>
-              <HiPencil className="mr-2" /> Bearbeiten
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={() => onShare(collection)}>
-              <HiShare className="mr-2" /> Link kopieren
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => onDelete(collection)} variant="destructive">
-              <HiTrash className="mr-2" /> Löschen
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
-      {(collection.is_public || isProcessing) && (
-        <div className="flex items-center gap-xs">
-          {collection.is_public ? (
-            <Badge variant="outline" className="text-xs">
-              Geteilt
-            </Badge>
-          ) : null}
-          {isProcessing ? (
-            <Badge variant="outline" className="gap-xs text-xs text-primary-600">
-              <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-              Wird verarbeitet…
-            </Badge>
-          ) : null}
-        </div>
-      )}
+        )}
       </div>
     </div>
   );
@@ -312,23 +315,15 @@ function MyNotebooksPageInner() {
   );
 
   const handleEditSave = useCallback(
-    async (collection: NotebookCollection, data: unknown) => {
-      const d = data as {
-        name: string;
-        description?: string;
-        documents?: (string | number)[];
-        labels?: string[];
-      };
+    async (collection: NotebookCollection, data: NotebookEditorSavePayload) => {
       const originalIds = new Set((collection.documents ?? []).map((doc) => String(doc.id)));
-      const addedIds = (d.documents ?? [])
-        .map((id) => String(id))
-        .filter((id) => !originalIds.has(id));
+      const addedIds = data.documents.filter((id) => !originalIds.has(id));
 
       await updateQACollection(collection.id, {
-        name: d.name,
-        description: d.description,
-        documents: d.documents,
-        labels: d.labels,
+        name: data.name,
+        description: data.description,
+        documents: data.documents,
+        labels: data.labels,
         selectionMode: collection.selection_mode,
         custom_prompt: collection.custom_prompt,
       });
@@ -351,18 +346,12 @@ function MyNotebooksPageInner() {
   );
 
   const handleCreateSave = useCallback(
-    async (data: unknown) => {
-      const d = data as {
-        name: string;
-        description?: string;
-        documents?: (string | number)[];
-        labels?: string[];
-      };
+    async (data: NotebookEditorSavePayload) => {
       await createQACollection({
-        name: d.name,
-        description: d.description,
-        documents: d.documents,
-        labels: d.labels,
+        name: data.name,
+        description: data.description,
+        documents: data.documents,
+        labels: data.labels,
       });
       closeDialog();
     },
@@ -393,7 +382,9 @@ function MyNotebooksPageInner() {
       const existingIds = (collection.documents ?? []).map((d) => String(d.id));
       const remainingSlots = MAX_DOCUMENTS_PER_NOTEBOOK - existingIds.length;
       if (remainingSlots <= 0) {
-        toast.error(`„${collection.name}" ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK} Dokumente)`);
+        toast.error(
+          `„${collection.name}" ist voll (${MAX_DOCUMENTS_PER_NOTEBOOK}/${MAX_DOCUMENTS_PER_NOTEBOOK} Dokumente)`
+        );
         return;
       }
       const filesToUpload = accepted.slice(0, remainingSlots);
@@ -402,9 +393,7 @@ function MyNotebooksPageInner() {
       setProcessingCollectionIds((prev) => new Set(prev).add(collection.id));
 
       try {
-        const uploaded = await Promise.all(
-          filesToUpload.map((f) => uploadFileOnly(f, f.name))
-        );
+        const uploaded = await Promise.all(filesToUpload.map((f) => uploadFileOnly(f, f.name)));
         const newIds = uploaded.map((d) => String(d.id));
 
         await updateQACollection(collection.id, {
@@ -456,127 +445,127 @@ function MyNotebooksPageInner() {
         </div>
 
         {isLoading ? (
-        <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div
-              key={i}
-              className="h-28 animate-pulse rounded-md border border-grey-200 bg-grey-50 dark:border-grey-700 dark:bg-grey-900"
-            />
-          ))}
-        </div>
-      ) : isEmpty ? (
-        <div className="flex flex-col items-center gap-md rounded-md border border-dashed border-grey-300 p-xl text-center dark:border-grey-700">
-          <HiBookOpen className="text-3xl text-grey-400" />
-          <div>
-            <div className="text-base font-medium text-foreground-heading">
-              Du hast noch keine eigenen Notebooks
-            </div>
-            <div className="mt-xs text-sm text-grey-500 dark:text-grey-400">
-              Erstelle dein erstes Notebook, um Dokumente und Quellen zu bündeln.
-            </div>
+          <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-28 animate-pulse rounded-md border border-grey-200 bg-grey-50 dark:border-grey-700 dark:bg-grey-900"
+              />
+            ))}
           </div>
-          <Button onClick={() => setPhase({ kind: 'create' })}>
-            <HiPlus className="mr-1" /> Eigenes Notebook erstellen
-          </Button>
-        </div>
-      ) : (
-        <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
-          {collections.map((c) => (
-            <NotebookManagementCard
-              key={c.id}
-              collection={c}
-              isProcessing={processingCollectionIds.has(c.id)}
-              onOpen={handleOpen}
-              onRename={(col) => setPhase({ kind: 'rename', collection: col })}
-              onEdit={(col) => setPhase({ kind: 'edit', collection: col })}
-              onShare={handleShare}
-              onDelete={(col) => setPhase({ kind: 'delete', collection: col })}
-              onAddFiles={handleAddFilesToCard}
-            />
-          ))}
-        </div>
-      )}
+        ) : isEmpty ? (
+          <div className="flex flex-col items-center gap-md rounded-md border border-dashed border-grey-300 p-xl text-center dark:border-grey-700">
+            <HiBookOpen className="text-3xl text-grey-400" />
+            <div>
+              <div className="text-base font-medium text-foreground-heading">
+                Du hast noch keine eigenen Notebooks
+              </div>
+              <div className="mt-xs text-sm text-grey-500 dark:text-grey-400">
+                Erstelle dein erstes Notebook, um Dokumente und Quellen zu bündeln.
+              </div>
+            </div>
+            <Button onClick={() => setPhase({ kind: 'create' })}>
+              <HiPlus className="mr-1" /> Eigenes Notebook erstellen
+            </Button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-4 gap-md max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1">
+            {collections.map((c) => (
+              <NotebookManagementCard
+                key={c.id}
+                collection={c}
+                isProcessing={processingCollectionIds.has(c.id)}
+                onOpen={handleOpen}
+                onRename={(col) => setPhase({ kind: 'rename', collection: col })}
+                onEdit={(col) => setPhase({ kind: 'edit', collection: col })}
+                onShare={handleShare}
+                onDelete={(col) => setPhase({ kind: 'delete', collection: col })}
+                onAddFiles={handleAddFilesToCard}
+              />
+            ))}
+          </div>
+        )}
 
-      {/* Rename dialog */}
-      <Dialog
-        open={phase.kind === 'rename'}
-        onOpenChange={(open) => {
-          if (!open) closeDialog();
-        }}
-      >
-        {phase.kind === 'rename' ? (
-          <RenameDialog
-            collection={phase.collection}
-            isUpdating={isUpdating}
-            onCancel={closeDialog}
-            onSubmit={(name, description) =>
-              void handleRenameSubmit(phase.collection, name, description)
-            }
-          />
-        ) : null}
-      </Dialog>
-
-      {/* Full editor dialog (create or edit) */}
-      <Dialog
-        open={phase.kind === 'create' || phase.kind === 'edit'}
-        onOpenChange={(open) => {
-          if (!open && !isCreating && !isUpdating) closeDialog();
-        }}
-      >
-        <DialogContent
-          className="sm:max-w-[min(1200px,calc(100%-2rem))] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
-          aria-describedby={undefined}
+        {/* Rename dialog */}
+        <Dialog
+          open={phase.kind === 'rename'}
+          onOpenChange={(open) => {
+            if (!open) closeDialog();
+          }}
         >
-          <DialogTitle className="sr-only">
-            {phase.kind === 'edit' ? 'Notebook bearbeiten' : 'Notebook erstellen'}
-          </DialogTitle>
-          {phase.kind === 'edit' ? (
-            <NotebookEditor
-              editingCollection={phase.collection}
-              loading={isUpdating}
+          {phase.kind === 'rename' ? (
+            <RenameDialog
+              collection={phase.collection}
+              isUpdating={isUpdating}
               onCancel={closeDialog}
-              onSave={(data) => handleEditSave(phase.collection, data)}
-            />
-          ) : phase.kind === 'create' ? (
-            <NotebookEditor
-              editingCollection={null}
-              loading={isCreating}
-              onCancel={closeDialog}
-              onSave={handleCreateSave}
+              onSubmit={(name, description) =>
+                void handleRenameSubmit(phase.collection, name, description)
+              }
             />
           ) : null}
-        </DialogContent>
-      </Dialog>
+        </Dialog>
 
-      {/* Delete confirmation */}
-      <AlertDialog
-        open={phase.kind === 'delete'}
-        onOpenChange={(open) => {
-          if (!open) closeDialog();
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Notebook löschen?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {phase.kind === 'delete'
-                ? `„${phase.collection.name}" wird unwiderruflich gelöscht. Die enthaltenen Dokumente bleiben in deiner Bibliothek erhalten.`
-                : null}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Abbrechen</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={(e) => {
-                e.preventDefault();
-                if (phase.kind === 'delete') void handleDeleteConfirm(phase.collection);
-              }}
-            >
-              Löschen
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        {/* Full editor dialog (create or edit) */}
+        <Dialog
+          open={phase.kind === 'create' || phase.kind === 'edit'}
+          onOpenChange={(open) => {
+            if (!open && !isCreating && !isUpdating) closeDialog();
+          }}
+        >
+          <DialogContent
+            className="sm:max-w-[min(1200px,calc(100%-2rem))] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
+            aria-describedby={undefined}
+          >
+            <DialogTitle className="sr-only">
+              {phase.kind === 'edit' ? 'Notebook bearbeiten' : 'Notebook erstellen'}
+            </DialogTitle>
+            {phase.kind === 'edit' ? (
+              <NotebookEditor
+                editingCollection={phase.collection}
+                loading={isUpdating}
+                onCancel={closeDialog}
+                onSave={(data) => handleEditSave(phase.collection, data)}
+              />
+            ) : phase.kind === 'create' ? (
+              <NotebookEditor
+                editingCollection={null}
+                loading={isCreating}
+                onCancel={closeDialog}
+                onSave={handleCreateSave}
+              />
+            ) : null}
+          </DialogContent>
+        </Dialog>
+
+        {/* Delete confirmation */}
+        <AlertDialog
+          open={phase.kind === 'delete'}
+          onOpenChange={(open) => {
+            if (!open) closeDialog();
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Notebook löschen?</AlertDialogTitle>
+              <AlertDialogDescription>
+                {phase.kind === 'delete'
+                  ? `„${phase.collection.name}" wird unwiderruflich gelöscht. Die enthaltenen Dokumente bleiben in deiner Bibliothek erhalten.`
+                  : null}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (phase.kind === 'delete') void handleDeleteConfirm(phase.collection);
+                }}
+              >
+                Löschen
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </PageContainer>
     </ErrorBoundary>
   );

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,15 +1,9 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import { Badge, Button } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import {
-  HiCheckCircle,
-  HiArrowLeft,
-  HiUpload,
-  HiX,
-  HiPlus,
-  HiPencil,
-} from 'react-icons/hi';
+import { HiCheckCircle, HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
@@ -84,7 +78,7 @@ function getFileTypeBadge(filename: string): { label: string; tagClass: string }
 }
 
 interface NotebookEditorProps {
-  onSave: (data: unknown) => Promise<void>;
+  onSave: (data: NotebookEditorSavePayload) => Promise<void>;
   editingCollection?: NotebookCollection | null;
   loading?: boolean;
   onCancel?: () => void;
@@ -287,16 +281,17 @@ const NotebookEditor = ({
   const onSubmit = async (data: NotebookEditorFormData): Promise<void> => {
     if (uploadedDocuments.length === 0) return;
 
-    const qaData = {
-      ...data,
+    const payload: NotebookEditorSavePayload = {
+      ...(editingCollection?.id ? { id: editingCollection.id } : {}),
+      name: data.name,
+      description: data.description,
       selectionMode: 'documents',
       documents: uploadedDocuments.map((doc) => doc.id),
       documentMeta: uploadedDocuments.map((doc) => ({ id: doc.id, title: doc.title })),
-      id: editingCollection?.id,
       labels,
     };
 
-    await onSave(qaData);
+    await onSave(payload);
   };
 
   const handleCancel = (): void => {

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -1,3 +1,4 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import {
   Dialog,
   DialogContent,
@@ -29,17 +30,17 @@ import { useNavigate } from 'react-router-dom';
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import apiClient from '../../../components/utils/apiClient';
 import { NotebookIcon } from '../../../config/icons';
-import { useGroups, type GroupSummary } from '../../groups/hooks/useGroups';
 import { useAuthStore } from '../../../stores/authStore';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import useSidebarFavouritesStore from '../../../stores/sidebarFavouritesStore';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+import { useGroups, type GroupSummary } from '../../groups/hooks/useGroups';
+import { getNotebookConfig } from '../config/notebookPagesConfig';
 import {
   getAustrianNotebooks,
   getNotebooksByCategory,
   type NotebookConfigEntry,
 } from '../config/notebooksConfig';
-import { getNotebookConfig } from '../config/notebookPagesConfig';
 
 import { LastAddedSection } from './LastAddedSection';
 import NotebookEditor from './NotebookEditor';
@@ -47,16 +48,6 @@ import { NotebookPageContent } from './NotebookPage';
 import { StatisticsSection } from './StatisticsSection';
 
 import type { NotebookCollection } from '../../../types/notebook';
-
-interface EditorSaveData {
-  id?: string;
-  name: string;
-  description?: string;
-  selectionMode?: 'documents' | 'wolke';
-  documents?: string[];
-  wolkeShareLinks?: string[];
-  labels?: string[];
-}
 
 const EMPTY_COLLECTIONS: NotebookCollection[] = [];
 
@@ -491,29 +482,26 @@ function NotebooksIndexFooter() {
   );
 
   const handleSave = useCallback(
-    async (data: unknown) => {
-      const saveData = data as EditorSaveData;
-      if (saveData.id) {
-        await updateQACollection(saveData.id, {
-          name: saveData.name,
-          description: saveData.description,
-          selectionMode: saveData.selectionMode,
-          documents: saveData.documents,
-          wolkeShareLinks: saveData.wolkeShareLinks,
-          labels: saveData.labels,
+    async (data: NotebookEditorSavePayload) => {
+      if (data.id) {
+        await updateQACollection(data.id, {
+          name: data.name,
+          description: data.description,
+          selectionMode: data.selectionMode,
+          documents: data.documents,
+          labels: data.labels,
         });
       } else {
         const result = await createQACollection({
-          name: saveData.name,
-          description: saveData.description,
-          selectionMode: saveData.selectionMode,
-          documents: saveData.documents,
-          wolkeShareLinks: saveData.wolkeShareLinks,
-          labels: saveData.labels,
+          name: data.name,
+          description: data.description,
+          selectionMode: data.selectionMode,
+          documents: data.documents,
+          labels: data.labels,
         });
 
-        if (result?.id && saveData.documents?.length) {
-          startPolling(String(result.id), saveData.documents);
+        if (result?.id && data.documents.length) {
+          startPolling(String(result.id), data.documents);
         }
       }
       setShowEditor(false);
@@ -556,9 +544,7 @@ function NotebooksIndexFooter() {
         <LastAddedSection collectionIds={systemCollectionIds} showSourceLabel />
       )}
 
-      {systemCollectionIds.length > 0 && (
-        <StatisticsSection collectionIds={systemCollectionIds} />
-      )}
+      {systemCollectionIds.length > 0 && <StatisticsSection collectionIds={systemCollectionIds} />}
 
       {/* Tools section commented out per request — chat composer at the top covers Suche. */}
 

--- a/apps/web/src/features/recherche/RecherchePage.tsx
+++ b/apps/web/src/features/recherche/RecherchePage.tsx
@@ -1,3 +1,4 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import {
   Dialog,
   DialogContent,
@@ -50,16 +51,6 @@ import type { ToolEntry } from '../../components/common/ToolGrid';
 import type { NotebookCollection } from '../../types/notebook';
 
 import { cn } from '@/utils/cn';
-
-interface EditorSaveData {
-  id?: string;
-  name: string;
-  description?: string;
-  selectionMode?: 'documents' | 'wolke';
-  documents?: string[];
-  wolkeShareLinks?: string[];
-  labels?: string[];
-}
 
 const tools: ToolEntry[] = [
   {
@@ -559,29 +550,26 @@ const RecherchePage = () => {
   );
 
   const handleSave = useCallback(
-    async (data: unknown) => {
-      const saveData = data as EditorSaveData;
-      if (saveData.id) {
-        await updateQACollection(saveData.id, {
-          name: saveData.name,
-          description: saveData.description,
-          selectionMode: saveData.selectionMode,
-          documents: saveData.documents,
-          wolkeShareLinks: saveData.wolkeShareLinks,
-          labels: saveData.labels,
+    async (data: NotebookEditorSavePayload) => {
+      if (data.id) {
+        await updateQACollection(data.id, {
+          name: data.name,
+          description: data.description,
+          selectionMode: data.selectionMode,
+          documents: data.documents,
+          labels: data.labels,
         });
       } else {
         const result = await createQACollection({
-          name: saveData.name,
-          description: saveData.description,
-          selectionMode: saveData.selectionMode,
-          documents: saveData.documents,
-          wolkeShareLinks: saveData.wolkeShareLinks,
-          labels: saveData.labels,
+          name: data.name,
+          description: data.description,
+          selectionMode: data.selectionMode,
+          documents: data.documents,
+          labels: data.labels,
         });
 
-        if (result?.id && saveData.documents?.length) {
-          startPolling(String(result.id), saveData.documents);
+        if (result?.id && data.documents.length) {
+          startPolling(String(result.id), data.documents);
         }
       }
       setShowEditor(false);

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -1,3 +1,4 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import { Dialog, DialogContent, DialogTitle, SectionHeader } from '@gruenerator/ui';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 
@@ -84,25 +85,16 @@ const NotebooksSection: React.FC = memo(() => {
   );
 
   const handleSave = useCallback(
-    async (data: unknown) => {
-      const saveData = data as {
-        name: string;
-        description?: string;
-        documents?: (string | number)[];
-        documentMeta?: Array<{ id: string; title: string }>;
-      };
+    async (data: NotebookEditorSavePayload) => {
       await createQACollection({
-        name: saveData.name,
-        description: saveData.description,
-        documents: saveData.documents,
+        name: data.name,
+        description: data.description,
+        documents: data.documents,
       });
       // Hand off to the progress view, which polls per-document status until terminal.
       // documentMeta carries the upload titles for the progress rows; the IDs from
-      // saveData.documents are authoritative for the polling query.
-      const docs = (saveData.documentMeta ?? []).filter(
-        (d): d is { id: string; title: string } => typeof d.id === 'string'
-      );
-      setPhase({ kind: 'processing', name: saveData.name, documents: docs });
+      // data.documents are authoritative for the polling query.
+      setPhase({ kind: 'processing', name: data.name, documents: data.documentMeta });
     },
     [createQACollection]
   );

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -38,6 +38,29 @@ export const bulkDeleteBodySchema = z.object({
   ids: z.array(z.string()),
 });
 
+/**
+ * Payload emitted by `NotebookEditor.onSave`.
+ *
+ * Frontend-internal boundary between the editor component and its caller's
+ * save handler — NOT an HTTP body. Each caller maps this to the backend
+ * `createCollectionBodySchema` / `updateCollectionBodySchema` (e.g.
+ * `documents` → `document_ids`, `selectionMode` → `selection_mode`).
+ *
+ * `documentMeta` carries upload titles for progress views (the IDs in
+ * `documents` are authoritative for indexing-status polling).
+ */
+export const notebookEditorSavePayloadSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  description: z.string(),
+  selectionMode: z.literal('documents'),
+  documents: z.array(z.string()),
+  documentMeta: z.array(z.object({ id: z.string(), title: z.string() })),
+  labels: z.array(z.string()),
+});
+
+export type NotebookEditorSavePayload = z.infer<typeof notebookEditorSavePayloadSchema>;
+
 // ── Shared sub-schemas ──────────────────────────────────────────────────────
 
 export const documentRecordSchema = z.object({


### PR DESCRIPTION
Follow-up to #829. The `NotebookEditor` component had `onSave: (data: unknown) => Promise<void>` — every one of its four callers re-declared a hand-written interface and cast `data as { … }`. That's exactly the kind of `unknown` boundary the project's 4-layer type-safety audit memo flags.

A single `notebookEditorSavePayloadSchema` now lives in `@gruenerator/contracts` and is the source of truth for what the editor emits. `NotebookEditorSavePayload = z.infer<typeof …>` propagates to:

- `NotebookEditor.tsx` — the prop signature, plus the `qaData` payload it constructs
- `NotebooksSection.tsx`, `NotebooksIndexPage.tsx`, `RecherchePage.tsx`, `MyNotebooksPage.tsx` — handler signatures (4 hand-written interfaces deleted, 4 casts removed)

Drive-bys made obvious by the new types:

- `RecherchePage` and `NotebooksIndexPage` forwarded `wolkeShareLinks` — the editor never emits it, so the field was always `undefined`. Dropped.
- `MyNotebooksPage`'s `addedIds.map(String)` defended against a `(string | number)[]` shape that the editor never produced. Replaced with a plain `filter`.
- `NotebookEditor` now conditionally builds the `id` field instead of passing `id: undefined`, in line with `feedback_no_undefined`.

Schema lives next to `createCollectionBodySchema` in `packages/contracts/src/schemas/notebookCollections.ts` and is documented as a frontend-internal boundary — each caller still maps it to the backend's snake_case schema (`document_ids`, `selection_mode`), which is a separate concern.

## Test plan
- [ ] `pnpm --filter @gruenerator/web typecheck` — no new errors caused by this diff (6 unrelated pre-existing errors remain on master; tracked separately).
- [ ] Create a notebook via `/notebooks/meine` → upload → Erstellen → polling kicks off as before.
- [ ] Edit an existing notebook → Aktualisieren → API receives the same payload as before.
- [ ] `/workplace` `+ Eigenes Notebook erstellen` → progress view shows correct document titles (uses `documentMeta`).