### PR TITLE
fix(web): gate unread-count on auth + drop session-probe theater

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -96,17 +96,6 @@
          while no longer parser-blocking on the critical path. -->
     <script defer src="/config.js"></script>
 
-    <!-- Kick the auth session probe from inline HTML so it runs in
-         parallel with bundle download rather than waiting for React to
-         mount AuthBootstrap. The response lands in the HTTP cache by the
-         time useAuth({ instant: true }) issues its actual fetch. Failure
-         is swallowed — this is a cache warmup, not a contract. -->
-    <script>
-      try {
-        fetch('/api/auth/v2/get-session', { credentials: 'include' }).catch(function () {});
-      } catch (e) {}
-    </script>
-
     <!-- Umami Analytics (GDPR-compliant with consent) -->
     <script>
       (function() {

--- a/apps/web/src/features/notifications/hooks/useNotifications.ts
+++ b/apps/web/src/features/notifications/hooks/useNotifications.ts
@@ -8,6 +8,7 @@ import {
   dismissNotificationById,
   dismissAllNotificationsClient,
 } from '../../../hooks/useNotificationsTyped';
+import { useAuthStore } from '../../../stores/authStore';
 import { useNotificationStore } from '../../../stores/notificationStore';
 
 import type { Notification } from '../types';
@@ -31,6 +32,7 @@ export function useNotifications() {
 
 export function useUnreadCount() {
   const setUnreadCount = useNotificationStore((s) => s.setUnreadCount);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
 
   return useQuery({
     queryKey: ['notifications', 'unread-count'],
@@ -39,6 +41,12 @@ export function useUnreadCount() {
       setUnreadCount(count);
       return count;
     },
+    // ProfileButton mounts on every route (including /login), but the
+    // unread-count endpoint requires auth. Without this gate, guests get
+    // a 401-retry storm that surfaces as an "Unerwarteter Fehler" toast
+    // and incidentally triggers apiClient's 401-recovery session probe.
+    enabled: isAuthenticated,
+    retry: false,
     staleTime: 30_000,
     refetchInterval: 60_000,
     refetchOnMount: false,


### PR DESCRIPTION
## Why

Chrome DevTools trace of \`/workplace\` (auth-redirect to \`/login\`) surfaced two coupled bugs that I'd previously misdiagnosed as separate:

### Bug 1: \"Unerwarteter Fehler\" toast on every redirect

\`useUnreadCount\` (\`apps/web/src/features/notifications/hooks/useNotifications.ts:32\`) fires \`/api/notifications/unread-count\` with no \`enabled\` gate. \`ProfileButton\` mounts on every route via \`PageLayout\`, so every guest hitting any auth-gated route fires the call **before** the route redirects. Returns 401 → React Query's default \`retry: 3\` → three 401s in a row → \`toastApiError\` surfaces the last failure as a user-visible toast.

### Bug 2: 3× session probe per page load

The trace recorded three calls to \`/api/auth/v2/get-session\` per page. Sources:

1. **Inline probe in \`index.html:106\`** (added in #817). Theory: warm HTTP cache before React Query fires. Reality: \`curl -I\` confirms zero \`Cache-Control\`/\`Expires\`/\`Last-Modified\`/\`ETag\` headers on the endpoint, so heuristic freshness ≈ 0, every fetch round-trips. The probe is pure perf theater.
2. **\`useAuth({instant:true})\`** → \`authClient.getSession()\` (\`useAuth.ts:22\`). Legitimate; deduped across the tree by React Query queryKey.
3. **apiClient's 401-recovery probe** (\`apiClient.ts:94\`). Fires when ANY auth'd API returns 401 to decide whether to redirect. **Triggered by Bug 1's notifications 401.**

So Bug 1 and Bug 2 share a root: an unauth'd component firing an auth-required API, which both surfaces a toast AND triggers a session-probe.

## Fix

**Two edits, both small:**

1. \`useUnreadCount\` (\`useNotifications.ts:32-46\`):
   - Add \`enabled: isAuthenticated\` (read from \`useAuthStore\`)
   - Add \`retry: false\` so transient 5xx doesn't storm either
2. Delete the inline session probe in \`index.html\` lines 99–108.

## Verification

\`\`\`
Before:  3 session probes per page load (1 inline + 1 useAuth + 1 apiClient 401-recovery)
         + 3× 401 from useUnreadCount on every unauth'd route hit
         + \"Unerwarteter Fehler\" toast surface

After:   1 session probe per page load (useAuth only)
         0 calls from useUnreadCount when unauth'd
         No toast
\`\`\`

Post-deploy verification (browser):

\`\`\`bash
# Hit /workplace from a guest browser. Network panel should show
# exactly one /api/auth/v2/get-session call. No /api/notifications/unread-count.
# No toast.
\`\`\`

## Other layout-mounted queries

I grep'd for the same anti-pattern across \`features/notifications\`, \`features/groups\`, and global layout hooks. \`useUnreadCount\` was the only globally-mounted unauth-firing query — the sibling \`useNotifications\` (list) is gated by \`open && user\` in \`ProfileButton.tsx\`, and \`useGroups.groupContentQuery\` is gated by \`groupId\` param. No further changes needed.

## Reverts a small piece of #817

#817 (\"trim first-load critical path\") had three commits — viewport-gate mocks, lazy-wrap TemplateStudioFlow, **and the inline session probe**. The first two stay; only the third commit's change is reverted here because empirical verification proved it has no effect (the response can't be cached).