### PR TITLE
feat(chat): auto-pair Österreich notebook for AT users when agent has none

### DIFF
--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -13,6 +13,16 @@ import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired
 import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
 import { SYSTEM_NOTEBOOKS } from '@/features/notebook/config/notebooksConfig';
 import { useFirstName } from '@/hooks/useFirstName';
+import { useAuthStore } from '@/stores/authStore';
+
+/**
+ * AT users get this notebook when their selected agent doesn't pin its own.
+ * Keeps `@notebook` lookups and RAG aligned to gruene.at content instead of
+ * silently retaining whichever (likely DE) notebook the user picked last.
+ * DE has no equivalent single-notebook default — DE keeps its current behavior
+ * (no auto-switch when the agent has no preference).
+ */
+const AT_DEFAULT_NOTEBOOK_ID = 'oesterreich-notebook';
 
 const notebookLinks: NotebookLink[] = SYSTEM_NOTEBOOKS.map((nb) => ({
   id: nb.id,
@@ -27,6 +37,7 @@ function ChatPage() {
   const chatViewMode = useAgentStore((s) => s.chatViewMode);
   const currentThreadTitle = useAgentStore((s) => s.currentThreadTitle);
   const firstName = useFirstName();
+  const userLocale = useAuthStore((s) => s.locale) ?? 'de-DE';
   // Path-based /agents/:slug is the canonical form; ?agent= is legacy but
   // still wins when explicitly set so old deep links keep their behavior.
   const agentParam = searchParams.get('agent') ?? (slug ? resolveAgentSlug(slug) : null);
@@ -62,6 +73,14 @@ function ChatPage() {
         store.selectedNotebookId !== agentMeta.defaultNotebookId
       ) {
         store.setSelectedNotebook(agentMeta.defaultNotebookId);
+      } else if (
+        !agentMeta?.defaultNotebookId &&
+        userLocale === 'de-AT' &&
+        store.selectedNotebookId !== AT_DEFAULT_NOTEBOOK_ID
+      ) {
+        // AT-first: agents without an explicit notebook pair with the
+        // Österreich notebook so RAG / @notebook queries stay in-locale.
+        store.setSelectedNotebook(AT_DEFAULT_NOTEBOOK_ID);
       }
     } else if (store.selectedAgentId !== null) {
       store.setSelectedAgent(null);
@@ -74,7 +93,7 @@ function ChatPage() {
       store.setThreadMode(modeParam);
       store.setChatViewMode('thread');
     }
-  }, [agentParam, modeParam]);
+  }, [agentParam, modeParam, userLocale]);
 
   const handleNavigate = useCallback((path: string) => navigate(path), [navigate]);
 


### PR DESCRIPTION
## Why

AT-first locale work, continuing after #845's audience filter. Today an AT user opening the universal Öffentlichkeitsarbeit, Antrag, Bürger*innenanfragen, or Suche agent keeps whichever notebook they had selected before — typically a German Landesverband notebook from a prior session. `@notebook` mentions and RAG retrieval then silently pull DE content into AT-shaped queries. The agent's `LÄNDERKONTEXT: ÖSTERREICH` system prompt fork can't compensate when the actual document corpus is German.

## What

Tiny ChatPage change: AT-only notebook fallback.

```ts
// In the agent-switch effect:
if (agentMeta?.defaultNotebookId) {
  setSelectedNotebook(agentMeta.defaultNotebookId);          // existing
} else if (!agentMeta?.defaultNotebookId && userLocale === 'de-AT') {
  setSelectedNotebook('oesterreich-notebook');               // new
}
```

`oesterreich-notebook` is the registered gruene.at notebook (mapped to the `oesterreich` Qdrant collection at `apps/api/config/notebookCollectionMap.ts:34`). Already known by the frontend (`apps/web/src/features/notebook/config/notebooksConfig.ts:162`) and by the backend's `isKnownNotebook` allow-list.

DE users unaffected — DE has many notebooks and no single sensible default. Per-LV PR agents (Berlin, Hamburg, etc.) keep their explicit `defaultNotebookId`; the fallback only fires when the agent has no preference.

## Test plan

- [ ] AT user opens `/agents/gruenerator-universal` from a thread that previously had a DE notebook selected → sidebar notebook switches to "Österreich" automatically.
- [ ] AT user opens `/agents/gruenerator-oeffentlichkeitsarbeit-bayern` (explicit `defaultNotebookId: 'bayern-notebook'`) → notebook switches to Bayern as before; the AT fallback does NOT override the agent's explicit preference. (Note: post-#845 this agent is hidden from AT users anyway.)
- [ ] DE user opens any `audience: 'all'` agent → notebook selection unchanged (no auto-switch from non-AT side).
- [ ] AT user with `oesterreich-notebook` already selected, switches agent → no redundant `setSelectedNotebook` call (the `!==` guard).
- [ ] `pnpm --filter @gruenerator/web exec tsc --noEmit` → exit 0.

## Why "AT-only" fallback and not "always pick a locale-appropriate default"

DE has 16+ Landesverband notebooks plus a federal one; choosing "the DE default" requires opinion (which LV? the user's own? the universal Bundespartei one?). AT has exactly one notebook (`oesterreich-notebook`) since gruene.at publishes as a single national content stream. The asymmetry is real — codifying it directly is more honest than inventing a DE default.

Part of the AT-first locale initiative documented in `CLAUDE.md` and user memory `project_austria_first_class_locale.md`.