### PR TITLE
fix(chat): wire examples-search tool card + per-agent collection override

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -1039,6 +1039,9 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
           ...(country && { country }),
           ...(lvScope !== undefined && { lvScope }),
           ...(state.platform && { platform: state.platform }),
+          ...(agentConfig.toolRestrictions?.examplesCollection != null && {
+            examplesCollection: agentConfig.toolRestrictions.examplesCollection,
+          }),
           fullBody: true,
         });
 

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -1003,6 +1003,11 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
                 if (r.relevance != null) result.relevance = r.relevance;
                 return result;
               }) ?? [],
+            ...((classifiedState.intent === 'examples' ||
+              classifiedState.intent === 'pressemitteilung_examples') &&
+            finalState.examplesResult
+              ? { examplesResult: finalState.examplesResult }
+              : {}),
           });
         }
       }


### PR DESCRIPTION
## Why

The Ricarda Lang agent generated tweets correctly after #840, but the chat UI never showed the "search_examples" tool-call card (the one users see for Öffentlichkeitsarbeit agents). And worse, the few-shot grounding was reading the *shared* social_media_examples corpus instead of the per-person ricarda_lang_tweets collection — so the tweets were stylistically off-target. Two compounding seams, both in the live ChatGraph router path.

### Bug 1: `examplesCollection` not plumbed through search

`searchNode.ts:1036` calls `searchExamples({ query, kinds, country, lvScope, platform, fullBody })` — never reads `agentConfig.toolRestrictions?.examplesCollection`. Ricarda's config has `examplesCollection: 'ricarda_lang_tweets'` (157 real tweets verified live via Qdrant scroll), but the override is dropped on the floor and the search falls back to the default `social_media_examples`. Documented intent in `services/examples/exampleSearchService.ts:57-62` and `database/services/QdrantService/types.ts:371-378`; just never wired in the graph's search node.

### Bug 2: `examplesResult` not spread into the live SSE

`chatGraphContractRouter.ts:986-1006` emits `search_complete` with `{ message, resultCount, results }` only. The legacy `intentExecutionService.ts:632-642` *does* spread `examplesResult` into the same event:

```ts
...((currentIntent === 'examples' || currentIntent === 'pressemitteilung_examples') &&
finalState.examplesResult ? { examplesResult: finalState.examplesResult } : {}),
```

The live router was missing this. The frontend `GrueneratorModelAdapter.ts:382-387` reads `examplesResult?.social` (or `.press`) from the event and uses it to populate the tool card's `examples` field. No payload → fallback to `{ results: [] }` → card hidden/empty. Persistence path in `postResponseService.ts:118-126` writes the same shape correctly, so the card *would* appear after a page reload — but mid-stream it was invisible. Exactly the "streaming-vs-persistence shape gap" pattern documented in memory.

The SSE schema at `sseHelpers.ts:107-124` already declares `examplesResult` as an optional field — no contract change needed, just wire the emission.

## Verification

- Qdrant collection `ricarda_lang_tweets`: 157 points, status=green, payload shape consistent with `social_media_examples` (verified via inline scroll, not committed)
- `pnpm --filter @gruenerator/api exec tsc --noEmit --project tsconfig.build.json` → exit 0

## Test plan

- [ ] After image rebuild + redeploy: `/agents/ricarda-lang` + "Tweete zur X" shows the tool-call card mid-stream with sampled Ricarda tweets visible
- [ ] Tweets generated are stylistically closer to real Ricarda corpus (since the few-shot grounding now uses her own tweets, not the shared green social pool)
- [ ] Öffentlichkeitsarbeit agents: "Schreib eine PM zu X" still renders its tool-card (no regression; same path is now emitting the same shape that was already in the legacy router)
- [ ] After page reload, the persisted tool card still renders (postResponseService path unchanged)

## Stacking note

This PR depends on #840 (Ricarda routing + prompt) for the user-visible effect, and #839 (api typecheck) for CI to build. None of the three needs the others to merge correctly — they touch disjoint files — but the order #839 → #840 → #841 gives a clean roll-up.