### PR TITLE
fix(api): bucket IPv6 clients by /64 in rate-limit key

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -4,7 +4,7 @@
  */
 
 import express from 'express';
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 
 import authMiddleware from './middleware/authMiddleware.js';
 import { rateLimitMiddleware } from './middleware/rateLimitMiddleware.js';
@@ -118,7 +118,10 @@ const isRateLimitDisabled = process.env.DISABLE_RATE_LIMITS === 'true';
 
 // Bucket key: authenticated user when known, else client IP. Without this,
 // users sharing an egress IP (office NAT, CGNAT, VPN) compete for one bucket.
-const perUserOrIpKey = (req: Request): string => req.user?.id ?? req.ip ?? 'anonymous';
+// IPv6 addresses are normalised to their /64 prefix via ipKeyGenerator so a
+// single user cannot bypass the limit by rotating low bits of their address.
+const perUserOrIpKey = (req: Request): string =>
+  req.user?.id ?? (req.ip ? ipKeyGenerator(req.ip) : 'anonymous');
 
 const aiGenerationLimiter = isRateLimitDisabled
   ? (_req: Request, _res: Response, next: NextFunction) => next()


### PR DESCRIPTION
## Why

`express-rate-limit@8` started validating `keyGenerator` at startup and threw `ERR_ERL_KEY_GEN_IPV6` four times on every API worker boot (once per limiter that uses `perUserOrIpKey`). The validator flagged that our IP fallback returned `req.ip` directly — for IPv6 that lets a single client multiply itself across buckets by rotating the low bits of its address.

Authenticated traffic was never affected (it buckets by `req.user.id`); the gap is on anonymous endpoints (login, embeds, `/api/rate-limit` probes). The fix routes the IP fallback through the package's own `ipKeyGenerator`, which collapses IPv6 to its /64 prefix and is a no-op for IPv4.