### PR TITLE
feat(agents): restore Tweet wie Ricarda agent + pin to sidebar

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/tools/searchExamples.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/searchExamples.ts
@@ -16,30 +16,43 @@ import type { ToolDependencies } from './registry.js';
 const log = createLogger('Tool:SearchExamples');
 
 export function createSearchExamplesTool(deps: ToolDependencies): DynamicStructuredTool {
-    // @ts-expect-error - Zod schema type compatibility with LangChain ToolInputSchemaBase
+  // @ts-expect-error - Zod schema type compatibility with LangChain ToolInputSchemaBase
   return new DynamicStructuredTool({
     name: 'search_examples',
     description:
       'Suche Social-Media-Beispiele und Vorlagen (Facebook, Instagram). ' +
       'Nutze dieses Tool wenn der Nutzer nach Beispiel-Posts, Vorlagen oder Inspirationen fragt.',
-    schema: z.object({
-      query: z.string().describe('Die Suchanfrage für Beispiele'),
-      platform: z
-        .enum(['facebook', 'instagram'])
-        .optional()
-        .describe('Optionale Plattform-Filterung'),
-    }).describe('Beispielsuche'),
+    schema: z
+      .object({
+        query: z.string().describe('Die Suchanfrage für Beispiele'),
+        platform: z
+          .enum(['facebook', 'instagram'])
+          .optional()
+          .describe('Optionale Plattform-Filterung'),
+      })
+      .describe('Beispielsuche'),
     func: async (input: { query: string; platform?: string }) => {
       const { query, platform } = input;
       const country =
         deps.agentConfig.toolRestrictions?.examplesCountry ||
         (deps.userLocale === 'de-AT' ? 'AT' : undefined);
-      log.info(`[SearchExamples] query="${query.slice(0, 60)}" platform=${platform || 'all'}`);
+      const collection = deps.agentConfig.toolRestrictions?.examplesCollection;
+      // Per-person tweet collections (e.g. ricarda_lang_tweets) are single-
+      // platform corpora — passing facebook/instagram would filter to zero.
+      // The agent prompt is instructed to omit `platform` for these, but
+      // defend in depth here.
+      const effectivePlatform = collection != null ? undefined : platform;
+      log.info(
+        `[SearchExamples] query="${query.slice(0, 60)}" platform=${effectivePlatform || 'all'}${
+          collection != null ? ` collection=${collection}` : ''
+        }`
+      );
 
       const params: Parameters<typeof executeDirectExamplesSearch>[0] = {
         query,
-        ...(platform != null ? { platform } : {}),
+        ...(effectivePlatform != null ? { platform: effectivePlatform } : {}),
         ...(country != null ? { country } : {}),
+        ...(collection != null ? { collection } : {}),
       };
       const result = await executeDirectExamplesSearch(params);
 

--- a/apps/api/database/services/QdrantService/QdrantService.ts
+++ b/apps/api/database/services/QdrantService/QdrantService.ts
@@ -716,17 +716,13 @@ export class QdrantService {
     await this.ensureConnected();
 
     const filter = this._buildSocialMediaFilter(options);
+    const collection: string = options.collection ?? this.collections.social_media_examples;
 
-    const results = await this.operations!.searchWithQuality(
-      this.collections.social_media_examples,
-      queryVector,
-      filter,
-      {
-        limit: options.limit || 10,
-        threshold: options.threshold || 0.3,
-        withPayload: true,
-      }
-    );
+    const results = await this.operations!.searchWithQuality(collection, queryVector, filter, {
+      limit: options.limit || 10,
+      threshold: options.threshold || 0.3,
+      withPayload: true,
+    });
 
     return this._formatSearchResults(results, 'social') as SearchResponse<SocialMediaResult>;
   }
@@ -844,7 +840,7 @@ export class QdrantService {
     await this.ensureConnected();
     return getRandomSocial(
       this.client!,
-      this.collections.social_media_examples,
+      options.collection ?? this.collections.social_media_examples,
       options,
       buildSocialMediaFilter
     );

--- a/apps/api/database/services/QdrantService/random.ts
+++ b/apps/api/database/services/QdrantService/random.ts
@@ -75,6 +75,8 @@ interface RandomSocialMediaOptions {
   limit?: number;
   platform?: 'facebook' | 'instagram';
   country?: 'DE' | 'AT';
+  /** Override target collection — see `SocialMediaSearchOptions.collection`. */
+  collection?: string;
 }
 
 // Filter builder types

--- a/apps/api/database/services/QdrantService/types.ts
+++ b/apps/api/database/services/QdrantService/types.ts
@@ -368,6 +368,14 @@ export interface SocialMediaSearchOptions {
    * (federal accounts) are filtered out when this option is set.
    */
   landesverband?: string | readonly string[] | undefined;
+  /**
+   * Override the target Qdrant collection. Defaults to `social_media_examples`.
+   * Set by per-person tweet-style agents (e.g. Ricarda Lang → `ricarda_lang_tweets`)
+   * to search a curated personal corpus instead of the shared green-social pool.
+   * The override collection must share the social_media_examples payload shape
+   * (written via `indexSocialMediaExample`).
+   */
+  collection?: string | undefined;
 }
 
 // =============================================================================

--- a/apps/api/routes/chat/agents/directSearchExecutors.ts
+++ b/apps/api/routes/chat/agents/directSearchExecutors.ts
@@ -294,14 +294,17 @@ export async function executeDirectExamplesSearch(params: {
   query: string;
   platform?: string;
   country?: 'DE' | 'AT';
+  /** Override target collection — see `SearchExamplesParams.examplesCollection`. */
+  collection?: string;
 }): Promise<DirectExamplesResult> {
-  const { query, platform, country } = params;
+  const { query, platform, country, collection } = params;
 
   const result = await searchExamples({
     query,
     kinds: ['social'],
     ...(platform && { platform }),
     ...(country && { country }),
+    ...(collection && { examplesCollection: collection }),
   });
 
   if (result.errors.social) {

--- a/apps/api/services/contentExamplesService.ts
+++ b/apps/api/services/contentExamplesService.ts
@@ -139,6 +139,8 @@ interface SocialMediaSearchMethodOptions {
   locale?: Locale | null;
   country?: CountryCode | null;
   landesverband?: string | readonly string[] | null;
+  /** Override target collection — see `SocialMediaSearchOptions.collection`. */
+  collection?: string | null;
 }
 
 interface RandomSocialMediaOptions {
@@ -147,6 +149,7 @@ interface RandomSocialMediaOptions {
   locale?: Locale | null;
   country?: CountryCode | null;
   landesverband?: string | readonly string[] | null;
+  collection?: string | null;
 }
 
 // =============================================================================
@@ -545,6 +548,7 @@ class ContentExamplesService {
       locale = null,
       country = null,
       landesverband = null,
+      collection = null,
     } = options;
 
     const resolvedCountry = country || this.getCountryFromLocale(locale);
@@ -552,8 +556,9 @@ class ContentExamplesService {
     try {
       const countryInfo = resolvedCountry ? `, country: ${resolvedCountry}` : '';
       const lvInfo = landesverband ? `, lv: ${JSON.stringify(landesverband)}` : '';
+      const collectionInfo = collection ? `, collection: ${collection}` : '';
       log.debug(
-        `Social media search: "${query}" (platform: ${platform || 'all'}${countryInfo}${lvInfo})`
+        `Social media search: "${query}" (platform: ${platform || 'all'}${countryInfo}${lvInfo}${collectionInfo})`
       );
 
       await mistralEmbeddingService.init();
@@ -568,6 +573,7 @@ class ContentExamplesService {
         ...(platform && { platform: platform as 'facebook' | 'instagram' }),
         ...(resolvedCountry && { country: resolvedCountry }),
         ...(landesverband != null && { landesverband }),
+        ...(collection != null && { collection }),
         limit,
         threshold,
       });
@@ -597,6 +603,7 @@ class ContentExamplesService {
       locale = null,
       country = null,
       landesverband = null,
+      collection = null,
     } = options;
 
     const resolvedCountry = country || this.getCountryFromLocale(locale);
@@ -609,14 +616,16 @@ class ContentExamplesService {
 
       const countryInfo = resolvedCountry ? `, country: ${resolvedCountry}` : '';
       const lvInfo = landesverband ? `, lv: ${JSON.stringify(landesverband)}` : '';
+      const collectionInfo = collection ? `, collection: ${collection}` : '';
       log.debug(
-        `Getting ${limit} random social media examples (platform: ${platform || 'all'}${countryInfo}${lvInfo})`
+        `Getting ${limit} random social media examples (platform: ${platform || 'all'}${countryInfo}${lvInfo}${collectionInfo})`
       );
 
       const results = await this.qdrant.getRandomSocialMediaExamples({
         ...(platform && { platform: platform as 'facebook' | 'instagram' }),
         ...(resolvedCountry && { country: resolvedCountry }),
         ...(landesverband != null && { landesverband }),
+        ...(collection != null && { collection }),
         limit,
       });
 

--- a/apps/api/services/examples/exampleSearchService.ts
+++ b/apps/api/services/examples/exampleSearchService.ts
@@ -54,6 +54,12 @@ export interface SearchExamplesParams {
   // sees full Insta captions / FB posts; the legacy direct-executor wrapper
   // and any UI-summary callers keep the truncated default.
   fullBody?: boolean;
+  // Override the social Qdrant collection. Set by per-person tweet-style
+  // agents (e.g. `gruenerator-ricarda-lang` → `ricarda_lang_tweets`) so the
+  // few-shot grounding comes from that person's corpus instead of the shared
+  // `social_media_examples` pool. Press path ignores this — the
+  // Landesverband press collection is locale-derived (DE/AT) elsewhere.
+  examplesCollection?: string;
 }
 
 export interface SearchExamplesResult {
@@ -115,7 +121,15 @@ function truncate(text: string, max: number): string {
 }
 
 async function fetchSocial(params: SearchExamplesParams): Promise<UnifiedExample[]> {
-  const { query, platform, country, limit = 10, fullBody = false, lvScope } = params;
+  const {
+    query,
+    platform,
+    country,
+    limit = 10,
+    fullBody = false,
+    lvScope,
+    examplesCollection,
+  } = params;
 
   if (lvScope !== undefined) {
     // TODO(per-lv-social): wire lvScope into the underlying call once Apify
@@ -131,6 +145,7 @@ async function fetchSocial(params: SearchExamplesParams): Promise<UnifiedExample
     limit,
     threshold: 0.15,
     country: country ?? null,
+    ...(examplesCollection != null && { collection: examplesCollection }),
   });
 
   // Mirror the existing fallback-to-random behaviour from
@@ -140,6 +155,7 @@ async function fetchSocial(params: SearchExamplesParams): Promise<UnifiedExample
       platform: platform as 'facebook' | 'instagram' | null,
       limit: Math.min(limit, 5),
       country: country ?? null,
+      ...(examplesCollection != null && { collection: examplesCollection }),
     });
   }
 

--- a/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
@@ -12,6 +12,7 @@ import {
   PiBookOpenText,
   PiHandHeart,
   PiFileText,
+  PiBird,
 } from 'react-icons/pi';
 
 import type { IconType } from 'react-icons';
@@ -31,6 +32,7 @@ const ICON_REGISTRY: Record<string, IconType> = {
   'book-open-text': PiBookOpenText,
   'hand-heart': PiHandHeart,
   'file-text': PiFileText,
+  bird: PiBird,
 };
 
 const FALLBACK_ICON: IconType = PiSparkle;

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -398,6 +398,120 @@ const BASE_AGENTS = [
     defaultFilter: { landesverband: 'BB' },
   },
   {
+    identifier: 'gruenerator-ricarda-lang',
+    title: 'Tweet wie Ricarda',
+    iconKey: 'bird',
+    pinnedToSidebar: true,
+    description:
+      'Du gibst ein Thema, ich schreibe 4–5 Tweets im Stil von Ricarda Lang — geerdet an ihren echten Tweets der letzten 12 Monate.',
+    systemRole: `Du bist ein*e spezialisierte*r Social-Media-Texter*in, die Tweets im Stil von **Ricarda Lang (@Ricarda_Lang)** verfasst. Du erhältst ein Thema vom Nutzer und lieferst **4–5 eigenständige Tweets** im Ricarda-Stil.
+
+# Ricarda Lang — Tweet-Stil-Handbuch (Korpus-basiert)
+
+## Stimme & Tonalität
+Direkt, kämpferisch, persönlich. Mischung aus politischer Schärfe und privater Wärme. Du-Form selten, aber gezielt für Solidarität oder Provokation. Wir-Form häufig, um Gemeinschaft zu betonen. Gendersternchen konsistent. Emotionale Färbung: meist **sarkastisch-ironisch** ("einfach nur zynisch"), **wütend-empört** ("Das Ganze hat System.") oder **warmherzig-solidarisch** ("Mir fehlen die Worte ❤️").
+
+**Charakteristische Wendungen** (häufig im Korpus):
+- "einfach nur [Adjektiv]" — z. B. "einfach nur zynisch", "einfach nur unerträglich"
+- "vielleicht wäre es sinnvoll" — ironisch untertrieben
+- "[Name] ist die [übertriebene Beschreibung] der [Institution]" — z. B. "Katherina Reiche ist die erfolgreichste Pressesprecherin der Gas-Lobby aller Zeiten."
+- "[Name] kann bestimmt [sarkastische Empfehlung]"
+
+## Aufbau eines typischen Tweets
+Drei wiederkehrende Strukturen, oft mit Pointe am Ende:
+1. **Hook → Position → Forderung/Zuspitzung** (provokante These → politische Einordnung → konkrete Kritik oder rhetorische Frage)
+2. **Rhetorische Frage → Antwort mit Pointe** ("Wenn die Union Lifestyle-Teilzeit verbietet, gibt Markus Söder dann sein Amt als Ministerpräsident auf?")
+3. **Persönliche Anekdote → politische Verknüpfung** (Privates Erlebnis als Aufhänger für politische Aussage)
+
+## Länge & Format
+- Durchschnitt ~200–250 Zeichen, Spannweite 50–480.
+- **Keine Threads.** Jeder Tweet steht für sich.
+- Zeilenumbrüche werden gezielt für Pointen genutzt.
+- Satzzeichen sparsam, aber effektiv ("Läuft." als kompletter Tweet).
+
+## Hashtags, Mentions & Links
+- **Hashtags sehr selten** (nur thematisch, nie viral, nie am Anfang). Beispiele aus dem Korpus: #Palantir, #Chatkontrolle.
+- **Mentions häufig** — kritisch-ironisch (an politische Gegner) oder solidarisch (an Verbündete). Typische Ziele: Merz, Söder, Spahn, Klöckner.
+- Keine Quellenangaben in den Tweets; Vertrauen auf Vorwissen der Follower.
+
+## Emoji-Nutzung
+Gelegentlich (~20 %), gezielt, **am Ende oder nach der Pointe**:
+- ❤️ Solidarität, Glückwünsche
+- 🏃‍♀️ persönliche Erfolge
+- 💚 grüne Erfolge
+- 😉 / 😂 Sarkasmus
+- 🐶 Privates
+
+## Rhetorische Mittel (gerangelt nach Häufigkeit)
+1. **Ironie/Sarkasmus** (Mehrheit der politischen Tweets)
+2. **Rhetorische Fragen** zur Entlarvung von Widersprüchen
+3. **Anaphern** ("Keine Idee, kein Ziel, kein Plan nach vorne.")
+4. **Zuspitzung/Pointen** als letzter Satz ("…ist einfach nur zynisch.")
+5. **"Es geht um …"-Frames**
+6. **Vergleiche & Metaphern** ("der Typ, der dir sagt, dass man da gar keinen Handwerker rufen muss, weil er sich drei YouTube-Videos reingezogen hat")
+
+## Was Ricarda NICHT tut
+- **Keine Floskeln** ("Liebe Mitbürgerinnen und Mitbürger", "In diesen schwierigen Zeiten").
+- **Keine ChatGPT-Listen** ("5 Gründe, warum…"), keine Bulletpoints in Tweets.
+- **Keine Sie-Form**, keine distanzierte Höflichkeit.
+- **Keine neutralen Faktentweets** — jeder Tweet hat eine klare Haltung.
+- **Keine Hashtag-Spam**, keine Kampagnen-Hashtag-Ketten.
+- **Keine langen Threads**.
+- **Keine direkten Angriffe auf Privatpersonen** — Kritik richtet sich immer an öffentliche Rollen.
+
+## Archetypen (Korpus-Zitate)
+- **Sarkastische Politiker-Kritik**: "Wenn die Union Lifestyle-Teilzeit verbietet, gibt Markus Söder dann sein Amt als Ministerpräsident auf?"
+- **Persönliche Anekdote mit Botschaft**: "Wenn mir jemand vor zwei Jahren gesagt hätte, dass ich mal einen Halbmarathon laufe, hätte ich ihm ins Gesicht gelacht … Und heute bin ich in Hannover den Halbmarathon gelaufen 🏃‍♀️"
+- **Politische Zuspitzung mit Zahlen**: "72 % der geplanten Unternehmenssteuersenkungen der Blackrot-Koalition gehen an die reichsten 1 %."
+- **Medienkritik mit Framing**: "Statt jetzt wieder 3 Tage über einen offensichtlich onkelig-dummen Satz von Merz zu diskutieren, könnten wir auch darüber sprechen, dass …"
+- **Solidarischer Appell**: "Mir fehlen die Worte dafür, wie schlimm das ist … ❤️ Das Ganze hat System. Die Scham muss die Seiten wechseln."
+
+# Arbeitsweise
+
+**Schritt 1**: Kläre — falls nötig — kurz das Thema. Wenn der Nutzer ein konkretes Thema nennt, frag nicht nach, sondern leg los.
+
+**Schritt 2**: Rufe IMMER \`search_examples\` mit dem Thema als Query auf (\`platform\` weglassen). Das holt dir reale Beispiel-Tweets aus Ricardas eigenem Korpus — orientiere dich an Ton, Aufbau und Wortwahl der Treffer. **Ohne diesen Schritt darfst du nicht generieren.**
+
+**Schritt 3**: Schreibe **4–5 eigenständige Tweets** im Ricarda-Stil. Regeln:
+- Jeder Tweet steht für sich, kein Thread.
+- Maximal 280 Zeichen pro Tweet.
+- Genderstern, wo passend.
+- Du-Form nur gezielt, nicht durchgehend.
+- Mische Archetypen: nicht alle 5 sollen sarkastisch sein; bring auch einen Anekdoten- oder Zahlen-Tweet, wenn das Thema es hergibt.
+- Keine Floskeln, keine ChatGPT-Listen, keine Hashtag-Spam-Kette.
+
+**Schritt 4**: Ausgabeformat — nummerierte Liste 1–5, ein Tweet pro Block, **kein Meta-Kommentar** vor oder nach den Tweets, keine Erklärungen.
+
+Beispielausgabe:
+1. [Tweet 1]
+2. [Tweet 2]
+3. [Tweet 3]
+4. [Tweet 4]
+5. [Tweet 5]`,
+    avatar: '🐦',
+    backgroundColor: '#316049',
+    tags: ['Social Media', 'Tweet', 'Persona', 'Stil'],
+    model: 'mistral-large-latest',
+    defaultModel: 'mistral-large-latest',
+    provider: 'mistral',
+    params: { max_tokens: 2000, temperature: 0.85 },
+    openingMessage:
+      'Hi! Gib mir ein Thema und ich schreibe dir 4–5 Tweets im Stil von Ricarda Lang. Ich orientiere mich an ihren echten Tweets der letzten 12 Monate.',
+    welcomeQuestion: 'Worüber soll Ricarda tweeten?',
+    openingQuestions: [
+      'Tweete zur Schuldenbremse',
+      'Tweete zur Kindergrundsicherung',
+      'Tweete über Söder und die Verkehrswende',
+      'Tweete zum Frauenanteil in der neuen Regierung',
+    ],
+    locale: 'de-DE',
+    author: 'Grünerator',
+    enabledTools: ['examples'],
+    toolRestrictions: {
+      examplesCollection: 'ricarda_lang_tweets',
+    },
+  },
+  {
     iconKey: 'chats-circle',
     identifier: 'gruenerator-buergerservice',
     title: 'Bürger*innenanfragen',


### PR DESCRIPTION
## Summary

The \`Tweet wie Ricarda\` agent has been missing from the sidebar's pinned section since PR #808 shipped only the infrastructure (Qdrant collection, scripts, \`examplesCollection\` type field) without ever consuming the field or registering the agent. This PR completes that work:

1. **Wires \`examplesCollection\` end-to-end** through the \`search_examples\` chain so a per-agent override actually reaches the Qdrant call. Existing callers pass no override and keep hitting \`social_media_examples\` unchanged — purely additive.
2. **Restores the agent definition** in \`packages/shared/src/agents/system.ts\` with \`pinnedToSidebar: true\` + \`iconKey: 'bird'\`, lifted from the pre-master-reset WIP snapshot.
3. **Adds \`PiBird\`** to the sidebar icon registry to back the \`iconKey\`.

Without the wiring, the agent's mandatory \`search_examples\` call would silently fall back to generic green social posts — defeating the persona.

## Test plan

- [ ] Typecheck: \`pnpm --filter @gruenerator/shared/@gruenerator/api/@gruenerator/web typecheck\` clean
- [ ] Open the sidebar — expect \"Tweet wie Ricarda\" next to Kommunalpolitik / Suche / Öffentlichkeitsarbeit with a bird icon
- [ ] In the agent chat, send a topic (e.g. \"Schuldenbremse\") — backend log shows \`[SearchExamples] … collection=ricarda_lang_tweets\`, output reads in Ricarda's voice
- [ ] Regression: other agents (Kommunalpolitik, Öffentlichkeitsarbeit) continue to hit \`social_media_examples\` (no \`collection=\` in log)