### PR TITLE
feat(chat): theme chat progress labels with rotating Grünerator phrases

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/intentPipeline.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/intentPipeline.vitest.ts
@@ -3,7 +3,7 @@
  *
  * Verifies that all SearchIntent values are consistently wired across:
  * - Backend types (SearchIntent union, ImageStyle union)
- * - SSE helpers (INTENT_MESSAGES, PROGRESS_MESSAGES)
+ * - SSE helpers (INTENT_MESSAGE_POOLS, PROGRESS_MESSAGES)
  * - ChatGraph routing (intentToToolKey, routeAfterClassification)
  * - Controller (TOOL_PRIORITY for forced tools)
  * - Frontend types (SearchIntent, GeneratedImage.style, styleLabels)
@@ -15,7 +15,7 @@
 import { describe, it, expect } from 'vitest';
 
 import {
-  INTENT_MESSAGES,
+  INTENT_MESSAGE_POOLS,
   PROGRESS_MESSAGES,
   getIntentMessage,
 } from '../../../routes/chat/services/sseHelpers.js';
@@ -75,23 +75,25 @@ const ALL_IMAGE_STYLES: ImageStyle[] = [
 // ============================================================================
 
 describe('SearchIntent type consistency', () => {
-  it('INTENT_MESSAGES has an entry for every SearchIntent', () => {
+  it('INTENT_MESSAGE_POOLS has a non-empty pool for every SearchIntent', () => {
     for (const intent of ALL_INTENTS) {
-      expect(
-        INTENT_MESSAGES[intent],
-        `Missing INTENT_MESSAGES entry for "${intent}"`
-      ).toBeDefined();
-      expect(typeof INTENT_MESSAGES[intent]).toBe('string');
-      expect(INTENT_MESSAGES[intent].length).toBeGreaterThan(0);
+      const pool = INTENT_MESSAGE_POOLS[intent];
+      expect(pool, `Missing INTENT_MESSAGE_POOLS entry for "${intent}"`).toBeDefined();
+      expect(Array.isArray(pool)).toBe(true);
+      expect(pool.length).toBeGreaterThan(0);
+      for (const message of pool) {
+        expect(typeof message).toBe('string');
+        expect(message.length).toBeGreaterThan(0);
+      }
     }
   });
 
-  it('INTENT_MESSAGES has no extra entries beyond SearchIntent', () => {
-    const intentKeys = Object.keys(INTENT_MESSAGES);
+  it('INTENT_MESSAGE_POOLS has no extra entries beyond SearchIntent', () => {
+    const intentKeys = Object.keys(INTENT_MESSAGE_POOLS);
     for (const key of intentKeys) {
       expect(
         ALL_INTENTS.includes(key as SearchIntent),
-        `INTENT_MESSAGES has unexpected key "${key}" not in SearchIntent`
+        `INTENT_MESSAGE_POOLS has unexpected key "${key}" not in SearchIntent`
       ).toBe(true);
     }
   });
@@ -226,39 +228,50 @@ describe('image-related intents', () => {
     expect(imageIntents.length).toBe(2);
   });
 
-  it('INTENT_MESSAGES differentiates image vs image_edit', () => {
-    expect(INTENT_MESSAGES['image']).not.toBe(INTENT_MESSAGES['image_edit']);
+  it('INTENT_MESSAGE_POOLS differentiates image vs image_edit', () => {
+    const imagePool = INTENT_MESSAGE_POOLS['image'];
+    const imageEditPool = INTENT_MESSAGE_POOLS['image_edit'];
+    const overlap = imagePool.filter((m) => imageEditPool.includes(m));
+    expect(overlap, 'image and image_edit pools must not share a phrase').toEqual([]);
   });
 
-  it('image_edit message mentions editing', () => {
-    expect(INTENT_MESSAGES['image_edit'].toLowerCase()).toContain('bearbeit');
+  it('image_edit pool mentions editing', () => {
+    expect(
+      INTENT_MESSAGE_POOLS['image_edit'].some((m) => m.toLowerCase().includes('bearbeit'))
+    ).toBe(true);
   });
 
-  it('image message mentions generation', () => {
-    expect(INTENT_MESSAGES['image'].toLowerCase()).toContain('generier');
+  it('image pool mentions generation', () => {
+    expect(INTENT_MESSAGE_POOLS['image'].some((m) => m.toLowerCase().includes('generier'))).toBe(
+      true
+    );
   });
 });
 
 // ============================================================================
-// 6. INTENT_MESSAGES are in German
+// 6. INTENT_MESSAGE_POOLS are in German
 // ============================================================================
 
-describe('INTENT_MESSAGES are German user-facing strings', () => {
+describe('INTENT_MESSAGE_POOLS are German user-facing strings', () => {
   it('all messages end with "..." (ellipsis pattern)', () => {
-    for (const [intent, message] of Object.entries(INTENT_MESSAGES)) {
-      expect(
-        message.endsWith('...'),
-        `INTENT_MESSAGES["${intent}"] = "${message}" should end with "..."`
-      ).toBe(true);
+    for (const [intent, pool] of Object.entries(INTENT_MESSAGE_POOLS)) {
+      for (const message of pool) {
+        expect(
+          message.endsWith('...'),
+          `INTENT_MESSAGE_POOLS["${intent}"] entry "${message}" should end with "..."`
+        ).toBe(true);
+      }
     }
   });
 
   it('no message is empty or just whitespace', () => {
-    for (const [intent, message] of Object.entries(INTENT_MESSAGES)) {
-      expect(
-        message.trim().length > 3,
-        `INTENT_MESSAGES["${intent}"] is too short: "${message}"`
-      ).toBe(true);
+    for (const [intent, pool] of Object.entries(INTENT_MESSAGE_POOLS)) {
+      for (const message of pool) {
+        expect(
+          message.trim().length > 3,
+          `INTENT_MESSAGE_POOLS["${intent}"] entry is too short: "${message}"`
+        ).toBe(true);
+      }
     }
   });
 });
@@ -319,15 +332,17 @@ describe('action-related intents', () => {
     }
   });
 
-  it('action intents have distinct INTENT_MESSAGES', () => {
-    const messages = ACTION_INTENTS.map((i) => INTENT_MESSAGES[i]);
-    const unique = new Set(messages);
-    expect(unique.size).toBe(ACTION_INTENTS.length);
+  it('action intents have distinct INTENT_MESSAGE_POOLS', () => {
+    const allPhrases = ACTION_INTENTS.flatMap((i) => INTENT_MESSAGE_POOLS[i]);
+    const unique = new Set(allPhrases);
+    expect(unique.size, 'action-intent pools must not share a phrase').toBe(allPhrases.length);
   });
 
-  it('INTENT_MESSAGES for action intents are in German', () => {
+  it('INTENT_MESSAGE_POOLS for action intents are in German', () => {
     for (const intent of ACTION_INTENTS) {
-      expect(INTENT_MESSAGES[intent].endsWith('...')).toBe(true);
+      for (const message of INTENT_MESSAGE_POOLS[intent]) {
+        expect(message.endsWith('...')).toBe(true);
+      }
     }
   });
 });

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -226,27 +226,74 @@ export interface SSEEventPayloads {
 }
 
 /**
- * German status messages for each intent type.
+ * Picks a random element — used to vary user-facing status copy per chat turn.
  */
-export const INTENT_MESSAGES: Record<SearchIntent, string> = {
-  research: 'Recherchiere im Web und in Dokumenten...',
-  compare: 'Vergleiche die referenzierten Dokumente...',
-  search: 'Durchsuche Grüne Positionen und Programme...',
+function pickOne<T>(pool: readonly T[]): T {
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+/**
+ * German status messages for each intent type. Each intent has a small pool of
+ * playful, on-brand phrases; `getIntentMessage` picks one per turn so the same
+ * intent feels fresh across messages. Register is mixed — cheeky for the
+ * fast/creative intents, calmer for research and document edits. Entries keep
+ * the trailing "..." progressive-action convention.
+ */
+export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
+  research: [
+    'Recherchiere im Web und in den Dokumenten...',
+    'Grabe mich durch Quellen und Programme...',
+    'Sammle Fakten von überall her...',
+  ],
+  compare: [
+    'Vergleiche die referenzierten Dokumente...',
+    'Lege die Dokumente nebeneinander...',
+    'Suche die Unterschiede heraus...',
+  ],
+  search: [
+    'Durchsuche Grüne Positionen und Programme...',
+    'Wälze die Parteiprogramme...',
+    'Stöbere in den Beschlüssen...',
+  ],
   // person: 'Suche Informationen zur Person...', // DISABLED: Person search not production ready
-  web: 'Suche aktuelle Informationen im Web...',
-  examples: 'Suche Social-Media-Beispiele...',
-  pressemitteilung_examples: 'Suche Pressemitteilungs-Vorlagen aus Landesverbänden...',
-  image: 'Generiere Bild...',
-  image_edit: 'Bearbeite Bild...',
-  sharepic: 'Erstelle Sharepic...',
-  summary: 'Fasse Dokument(e) zusammen...',
-  chart: 'Erstelle Diagramm...',
-  save_as_doc: 'Erstelle Dokument aus Antwort...',
-  modify_doc: 'Bearbeite Dokument...',
-  edit_current_doc: 'Bearbeite das aktuelle Dokument...',
-  modify_board: 'Aktualisiere Board...',
-  share_doc: 'Teile Dokument mit Gruppe...',
-  direct: 'Beantworte direkt...',
+  web: [
+    'Suche aktuelle Informationen im Web...',
+    'Hole frische Infos aus dem Netz...',
+    'Schaue im Web nach dem neuesten Stand...',
+  ],
+  examples: [
+    'Suche Social-Media-Beispiele...',
+    'Krame in der Social-Media-Kiste...',
+    'Hole Inspiration aus alten Posts...',
+  ],
+  pressemitteilung_examples: [
+    'Suche Pressemitteilungs-Vorlagen aus Landesverbänden...',
+    'Blättere durch Pressemitteilungen der Landesverbände...',
+    'Hole Vorlagen aus den Landesverbänden...',
+  ],
+  image: ['Generiere Bild...', 'Mische die Farben...', 'Spanne die Leinwand auf...'],
+  image_edit: [
+    'Bearbeite Bild...',
+    'Bearbeite das Bild mit dem Pinsel...',
+    'Werfe Farbbeutel auf das Bild...',
+  ],
+  sharepic: [
+    'Erstelle Sharepic...',
+    'Baue dein Sharepic...',
+    'Bringe die Botschaft aufs Sharepic...',
+  ],
+  summary: [
+    'Fasse Dokument(e) zusammen...',
+    'Koche die Dokumente auf das Wichtigste ein...',
+    'Bündele den Inhalt...',
+  ],
+  chart: ['Erstelle Diagramm...', 'Bringe die Zahlen in Form...', 'Zeichne das Diagramm...'],
+  save_as_doc: ['Erstelle Dokument aus Antwort...', 'Gieße die Antwort in ein Dokument...'],
+  modify_doc: ['Bearbeite Dokument...', 'Feile am Dokument...'],
+  edit_current_doc: ['Bearbeite das aktuelle Dokument...', 'Lege im offenen Dokument Hand an...'],
+  modify_board: ['Aktualisiere Board...', 'Bringe das Board auf Stand...'],
+  share_doc: ['Teile Dokument mit Gruppe...', 'Reiche das Dokument an die Gruppe weiter...'],
+  direct: ['Beantworte direkt...', 'Antworte aus dem Stand...', 'Lege direkt los...'],
 };
 
 /**
@@ -345,10 +392,11 @@ export class SSEWriter {
 }
 
 /**
- * Get the German status message for an intent.
+ * Get a German status message for an intent — one phrase picked at random from
+ * the intent's pool, so the copy varies from one chat turn to the next.
  */
 export function getIntentMessage(intent: SearchIntent): string {
-  return INTENT_MESSAGES[intent] || 'Verarbeite Anfrage...';
+  return pickOne(INTENT_MESSAGE_POOLS[intent] ?? ['Verarbeite Anfrage...']);
 }
 
 /**

--- a/packages/chat/src/components/assistant-ui/reasoning.tsx
+++ b/packages/chat/src/components/assistant-ui/reasoning.tsx
@@ -55,7 +55,7 @@ export function ReasoningTrigger({
   label?: string;
   className?: string;
 }) {
-  const computedLabel = label ?? (active ? 'Denkt nach …' : 'Gedanken');
+  const computedLabel = label ?? (active ? 'Grünerator denkt nach …' : 'Grünerators Gedanken');
   return (
     <CollapsibleTrigger
       className={cn(

--- a/packages/chat/src/lib/progressLabels.ts
+++ b/packages/chat/src/lib/progressLabels.ts
@@ -1,0 +1,62 @@
+/**
+ * Grünerator-themed progress labels for the chat ProgressTracker.
+ *
+ * Each pipeline stage has a small pool of playful German phrases. One phrase
+ * per stage is picked at the start of a chat turn (see `pickStageLabels`) and
+ * stays stable for that turn, so the same stage feels fresh across messages
+ * without flickering mid-stream.
+ *
+ * Register is mixed on purpose: cheeky for the fast stages (classify, image),
+ * calmer for the longer ones (search, summary, response).
+ */
+
+import type { ProgressStage } from '../hooks/useChatGraphStream';
+
+/** The stages that actually show a progress label (terminal stages don't). */
+type LabelledStage = Extract<
+  ProgressStage,
+  'classifying' | 'searching' | 'summarizing' | 'generating_image' | 'generating'
+>;
+
+export const STAGE_LABEL_POOLS: Record<LabelledStage, readonly string[]> = {
+  classifying: [
+    'Sortiere dein Anliegen …',
+    'Stricke einen Plan …',
+    'Lese zwischen den Zeilen …',
+    'Denke kurz nach …',
+  ],
+  searching: [
+    'Stöbere im Archiv …',
+    'Wälze die Parteiprogramme …',
+    'Durchforste die Quellen …',
+    'Blättere durch die Anträge …',
+  ],
+  summarizing: [
+    'Bündele die Argumente …',
+    'Koche es auf den Punkt ein …',
+    'Fasse das Wichtigste zusammen …',
+  ],
+  generating_image: [
+    'Mische die Farben …',
+    'Werfe Farbbeutel auf die Leinwand …',
+    'Spanne die Leinwand auf …',
+    'Male dein Sharepic …',
+  ],
+  generating: ['Formuliere die Antwort …', 'Feile an den Worten …', 'Bringe es aufs Papier …'],
+};
+
+/**
+ * Picks one label per stage. Call once per chat turn (e.g. at the top of the
+ * model adapter's `run()`), then reuse the result for the whole turn.
+ *
+ * Returned as `Record<string, string>` so it drops in where the adapter
+ * previously held a flat `STAGE_LABELS` map; unknown/terminal stages resolve
+ * to `undefined`, which the adapter already guards against.
+ */
+export function pickStageLabels(): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  for (const [stage, pool] of Object.entries(STAGE_LABEL_POOLS)) {
+    resolved[stage] = pool[Math.floor(Math.random() * pool.length)];
+  }
+  return resolved;
+}

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -21,6 +21,7 @@ import { getSystemAgent } from '@gruenerator/shared/agents';
 import { parseAllMentions } from '../lib/mentionParser';
 import { parseSSELine } from '../lib/sseParser';
 import { INTENT_TO_TOOL, DEEP_TOOL_MAP } from '../lib/toolMappings';
+import { pickStageLabels } from '../lib/progressLabels';
 import { useDocumentChatStore } from '../stores/documentChatStore';
 import { streamErrorMessage } from './streamErrorMessage';
 import type { ConfirmActionData, DocumentCreatedData } from '../types/messageMetadata';
@@ -102,21 +103,15 @@ async function* parseSSEStream(
   const currentEvent = { type: '' };
   let accumulatedText = '';
   let accumulatedReasoning = '';
+  // Themed progress labels — picked once per turn, stable for the whole stream.
+  const stageLabels = pickStageLabels();
   let currentProgress: ChatProgress = {
     stage: 'classifying',
-    message: 'Analysiere Anfrage...',
+    message: stageLabels.classifying,
   };
   const progressSteps: ProgressStep[] = [
-    { stage: 'classifying', label: 'Klassifizierung', status: 'in-progress' },
+    { stage: 'classifying', label: stageLabels.classifying, status: 'in-progress' },
   ];
-
-  const STAGE_LABELS: Record<string, string> = {
-    classifying: 'Klassifizierung',
-    searching: 'Suche',
-    summarizing: 'Zusammenfassung',
-    generating_image: 'Bildgenerierung',
-    generating: 'Generierung',
-  };
 
   function transitionStep(newStage: ProgressStage, labelOverride?: string) {
     // Mark current in-progress step as completed
@@ -127,7 +122,7 @@ async function* parseSSEStream(
       }
     }
     // Add new step if it has a label and isn't 'complete'/'error'/'idle'
-    const label = labelOverride || STAGE_LABELS[newStage];
+    const label = labelOverride || stageLabels[newStage];
     if (label && newStage !== 'complete' && newStage !== 'error' && newStage !== 'idle') {
       // Don't duplicate if the same stage already exists
       if (!progressSteps.some((s) => s.stage === newStage)) {
@@ -362,7 +357,7 @@ async function* parseSSEStream(
             searchStep.status = 'completed';
             searchStep.completedAt = Date.now();
           }
-          transitionStep('generating', 'Generiere Antwort');
+          transitionStep('generating');
           currentProgress = {
             ...currentProgress,
             stage: 'generating',
@@ -415,7 +410,7 @@ async function* parseSSEStream(
 
         case 'summary_complete': {
           const { message } = data as { message: string };
-          transitionStep('generating', 'Generiere Antwort');
+          transitionStep('generating');
           currentProgress = { ...currentProgress, stage: 'generating', message };
           yield buildResult();
           break;
@@ -490,7 +485,7 @@ async function* parseSSEStream(
 
         case 'response_start': {
           const { message } = data as { message: string };
-          transitionStep('generating', 'Generiere Antwort');
+          transitionStep('generating');
           currentProgress = { ...currentProgress, stage: 'generating', message };
           yield buildResult();
           break;


### PR DESCRIPTION
The chat's working-status text — "Klassifizierung", "Suche", "Gedanken" … — read like a debug log rather than like Grünerator. This re-themes every web-facing progress label into playful, on-brand German copy that rotates through a small pool per chat turn: a stage's label is picked once per turn, so it stays stable mid-stream but feels fresh across messages. Register is mixed — cheeky for the fast stages, calmer for research and document edits; error copy stays plain.

Scope context (not visible in the diff): the persistent tool-call chip labels (`ToolCallUI`'s `TOOL_CONFIG`) and the low-visibility `PROGRESS_MESSAGES` / registry `TOOL_LABELS` were deliberately left as-is — they sit next to queries and result counts where playful copy would read as confusing, or are effectively dead code.

Verified: `@gruenerator/api` typecheck clean, `intentPipeline.vitest.ts` 48/48 green. (The local `@gruenerator/chat` typecheck hit a pre-existing unrelated `@gruenerator/contracts` workspace-symlink issue — CI's fresh install is unaffected.)