### PR TITLE
fix(chat): resolve "this document" anaphora for docs-agent notebook search

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
@@ -70,6 +70,11 @@ export function buildDocumentSources(opts: BuildOpts): DocumentSource[] {
   }
 
   for (const id of opts.docMentionIds) {
+    // The open document is already represented by the `current_doc` source
+    // below — its content is injected directly into the prompt and it has no
+    // separate Qdrant index to retrieve from. Skip it here so it isn't fanned
+    // out as a phantom 0-result search source. Mirrors classifierNode.ts:150-152.
+    if (id === opts.currentDocument?.id) continue;
     sources.push({ kind: 'doc_mention', id, label: `@${shortId(id)}` });
   }
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -669,15 +669,41 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
 }
 
 /**
+ * Compact topic hint from the open document so the query optimizer can resolve
+ * anaphora like "dieses Dokument" to a concrete subject. Heuristic only (no LLM)
+ * — the classifier path is latency-sensitive. Caps the excerpt so it stays a
+ * hint, not a full document dump.
+ */
+function extractDocumentTopicHint(
+  currentDocument: NonNullable<ChatGraphState['currentDocument']>
+): string {
+  const excerpt = currentDocument.markdown
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code blocks
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // links/images → label text
+    .replace(/[#>*_`~|-]/g, ' ') // markdown punctuation
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 280);
+  const title = currentDocument.title?.trim();
+  if (title) return `"${title}" — ${excerpt}`;
+  return excerpt || 'das geöffnete Dokument';
+}
+
+/**
  * Compact topical hint for the query optimizer so anaphoric pronouns
- * ("dazu", "dies", "darüber") can resolve to a concrete subject. Skips
- * `documentChat` — that anchor lives in its own classifier branch above.
+ * ("dazu", "dies", "darüber", "dieses Dokument") can resolve to a concrete
+ * subject. Skips `documentChat` — that anchor lives in its own classifier
+ * branch above.
  */
 function formatTopicalContext(state: ChatGraphState): string | null {
   const lines = getActiveAnchors(state).flatMap((a): string[] => {
     switch (a.kind) {
       case 'currentDocument':
-        return [`- Aktuell geöffnetes Dokument: "${a.title}"`];
+        return state.currentDocument
+          ? [
+              `- Aktuell geöffnetes Dokument — Inhalt: "${extractDocumentTopicHint(state.currentDocument)}"`,
+            ]
+          : [];
       case 'documentMention':
         return [`- Referenzierte Dokumente: ${a.titles.map((t) => `"${t}"`).join(', ')}`];
       case 'board':

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierPrompt.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierPrompt.ts
@@ -77,6 +77,8 @@ Wenn intent search/research/web/examples ist, erstelle eine optimierte Suchquery
 - Beispiel: "Schreib eine Pressemitteilung über die Klimapolitik der Grünen" → "Klimapolitik der Grünen"
 - Beispiel: "Erstelle mir Argumente zur Energiewende" → "Energiewende Argumente"
 - Beispiel: "Was sagen die Grünen zum Kohleausstieg?" → "Grüne Kohleausstieg Position"
+- ANAPHER AUFLÖSEN: Wenn die Nachricht sich auf das geöffnete Dokument bezieht ("dieses/diesem Dokument", "hier", "das hier", "dazu") UND ein THEMENKONTEXT mitgeliefert wird, löse die Referenz auf das tatsächliche Thema des Dokuments auf (aus dem Themenkontext) und baue searchQuery + optimizedSearchQuery aus diesem Thema. Suche NIE nach der wörtlichen Meta-Frage.
+- Beispiel: "wie ist unsere position zu diesem dokument" + Themenkontext (Dokument über kommunalen Klimaschutz) → optimizedSearchQuery: "Grüne Position kommunaler Klimaschutz"
 
 SCHRITT 5 - KOMPLEXE ANFRAGEN ZERLEGEN:
 Wenn die Anfrage MEHRERE VERSCHIEDENE Themen vergleicht, kombiniert, ODER verschiedene Aufgaben enthält die verschiedene Themen betreffen:

--- a/apps/web/src/features/docs/DocsChatPanel.tsx
+++ b/apps/web/src/features/docs/DocsChatPanel.tsx
@@ -7,6 +7,8 @@ interface DocsChatPanelProps {
   documentId: string;
   userId: string | null;
   userName: string | null;
+  /** Real document title, threaded into the chat's currentDocument context. */
+  documentTitle: string | null;
   /**
    * When true, the chat UI renders inside the provider. When false, the
    * provider stays mounted (runtime + Hocuspocus alive) but no UI shows.
@@ -16,17 +18,26 @@ interface DocsChatPanelProps {
   isOpen: boolean;
 }
 
-export function DocsChatPanel({ documentId, userId, userName, isOpen }: DocsChatPanelProps) {
+export function DocsChatPanel({
+  documentId,
+  userId,
+  userName,
+  documentTitle,
+  isOpen,
+}: DocsChatPanelProps) {
   return (
-    <DocsChatProvider documentId={documentId} userId={userId} userName={userName}>
+    <DocsChatProvider
+      documentId={documentId}
+      userId={userId}
+      userName={userName}
+      documentTitle={documentTitle}
+    >
       {isOpen ? (
         <DocsAssistantChat />
-      ) : (
-        // Provider still mounted; runtime + thread + WS connection alive.
-        // Rendering null keeps the chat view out of the layout while
-        // preserving all chat state for instant reopen.
-        null
-      )}
+      ) : // Provider still mounted; runtime + thread + WS connection alive.
+      // Rendering null keeps the chat view out of the layout while
+      // preserving all chat state for instant reopen.
+      null}
     </DocsChatProvider>
   );
 }

--- a/apps/web/src/features/docs/DocsChatProvider.tsx
+++ b/apps/web/src/features/docs/DocsChatProvider.tsx
@@ -62,6 +62,7 @@ interface DocsChatProviderProps {
   documentId: string;
   userId: string | null;
   userName: string | null;
+  documentTitle: string | null;
   children: ReactNode;
 }
 
@@ -69,6 +70,7 @@ export function DocsChatProvider({
   documentId,
   userId,
   userName,
+  documentTitle,
   children,
 }: DocsChatProviderProps) {
   if (!userId) {
@@ -78,7 +80,12 @@ export function DocsChatProvider({
   }
   return (
     <DocsAuiReset>
-      <DocsChatProviderInner documentId={documentId} userId={userId} userName={userName}>
+      <DocsChatProviderInner
+        documentId={documentId}
+        userId={userId}
+        userName={userName}
+        documentTitle={documentTitle}
+      >
         {children}
       </DocsChatProviderInner>
     </DocsAuiReset>
@@ -94,10 +101,17 @@ interface InnerProps {
   documentId: string;
   userId: string;
   userName: string | null;
+  documentTitle: string | null;
   children: ReactNode;
 }
 
-function DocsChatProviderInner({ documentId, userId, userName, children }: InnerProps) {
+function DocsChatProviderInner({
+  documentId,
+  userId,
+  userName,
+  documentTitle,
+  children,
+}: InnerProps) {
   const {
     data: threadResp,
     error: threadError,
@@ -144,6 +158,7 @@ function DocsChatProviderInner({ documentId, userId, userName, children }: Inner
       documentId={documentId}
       userId={userId}
       userName={userName}
+      documentTitle={documentTitle}
     >
       {children}
     </DocsChatReadyHost>
@@ -155,10 +170,18 @@ interface ReadyHostProps {
   documentId: string;
   userId: string;
   userName: string | null;
+  documentTitle: string | null;
   children: ReactNode;
 }
 
-function DocsChatReadyHost({ threadId, documentId, userId, userName, children }: ReadyHostProps) {
+function DocsChatReadyHost({
+  threadId,
+  documentId,
+  userId,
+  userName,
+  documentTitle,
+  children,
+}: ReadyHostProps) {
   const fetchFn = useChatConfigStore((s) => s.fetch);
   const endpoints = useChatConfigStore((s) => s.endpoints);
   const registerContextProvider = useChatConfigStore((s) => s.registerContextProvider);
@@ -191,14 +214,14 @@ function DocsChatReadyHost({ threadId, documentId, userId, userName, children }:
       return {
         currentDocument: {
           id: documentId,
-          title: null,
+          title: documentTitle?.trim() || null,
           markdown,
           selectionText: selection,
         },
       };
     };
     return registerContextProvider(threadId, provider);
-  }, [threadId, documentId, registerContextProvider]);
+  }, [threadId, documentId, documentTitle, registerContextProvider]);
 
   // Per-surface store: docs panel keeps its own selectedAgentId / threadMode /
   // searchMode / model / notebook / custom prompt. The main /chat surface has

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -748,6 +748,7 @@ function EditorContent() {
                 documentId={id}
                 userId={user ? String(user.id) : null}
                 userName={user?.display_name ?? null}
+                documentTitle={docData?.title ?? null}
                 isOpen={effectivePanel === 'chat'}
               />
             </Suspense>


### PR DESCRIPTION
## Why

Follow-up to #853. That fix stopped the docs agent from *ignoring* `@berlin`, but a re-test (`@berlin wie ist unsere position zu diesem dokument`) showed the answer was still poor: the notebook got searched for the literal meta-question because the query optimizer never resolved the anaphor *"diesem dokument"* into the open document's actual topic. Berlin returned semantically-random documents and the model honestly reported they didn't address the document.

The optimizer had no signal to resolve the anaphor with — the open document's content sits in `ChatGraphState` but was invisible to the classifier, and `CLASSIFIER_PROMPT` only resolved references from conversation history, never from the open-document `Themenkontext`. This wires a markdown-derived topic excerpt into the optimizer's input and instructs the prompt to use it.

Also removes a wasted 0-result Qdrant query (the open document was being fanned out as a phantom doc-mention search source — docs-editor documents aren't indexed in the `documents` collection) and threads the real document title from `DocsEditorPage` into the chat's `currentDocument` context, where it was previously hardcoded `null`.

Verified: `api` + `web` typecheck clean, 59 classifier/compound-pipeline regression tests pass.