### PR TITLE
fix(chat): set type="button" on skills popup buttons

### DIFF
--- a/packages/chat/src/components/skills/SkillLibraryModal.tsx
+++ b/packages/chat/src/components/skills/SkillLibraryModal.tsx
@@ -78,6 +78,7 @@ export function SkillLibraryModal({ open, onClose, onSelect }: SkillLibraryModal
             </p>
           </div>
           <button
+            type="button"
             onClick={onClose}
             className="rounded-lg p-1.5 text-foreground-muted hover:bg-grey-100 hover:text-foreground dark:hover:bg-grey-800"
             aria-label="Schließen"
@@ -112,6 +113,7 @@ export function SkillLibraryModal({ open, onClose, onSelect }: SkillLibraryModal
                 return (
                   <div key={skill.mention} className="flex items-center gap-1">
                     <button
+                      type="button"
                       className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-primary/5"
                       onClick={() => onSelect(skill)}
                     >
@@ -124,6 +126,7 @@ export function SkillLibraryModal({ open, onClose, onSelect }: SkillLibraryModal
                       </div>
                     </button>
                     <button
+                      type="button"
                       onClick={() => toggleFavorite(skill.mention)}
                       className="flex-shrink-0 rounded-lg p-2 transition-colors hover:bg-grey-100 dark:hover:bg-grey-800"
                       aria-label={isFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
@@ -150,6 +153,7 @@ export function SkillLibraryModal({ open, onClose, onSelect }: SkillLibraryModal
                 return (
                   <div key={skill.mention} className="flex items-center gap-1">
                     <button
+                      type="button"
                       className="flex flex-1 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-primary/5"
                       onClick={() => onSelect(skill)}
                     >
@@ -162,6 +166,7 @@ export function SkillLibraryModal({ open, onClose, onSelect }: SkillLibraryModal
                       </div>
                     </button>
                     <button
+                      type="button"
                       onClick={() => toggleFavorite(skill.mention)}
                       className="flex-shrink-0 rounded-lg p-2 transition-colors hover:bg-grey-100 dark:hover:bg-grey-800"
                       aria-label={isFav ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -97,6 +97,7 @@ function MentionItem({
 }) {
   return (
     <button
+      type="button"
       role="option"
       aria-selected={isSelected}
       data-selected={isSelected}

--- a/packages/chat/src/components/thread/SkillPopover.tsx
+++ b/packages/chat/src/components/thread/SkillPopover.tsx
@@ -109,6 +109,7 @@ export function SkillPopover({
         <div className="px-3 py-3 text-xs text-foreground-muted">Kein Skill gefunden</div>
       )}
       <button
+        type="button"
         className="flex w-full items-center gap-2 border-t border-border px-3 py-2 text-xs text-foreground-muted transition-colors hover:bg-primary/5 hover:text-foreground"
         onMouseDown={(e) => {
           e.preventDefault();
@@ -133,6 +134,7 @@ function SkillItem({
 }) {
   return (
     <button
+      type="button"
       role="option"
       aria-selected={isSelected}
       data-selected={isSelected}


### PR DESCRIPTION
The chat composer (`ComposerPrimitive.Root`) is a real `<form>`, and every mention/skill popover renders as a DOM descendant of it — including the `position: fixed` skill-library modal. A `<button>` with no `type` attribute defaults to `type="submit"`, so clicking the favourite star toggled the favourite *and* submitted the chat, sending the leftover `/` trigger char as an empty message.

Skill/mention *item* buttons dodged this only by accident — their `onMouseDown` handler unmounts the popover before the native `click` fires. The star buttons use `onClick` and stay mounted, so the submit went through. Adding an explicit `type="button"` to every non-submit button in the popovers removes the dependence on that timing; `ComposerButtons` remains the sole submit button.