### PR TITLE
fix(auth): keep session on transient auth-probe failures

### DIFF
--- a/apps/web/src/components/routing/RequireAuth.tsx
+++ b/apps/web/src/components/routing/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
-import { useAuthBootstrapped } from '../../hooks/useAuthBootstrapped';
+import { useAuthBootstrap } from '../../hooks/useAuthBootstrapped';
 import { useAuthStore } from '../../stores/authStore';
 
 import AuthSplash from './AuthSplash';
@@ -8,21 +8,22 @@ import AuthSplash from './AuthSplash';
 /**
  * The single auth gate for the whole app.
  *
- *   - !bootstrapped     → <AuthSplash />     (we don't know yet)
- *   - authenticated     → <Outlet />         (render the protected route)
- *   - guest             → /login?redirectTo=<current>
+ *   - !bootstrapped       → <AuthSplash />     (we don't know yet)
+ *   - authenticated       → <Outlet />         (render the protected route)
+ *   - guest (probe ok)    → /login?redirectTo=<current>
+ *   - guest (probe error) → <AuthSplash />     (server unreachable — don't bounce)
  *
  * Public routes (marketing startpage, legal pages, login UI, shares) bypass
  * this guard entirely — they are mounted bare in `App.tsx`. The list of
  * public routes is `routes.filter((r) => r.public)` from `config/routes.ts`.
  *
- * Bootstrap state is read from React Query via `useAuthBootstrapped()`, not
+ * Bootstrap state is read from React Query via `useAuthBootstrap()`, not
  * from a mirrored Zustand flag — see that hook for why.
  */
 const RequireAuth = () => {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
-  const isBootstrapped = useAuthBootstrapped();
+  const { isBootstrapped, isError } = useAuthBootstrap();
   const location = useLocation();
 
   // During logout the store may momentarily show authenticated from stale
@@ -33,6 +34,14 @@ const RequireAuth = () => {
   if (!isBootstrapped) return <AuthSplash />;
 
   if (!isAuthenticated) {
+    // The session probe errored (server unreachable) and there's no cached
+    // session to fall back on. Redirecting to `/login` is misleading — login
+    // can't reach the server either, and it would strand the user with a
+    // `redirectTo` they never asked for. Hold the splash; the query's
+    // refetchOnReconnect / refetchOnWindowFocus recovers once the server is
+    // back. A `success` answer of "guest" still falls through to the redirect.
+    if (isError) return <AuthSplash />;
+
     const currentPath = location.pathname + location.search;
     return <Navigate to={`/login?redirectTo=${encodeURIComponent(currentPath)}`} replace />;
   }

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -28,6 +28,35 @@ async function fetchAuthStatus(): Promise<AuthData> {
   };
 }
 
+/**
+ * Three-way classification of a session probe. The key distinction `queryFn`
+ * needs is `guest` (server definitively answered "no session") vs
+ * `transient-error` (we couldn't reach or trust the server) — only the former
+ * may tear down auth state. `authClient.getSession()` returns
+ * `{ data: null, error: null }` for a genuine logged-out user, so any populated
+ * `error` is a transport/server failure (network blip, 5xx, timeout, deploy
+ * cold-start) and must NOT be treated as a logout.
+ */
+type AuthProbeResult =
+  | { kind: 'authenticated'; user: UserProfile }
+  | { kind: 'guest' }
+  | { kind: 'transient-error'; error: unknown };
+
+async function probeAuthStatus(): Promise<AuthProbeResult> {
+  try {
+    const { data, error } = await authClient.getSession();
+    if (error) return { kind: 'transient-error', error };
+    if (!data?.user) return { kind: 'guest' };
+    return {
+      kind: 'authenticated',
+      user: sessionUserToProfile(data.user as unknown as Record<string, unknown>),
+    };
+  } catch (error) {
+    // getSession() threw before returning a response — network failure.
+    return { kind: 'transient-error', error };
+  }
+}
+
 interface AuthOptions {
   skipAuth?: boolean;
   lazy?: boolean;
@@ -488,25 +517,36 @@ export const useAuth = (options: AuthOptions = {}) => {
         return data;
       }
 
-      try {
-        const data = await fetchAuthStatus();
-        applyAuthAnswer(data, queryClient);
-        return data;
-      } catch (error) {
-        // Session probe failed. Tear down auth state and rethrow so React
-        // Query enters its error branch. `useAuthBootstrapped` treats `error`
-        // as "bootstrapped" (the splash unhangs into Startseite via the guard).
-        clearCachedAuthState();
-        useAuthStore.getState().clearAuth();
-        throw error;
+      const result = await probeAuthStatus();
+      if (result.kind === 'transient-error') {
+        // We couldn't reach or trust the server — this is NOT a logout. Leave
+        // the optimistic store state AND the localStorage caches untouched.
+        // Throw so React Query retries and enters its error branch; the
+        // last-good `data` (or `initialData`) survives, so a logged-in user
+        // keeps rendering instead of being torn down to `/login`.
+        throw result.error;
       }
+
+      const data: AuthData =
+        result.kind === 'authenticated'
+          ? { isAuthenticated: true, user: result.user }
+          : { isAuthenticated: false };
+      // `guest` flows through here too: applyAuthAnswer's else-branch wipes
+      // the cache and clears the store — correct, the server definitively
+      // said there is no session.
+      applyAuthAnswer(data, queryClient);
+      return data;
     },
     enabled: isServerAvailable && !skipAuth,
     initialData: cachedEntry?.data,
     initialDataUpdatedAt: cachedEntry?.timestamp,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes (formerly cacheTime)
-    retry: 1,
+    // `queryFn` now only throws on transient (transport/server) failures —
+    // a genuine guest answer resolves normally — so every throw is worth
+    // retrying. Backoff rides out a backend deploy / cold-start window.
+    retry: (failureCount) => failureCount < 3,
+    retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 8000),
     // Auth specifically must stay live: sessions can die while a tab sits
     // idle (Better Auth cookie revalidation against a stale row). On focus
     // we want the UI to learn about it immediately, rather than waiting for

--- a/apps/web/src/hooks/useAuthBootstrapped.ts
+++ b/apps/web/src/hooks/useAuthBootstrapped.ts
@@ -17,7 +17,16 @@ import { useQuery } from '@tanstack/react-query';
  * `initialData` from the instant-auth cache). React Query dedupes by
  * `queryKey`, so both subscribers see the same status.
  */
