### PR TITLE
fix: unblock CI Quality Checks — resurrect mobile typecheck + wolke

### DIFF
--- a/apps/mobile/components/chat/ChatSettingsSheet.tsx
+++ b/apps/mobile/components/chat/ChatSettingsSheet.tsx
@@ -6,6 +6,7 @@ import {
   type ToolKey,
   type ThreadMode,
 } from '@gruenerator/chat';
+import { QWEN_WARNING } from '@gruenerator/shared/models';
 import { memo, useCallback } from 'react';
 import { View, Text, Pressable, Switch, ScrollView, StyleSheet } from 'react-native';
 import { useShallow } from 'zustand/shallow';
@@ -189,14 +190,14 @@ export const ChatSettingsSheet = memo(function ChatSettingsSheet({ visible, onDi
                 >
                   {model.description}
                 </Text>
-                {model.warning && (
+                {model.region === 'cn' && (
                   <Text
                     style={[
                       styles.modelChipWarningText,
                       { color: active ? colors.white : colors.warning },
                     ]}
                   >
-                    {model.warning}
+                    {QWEN_WARNING}
                   </Text>
                 )}
               </Pressable>

--- a/apps/mobile/components/chat/ComposerActionSheet.tsx
+++ b/apps/mobile/components/chat/ComposerActionSheet.tsx
@@ -1,5 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import { useAgentStore, MODEL_OPTIONS, type ToolKey } from '@gruenerator/chat';
+import { QWEN_WARNING } from '@gruenerator/shared/models';
 import { memo, useCallback } from 'react';
 import { View, Text, Pressable, Switch, ScrollView, StyleSheet } from 'react-native';
 import { useShallow } from 'zustand/shallow';
@@ -131,14 +132,14 @@ export const ComposerActionSheet = memo(function ComposerActionSheet({
                 >
                   {model.description}
                 </Text>
-                {model.warning && (
+                {model.region === 'cn' && (
                   <Text
                     style={[
                       styles.modelChipWarningText,
                       { color: active ? colors.white : colors.warning },
                     ]}
                   >
-                    {model.warning}
+                    {QWEN_WARNING}
                   </Text>
                 )}
               </Pressable>

--- a/apps/mobile/hooks/useSearchRuntime.ts
+++ b/apps/mobile/hooks/useSearchRuntime.ts
@@ -14,7 +14,13 @@ export function useSearchRuntime(searchMode: SearchMode) {
     (): GrueneratorAdapterConfig => ({
       agentId: null,
       modelId: 'mistral',
-      enabledTools: { search: true, web: true, examples: false, research: false },
+      enabledTools: {
+        search: true,
+        web: true,
+        examples: false,
+        pressemitteilung_examples: false,
+        research: false,
+      },
       threadId: null,
       threadMode: 'search',
       searchMode,

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitOverride": true,
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": false,
 
     "paths": {
       "@gruenerator/shared": ["../../packages/shared/src/index.ts"],

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -8,7 +8,6 @@
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": ".",
     "paths": {
       "@gruenerator/shared": ["../../packages/shared/src/index.ts"],
       "@gruenerator/shared/*": ["../../packages/shared/src/*"]

--- a/packages/wolke/src/components/WolkeSaveModal.tsx
+++ b/packages/wolke/src/components/WolkeSaveModal.tsx
@@ -41,7 +41,7 @@ export const WolkeSaveModal = ({
 
   const activeShareLinks = shareLinks.filter((l) => l.is_active);
   const effectiveShareLinkId =
-    selectedShareLinkId ?? (activeShareLinks.length === 1 ? activeShareLinks[0].id : null);
+    selectedShareLinkId ?? (activeShareLinks.length === 1 ? (activeShareLinks[0]?.id ?? null) : null);
   const selectedShareLink = activeShareLinks.find((l) => l.id === effectiveShareLinkId);
   const canSwitchShareLink = activeShareLinks.length > 1;
 


### PR DESCRIPTION
CI's **Quality Checks** job has been red on `master`. The root cause was
a chain of pre-existing typecheck errors hidden by `turbo run typecheck`'s
fail-fast: it aborts the whole task graph on the first package failure,
so only the *first* error is ever visible. Fixing each one unmasks the
next.

The deepest issue: `@gruenerator/mobile`'s typecheck was effectively
**dead**. `mobile/tsconfig.json` extends `expo/tsconfig.base` (not the
repo's `tsconfig.base.json`), and its `baseUrl: "."` emitted `TS5101` —
a *config-level* error that short-circuits compilation before tsc reads
a single source file. So mobile's source has not actually been
typechecked for however long that deprecation has been firing, and rot
accumulated invisibly.

Fixes, in unmask order:

1. **`apps/mobile/tsconfig.json` — drop `baseUrl`.** Redundant: `paths`
   entries are already written relative to the tsconfig directory, and
   TS 5.x resolves `paths` relative to the config file when `baseUrl` is
   absent. Forward-compatible with TS 7.0, which removes `baseUrl`.
2. **`packages/wolke/.../WolkeSaveModal.tsx`** — `activeShareLinks[0].id`
   violated `noUncheckedIndexedAccess`; optional chaining + `null`
   fallback, behavior unchanged.
3. **`apps/mobile/tsconfig.json` — add `noUncheckedSideEffectImports:
   false`.** Mobile never inherited this from the repo base, so the
   untyped CSS side-effect imports in the Expo DOM components (and the
   canvas-editor / docs sources they pull in) surfaced as TS2882. Every
   other package relies on the base config for this.
4. **`apps/mobile/components/chat/{ChatSettingsSheet,ComposerActionSheet}.tsx`**
   — `ModelOption` no longer has a per-model `warning` field; switched to
   the web app's `region === 'cn'` + shared `QWEN_WARNING` pattern.
5. **`apps/mobile/hooks/useSearchRuntime.ts`** — `enabledTools` literal
   was missing `pressemitteilung_examples` from `Record<ToolKey,
   boolean>`.

Verified locally: full `turbo run typecheck --continue` → **19/19
packages pass**. No further masked packages behind mobile.