### PR TITLE
fix(web): resolve 6 pre-existing typecheck errors

### DIFF
--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -158,7 +158,7 @@ function EditorContent() {
   const adapter = useDocsAdapter();
   const apiClient = useMemo(() => createDocsApiClient(adapter), [adapter]);
   const { user, isAuthResolved, loading: authLoading, isInitialLoad } = useAuth({ lazy: true });
-  const isGuest = isAuthResolved && !user;
+  const isGuest = Boolean(isAuthResolved) && !user;
   console.warn('[Docs] Auth debug:', {
     isAuthResolved,
     authLoading,

--- a/apps/web/src/features/groups/pages/JoinGroupPage.tsx
+++ b/apps/web/src/features/groups/pages/JoinGroupPage.tsx
@@ -37,7 +37,7 @@ const JoinGroupPage = () => {
       }
       return response.data;
     },
-    enabled: Boolean(joinToken) && !isLoading && isAuthResolved && Boolean(user),
+    enabled: Boolean(joinToken) && !isLoading && Boolean(isAuthResolved) && Boolean(user),
     retry: false,
   });
 

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -35,6 +35,7 @@ interface GrueneratorThreadProps {
     belowInput?: ReactNode;
     sendAdornment?: ReactNode;
   };
+  requireProfileHydration?: boolean;
 }
 
 function VoiceOrbOverlay() {
@@ -76,6 +77,7 @@ export function GrueneratorThread({
   showModelPicker,
   composerLayout,
   composerSlots,
+  requireProfileHydration,
 }: GrueneratorThreadProps = {}) {
   const isRunning = useAuiState((s) => s.thread.isRunning);
   const messageComponents = useMemo(() => ({ UserMessage, AssistantMessage }), []);
@@ -146,6 +148,7 @@ export function GrueneratorThread({
           {...(showModelPicker !== undefined && { showModelPicker })}
           {...(composerLayout !== undefined && { layout: composerLayout })}
           {...(composerSlots ? { slots: composerSlots } : {})}
+          {...(requireProfileHydration !== undefined && { requireProfileHydration })}
         />
       </ThreadPrimitive.Root>
     </ChatDensityContext.Provider>


### PR DESCRIPTION
\`pnpm --filter @gruenerator/web typecheck\` was failing on master with 6 errors across 4 files. Root causes were two: (a) one missing prop forward in \`packages/chat\`, and (b) \`isAuthResolved\` from \`useAuth\`/\`useOptimizedAuth\` widening to \`boolean | null\` and leaking into APIs typed as \`boolean\`.

## Changes

### \`packages/chat/src/components/thread/GrueneratorThread.tsx\`
Adds \`requireProfileHydration?: boolean\` to \`GrueneratorThreadProps\` and forwards it to \`GrueneratorComposer\`. The composer already implemented it (line 72), but the parent wrapper never exposed it — so every caller that tried to set it (ChatPage:105, SearchPage:112) was a type error. Fixes the two \`TS2322\` errors in those files.

### \`apps/web/src/features/docs/DocsEditorPage.tsx\`
\`const isGuest = isAuthResolved && !user\` widens to \`boolean | null\` because \`isAuthResolved\` itself is \`boolean | null\` (its definition in \`useAuth.ts:531\` is \`hasCachedData || (... || queryError) && ...\`, and \`queryError\` brings \`null\`). The \`useCollaboration\` hook expects \`boolean | undefined\` for \`isGuest\`. One-character fix: \`Boolean(isAuthResolved) && !user\`.

### \`apps/web/src/features/groups/pages/JoinGroupPage.tsx\`
The \`useQuery\` \`enabled\` option must be \`boolean | undefined\`. With \`isAuthResolved\` widening to \`boolean | null\`, the entire \`enabled\` expression carried \`null\` — TanStack's overload resolution then fell back to \`TQueryFnData = unknown\`, which cascaded into the \`data?.group\` and \`data?.alreadyMember\` "property does not exist" errors. Coercing the one wide term with \`Boolean(isAuthResolved)\` restores inference; all three errors clear together.

## Test plan
- [ ] \`pnpm --filter @gruenerator/web typecheck\` — exit 0 (previously: 6 errors)
- [ ] \`pnpm --filter @gruenerator/chat typecheck\` — exit 0
- [ ] Chat / Search pages still hydrate the composer's send button correctly (no regression in \`requireProfileHydration\` behaviour, since the composer already received \`false\` as the destructured default).
- [ ] Docs editor still treats unauthenticated visitors as guests.
- [ ] Group-join flow still gates the token verification query behind auth resolution.

## Follow-up consideration
\`isAuthResolved\` from \`useAuth\` arguably should be a strict \`boolean\` at the source — the \`hasCachedData || (... || queryError) && ...\` composition leaks \`null\` into every consumer. A future PR could tighten the return type there and remove these per-caller coercions. Out of scope here to keep the diff surgical.