### PR TITLE
fix(skills): remove the redundant contextPrefix prompt prefix

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/compoundPipeline.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/compoundPipeline.vitest.ts
@@ -65,7 +65,6 @@ function makeAgentConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
     systemRole: 'Du schreibst Pressemitteilungen für die Grünen.',
     model: 'mistral-small-latest',
     params: { max_tokens: 2048, temperature: 0.7 },
-    contextPrefix: '[Plattform: Pressemitteilung]',
     ...overrides,
   } as AgentConfig;
 }
@@ -382,7 +381,6 @@ describe('Compound Pipeline: @notebook + @skill', () => {
 
       // Step 7: Verify agent config is preserved for response phase
       expect(searchedState.agentConfig.identifier).toBe('gruenerator-oeffentlichkeitsarbeit');
-      expect(searchedState.agentConfig.contextPrefix).toBe('[Plattform: Pressemitteilung]');
     });
 
     it('handles empty user text (@hamburg @presse with no topic)', async () => {

--- a/packages/chat/src/lib/mentionInsertion.ts
+++ b/packages/chat/src/lib/mentionInsertion.ts
@@ -20,11 +20,10 @@ export function computeMentionInsertion(
   const before = currentText.slice(0, insertAt);
   const after = mentionStart >= 0 ? currentText.slice(caretPosition) : '';
   const prefix = before.length > 0 && !before.endsWith(' ') && mentionStart < 0 ? ' ' : '';
-  const ctxSuffix = mentionable.contextPrefix ? `${mentionable.contextPrefix} ` : '';
   const tmpl = mentionable.promptTemplate ?? '';
-  const newText = `${before}${prefix}${trigger}${mentionable.mention} ${ctxSuffix}${tmpl}${after}`;
+  const newText = `${before}${prefix}${trigger}${mentionable.mention} ${tmpl}${after}`;
   const cursorPosition =
-    before.length + prefix.length + mentionable.mention.length + 2 + ctxSuffix.length + tmpl.length;
+    before.length + prefix.length + mentionable.mention.length + 2 + tmpl.length;
 
   return { newText, cursorPosition };
 }

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -41,7 +41,6 @@ export interface Mentionable {
   avatar: string;
   backgroundColor: string;
   mention: string;
-  contextPrefix?: string;
   skillCategory?: import('./agents').SkillCategory;
   promptTemplate?: string;
   isSystemDefault?: boolean;
@@ -83,7 +82,6 @@ export function agentToMentionable(agent: AgentListItem): Mentionable {
     avatar: agent.avatar,
     backgroundColor: agent.backgroundColor,
     mention: agent.mention,
-    contextPrefix: agent.contextPrefix,
     skillCategory: agent.skillCategory,
     promptTemplate: agent.promptTemplate,
     isSystemDefault: agent.isSystemDefault,

--- a/packages/shared/src/agents/mcpProjection.ts
+++ b/packages/shared/src/agents/mcpProjection.ts
@@ -47,15 +47,12 @@ export interface McpSocialMediaVariant {
   platform: string;
   title: string;
   description: string;
-  contextPrefix: string;
 }
 
 export const MCP_SOCIAL_MEDIA_VARIANTS: readonly McpSocialMediaVariant[] = SKILLS.filter(
-  (skill): skill is typeof skill & { contextPrefix: string } =>
-    skill.identifier === 'gruenerator-oeffentlichkeitsarbeit' && Boolean(skill.contextPrefix)
+  (skill) => skill.identifier === 'gruenerator-oeffentlichkeitsarbeit'
 ).map((skill) => ({
   platform: skill.mention,
   title: skill.title,
   description: skill.description,
-  contextPrefix: skill.contextPrefix,
 }));

--- a/packages/shared/src/agents/skills/aktionsideen.ts
+++ b/packages/shared/src/agents/skills/aktionsideen.ts
@@ -8,7 +8,6 @@ export const AKTIONSIDEEN_SKILL = {
   avatar: '💡',
   backgroundColor: '#316049',
   mention: 'aktion',
-  contextPrefix: '[Plattform: Aktionsideen]',
   skillCategory: 'sonstiges',
   promptTemplate: 'Entwickle Aktionsideen zu: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/facebook.ts
+++ b/packages/shared/src/agents/skills/facebook.ts
@@ -8,7 +8,6 @@ export const FACEBOOK_SKILL = {
   avatar: '👍',
   backgroundColor: '#316049',
   mention: 'facebook',
-  contextPrefix: '[Plattform: Facebook]',
   skillCategory: 'social',
   promptTemplate: 'Beitrag zu folgendem Thema: ',
   skillSystemPrompt: `**FACEBOOK-POST (max. 600 Zeichen):**

--- a/packages/shared/src/agents/skills/instagram.ts
+++ b/packages/shared/src/agents/skills/instagram.ts
@@ -8,7 +8,6 @@ export const INSTAGRAM_SKILL = {
   avatar: '📸',
   backgroundColor: '#316049',
   mention: 'instagram',
-  contextPrefix: '[Plattform: Instagram]',
   skillCategory: 'social',
   isSystemDefault: true,
   promptTemplate: 'Post zu folgendem Thema: ',

--- a/packages/shared/src/agents/skills/linkedin.ts
+++ b/packages/shared/src/agents/skills/linkedin.ts
@@ -8,7 +8,6 @@ export const LINKEDIN_SKILL = {
   avatar: '💼',
   backgroundColor: '#316049',
   mention: 'linkedin',
-  contextPrefix: '[Plattform: LinkedIn]',
   skillCategory: 'social',
   promptTemplate: 'LinkedIn-Post zu: ',
   skillSystemPrompt: `**LINKEDIN-POST (max. 600 Zeichen):**

--- a/packages/shared/src/agents/skills/presse-berlin.ts
+++ b/packages/shared/src/agents/skills/presse-berlin.ts
@@ -8,7 +8,6 @@ export const PRESSE_BERLIN_SKILL = {
   avatar: '🐻',
   backgroundColor: '#316049',
   mention: 'presse-berlin',
-  contextPrefix: '[LV: Berlin / Modus: PM]',
   skillCategory: 'presse',
   promptTemplate: 'Schreibe eine Pressemitteilung im Stil Grüne Berlin zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/presse-brandenburg.ts
+++ b/packages/shared/src/agents/skills/presse-brandenburg.ts
@@ -8,7 +8,6 @@ export const PRESSE_BRANDENBURG_SKILL = {
   avatar: '🌻',
   backgroundColor: '#316049',
   mention: 'presse-brandenburg',
-  contextPrefix: '[LV: Brandenburg / Modus: PM]',
   skillCategory: 'presse',
   promptTemplate: 'Schreibe eine Pressemitteilung im Stil Brandenburger Bündnisgrüne zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/presse-hamburg.ts
+++ b/packages/shared/src/agents/skills/presse-hamburg.ts
@@ -8,7 +8,6 @@ export const PRESSE_HAMBURG_SKILL = {
   avatar: '⚓',
   backgroundColor: '#316049',
   mention: 'presse-hamburg',
-  contextPrefix: '[LV: Hamburg / Modus: PM]',
   skillCategory: 'presse',
   promptTemplate: 'Schreibe eine Pressemitteilung im Stil Grüne Hamburg zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/presse-mv.ts
+++ b/packages/shared/src/agents/skills/presse-mv.ts
@@ -8,7 +8,6 @@ export const PRESSE_MV_SKILL = {
   avatar: '🌊',
   backgroundColor: '#316049',
   mention: 'presse-mv',
-  contextPrefix: '[LV: Mecklenburg-Vorpommern / Modus: PM]',
   skillCategory: 'presse',
   promptTemplate: 'Schreibe eine Pressemitteilung im Stil Grüne MV zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/presse-thueringen.ts
+++ b/packages/shared/src/agents/skills/presse-thueringen.ts
@@ -8,7 +8,6 @@ export const PRESSE_THUERINGEN_SKILL = {
   avatar: '🌲',
   backgroundColor: '#316049',
   mention: 'presse-thueringen',
-  contextPrefix: '[LV: Thüringen / Modus: PM]',
   skillCategory: 'presse',
   promptTemplate: 'Schreibe eine Pressemitteilung im Stil Bündnisgrüne Thüringen zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/pressemitteilung.ts
+++ b/packages/shared/src/agents/skills/pressemitteilung.ts
@@ -8,7 +8,6 @@ export const PRESSEMITTEILUNG_SKILL = {
   avatar: '📰',
   backgroundColor: '#316049',
   mention: 'presse',
-  contextPrefix: '[Plattform: Pressemitteilung]',
   skillCategory: 'presse',
   isSystemDefault: true,
   promptTemplate: 'Schreibe eine PM zum Thema: ',

--- a/packages/shared/src/agents/skills/reel.ts
+++ b/packages/shared/src/agents/skills/reel.ts
@@ -8,7 +8,6 @@ export const REEL_SKILL = {
   avatar: '🎬',
   backgroundColor: '#316049',
   mention: 'reel',
-  contextPrefix: '[Plattform: Reel/TikTok-Skript]',
   skillCategory: 'social',
   promptTemplate: 'Skript zu folgendem Thema: ',
   skillSystemPrompt: `**REEL / TIKTOK-SKRIPT (max. 1500 Zeichen):**

--- a/packages/shared/src/agents/skills/social-berlin.ts
+++ b/packages/shared/src/agents/skills/social-berlin.ts
@@ -8,7 +8,6 @@ export const SOCIAL_BERLIN_SKILL = {
   avatar: '🐻',
   backgroundColor: '#316049',
   mention: 'social-berlin',
-  contextPrefix: '[LV: Berlin / Modus: Social Media]',
   skillCategory: 'social',
   promptTemplate:
     'Erstelle Social-Media-Posts im Stil Grüne Berlin (Facebook, Instagram, Twitter/X, LinkedIn) zum Thema: ',

--- a/packages/shared/src/agents/skills/social-brandenburg.ts
+++ b/packages/shared/src/agents/skills/social-brandenburg.ts
@@ -8,7 +8,6 @@ export const SOCIAL_BRANDENBURG_SKILL = {
   avatar: '🌻',
   backgroundColor: '#316049',
   mention: 'social-brandenburg',
-  contextPrefix: '[LV: Brandenburg / Modus: Social Media]',
   skillCategory: 'social',
   promptTemplate: 'Erstelle Social-Media-Posts im Stil Brandenburger Bündnisgrüne zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/social-hamburg.ts
+++ b/packages/shared/src/agents/skills/social-hamburg.ts
@@ -8,7 +8,6 @@ export const SOCIAL_HAMBURG_SKILL = {
   avatar: '⚓',
   backgroundColor: '#316049',
   mention: 'social-hamburg',
-  contextPrefix: '[LV: Hamburg / Modus: Social Media]',
   skillCategory: 'social',
   promptTemplate: 'Erstelle Social-Media-Posts im Stil Grüne Hamburg zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/social-mv.ts
+++ b/packages/shared/src/agents/skills/social-mv.ts
@@ -8,7 +8,6 @@ export const SOCIAL_MV_SKILL = {
   avatar: '🌊',
   backgroundColor: '#316049',
   mention: 'social-mv',
-  contextPrefix: '[LV: Mecklenburg-Vorpommern / Modus: Social Media]',
   skillCategory: 'social',
   promptTemplate: 'Erstelle Social-Media-Posts im Stil Grüne MV zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/social-thueringen.ts
+++ b/packages/shared/src/agents/skills/social-thueringen.ts
@@ -8,7 +8,6 @@ export const SOCIAL_THUERINGEN_SKILL = {
   avatar: '🌲',
   backgroundColor: '#316049',
   mention: 'social-thueringen',
-  contextPrefix: '[LV: Thüringen / Modus: Social Media]',
   skillCategory: 'social',
   promptTemplate: 'Erstelle Social-Media-Posts im Stil Bündnisgrüne Thüringen zum Thema: ',
 } as const satisfies SystemSkill;

--- a/packages/shared/src/agents/skills/twitter.ts
+++ b/packages/shared/src/agents/skills/twitter.ts
@@ -8,7 +8,6 @@ export const TWITTER_SKILL = {
   avatar: '🐦',
   backgroundColor: '#316049',
   mention: 'twitter',
-  contextPrefix: '[Plattform: Twitter]',
   skillCategory: 'social',
   promptTemplate: 'Tweet zu folgendem Thema: ',
   skillSystemPrompt: `**TWEET / X-POST (max. 280 Zeichen):**

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -191,7 +191,6 @@ export interface Skill {
   avatar: string;
   backgroundColor: string;
   mention: string;
-  contextPrefix?: string;
   skillCategory?: SkillCategory;
   promptTemplate?: string;
   isSystemDefault?: boolean;

--- a/services/mcp/src/prompts/agent-prompts.ts
+++ b/services/mcp/src/prompts/agent-prompts.ts
@@ -46,8 +46,7 @@ function localizeAgent(agent: McpAgentDefinition, country: Country): McpAgentDef
 function buildPromptMessages(
   agent: McpAgentDefinition,
   message: string,
-  country: Country,
-  platformPrefix?: string
+  country: Country
 ): PromptMessage[] {
   const localizedAgent = localizeAgent(agent, country);
   const messages: PromptMessage[] = [];
@@ -82,11 +81,10 @@ function buildPromptMessages(
     }
   }
 
-  // 4. Actual user message (with optional platform prefix)
-  const userText = platformPrefix ? `${platformPrefix} ${message}` : message;
+  // 4. Actual user message
   messages.push({
     role: 'user',
-    content: { type: 'text', text: userText },
+    content: { type: 'text', text: message },
   });
 
   return messages;
@@ -141,12 +139,7 @@ export function registerAgentPrompts(server: McpServer): void {
 
           return {
             description: variant ? `${agent.title} — ${variant.title}` : agent.description,
-            messages: buildPromptMessages(
-              agent,
-              message,
-              country as Country,
-              variant?.contextPrefix
-            ),
+            messages: buildPromptMessages(agent, message, country as Country),
           };
         }
       );


### PR DESCRIPTION
Selecting a skill like `/presse-berlin` injected a bracketed tag — `[LV: Berlin / Modus: PM]` — into the user's message. Nothing consumed it as structured data: the Landesverband and the mode (PM vs Social) are already encoded by the agent identity and the skill itself. Meanwhile it leaked into the search-embedding query and the auto-generated thread title as visible noise.

Removes `contextPrefix` entirely — from the `Skill` and `Mentionable` types, all 17 skill configs, both injection sites (`mentionInsertion` for chat, `agent-prompts` for MCP), and the MCP social-media-variant projection (whose filter now keys on `identifier` alone, which already uniquely identifies the 7 platform variants).

Note: CI's "Quality Checks" job currently fails for an unrelated, pre-existing reason — `@gruenerator/sites` has a broken ESLint setup on `master` (see #858). This PR's own changes typecheck and lint clean across `@gruenerator/shared`, `@gruenerator/chat`, `@gruenerator/mcp` and `@gruenerator/api`.
