### PR TITLE
fix(skills): stop Bibliothek card action buttons triggering chat navigation

### DIFF
--- a/apps/web/src/features/skills/SkillsPage.tsx
+++ b/apps/web/src/features/skills/SkillsPage.tsx
@@ -57,8 +57,12 @@ function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardP
       <div
         role="button"
         tabIndex={0}
-        onClick={() => onSelect(skill)}
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest('button')) return;
+          onSelect(skill);
+        }}
         onKeyDown={(e) => {
+          if ((e.target as HTMLElement).closest('button')) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             onSelect(skill);
@@ -83,7 +87,8 @@ function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardP
                     e.stopPropagation();
                     setShowText(true);
                   }}
-                  className="rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
+                  onKeyDown={(e) => e.stopPropagation()}
+                  className="rounded-md p-2 text-secondary-600 transition-colors hover:bg-secondary-600/10"
                 >
                   <PiEye className="h-4 w-4" />
                 </button>
@@ -95,7 +100,8 @@ function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardP
                   e.stopPropagation();
                   onToggleFavorite(skill.mention);
                 }}
-                className="rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
+                onKeyDown={(e) => e.stopPropagation()}
+                className="rounded-md p-2 text-secondary-600 transition-colors hover:bg-secondary-600/10"
               >
                 {isFavorite ? <PiStarFill className="h-4 w-4" /> : <PiStar className="h-4 w-4" />}
               </button>
@@ -133,8 +139,12 @@ function AgentCard({ agent, onSelect, onEdit, onDelete }: AgentCardProps) {
     <div
       role="button"
       tabIndex={0}
-      onClick={() => onSelect(agent)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('button')) return;
+        onSelect(agent);
+      }}
       onKeyDown={(e) => {
+        if ((e.target as HTMLElement).closest('button')) return;
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           onSelect(agent);
@@ -159,7 +169,8 @@ function AgentCard({ agent, onSelect, onEdit, onDelete }: AgentCardProps) {
                   e.stopPropagation();
                   onEdit(agent);
                 }}
-                className="rounded-md p-1 text-secondary-600 transition-colors hover:bg-secondary-600/10"
+                onKeyDown={(e) => e.stopPropagation()}
+                className="rounded-md p-2 text-secondary-600 transition-colors hover:bg-secondary-600/10"
               >
                 <PiPencilSimple className="h-4 w-4" />
               </button>
@@ -172,7 +183,8 @@ function AgentCard({ agent, onSelect, onEdit, onDelete }: AgentCardProps) {
                   e.stopPropagation();
                   onDelete(agent);
                 }}
-                className="rounded-md p-1 text-red-600 transition-colors hover:bg-red-600/10"
+                onKeyDown={(e) => e.stopPropagation()}
+                className="rounded-md p-2 text-red-600 transition-colors hover:bg-red-600/10"
               >
                 <PiTrash className="h-4 w-4" />
               </button>


### PR DESCRIPTION
Activating an action button on a card in the Bibliothek (the favorite star, and now also the skill-text "eye" preview button from #856, plus agent edit/delete) could also navigate the user into chat instead of only performing the button's own action.

Root cause: each card is a `<div role="button" onClick={navigate} onKeyDown={…}>` with the action buttons nested *inside* it. The nested buttons stopped `onClick` propagation but had no `onKeyDown` guard — so keyboard activation (Enter/Space on a focused button) bubbled to the parent `<div>`'s `onKeyDown` and navigated. The parent handlers now also bail out when an event originates inside a nested `<button>` (`closest('button')`), making them robust regardless of any child's propagation handling. Action-button tap targets were enlarged (`p-1` → `p-2`) to also cover the near-miss-click case where a slightly-off click lands on the surrounding card surface.

`SharedAgentCard` is intentionally untouched — it has no nested interactive children.

Verified: web typecheck clean on the change (the post-rebase merge with #856 only re-applies the same already-verified `onKeyDown` guard to the new eye button). Manual checks (mouse-click, keyboard Enter/Space on a focused button, near-miss) still want a run against `pnpm dev:web`.