### PR TITLE
fix(web): resolve /agents/:slug path param to system agent

### DIFF
--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -5,9 +5,9 @@ import {
   useAgentStore,
   type UserRole,
 } from '@gruenerator/chat';
-import { getSystemAgent } from '@gruenerator/shared/agents';
+import { getSystemAgent, resolveAgentSlug } from '@gruenerator/shared/agents';
 import { useCallback, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired';
 import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
@@ -22,11 +22,14 @@ const notebookLinks: NotebookLink[] = SYSTEM_NOTEBOOKS.map((nb) => ({
 
 function ChatPage() {
   const [searchParams] = useSearchParams();
+  const { slug } = useParams<{ slug?: string }>();
   const navigate = useNavigate();
   const chatViewMode = useAgentStore((s) => s.chatViewMode);
   const currentThreadTitle = useAgentStore((s) => s.currentThreadTitle);
   const firstName = useFirstName();
-  const agentParam = searchParams.get('agent');
+  // Path-based /agents/:slug is the canonical form; ?agent= is legacy but
+  // still wins when explicitly set so old deep links keep their behavior.
+  const agentParam = searchParams.get('agent') ?? (slug ? resolveAgentSlug(slug) : null);
   const modeParam = searchParams.get('mode');
 
   // When the URL carries an agent or mode param, jump straight into the thread —


### PR DESCRIPTION
## Why

After #837 merged the Ricarda Lang agent and pinned it to the sidebar at `/agents/ricarda-lang`, clicking the pin (or sharing any deep link of that shape) silently landed users on the default chat overview. Same for every other system-agent slug.

Root cause: `ChatPage` only ever read `?agent=` from the query string. The `/agents/:slug` route matched, but the `:slug` path param was never resolved to an agent identifier — so `agentParam` was `null` and the effect reset `selectedAgentId`.

The path-based form has been the documented canonical entry point since `routes.ts:248-251` was written, and `resolveAgentSlug()` in `@gruenerator/shared/agents` was clearly built for this seam, but the wire was missing. This PR adds the wire: read `:slug` via `useParams`, resolve via the existing helper, fall back to it when no `?agent=` is set. Query param wins when explicit so legacy `/chat?agent=…` bookmarks behave identically.

## Test plan

- [ ] `/agents/ricarda-lang` opens a thread with Ricarda Lang pre-selected (not overview)
- [ ] `/agents/oeffentlichkeitsarbeit` (or any other system agent slug) likewise
- [ ] Legacy `/chat?agent=gruenerator-ricarda-lang` still works
- [ ] Legacy singular `/agent/ricarda-lang` redirects and resolves
- [ ] Unknown slug (`/agents/does-not-exist`) renders thread with no system prompt — matches existing unknown-`?agent=` behavior