### PR TITLE
refactor(chat): split internal-progress and user-tool SSE events

### DIFF
--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -236,7 +236,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       // instead of looking frozen during attachment processing + memory fetch
       // + classification (collectively 1–8s on a cold path).
       const classifyStepId = `classify_${Date.now()}`;
-      sse.send('thinking_step', {
+      sse.send('progress_step', {
         stepId: classifyStepId,
         toolName: 'classify',
         title: 'Verstehe Anfrage…',
@@ -498,7 +498,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         );
       }
 
-      sse.send('thinking_step', {
+      sse.send('progress_step', {
         stepId: classifyStepId,
         toolName: 'classify',
         title: 'Verstehe Anfrage…',

--- a/apps/api/routes/chat/services/intentExecutionService.ts
+++ b/apps/api/routes/chat/services/intentExecutionService.ts
@@ -561,7 +561,7 @@ export async function executeIntentPipeline(opts: {
         if (willGenerateBrief && briefStepId) {
           // brief generator is a silent LLM call (~1–3s); ping so the UI doesn't
           // sit on the stale "intent" message during this window.
-          sse.send('thinking_step', {
+          sse.send('progress_step', {
             stepId: briefStepId,
             toolName: 'brief',
             title: 'Plane Recherche…',
@@ -569,7 +569,7 @@ export async function executeIntentPipeline(opts: {
           });
           const briefResult = await briefGeneratorNode(finalState);
           searchInputState = { ...finalState, ...briefResult } as ChatGraphState;
-          sse.send('thinking_step', {
+          sse.send('progress_step', {
             stepId: briefStepId,
             toolName: 'brief',
             title: 'Plane Recherche…',
@@ -598,7 +598,7 @@ export async function executeIntentPipeline(opts: {
 
         if (finalState.searchResults?.length > 2) {
           const rerankStepId = `rerank_${Date.now()}`;
-          sse.send('thinking_step', {
+          sse.send('progress_step', {
             stepId: rerankStepId,
             toolName: 'rerank',
             title: 'Bewerte Quellen…',
@@ -609,7 +609,7 @@ export async function executeIntentPipeline(opts: {
           if (finalState.searchResults.length > 0) {
             finalState.citations = buildCitations(finalState.searchResults);
           }
-          sse.send('thinking_step', {
+          sse.send('progress_step', {
             stepId: rerankStepId,
             toolName: 'rerank',
             title: 'Bewerte Quellen…',

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -33,6 +33,7 @@ export type SSEEventType =
   | 'sharepic_complete'
   | 'response_start'
   | 'thinking_step'
+  | 'progress_step'
   | 'text_delta'
   | 'reasoning_delta'
   | 'fallback'
@@ -83,6 +84,20 @@ export interface ThinkingStepPayload {
     error?: string;
   };
 }
+
+/**
+ * Payload for internal pipeline-progress events (classify, rerank, brief).
+ *
+ * Shape mirrors ThinkingStepPayload but the *semantics* differ:
+ * `thinking_step` is a user-facing tool call (search_examples, ask_human, …)
+ * that renders a tool-card and persists in `allToolCalls`.
+ * `progress_step` is a transient internal stage that drives ONLY the
+ * progress indicator — it must NOT mutate the active/persisted tool-call
+ * stream, or it clobbers the intent-derived tool-call between `intent`
+ * and `search_complete` (the race that made every search→rerank flow
+ * silently drop its rich tool-card).
+ */
+export type ProgressStepPayload = ThinkingStepPayload;
 
 /**
  * SSE event payloads by type.
@@ -138,6 +153,7 @@ export interface SSEEventPayloads {
   };
   response_start: { message: string };
   thinking_step: ThinkingStepPayload;
+  progress_step: ProgressStepPayload;
   text_delta: { text: string };
   reasoning_delta: { text: string };
   fallback: {

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -544,6 +544,28 @@ async function* parseSSEStream(
           break;
         }
 
+        case 'progress_step': {
+          // Internal pipeline stage (classify, rerank, brief). Updates the
+          // progress indicator but MUST NOT touch activeToolCall/allToolCalls
+          // — those are reserved for user-facing tools dispatched via the
+          // `intent` event + `thinking_step`. Conflating the two is what
+          // caused the search→rerank race that orphaned the rich
+          // examples/search/web tool-cards (see PR history).
+          const { title, status } = data as {
+            stepId: string;
+            toolName: string;
+            title: string;
+            status: 'in_progress' | 'completed';
+          };
+          if (status === 'in_progress') {
+            currentProgress = { ...currentProgress, stage: 'searching', message: title };
+          } else if (status === 'completed') {
+            currentProgress = { ...currentProgress, message: title };
+          }
+          yield buildResult();
+          break;
+        }
+
         case 'text_delta': {
           const delta = (data as { text: string }).text;
           accumulatedText += delta;


### PR DESCRIPTION
## Why

Conflating internal pipeline stages (classify, rerank, brief) with user-facing tool calls (`search_examples`, `web_search`, `gruenerator_search`, …) under a single `thinking_step` SSE event was an event-shape mismatch that caused every search→rerank flow to silently destroy its rich tool-card. The race documented in PR #843:

```
thinking_step{rerank, in_progress}  → overwrites activeToolCall (was gruenerator_examples_search)
search_complete arrives with examplesResult.social[10]
  → activeToolCall is now `rerank` (no result-shape match)
  → no examples card renders, only unlabeled classify/rerank chips
```

PR #843 patches the symptom defensively (preserve `activeToolCall` when a `thinking_step` overwrites it). **This PR patches the cause**: don't emit internal pipeline pings as `thinking_step` in the first place.

## Architectural split

- **`thinking_step`** (kept) — user-facing tool calls (`ask_human`, future real tools). Mutates `activeToolCall` and persists to `allToolCalls`. Renders as a tool-card via the toolkit.
- **`progress_step`** (new) — internal pipeline stages. Drives ONLY the progress indicator. Never touches the tool-call stream.

Backend emit sites moved to `progress_step`:
- `chatGraphContractRouter.ts` — classify (in_progress + completed, 2 sites)
- `intentExecutionService.ts` — brief (2 sites), rerank (2 sites)

Adapter gets a new `progress_step` case handler that updates `currentProgress` without mutating tool-calls.

Same-shape payload (`ProgressStepPayload = ThinkingStepPayload`) keeps the `SSEWriter` type-safe with zero schema churn for callers, just a new event name in the union.

## Relationship to #843

#843 stays as a defensive backstop for any future `thinking_step` that does fire mid-search (e.g., if `ask_human` ever triggers mid-stream). This PR ensures the common case (Ricarda, Öffentlichkeitsarbeit, Suche, web-search, every intent that goes through search→rerank) never produces the race in the first place. They compose cleanly: deeper architecture fix + symptom backstop.

## Test plan

- [ ] `/agents/ricarda-lang` + "Tweete zur Schuldenbremse" — examples card renders with 3-5 real Ricarda tweets, no empty classify/rerank chips
- [ ] Öffentlichkeitsarbeit (any LV) + "Schreib eine PM zu X" — `gruenerator_pressemitteilung_examples` card renders with regional PMs
- [ ] Suche agent — `gruenerator_search` card renders with search results
- [ ] Deep research intent — `research` card with `ResearchToolRender` (existing) still renders
- [ ] `ask_human` clarification flow — interrupt + tool-card still works (still uses `thinking_step`)
- [ ] No visible UI noise from classify/rerank/brief (progress indicator still shows the German title text)
- [ ] Local typecheck: `pnpm --filter @gruenerator/chat exec tsc --noEmit` → exit 0 (api typecheck running in background)

## Note on cleanup

`DEEP_TOOL_MAP` in `packages/chat/src/lib/toolMappings.ts` no longer needs entries for `classify`/`rerank`/`brief` going forward — kept for now in case third-party MCP tools recycle those names. Cheap insurance, can be pruned in a follow-up.