### PR TITLE
fix(chat): preserve intent-derived tool-call across rerank thinking_step (+ Ricarda rename)

### DIFF
--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -514,6 +514,15 @@ async function* parseSSEStream(
           const mappedToolName = DEEP_TOOL_MAP[toolName] || toolName;
 
           if (status === 'in_progress') {
+            // Preserve any pre-existing activeToolCall (e.g. the intent-derived
+            // gruenerator_examples_search tool-call set by the `intent` event)
+            // before overwriting with this thinking_step's tool. Otherwise the
+            // examples tool-call is orphaned and search_complete's result has
+            // nowhere to land — leaving the UI with classify/rerank chips and
+            // no examples card.
+            if (activeToolCall && !allToolCalls.includes(activeToolCall)) {
+              allToolCalls.push(activeToolCall);
+            }
             const toolArgs = { query: (args?.query as string) || title, ...args };
             activeToolCall = {
               type: 'tool-call',

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -399,7 +399,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-ricarda-lang',
-    title: 'Tweet wie Ricarda',
+    title: 'Tweet like Ricarda',
     iconKey: 'bird',
     pinnedToSidebar: true,
     description:


### PR DESCRIPTION
## Why

Every chat agent that goes through `search → rerank` (which is most of them, whenever search returns more than 2 hits) was silently losing its rich tool-call card. The Ricarda Lang agent never showed its `gruenerator_examples_search` examples card; the Öffentlichkeitsarbeit agents never showed their `gruenerator_pressemitteilung_examples` card; the Suche agent never showed `gruenerator_search`. What rendered instead were unlabeled "classify" + "rerank" chips with empty results — the "empty citations that aren't needed" the user reported.

### Root cause (event-ordering race in the SSE adapter)

The `chatGraphContractRouter` + `intentExecutionService` emit this sequence:

```
1. thinking_step{classify, in_progress}   → activeToolCall = classify
2. thinking_step{classify, completed}     → push classify → allToolCalls, clear
3. intent{intent: 'examples'}             → activeToolCall = gruenerator_examples_search
4. search_start
5. thinking_step{rerank, in_progress}     → activeToolCall = rerank   ← clobbers (3)
6. thinking_step{rerank, completed}       → push rerank → allToolCalls, clear
7. search_complete with examplesResult.social[10]
   → tries to populate activeToolCall.result, but activeToolCall is null
   → tries to populate allToolCalls[i].result, but only [classify, rerank]
     exist — the examples tool-call was orphaned in step 5
```

The `thinking_step` handler in `GrueneratorModelAdapter.ts:524` unconditionally overwrites `activeToolCall`, with no awareness that the previous `intent` event had set it for `search_complete` to fill in.

Confirmed via diagnostic logs against `gruenerator.eu` and localhost:

```
[adapter:intent] intent=examples → toolName=gruenerator_examples_search (will-create-toolcall=true)
[adapter:search_complete] hasExamplesResult=true social=10 press=0 results=3 activeToolCall=none allToolCalls=2
```

`hasExamplesResult=true social=10` proves the backend SSE shape from #842 is correct. `activeToolCall=none allToolCalls=2` proves the rerank handoff destroyed the examples tool-call. Two entries in `allToolCalls` are classify + rerank; the examples one is missing.

### Fix

`packages/chat/src/runtime/GrueneratorModelAdapter.ts` — in the `thinking_step` `in_progress` branch, archive the existing `activeToolCall` into `allToolCalls` before overwriting. The existing `search_complete` loop at line 391-398 (which already iterates `allToolCalls` and updates results via `resultForTool()`) will then find the examples tool-call there and populate it with the rich shape `{ results, examples: social[] }`. `CompactExampleResults` renders the 3-5 sampled tweets.

Same fix benefits every other intent that runs through rerank:

- Ricarda Lang → `gruenerator_examples_search` (5 of her own tweets visible)
- Öffentlichkeitsarbeit Berlin/Hamburg/MV/Thüringen/Brandenburg → `gruenerator_pressemitteilung_examples` + `gruenerator_examples_search`
- LV-PR factory agents (Schleswig-Holstein, Bayern) → same
- Suche agent → `gruenerator_search` card
- Anything using `web_search` intent → web card

### Bonus

Second commit renames the Ricarda agent's display title from "Tweet wie Ricarda" to "Tweet like Ricarda" per request. Cosmetic only.

## Test plan

- [ ] `/agents/ricarda-lang` + "Tweete zur Schuldenbremse" — examples card appears mid-stream with 3-5 real Ricarda tweets
- [ ] Öffentlichkeitsarbeit (any LV) + "Schreib eine PM zu X" — `gruenerator_pressemitteilung_examples` card appears with sampled regional PMs
- [ ] Default chat with research/search intent — `gruenerator_search` card appears
- [ ] After page reload, persisted tool-call cards still render (no regression on persistence path)
- [ ] Local: console no longer needs the diagnostic logs that proved the bug; CI typecheck on `@gruenerator/chat` was clean