### PR TITLE
fix(chat): render the agent icon instead of the legacy emoji avatar

### DIFF
--- a/packages/chat/src/components/message-parts/SkillBadge.tsx
+++ b/packages/chat/src/components/message-parts/SkillBadge.tsx
@@ -1,23 +1,26 @@
 import { memo } from 'react';
+import type { SkillIcon } from '@gruenerator/shared/agents';
 
 interface SkillBadgeProps {
   avatar: string;
+  icon?: SkillIcon;
   title: string;
   backgroundColor: string;
 }
 
 export const SkillBadge = memo(function SkillBadge({
   avatar,
+  icon: Icon,
   title,
   backgroundColor,
 }: SkillBadgeProps) {
   return (
     <div className="mb-1.5 inline-flex items-center gap-1.5 rounded-full bg-primary/5 px-2.5 py-1 text-xs">
       <span
-        className="flex h-4 w-4 items-center justify-center rounded-full text-[10px] leading-none"
+        className="flex h-4 w-4 items-center justify-center rounded-full text-[10px] leading-none text-white"
         style={{ backgroundColor }}
       >
-        {avatar}
+        {Icon ? <Icon className="h-2.5 w-2.5" aria-hidden /> : avatar}
       </span>
       <span className="font-medium text-foreground-muted">{title}</span>
     </div>

--- a/packages/chat/src/components/thread/AssistantMessage.tsx
+++ b/packages/chat/src/components/thread/AssistantMessage.tsx
@@ -96,12 +96,12 @@ export const AssistantMessage = memo(function AssistantMessage() {
         <div
           className={
             isCompact
-              ? 'flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs'
-              : 'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm'
+              ? 'flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-white'
+              : 'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-white'
           }
           style={{ backgroundColor: messageAgent.backgroundColor }}
         >
-          {messageAgent.avatar}
+          <messageAgent.icon className={isCompact ? 'h-3.5 w-3.5' : 'h-4 w-4'} aria-hidden />
         </div>
       ) : (
         <ChatIcon size={isCompact ? 24 : 32} className="flex-shrink-0" />
@@ -110,6 +110,7 @@ export const AssistantMessage = memo(function AssistantMessage() {
         {isNonDefaultAgent && messageAgent && (
           <SkillBadge
             avatar={messageAgent.avatar}
+            icon={messageAgent.icon}
             title={messageAgent.title}
             backgroundColor={messageAgent.backgroundColor}
           />

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -119,6 +119,7 @@ export function GrueneratorThread({
                 description={activeAgent?.description}
                 questions={activeAgent?.openingQuestions?.map((text) => ({ text }))}
                 avatar={activeAgent?.avatar}
+                {...(activeAgent?.icon ? { icon: activeAgent.icon } : {})}
                 {...(activeAgent?.welcomeQuestion
                   ? { welcomeQuestion: activeAgent.welcomeQuestion }
                   : {})}

--- a/packages/chat/src/components/thread/WelcomeScreen.tsx
+++ b/packages/chat/src/components/thread/WelcomeScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ThreadPrimitive, SuggestionPrimitive } from '@assistant-ui/react';
+import type { SkillIcon } from '@gruenerator/shared/agents';
 import { cn } from '../../lib/utils';
 import { useChatDensity } from './chatDensityContext';
 
@@ -11,6 +12,9 @@ interface WelcomeScreenProps {
   description?: string;
   questions?: Array<{ text: string }>;
   avatar?: string;
+  /** Resolved icon component for the active agent/skill — preferred over the
+   *  emoji `avatar` when present. */
+  icon?: SkillIcon;
   firstName?: string | null;
   /**
    * Agent-specific welcome question. May contain the `{firstName}` token,
@@ -28,7 +32,10 @@ function welcomeQuestion(
   if (agentQuestion) {
     return firstName
       ? agentQuestion.replace(/\{firstName\}/g, firstName)
-      : agentQuestion.replace(/\{firstName\}/g, '').replace(/\s+,/g, ',').trim();
+      : agentQuestion
+          .replace(/\{firstName\}/g, '')
+          .replace(/\s+,/g, ',')
+          .trim();
   }
   return firstName ? `Hallo ${firstName}, wie kann ich helfen?` : 'Wie kann ich dir helfen?';
 }
@@ -56,6 +63,7 @@ export function WelcomeScreen({
   description,
   questions,
   avatar,
+  icon: Icon,
   firstName,
   welcomeQuestion: agentWelcomeQuestion,
 }: WelcomeScreenProps = {}) {
@@ -71,14 +79,19 @@ export function WelcomeScreen({
       )}
     >
       <div className="flex w-full flex-col">
-        {avatar && (
+        {Icon ? (
+          <Icon
+            aria-hidden
+            className={cn('text-primary', isCompact ? 'mb-2 h-6 w-6' : 'mb-3 h-9 w-9')}
+          />
+        ) : avatar ? (
           <span
             aria-hidden
             className={cn('leading-none', isCompact ? 'mb-2 text-2xl' : 'mb-3 text-4xl')}
           >
             {avatar}
           </span>
-        )}
+        ) : null}
         <h1
           className={cn(
             'm-0 font-semibold text-foreground-heading',
@@ -90,10 +103,7 @@ export function WelcomeScreen({
 
         {fallbackDescription && (
           <p
-            className={cn(
-              'm-0 mt-1 text-foreground-muted',
-              isCompact ? 'text-[12px]' : 'text-sm'
-            )}
+            className={cn('m-0 mt-1 text-foreground-muted', isCompact ? 'text-[12px]' : 'text-sm')}
           >
             {fallbackDescription}
           </p>
@@ -112,9 +122,7 @@ export function WelcomeScreen({
                   type="button"
                   className={cn(
                     'h-auto w-full border border-border text-left transition-colors hover:border-primary/40 hover:bg-primary/5',
-                    isCompact
-                      ? 'rounded-xl px-3 py-2 text-[12px]'
-                      : 'rounded-2xl px-5 py-4 text-sm'
+                    isCompact ? 'rounded-xl px-3 py-2 text-[12px]' : 'rounded-2xl px-5 py-4 text-sm'
                   )}
                 >
                   <span className="font-medium text-foreground">{question.text}</span>

--- a/packages/chat/src/lib/useActiveAgentMeta.ts
+++ b/packages/chat/src/lib/useActiveAgentMeta.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
-import { SKILLS, getSystemAgent, localizeAgent } from '@gruenerator/shared/agents';
+import { SKILLS, getSystemAgent, localizeAgent, type SkillIcon } from '@gruenerator/shared/agents';
+import { agentsList } from './agents';
 import { useScopedAgentId } from './useScopedAgentState';
 
 export interface ActiveAgentMeta {
   identifier: string;
   avatar: string;
+  icon?: SkillIcon;
   title: string;
   description: string;
   openingMessage?: string;
@@ -24,6 +26,9 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
 
   return useMemo(() => {
     if (!selectedAgentId) return null;
+    // The resolved icon component lives on the skills catalog; system agents
+    // and skills that share an identifier reuse the same branding.
+    const icon = agentsList.find((a) => a.identifier === selectedAgentId)?.icon;
     const rawAgent = getSystemAgent(selectedAgentId);
     if (rawAgent) {
       // Prefer the canonical system-agent metadata when navigating via URL or
@@ -34,6 +39,7 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
       return {
         identifier: selectedAgentId,
         avatar: agent.avatar,
+        ...(icon ? { icon } : {}),
         title: agent.title,
         description: agent.description,
         openingMessage: agent.openingMessage,
@@ -46,6 +52,7 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
     return {
       identifier: selectedAgentId,
       avatar: skill.avatar,
+      ...(icon ? { icon } : {}),
       title: skill.title,
       description: skill.description,
     };


### PR DESCRIPTION
A skill like `/presse-berlin` showed an emoji (🐻) in the chat avatar badge and skill badge, while the mention popover and the skills library already rendered its proper icon component — a visible inconsistency.

The assistant-message avatar badge, `SkillBadge` and the welcome screen now prefer the resolved icon component (threaded through `useActiveAgentMeta`), falling back to the emoji `avatar` only for custom user agents that have no icon component.

Note: CI's "Quality Checks" job currently fails for an unrelated, pre-existing reason — `@gruenerator/sites` has a broken ESLint config on `master` (fixed by #858). This PR's own changes typecheck and lint clean.