-export const useAuthBootstrapped = (): boolean => {
+/**
+ * Same read-only subscription as `useAuthBootstrapped`, but also surfaces
+ * whether the probe *errored* (server unreachable / transient failure) rather
+ * than answering. `RequireAuth` needs this distinction: an errored probe with
+ * no cached session must not bounce the user to `/login` — login can't reach
+ * the server either. A `success` status with a guest answer still redirects.
+ */
+export const useAuthBootstrap = (): { isBootstrapped: boolean; isError: boolean } => {
   const { status } = useQuery({ queryKey: ['authStatus'], enabled: false });
-  return status !== 'pending';
+  return { isBootstrapped: status !== 'pending', isError: status === 'error' };
 };
+
+export const useAuthBootstrapped = (): boolean => useAuthBootstrap().isBootstrapped;


### PR DESCRIPTION
Logged-in users reloading a protected page (e.g. `/workplace`) were **sometimes** bounced to `/login?redirectTo=...` even with a valid session.

Better Auth's `getSession()` populates an `error` only on transport/server failures — a network blip, a 5xx, a backend deploy cold-start. A genuine logged-out user comes back as `{ data: null, error: null }`. But the `['authStatus']` query's `queryFn` treated *any* error as a logout: it ran `clearAuth()`, flipped `isAuthenticated` to false, and `RequireAuth` redirected. `clearAuth()` also stamps `LOGOUT_TIMESTAMP`, arming a 60s cache-restore cooldown — which is why the breakage was sticky and intermittent.

The probe now classifies transient errors as their own outcome: they leave the optimistic store state and localStorage caches untouched and only trigger a retry (bumped from 1 to 3 with backoff to ride out a deploy window). `RequireAuth` additionally holds the loading splash instead of redirecting when the probe errored with no cached session to fall back on — `/login` can't reach the server either.

This mirrors the "never trust a single failure" hardening already applied to the `apiClient` 401 interceptor (2026-04-13); the auth-bootstrap query had never received the same treatment.

Verification: with DevTools blocking `**/auth/v2/get-session`, reload `/workplace` — before, it redirects to login; after, it stays put (warm path) or shows the splash and recovers on reconnect (cold path). Genuine logout and genuine session expiry still redirect correctly. `pnpm --filter @gruenerator/web typecheck` passes.