### PR TITLE
perf(chat): lazy-mount ShareThreadDialog per thread row

### DIFF
--- a/packages/chat/src/components/thread/ThreadListItem.tsx
+++ b/packages/chat/src/components/thread/ThreadListItem.tsx
@@ -161,7 +161,13 @@ export function GrueneratorThreadListItem() {
         </ThreadListItemMorePrimitive.Root>
       </ThreadListItemPrimitive.Root>
 
-      <ShareThreadDialog threadId={remoteId ?? null} open={shareOpen} onOpenChange={setShareOpen} />
+      {shareOpen && (
+        <ShareThreadDialog
+          threadId={remoteId ?? null}
+          open={shareOpen}
+          onOpenChange={setShareOpen}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Why

Profiling the workplace page showed a long repeating cascade — `ThreadListItemByIndexProvider → AuiProvider → RenderChildrenWithAccessor → ShareThreadDialog → Dialog → DialogProvider → DialogPortal → DialogPortalProvider → Presence → Presence` — once per thread in the list. Each `GrueneratorThreadListItem` was mounting `<ShareThreadDialog>` unconditionally, so for N threads we paid the full Radix Dialog context tree N times on every assistant-ui store tick. `memo()` didn't help because `RenderChildrenWithAccessor` re-runs item bodies on every store update, and Radix's eager context tree exists whether `open` is `true` or `false`.

Gating the mount on `shareOpen` collapses the per-row cost to ~0 until the user actually opens a share dialog.

**Tradeoff:** no Radix exit animation when closing — `Presence` needs the tree to remain mounted briefly after `open=false`. Acceptable for a row-level action; standard shadcn pattern.