### PR TITLE
feat(shared): short URL slugs for regional Öffentlichkeitsarbeit agents

### DIFF
--- a/packages/shared/src/agents/slug.ts
+++ b/packages/shared/src/agents/slug.ts
@@ -1,16 +1,29 @@
-import { getSystemAgent } from './system.js';
+import { getSystemAgent, SYSTEM_AGENTS } from './system.js';
 
 const AGENT_ID_PREFIX = 'gruenerator-';
 
 /**
- * Convert an agent identifier to its URL slug form by stripping the
- * `gruenerator-` registry prefix. Used when generating `/chat?agent=…` URLs
- * so the browser bar shows `?agent=oeffentlichkeitsarbeit` instead of the
- * verbose `?agent=gruenerator-oeffentlichkeitsarbeit`.
+ * Custom slug → identifier map, built from agents that declare an explicit
+ * `slug`. Lets short, branded URLs (`/agents/gruene-berlin`) resolve to the
+ * verbose identifier (`gruenerator-oeffentlichkeitsarbeit-berlin`).
+ */
+const customSlugToIdentifier = new Map<string, string>(
+  SYSTEM_AGENTS.flatMap((agent) =>
+    agent.slug ? [[agent.slug, agent.identifier] as const] : []
+  )
+);
+
+/**
+ * Convert an agent identifier to its URL slug form. Agents with an explicit
+ * `slug` use it verbatim; otherwise the `gruenerator-` registry prefix is
+ * stripped so the browser bar shows `/agents/oeffentlichkeitsarbeit` instead
+ * of the verbose `/agents/gruenerator-oeffentlichkeitsarbeit`.
  *
  * Identifiers without the prefix (user-defined agents) pass through unchanged.
  */
 export function getAgentSlug(identifier: string): string {
+  const explicit = getSystemAgent(identifier)?.slug;
+  if (explicit) return explicit;
   return identifier.startsWith(AGENT_ID_PREFIX)
     ? identifier.slice(AGENT_ID_PREFIX.length)
     : identifier;
@@ -19,15 +32,19 @@ export function getAgentSlug(identifier: string): string {
 /**
  * Resolve a URL slug back to a system agent identifier.
  *
+ * - An explicit custom slug (e.g. `gruene-berlin`) maps straight to its agent.
  * - If `slug` already carries the `gruenerator-` prefix (legacy URL), return
  *   it unchanged — backwards-compatible with bookmarks predating the slug
  *   refactor.
  * - Otherwise re-prefix and verify a system agent exists; if so, return the
- *   full identifier. If no system agent matches, return the slug as-is so
- *   user-defined agents (whose identifiers don't follow the registry
- *   convention) still route correctly.
+ *   full identifier. This still resolves the prefix-stripped derived slug, so
+ *   a custom-slug agent stays reachable under both forms. If no system agent
+ *   matches, return the slug as-is so user-defined agents (whose identifiers
+ *   don't follow the registry convention) still route correctly.
  */
 export function resolveAgentSlug(slug: string): string {
+  const custom = customSlugToIdentifier.get(slug);
+  if (custom) return custom;
   if (slug.startsWith(AGENT_ID_PREFIX)) return slug;
   const candidate = `${AGENT_ID_PREFIX}${slug}`;
   return getSystemAgent(candidate) ? candidate : slug;

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -245,6 +245,7 @@ const BASE_AGENTS = [
   // wrong LV. Skills `/presse-<lv>` and `/social-<lv>` route to these agents.
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-berlin',
+    slug: 'gruene-berlin',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Berlin',
     description:
@@ -285,6 +286,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
+    slug: 'gruene-hamburg',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Hamburg',
     description:
@@ -325,6 +327,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
+    slug: 'gruene-mv',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit MV',
     description:
@@ -365,6 +368,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
+    slug: 'gruene-thueringen',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Thüringen',
     description:
@@ -405,6 +409,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
+    slug: 'gruene-brandenburg',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Brandenburg',
     description:
@@ -452,6 +457,7 @@ const BASE_AGENTS = [
   // deutscher Landesverbands-PMs.
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-at',
+    slug: 'gruene-oesterreich',
     audience: 'de-AT',
     title: 'Öffentlichkeitsarbeit Österreich',
     iconKey: 'megaphone',

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -81,6 +81,13 @@ export interface AgentLocalization {
 
 export interface Agent {
   identifier: string;
+  /**
+   * Optional URL slug override. When set, `/agents/<slug>` resolves here and
+   * link-builders emit this instead of the `gruenerator-`-stripped identifier.
+   * The derived slug stays a working alias, so old links never break. Used for
+   * agents whose derived slug is unwieldy (`oeffentlichkeitsarbeit-mecklenburg-vorpommern`).
+   */
+  slug?: string;
   title: string;
   description: string;
   systemRole: string;


### PR DESCRIPTION
## Why

The six regional Öffentlichkeitsarbeit agents (Berlin, Hamburg, MV, Thüringen, Brandenburg, Österreich) were only reachable via their prefix-stripped identifier — e.g. `/agents/oeffentlichkeitsarbeit-mecklenburg-vorpommern`, a 50-character path that's neither memorable nor shareable. System agents like `/agents/oeffentlichkeitsarbeit` get a clean URL by virtue of a short identifier; the regional agents didn't.

They now carry an explicit `slug` and resolve at `/agents/gruene-<region>` — matching how each Landesverband is actually referred to ("die Grünen Berlin"):

| Agent | New URL | Old URL (still works) |
|---|---|---|
| Berlin | `/agents/gruene-berlin` | `/agents/oeffentlichkeitsarbeit-berlin` |
| Hamburg | `/agents/gruene-hamburg` | `/agents/oeffentlichkeitsarbeit-hamburg` |
| MV | `/agents/gruene-mv` | `/agents/oeffentlichkeitsarbeit-mecklenburg-vorpommern` |
| Thüringen | `/agents/gruene-thueringen` | `/agents/oeffentlichkeitsarbeit-thueringen` |
| Brandenburg | `/agents/gruene-brandenburg` | `/agents/oeffentlichkeitsarbeit-brandenburg` |
| Österreich | `/agents/gruene-oesterreich` | `/agents/oeffentlichkeitsarbeit-at` |

The derived (prefix-stripped) slug stays a working alias — `resolveAgentSlug` still re-prefixes and verifies — so existing links and bookmarks don't break. The custom slug is layered in front via a `slug → identifier` map built from the registry; `getAgentSlug` returns the explicit slug so all four link-builder components (Sidebar, AllAgentsDialog, SkillsPage, CustomGeneratorPage) emit the pretty URL with no changes of their own.

The Austria agent (merged in #850) is included deliberately — leaving it out would be the DE-with-AT-toggle anti-pattern the project's locale policy warns against.

Typechecked: `@gruenerator/shared` + `@gruenerator/web` both clean.