### PR TITLE
fix(api): unblock Docker build broken since #837 (Ricarda merge)

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -727,6 +727,7 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     searchErrors: [],
     briefGenerationFailed: false,
     rerankFailed: false,
+    topRerankScore: null,
 
     // Image generation (will be set by image node)
     imagePrompt: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -227,6 +227,7 @@ async function testExpandedContextWindow() {
     searchErrors: [],
     briefGenerationFailed: false,
     rerankFailed: false,
+    topRerankScore: null,
     qualityScore: 0,
     qualityAssessmentTimeMs: 0,
     imagePrompt: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -268,6 +268,7 @@ async function evaluateBudgetAllocation() {
     searchErrors: [],
     briefGenerationFailed: false,
     rerankFailed: false,
+    topRerankScore: null,
     qualityScore: 0,
     qualityAssessmentTimeMs: 0,
     imagePrompt: null,

--- a/apps/api/database/services/QdrantService/search.ts
+++ b/apps/api/database/services/QdrantService/search.ts
@@ -51,6 +51,7 @@ interface SocialMediaSearchOptions extends BaseSearchOptions {
   platform?: string;
   country?: string;
   landesverband?: string | readonly string[];
+  collection?: string;
 }
 
 // Search result interfaces


### PR DESCRIPTION
## Why

The api Docker build has been failing on every push to master since #837 (`feat/restore-ricarda-lang-agent`) merged. The build's `tsc --project tsconfig.build.json` step (`apps/api/Dockerfile:53`) exits with code 2 from 4 unfixed type errors. Because `docker-compose.prod.yml:49` pulls the api image from `ghcr.io/netzbegruenung/gruenerator-api` rather than building locally, the production container has been frozen at the pre-#837 image — its compiled `SYSTEM_AGENTS` array literally doesn't contain `gruenerator-ricarda-lang`, even though master's source does.

Symptom in prod: `https://gruenerator.eu/agents/ricarda-lang` returns `Internal server error`, api log shows `Agent not found: gruenerator-ricarda-lang` thrown from `initializeChatState` (`ChatGraph.ts:618`) even after the slug-routing fix in #838 landed.

The per-package `pnpm --filter @gruenerator/api typecheck` script uses `tsc --noEmit` against the default `tsconfig.json`, which apparently has wider/looser settings than `tsconfig.build.json` (the latter is what the Dockerfile invokes). Hence local typechecks were green while CI builds silently failed.

## Verification

- `pnpm --filter @gruenerator/api exec tsc --noEmit --project tsconfig.build.json` → exit 0
- The same command failed pre-fix with the same 4 errors that block CI

## Follow-ups (not in this PR)

- The duplicate `SocialMediaSearchOptions` declaration in `search.ts:50` vs `types.ts:355` is a half-done refactor seam — worth consolidating, but outside this fix's scope.
- Per-package `typecheck` script could be wired to `tsconfig.build.json` so this class of bug surfaces locally next time. Also outside scope.

## Test plan

- [ ] CI `build-images.yml` → `build-api` job succeeds on this PR's merge (path filter includes `apps/api/**`)
- [ ] After merge: pull the new `ghcr.io/netzbegruenung/gruenerator-api:latest` on the prod host and `docker compose up -d --force-recreate api`
- [ ] `https://gruenerator.eu/agents/ricarda-lang` opens a Ricarda thread end-to-end