### PR TITLE
fix(chat): unblock Ricarda tweet generation — classifier + prompt

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -51,7 +51,7 @@ const log = createLogger('ChatGraph:Classifier');
 const PM_NOUN_PATTERN =
   /\b(pressemitteilung|pressemeldung|pm|presseaussendung|presse[-\s]?statement)\b/i;
 const SOCIAL_NOUN_PATTERN =
-  /\b(post|tweet|posting|reel|tiktok|instagram|facebook|linkedin|twitter|social[-\s]?media)\b/i;
+  /\b(post|tweet|tweete|tweeten|posting|reel|tiktok|instagram|facebook|linkedin|twitter|social[-\s]?media)\b/i;
 const INSTAGRAM_PATTERN = /\b(instagram|insta|reel|story)\b/i;
 const FACEBOOK_PATTERN = /\b(facebook|\bfb\b|fb-?post|fb-?beitrag)\b/i;
 

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -470,7 +470,7 @@ Gelegentlich (~20 %), gezielt, **am Ende oder nach der Pointe**:
 
 **Schritt 1**: Kläre — falls nötig — kurz das Thema. Wenn der Nutzer ein konkretes Thema nennt, frag nicht nach, sondern leg los.
 
-**Schritt 2**: Rufe IMMER \`search_examples\` mit dem Thema als Query auf (\`platform\` weglassen). Das holt dir reale Beispiel-Tweets aus Ricardas eigenem Korpus — orientiere dich an Ton, Aufbau und Wortwahl der Treffer. **Ohne diesen Schritt darfst du nicht generieren.**
+**Schritt 2**: Nutze IMMER die mitgelieferten **Beispiel-Tweets** aus Ricardas eigenem Korpus (als VORLAGEN im Kontext mitgegeben) als Verankerung — orientiere dich an Ton, Aufbau und Wortwahl der Treffer. **Ohne diese Verankerung darfst du nicht generieren.**
 
 **Schritt 3**: Schreibe **4–5 eigenständige Tweets** im Ricarda-Stil. Regeln:
 - Jeder Tweet steht für sich, kein Thread.


### PR DESCRIPTION
## Why

`/agents/ricarda-lang` prompts like "Tweete zur Schuldenbremse" were returning the literal string `search_examples({"query": "Schuldenbremse"})` as the assistant response instead of the actual tweets (visible end-to-end at https://gruenerator.eu with a freshly-deployed api image). Per `feedback_prompt_before_code.md` — the model usually does what it's told, and it did exactly that.

Three compounding bugs:

1. **Classifier regex was noun-only.** `SOCIAL_NOUN_PATTERN` at `classifierNode.ts:53-54` matched `\b(post|tweet|...)\b`. The user wrote "Tweete" (German imperative verb) — `\btweet\b` doesn't match inside it. Every single `openingQuestion` on the Ricarda agent (`system.ts:502-505`) uses this verb form, so the agent's own suggested prompts all tripped this.

2. **Ricarda's systemRole told the model to call a tool it has no SDK binding for.** `system.ts:473` literally said *"Rufe IMMER `search_examples` mit dem Thema als Query auf … Ohne diesen Schritt darfst du nicht generieren."* `respondNode` does not bind `search_examples` — the graph orchestrates tools by intent classification (classifier → search → socialMediaComposer). The model obediently emitted the function-call syntax as text content and stopped.

3. **Ricarda was the legacy outlier.** Every regional Öffentlichkeitsarbeit agent (Berlin, Hamburg, MV, Thüringen, Brandenburg) already uses passive tool-grounding language (`pressemitteilung_examples — automatisch auf … gefiltert`). Ricarda alone used the imperative "Rufe IMMER `search_examples`" pattern. This PR aligns Ricarda with the existing convention rather than introducing a new one.

## Changes

- **`classifierNode.ts:53-54`** — extend `SOCIAL_NOUN_PATTERN` to catch "tweete"/"tweeten" verb forms.
- **`system.ts:473`** — rewrite Schritt 2 from imperative tool-call directive to passive grounding ("Nutze IMMER die mitgelieferten Beispiel-Tweets … als Verankerung"). Removes the `search_examples` function name from the prompt entirely.

## Test plan

- [ ] `/agents/ricarda-lang` + "Tweete zur Schuldenbremse" produces 4–5 Ricarda-style tweets (not a `search_examples(...)` string)
- [ ] Same with the other three openingQuestions ("Kindergrundsicherung", "Söder und die Verkehrswende", "Frauenanteil")
- [ ] Noun form "Tweet zur X" still works (regression check; this path was already correct)
- [ ] Sidebar pin for Ricarda still navigates to `/agents/ricarda-lang` (no routing regression)

## Notes on the `/Nutze IMMER/i` heuristic

The classifier's `agentWantsExamples` check (`classifierNode.ts:466`) ANDs together `enabledTools.includes('examples')` and `/Nutze IMMER/i.test(systemRole)`. The regex matches nothing in the current registry — *no agent currently has "Nutze IMMER" in its systemRole*. The regional agents work via the LLM-based default classifier. With this change Ricarda becomes the first agent to satisfy the heuristic, which is a small classifier-fast-path optimization (no LLM call for routing) and *not* a correctness fix on its own.

## Follow-up (out of scope)

The `search.ts` vs `types.ts` `SocialMediaSearchOptions` duplicate noted in #839 still exists. The `/Nutze IMMER/i` heuristic gating on a copy-pasted prompt-string is also brittle — a better signal would be an explicit boolean on the agent config (`groundOnExamples?: true`). Both reasonable follow-ups, neither blocks this fix.