### PR TITLE
feat(skills): preview skill prompt text and unify agent card icons

### DIFF
--- a/apps/web/src/features/skills/SkillsPage.tsx
+++ b/apps/web/src/features/skills/SkillsPage.tsx
@@ -6,12 +6,21 @@ import {
   type SkillCategory,
 } from '@gruenerator/chat';
 import { AGENT_CATEGORY_LABELS, getAgentSlug, type Agent } from '@gruenerator/shared/agents';
-import { Input, SectionHeader, CardGrid } from '@gruenerator/ui';
+import {
+  Input,
+  SectionHeader,
+  CardGrid,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@gruenerator/ui';
 import { useMemo, useState } from 'react';
 import {
   PiSparkle,
   PiStar,
   PiStarFill,
+  PiEye,
   PiMagnifyingGlass,
   PiPencilSimple,
   PiTrash,
@@ -26,8 +35,10 @@ import {
   type SharedAgentEntry,
 } from '../agents/api';
 
+import { Markdown } from '@/components/common/Markdown';
 import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired';
 import PageContainer from '@/components/common/PageContainer';
+import { getAgentIcon } from '@/components/layout/Sidebar/sidebarAgentConfig';
 
 const CATEGORY_ORDER: SkillCategory[] = ['presse', 'social', 'dokumente', 'recherche', 'sonstiges'];
 
@@ -40,44 +51,72 @@ interface SkillCardProps {
 
 function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardProps) {
   const Icon = skill.icon ?? PiSparkle;
+  const [showText, setShowText] = useState(false);
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onSelect(skill)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect(skill);
-        }
-      }}
-      className="group relative flex flex-row bg-background border border-grey-200 dark:border-grey-700 rounded-md overflow-hidden cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
-    >
-      <div className="flex items-center justify-center px-md text-secondary-600 shrink-0">
-        <Icon className="text-2xl" />
-      </div>
-      <div className="flex flex-col flex-1 p-md min-w-0">
-        <div className="flex justify-between items-start gap-sm mb-xs">
-          <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
-            {skill.title}
-          </h3>
-          <button
-            type="button"
-            aria-label={isFavorite ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleFavorite(skill.mention);
-            }}
-            className="shrink-0 rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
-          >
-            {isFavorite ? <PiStarFill className="h-4 w-4" /> : <PiStar className="h-4 w-4" />}
-          </button>
+    <>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => onSelect(skill)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect(skill);
+          }
+        }}
+        className="group relative flex flex-row bg-background border border-grey-200 dark:border-grey-700 rounded-md overflow-hidden cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
+      >
+        <div className="flex items-center justify-center px-md text-secondary-600 shrink-0">
+          <Icon className="text-2xl" />
         </div>
-        <p className="text-sm text-foreground leading-relaxed m-0 line-clamp-2">
-          {skill.description}
-        </p>
+        <div className="flex flex-col flex-1 p-md min-w-0">
+          <div className="flex justify-between items-start gap-sm mb-xs">
+            <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+              {skill.title}
+            </h3>
+            <div className="flex shrink-0 gap-1">
+              {skill.skillSystemPrompt && (
+                <button
+                  type="button"
+                  aria-label="Skill-Text anzeigen"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setShowText(true);
+                  }}
+                  className="rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
+                >
+                  <PiEye className="h-4 w-4" />
+                </button>
+              )}
+              <button
+                type="button"
+                aria-label={isFavorite ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleFavorite(skill.mention);
+                }}
+                className="rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
+              >
+                {isFavorite ? <PiStarFill className="h-4 w-4" /> : <PiStar className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+          <p className="text-sm text-foreground leading-relaxed m-0 line-clamp-2">
+            {skill.description}
+          </p>
+        </div>
       </div>
-    </div>
+      {skill.skillSystemPrompt && (
+        <Dialog open={showText} onOpenChange={setShowText}>
+          <DialogContent className="max-h-[80vh] overflow-y-auto">
+            <DialogHeader>
+              <DialogTitle>{skill.title}</DialogTitle>
+            </DialogHeader>
+            <Markdown fallback={<p>{skill.description}</p>}>{skill.skillSystemPrompt}</Markdown>
+          </DialogContent>
+        </Dialog>
+      )}
+    </>
   );
 }
 
@@ -89,6 +128,7 @@ interface AgentCardProps {
 }
 
 function AgentCard({ agent, onSelect, onEdit, onDelete }: AgentCardProps) {
+  const Icon = getAgentIcon(agent.identifier);
   return (
     <div
       role="button"
@@ -102,11 +142,8 @@ function AgentCard({ agent, onSelect, onEdit, onDelete }: AgentCardProps) {
       }}
       className="group relative flex flex-row bg-background border border-grey-200 dark:border-grey-700 rounded-md overflow-hidden cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
     >
-      <div
-        className="flex items-center justify-center px-md text-2xl shrink-0"
-        style={{ backgroundColor: agent.backgroundColor, color: 'white' }}
-      >
-        {agent.avatar}
+      <div className="flex items-center justify-center px-md text-secondary-600 shrink-0">
+        <Icon className="text-2xl" />
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <div className="flex justify-between items-start gap-sm mb-xs">
@@ -157,6 +194,7 @@ interface SharedAgentCardProps {
 
 function SharedAgentCard({ entry, onSelect }: SharedAgentCardProps) {
   const { agent, groups } = entry;
+  const Icon = getAgentIcon(agent.identifier);
   return (
     <div
       role="button"
@@ -170,11 +208,8 @@ function SharedAgentCard({ entry, onSelect }: SharedAgentCardProps) {
       }}
       className="group relative flex flex-row bg-background border border-grey-200 dark:border-grey-700 rounded-md overflow-hidden cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
     >
-      <div
-        className="flex items-center justify-center px-md text-2xl shrink-0"
-        style={{ backgroundColor: agent.backgroundColor, color: 'white' }}
-      >
-        {agent.avatar}
+      <div className="flex items-center justify-center px-md text-secondary-600 shrink-0">
+        <Icon className="text-2xl" />
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <h3 className="mb-xs text-base font-semibold text-foreground-heading m-0 truncate">


### PR DESCRIPTION
The `/skills` "Bibliothek" page had two rough edges.

Skills carry a full prompt (`skillSystemPrompt`) that already ships in the client bundle, but nothing in the UI let users see what a skill actually does before picking it. Skill cards now have an eye-icon button (shown only when the skill has prompt text) that opens a dialog with the markdown-rendered prompt.

Agent cards were also the last holdout still rendering the emoji + colored-chip avatar — the sidebar, the "Alle Agents" dialog, and every skill card already use the flat `getAgentIcon()` ghost style, so agents and skills looked mismatched side-by-side in the same grid. Both agent card types now use that shared style.