### PR TITLE
fix(chat): honor selected model & stream reasoning models in respond path

### DIFF
--- a/apps/api/routes/chat/services/responseStreamingService.ts
+++ b/apps/api/routes/chat/services/responseStreamingService.ts
@@ -9,6 +9,7 @@
 
 import { streamText, type ModelMessage, type LanguageModel } from 'ai';
 
+import { isReasoningCapable } from '../../../services/ai/modelDiscovery.js';
 import {
   isRegoloReasoningModel,
   streamRegoloWithReasoning,
@@ -274,6 +275,7 @@ async function streamAndAccumulateOrThrow(params: {
   sse: SSEWriter;
   signal?: AbortSignal;
   logPrefix?: string;
+  providerOptions?: Parameters<typeof streamText>[0]['providerOptions'];
 }): Promise<string | null> {
   const {
     model,
@@ -283,6 +285,7 @@ async function streamAndAccumulateOrThrow(params: {
     sse,
     signal,
     logPrefix = '[ChatGraph]',
+    providerOptions,
   } = params;
 
   const { deadline, signal: deadlineSignal, clear } = createFirstTokenDeadline();
@@ -299,26 +302,48 @@ async function streamAndAccumulateOrThrow(params: {
     maxOutputTokens: maxTokens,
     temperature,
     abortSignal: composed,
+    ...(providerOptions && { providerOptions }),
   });
 
-  const iterator = result.textStream[Symbol.asyncIterator]();
+  // fullStream (not textStream) so reasoning models surface their thinking as
+  // `reasoning_delta` SSE events alongside the answer. A reasoning delta clears
+  // the first-token deadline (the model is demonstrably alive), but only a
+  // `text-delta` ends phase 1 — until visible answer text is on the wire we
+  // can still fall back cleanly.
+  const iterator = result.fullStream[Symbol.asyncIterator]();
   let fullText = '';
+  let textStarted = false;
+  let deadlineCleared = false;
   const stopHeartbeat = startResponseHeartbeat(sse);
 
-  // Single shared deadline across all initial-probe iterations. Some providers
-  // emit empty initial chunks before content; we keep racing against the SAME
-  // timeout (not a fresh one each time) until either content arrives or the
-  // deadline fires.
+  // Phase 1 — race the shared deadline until the first visible text delta.
+  // Some providers emit empty/structural parts (start, text-start, …) and a
+  // reasoning preamble first; we keep racing against the SAME timeout until
+  // text arrives or the deadline fires.
   try {
-    while (true) {
-      const next = await Promise.race([iterator.next(), deadline]);
+    while (!textStarted) {
+      const next = deadlineCleared
+        ? await iterator.next()
+        : await Promise.race([iterator.next(), deadline]);
       if (next.done) throw new EmptyCompletionError();
-      if (next.value.length > 0) {
-        clear();
-        stopHeartbeat();
-        fullText += next.value;
-        sse.send('text_delta', { text: next.value });
-        break;
+      const part = next.value;
+      if (part.type === 'error') throw part.error;
+      if (part.type === 'reasoning-delta' && part.text.length > 0) {
+        if (!deadlineCleared) {
+          clear();
+          stopHeartbeat();
+          deadlineCleared = true;
+        }
+        sse.send('reasoning_delta', { text: part.text });
+      } else if (part.type === 'text-delta' && part.text.length > 0) {
+        if (!deadlineCleared) {
+          clear();
+          stopHeartbeat();
+          deadlineCleared = true;
+        }
+        fullText += part.text;
+        sse.send('text_delta', { text: part.text });
+        textStarted = true;
       }
     }
   } catch (err) {
@@ -327,13 +352,19 @@ async function streamAndAccumulateOrThrow(params: {
     throw err;
   }
 
-  // Past the first real chunk: no more deadline races, just drain.
+  // Phase 2 — visible text is on the wire; just drain. Errors here can't
+  // trigger a clean fallback, so they end the stream gracefully.
   try {
     while (true) {
       const { done, value } = await iterator.next();
       if (done) break;
-      fullText += value;
-      sse.send('text_delta', { text: value });
+      if (value.type === 'error') throw value.error;
+      if (value.type === 'reasoning-delta' && value.text.length > 0) {
+        sse.send('reasoning_delta', { text: value.text });
+      } else if (value.type === 'text-delta' && value.text.length > 0) {
+        fullText += value.text;
+        sse.send('text_delta', { text: value.text });
+      }
     }
   } catch (streamError: unknown) {
     const errorMessage = streamError instanceof Error ? streamError.message : 'Unknown error';
@@ -564,5 +595,11 @@ export async function streamForResolution(params: {
   };
   if (signal) args.signal = signal;
   if (logPrefix) args.logPrefix = logPrefix;
+  // Mistral reasoning models (e.g. Medium 3.5) only think when `reasoningEffort`
+  // is set per request; @ai-sdk/mistral then surfaces the reasoning via
+  // fullStream so streamAndAccumulateOrThrow can emit it as reasoning_delta.
+  if (resolution.provider === 'mistral' && isReasoningCapable(resolution.modelName)) {
+    args.providerOptions = { mistral: { reasoningEffort: 'high' } };
+  }
   return streamAndAccumulateOrThrow(args);
 }

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -29,25 +29,30 @@ interface OpenAIModelsResponse {
   data: Array<{ id: string; object?: string; owned_by?: string }>;
 }
 
+// Mistral Medium 3.5, Gemma 4 and the gpt-oss/qwen families are all reasoning
+// models with configurable thinking. `reasoning: true` here flags that; how (or
+// whether) that reasoning is surfaced to the UI depends on the streaming path
+// (SDK fullStream for Mistral; Regolo raw streamer for Regolo's reasoning_content).
 const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision: boolean }> = {
-  'mistral-medium-2604': { name: 'Mistral Medium 3.5', reasoning: false, vision: false },
-  'mistral-medium-3.5': { name: 'Mistral Medium 3.5', reasoning: false, vision: false },
+  'mistral-medium-2604': { name: 'Mistral Medium 3.5', reasoning: true, vision: false },
+  'mistral-medium-3.5': { name: 'Mistral Medium 3.5', reasoning: true, vision: false },
   'mistral-large-2512': { name: 'Mistral Large', reasoning: false, vision: false },
   'mistral-large-latest': { name: 'Mistral Large', reasoning: false, vision: false },
   'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
   'mistral-small-2503': { name: 'Mistral Small (Vision)', reasoning: false, vision: true },
-  'gemma4-31b': { name: 'Gemma 4 31B', reasoning: false, vision: true },
+  'gemma4-31b': { name: 'Gemma 4 31B', reasoning: true, vision: true },
   // Verdigado/LiteLLM serves Gemma 4 under the bare alias 'gemma' (resolves
   // server-side to gemma4:26b-ctx16k). Without this entry, isVisionCapable
   // would return false and the vision-override would hijack every image
   // request on the gemma-4 overflow lane to Regolo, defeating alternation.
-  gemma: { name: 'Gemma 4', reasoning: false, vision: true },
+  gemma: { name: 'Gemma 4', reasoning: true, vision: true },
   'mistral-medium-latest': { name: 'Mistral Medium', reasoning: false, vision: false },
   'pixtral-large-latest': { name: 'Pixtral Large', reasoning: false, vision: true },
   'gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'gpt-oss:120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'openai/gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'qwen3.5-122b': { name: 'Qwen 3.5 122B', reasoning: true, vision: true },
+  'qwen3.6-27b': { name: 'Qwen 3.6 27B', reasoning: true, vision: false },
   'mistral-small-4-119b': { name: 'Mistral Small 4 119B', reasoning: true, vision: true },
   'Llama-3.3-70B-Instruct': { name: 'Llama 3.3 70B', reasoning: false, vision: false },
   'mistral-small3.2': { name: 'Mistral Small 3.2', reasoning: false, vision: false },
@@ -256,6 +261,16 @@ export async function getAvailableModels(forceRefresh = false): Promise<Playgrou
 export function isVisionCapable(modelId: string): boolean {
   const meta = MODEL_METADATA[modelId];
   return meta?.vision ?? false;
+}
+
+/**
+ * Check if a model ID is a reasoning/thinking model.
+ * Uses MODEL_METADATA (synchronous, no API call needed). Drives request-level
+ * reasoning enablement (e.g. Mistral `reasoningEffort`).
+ */
+export function isReasoningCapable(modelId: string): boolean {
+  const meta = MODEL_METADATA[modelId];
+  return meta?.reasoning ?? false;
 }
 
 /**

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -251,6 +251,7 @@ function GrueneratorHistoryProvider({ children }: PropsWithChildren) {
 function useGrueneratorThreadRuntime() {
   const {
     selectedAgentId,
+    selectedModel,
     enabledTools,
     selectedNotebookId,
     threadMode,
@@ -262,6 +263,7 @@ function useGrueneratorThreadRuntime() {
   } = useAgentStore(
     useShallow((s) => ({
       selectedAgentId: s.selectedAgentId,
+      selectedModel: s.selectedModel,
       enabledTools: s.enabledTools,
       selectedNotebookId: s.selectedNotebookId,
       threadMode: s.threadMode,
@@ -280,7 +282,7 @@ function useGrueneratorThreadRuntime() {
   const getConfig = useCallback(
     (): GrueneratorAdapterConfig => ({
       agentId: selectedAgentId,
-      modelId: 'litellm',
+      modelId: selectedModel,
       enabledTools,
       threadId: useAgentStore.getState().currentThreadId,
       selectedNotebookId,
@@ -293,6 +295,7 @@ function useGrueneratorThreadRuntime() {
     }),
     [
       selectedAgentId,
+      selectedModel,
       enabledTools,
       selectedNotebookId,
       threadMode,

--- a/packages/shared/src/models/catalog.ts
+++ b/packages/shared/src/models/catalog.ts
@@ -30,7 +30,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     id: 'gemma-litellm',
     name: '🌳 Gemma 4',
     description: 'Leichtgewichtig, antwortet schnell',
-    model: 'gpt-oss:120b',
+    model: 'gemma',
     provider: 'litellm',
     icon: 'zap',
     region: 'self-hosted',


### PR DESCRIPTION
Chat skills (e.g. `/presse-berlin`) appeared to never produce any text — the backend generated and persisted a full response, but nothing reached the UI.

Two stacked bugs behind it:

- The request config in `GrueneratorChatProvider` hardcoded `modelId: 'litellm'`, so every chat ran gpt-oss regardless of the user's model pick. The model picker, store and persistence were all wired up — only the read into the request body was missing.
- gpt-oss (and Mistral Medium 3.5, Gemma 4) are reasoning models, but the ChatGraph respond path consumed `result.textStream`, which carries only answer text — a reasoning model's output never reached the client. `streamAndAccumulateOrThrow` now drains `result.fullStream`, emitting `reasoning_delta` SSE events alongside the answer, and Mistral reasoning models get `reasoningEffort` set per request.

Follow-up (not in this PR): LiteLLM/Ollama reasoning (gemma, gpt-oss) needs a raw-fetch streamer — `@ai-sdk/openai` doesn't bridge Chat-Completions reasoning, so enabling `think:true` there would risk regressing gemma's first-token timing.
