### PR TITLE
feat(agents): per-locale audience filter — Austria as first-class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@
 
 Grünerator: AI content creation platform for Die Grünen. pnpm monorepo (web, mobile, desktop, API). EU-hosted infrastructure.
 
+**Locale: Austria (de-AT) is a first-class audience alongside Germany (de-DE).** Default to AT-aware code, not DE-with-AT-toggle. When adding agents, tag `audience: 'de-DE' | 'de-AT' | 'all'` explicitly — leaving it undefined defaults to `'all'` for backward compat, not as a way to skip the decision. System prompts with DE-specific terminology must fork via `userLocale === 'de-AT'`; the `## LÄNDERKONTEXT: ÖSTERREICH` block in `systemPrompt.ts` is the established seam. Notebook routing falls back to `oesterreich-notebook` for AT users when an agent has no `defaultNotebookId`.
+
 ## Commands
 
 All from repo root (pnpm + Turborepo):

--- a/apps/web/src/components/layout/Sidebar/AllAgentsDialog.tsx
+++ b/apps/web/src/components/layout/Sidebar/AllAgentsDialog.tsx
@@ -1,12 +1,13 @@
 import { getAgentSlug } from '@gruenerator/shared/agents';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@gruenerator/ui';
-import { type ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { PiStarFill } from 'react-icons/pi';
 
 import { useUserAgents } from '../../../features/agents/api';
 import useAgentFavoritesStore from '../../../stores/agentFavoritesStore';
+import { useAuthStore } from '../../../stores/authStore';
 
-import { DEFAULT_AGENT_ENTRIES, VISIBLE_SYSTEM_AGENTS, getAgentIcon } from './sidebarAgentConfig';
+import { getDefaultAgentEntries, getVisibleSystemAgents, getAgentIcon } from './sidebarAgentConfig';
 import { menuLinkClass } from './sidebarStyles';
 
 import { cn } from '@/utils/cn';
@@ -71,6 +72,9 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
   const favoriteIdentifiers = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
   const toggle = useAgentFavoritesStore((s) => s.toggle);
   const { data: userAgents = [] } = useUserAgents();
+  const userLocale = useAuthStore((state) => state.locale) ?? 'de-DE';
+  const defaultAgentEntries = useMemo(() => getDefaultAgentEntries(userLocale), [userLocale]);
+  const visibleSystemAgents = useMemo(() => getVisibleSystemAgents(userLocale), [userLocale]);
 
   return (
     <Dialog>
@@ -88,7 +92,7 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
           <DialogTitle>Alle Agents</DialogTitle>
         </DialogHeader>
         <ul className="list-none m-0 p-0 max-h-[60vh] overflow-y-auto scrollbar-thin">
-          {DEFAULT_AGENT_ENTRIES.map((entry) => {
+          {defaultAgentEntries.map((entry) => {
             const Icon = getAgentIcon(entry.identifier);
             return (
               <AgentListRow
@@ -109,7 +113,7 @@ export function AllAgentsDialog({ onLinkClick, titleClass }: AllAgentsDialogProp
 
           <li className="my-2 border-t border-grey-200 dark:border-grey-800" aria-hidden="true" />
 
-          {VISIBLE_SYSTEM_AGENTS.map((agent) => {
+          {visibleSystemAgents.map((agent) => {
             const Icon = getAgentIcon(agent.identifier);
             return (
               <AgentListRow

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
 
 import { AllAgentsDialog } from './AllAgentsDialog';
 import NewItemDropdown from './NewItemDropdown';
-import { DEFAULT_AGENT_ENTRIES, PINNED_AGENT_IDS, getAgentIcon } from './sidebarAgentConfig';
+import { getDefaultAgentEntries, getPinnedAgentIds, getAgentIcon } from './sidebarAgentConfig';
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
 import { cn } from '@/utils/cn';
@@ -452,18 +452,21 @@ const SidebarAgents = memo(function SidebarAgents({
   onLinkClick: (path: string, title: string) => void;
 }) {
   const { data: userAgents = [] } = useUserAgents();
+  const userLocale = useAuthStore((state) => state.locale) ?? 'de-DE';
+  const pinnedAgentIds = useMemo(() => getPinnedAgentIds(userLocale), [userLocale]);
+  const defaultAgentEntries = useMemo(() => getDefaultAgentEntries(userLocale), [userLocale]);
 
   const favoriteIdentifiers = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
   const favoriteAgents = useMemo(() => {
     const out: Agent[] = [];
     for (const identifier of favoriteIdentifiers) {
-      if (PINNED_AGENT_IDS.has(identifier)) continue;
+      if (pinnedAgentIds.has(identifier)) continue;
       const agent = getSystemAgent(identifier);
       if (!agent) continue; // covers deleted agents + migration unknowns
       out.push(agent);
     }
     return out;
-  }, [favoriteIdentifiers]);
+  }, [favoriteIdentifiers, pinnedAgentIds]);
 
   // Favorites store uses identifier strings as keys; user-agent identifiers
   // don't collide with skill mentions (different namespaces).
@@ -515,7 +518,7 @@ const SidebarAgents = memo(function SidebarAgents({
       </button>
       {isExpanded && (
         <ul className="list-none m-0 p-0">
-          {DEFAULT_AGENT_ENTRIES.map((entry) => {
+          {defaultAgentEntries.map((entry) => {
             const Icon = getAgentIcon(entry.identifier);
             return (
               <li key={entry.key}>

--- a/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts
@@ -1,5 +1,6 @@
 import {
   VISIBLE_SYSTEM_AGENTS as ALL_VISIBLE_SYSTEM_AGENTS,
+  getVisibleSystemAgentsForLocale,
   type Agent,
 } from '@gruenerator/shared/agents';
 import {
@@ -57,34 +58,40 @@ export interface DefaultAgentEntry {
 
 /**
  * Pinned defaults — always visible at the top of the sidebar regardless of
- * favorites. Derived from `pinnedToSidebar: true` on the agent definition.
- * To pin a new agent: flip that flag on its `SYSTEM_AGENTS` entry and add an
- * `iconKey` — no edits in this file.
+ * favorites. Derived from `pinnedToSidebar: true` on the agent definition,
+ * then filtered + localized for the user's locale via the shared registry
+ * helper. To pin a new agent: flip that flag on its `SYSTEM_AGENTS` entry
+ * and add an `iconKey` — no edits in this file.
  *
  * Order follows array order in `SYSTEM_AGENTS`.
  */
-export const DEFAULT_AGENT_ENTRIES: readonly DefaultAgentEntry[] = ALL_VISIBLE_SYSTEM_AGENTS.filter(
-  (a) => a.pinnedToSidebar === true
-).map((a) => ({
-  key: `default-${a.identifier.replace(/^gruenerator-/, '')}`,
-  label: a.title,
-  identifier: a.identifier,
-}));
+export function getDefaultAgentEntries(userLocale: string): readonly DefaultAgentEntry[] {
+  return getVisibleSystemAgentsForLocale(userLocale)
+    .filter((a) => a.pinnedToSidebar === true)
+    .map((a) => ({
+      key: `default-${a.identifier.replace(/^gruenerator-/, '')}`,
+      label: a.title,
+      identifier: a.identifier,
+    }));
+}
 
 /**
  * Identifier set for the pinned agents. Used by sidebar consumers (e.g.
  * `Sidebar.tsx`) to filter the favorites list and avoid double-rendering
- * agents that are already pinned at the top.
+ * agents that are already pinned at the top. Locale-aware so AT users
+ * don't accidentally de-dupe a DE-only pinned agent they can't see.
  */
-export const PINNED_AGENT_IDS: ReadonlySet<string> = new Set(
-  DEFAULT_AGENT_ENTRIES.map((e) => e.identifier)
-);
+export function getPinnedAgentIds(userLocale: string): ReadonlySet<string> {
+  return new Set(getDefaultAgentEntries(userLocale).map((e) => e.identifier));
+}
 
 /**
  * Agents shown in the "Alle Agents" modal: visible registry minus the pinned
- * set (those are rendered separately). Single source of truth for the modal
- * — keeps it from drifting against the sidebar.
+ * set (those are rendered separately) and minus those whose `audience`
+ * excludes this user's locale. Single source of truth for the modal — keeps
+ * it from drifting against the sidebar.
  */
-export const VISIBLE_SYSTEM_AGENTS: readonly Agent[] = ALL_VISIBLE_SYSTEM_AGENTS.filter(
-  (a) => !PINNED_AGENT_IDS.has(a.identifier)
-);
+export function getVisibleSystemAgents(userLocale: string): readonly Agent[] {
+  const pinned = getPinnedAgentIds(userLocale);
+  return getVisibleSystemAgentsForLocale(userLocale).filter((a) => !pinned.has(a.identifier));
+}

--- a/packages/shared/src/agents/audience.ts
+++ b/packages/shared/src/agents/audience.ts
@@ -1,0 +1,52 @@
+import { SYSTEM_AGENTS, VISIBLE_SYSTEM_AGENTS } from './system.js';
+
+import type { Agent } from './types.js';
+
+/**
+ * Should the user with `userLocale` see this agent in the inventory / sidebar?
+ *
+ * - `audience: 'all'` or `undefined` → always visible (default).
+ * - `audience: 'de-DE'` → only visible to German-locale users.
+ * - `audience: 'de-AT'` → only visible to Austrian-locale users.
+ *
+ * Backend resolution by identifier is unaffected — this only governs which
+ * agents the user discovers through the UI. Direct URL/legacy thread access
+ * still resolves any registry agent.
+ */
+export function isAgentVisibleForLocale(agent: Agent, userLocale: string): boolean {
+  if (agent.audience === undefined || agent.audience === 'all') return true;
+  return agent.audience === userLocale;
+}
+
+/**
+ * Apply `agent.localized[userLocale]` overrides on top of the agent's
+ * defaults, returning a new Agent. Cheap shallow merge — pass-through if
+ * no localized bundle matches the locale.
+ */
+export function localizeAgent(agent: Agent, userLocale: string): Agent {
+  const overrides = agent.localized?.[userLocale === 'de-AT' ? 'de-AT' : 'de-DE'];
+  if (!overrides) return agent;
+  return { ...agent, ...overrides };
+}
+
+/**
+ * Convenience: filtered + localized view of every system agent for a user.
+ * Mirrors `SYSTEM_AGENTS` but per-locale. Includes inventory-hidden agents
+ * — callers that need the public list should compose with `VISIBLE_SYSTEM_AGENTS`.
+ */
+export function getSystemAgentsForLocale(userLocale: string): readonly Agent[] {
+  return SYSTEM_AGENTS.filter((a) => isAgentVisibleForLocale(a, userLocale)).map((a) =>
+    localizeAgent(a, userLocale)
+  );
+}
+
+/**
+ * Convenience: the public, locale-filtered, localized inventory list.
+ * The right starting point for sidebar / picker UIs that want a clean
+ * per-user-locale view of available agents.
+ */
+export function getVisibleSystemAgentsForLocale(userLocale: string): readonly Agent[] {
+  return VISIBLE_SYSTEM_AGENTS.filter((a) => isAgentVisibleForLocale(a, userLocale)).map((a) =>
+    localizeAgent(a, userLocale)
+  );
+}

--- a/packages/shared/src/agents/index.ts
+++ b/packages/shared/src/agents/index.ts
@@ -1,6 +1,8 @@
 export type {
   Agent,
+  AgentAudience,
   AgentCategory,
+  AgentLocalization,
   AgentParams,
   AgentProvider,
   FewShotExample,
@@ -10,6 +12,13 @@ export type {
   ToolRestrictions,
 } from './types.js';
 export { AGENT_CATEGORY_LABELS, SKILL_CATEGORY_LABELS } from './types.js';
+
+export {
+  isAgentVisibleForLocale,
+  localizeAgent,
+  getSystemAgentsForLocale,
+  getVisibleSystemAgentsForLocale,
+} from './audience.js';
 
 export {
   SYSTEM_AGENTS,

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -204,6 +204,7 @@ const BASE_AGENTS = [
   // wrong LV. Skills `/presse-<lv>` and `/social-<lv>` route to these agents.
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-berlin',
+    audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Berlin',
     description:
       'Pressemitteilungen und Social-Media-Inhalte im Stil der Grünen Berlin (AGH-Wahlkampf, Wegner-Attacke, Kiez-Frame).',
@@ -243,6 +244,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
+    audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Hamburg',
     description:
       'Pressemitteilungen und Social-Media-Inhalte im Stil der Grünen Hamburg (Rot-Grün-Regierungston, hanseatischer Weg, Bürgerschafts-Anker).',
@@ -282,6 +284,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
+    audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit MV',
     description:
       'Pressemitteilungen und Social-Media-Inhalte im Stil der Grünen Mecklenburg-Vorpommern (Ostsee-Frame, Erneuerbare als Wirtschaftsthema, Reiche-Personalisierung).',
@@ -321,6 +324,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
+    audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Thüringen',
     description:
       'Pressemitteilungen und Social-Media-Inhalte im Stil der Grünen Thüringen (außerparlamentarische Opposition, Brombeer-Regierung, „Vorreiter verspielt").',
@@ -360,6 +364,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
+    audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Brandenburg',
     description:
       'Pressemitteilungen und Social-Media-Inhalte im Stil der Brandenburger Bündnisgrünen (Bündnisgrüne statt Grüne, Strukturwandel/Lausitz, außerparlamentarisch).',
@@ -399,6 +404,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-ricarda-lang',
+    audience: 'de-DE',
     title: 'Tweet like Ricarda',
     iconKey: 'bird',
     pinnedToSidebar: true,
@@ -837,6 +843,7 @@ Schritt 6: Überarbeite bei Score unter 4.`;
 
 const LV_PR_AGENTS: Agent[] = LV_PR_SPECS.map((spec) => ({
   identifier: `gruenerator-oeffentlichkeitsarbeit-${spec.lv}`,
+  audience: 'de-DE',
   title: `Öffentlichkeitsarbeit (${spec.title})`,
   description: `Erstellt Pressemitteilungen und Social-Media-Inhalte für die Grünen ${spec.title} — mit regionaler Verankerung und LV-spezifischen Vorlagen.`,
   systemRole: buildLvPrSystemRole(spec),

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -54,6 +54,31 @@ export interface AgentDefaultFilter {
   landesverband?: readonly string[] | string;
 }
 
+/**
+ * Which user-locale audience an agent is meant for.
+ * - `'de-DE'` — only German users see it (Landesverband PR agents, German-only
+ *   persona agents, anything tied to Bundestag / German LV substrates).
+ * - `'de-AT'` — only Austrian users see it (none yet at the time of writing).
+ * - `'all'` — visible to everyone; the agent itself adapts to `userLocale`
+ *   (e.g. system prompt forks via `LÄNDERKONTEXT: ÖSTERREICH` for AT users).
+ * - `undefined` — treated as `'all'` for backward compatibility.
+ */
+export type AgentAudience = 'de-DE' | 'de-AT' | 'all';
+
+/**
+ * Per-locale UI override bundle. Fields here win over the agent's top-level
+ * defaults when a matching user locale resolves the agent. Used for agents
+ * marked `audience: 'all'` that want to swap welcome copy, opening questions,
+ * or description text per locale without forking into two registry entries.
+ */
+export interface AgentLocalization {
+  title?: string;
+  description?: string;
+  openingMessage?: string;
+  welcomeQuestion?: string;
+  openingQuestions?: readonly string[];
+}
+
 export interface Agent {
   identifier: string;
   title: string;
@@ -119,6 +144,19 @@ export interface Agent {
    * Additional categories will be added as the agent taxonomy stabilizes.
    */
   category?: AgentCategory;
+  /**
+   * Which user-locale audience this agent is meant for. Governs sidebar /
+   * inventory visibility — backend can still resolve the agent by identifier
+   * regardless (for direct URL access or legacy thread reconstruction).
+   * See `AgentAudience` for the semantics; undefined ≈ `'all'`.
+   */
+  audience?: AgentAudience;
+  /**
+   * Optional per-locale overrides applied by `localizeAgent(agent, locale)`.
+   * Useful for `audience: 'all'` agents that should swap title / opening
+   * copy per user locale without forking into two registry entries.
+   */
+  localized?: Partial<Record<'de-DE' | 'de-AT', AgentLocalization>>;
 }
 
 export type AgentCategory = 'gruppen';


### PR DESCRIPTION
## Why

Austria (de-AT) is a first-class audience alongside Germany (de-DE), but `Agent.locale` had become dead code — every agent set `'de-DE'` and nothing consulted it. AT users saw DE-only Landesverband PR agents (Berlin, Hamburg, MV, Thüringen, Brandenburg, plus the factory LV-PR SH+BY) and Ricarda Lang in their sidebar with zero AT relevance. The agent registry didn't divide cleanly.

## What

Adds explicit per-locale conditioning at the registry level. Surgical first cut; further AT-specific content lands progressively.

### Type

- `Agent.audience: 'de-DE' | 'de-AT' | 'all'` (optional, undefined ≈ `'all'` for backward compat). Governs sidebar / inventory visibility. Backend identifier resolution stays unaffected — legacy threads and direct URL access keep working.
- `Agent.localized?: { 'de-DE'?, 'de-AT'? }` — per-locale override bundle (`title`, `description`, `openingMessage`, `welcomeQuestion`, `openingQuestions`) for agents marked `'all'` that want to swap greeting copy without forking into two registry entries.

### Helpers (`packages/shared/src/agents/audience.ts`)

- `isAgentVisibleForLocale(agent, locale): boolean`
- `localizeAgent(agent, locale): Agent` (shallow merge of localized overrides)
- `getSystemAgentsForLocale(locale): readonly Agent[]`
- `getVisibleSystemAgentsForLocale(locale): readonly Agent[]`

### Tagged DE-only agents

| Agent | Reason |
|---|---|
| `gruenerator-oeffentlichkeitsarbeit-berlin` | Berlin LV — DE-only by geography |
| `gruenerator-oeffentlichkeitsarbeit-hamburg` | Hamburg LV |
| `gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern` | MV LV |
| `gruenerator-oeffentlichkeitsarbeit-thueringen` | Thüringen LV |
| `gruenerator-oeffentlichkeitsarbeit-brandenburg` | Brandenburg LV |
| `gruenerator-oeffentlichkeitsarbeit-{schleswig-holstein,bayern}` (factory) | SH + BY LVs |
| `gruenerator-ricarda-lang` | German politician, German corpus |

Everything else stays implicit (= `'all'`) and continues to serve both locales. The universal Öffentlichkeitsarbeit agent already branches its prompt via `LÄNDERKONTEXT: ÖSTERREICH` for AT users — that mechanism stays untouched.

### Consumers

- `sidebarAgentConfig.ts`: constants → functions (`getDefaultAgentEntries(locale)`, `getPinnedAgentIds(locale)`, `getVisibleSystemAgents(locale)`).
- `Sidebar.tsx` + `AllAgentsDialog.tsx`: read `userLocale` from `useAuthStore`, wrap function calls in `useMemo([userLocale])`.

### Documentation

- `CLAUDE.md` gains a paragraph documenting the convention: tag `audience` explicitly when adding agents; AT is first-class; AT-aware code defaults.
- New user memory `project_austria_first_class_locale.md` tracks gap audit and follow-ups (private to author).

## Test plan

- [ ] AT user (`profiles.locale = 'de-AT'`) opens sidebar — no Berlin/Hamburg/MV/Thüringen/Brandenburg/SH/BY/Ricarda agents visible.
- [ ] DE user — sidebar identical to before this PR (universal + LV PR + Ricarda + everything else).
- [ ] "Alle anzeigen" modal — same per-locale filtering as sidebar.
- [ ] Direct URL `/agents/gruenerator-oeffentlichkeitsarbeit-berlin` for an AT user still resolves and opens the chat (visibility ≠ resolution; backend agnostic).
- [ ] Tagged DE-only agents with `audience: 'de-DE'` still appear for DE users without regression.
- [ ] `pnpm --filter @gruenerator/web exec tsc --noEmit` clean (running in background).

## Follow-ups (out of scope)

Tracked in user memory `project_austria_first_class_locale.md`. Highlights:

1. No AT-locale opening messages on `audience: 'all'` agents yet — all agents open with DE-flavored copy.
2. No dedicated AT öffentlichkeitsarbeit agent — only the universal with internal `LÄNDERKONTEXT` branching.
3. No AT briefing / monitoring counterparts.
4. ChatPage's `defaultNotebookId` auto-pair could fall back to `oesterreich-notebook` for AT users when an agent has no notebook.