### PR TITLE
fix(chat): shorten progress labels to terse single verbs

### DIFF
--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -240,60 +240,24 @@ function pickOne<T>(pool: readonly T[]): T {
  * the trailing "..." progressive-action convention.
  */
 export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
-  research: [
-    'Recherchiere im Web und in den Dokumenten...',
-    'Grabe mich durch Quellen und Dokumente...',
-    'Sammle Fakten von überall her...',
-  ],
-  compare: [
-    'Vergleiche die referenzierten Dokumente...',
-    'Lege die Dokumente nebeneinander...',
-    'Suche die Unterschiede heraus...',
-  ],
-  search: [
-    'Durchsuche Grüne Positionen und Programme...',
-    'Wälze die Unterlagen...',
-    'Stöbere in den Grünen Dokumenten...',
-  ],
+  research: ['Recherchiere...', 'Grabe...', 'Sammle...'],
+  compare: ['Vergleiche...', 'Stelle gegenüber...', 'Prüfe...'],
+  search: ['Durchsuche...', 'Stöbere...', 'Wälze...'],
   // person: 'Suche Informationen zur Person...', // DISABLED: Person search not production ready
-  web: [
-    'Suche aktuelle Informationen im Web...',
-    'Hole frische Infos aus dem Netz...',
-    'Schaue im Web nach dem neuesten Stand...',
-  ],
-  examples: [
-    'Suche Social-Media-Beispiele...',
-    'Krame in der Social-Media-Kiste...',
-    'Hole Inspiration aus alten Posts...',
-  ],
-  pressemitteilung_examples: [
-    'Suche Pressemitteilungs-Vorlagen aus Landesverbänden...',
-    'Blättere durch Pressemitteilungen der Landesverbände...',
-    'Hole Vorlagen aus den Landesverbänden...',
-  ],
-  image: ['Generiere Bild...', 'Mische die Farben...', 'Spanne die Leinwand auf...'],
-  image_edit: [
-    'Bearbeite Bild...',
-    'Bearbeite das Bild mit dem Pinsel...',
-    'Werfe Farbbeutel auf das Bild...',
-  ],
-  sharepic: [
-    'Erstelle Sharepic...',
-    'Baue dein Sharepic...',
-    'Bringe die Botschaft aufs Sharepic...',
-  ],
-  summary: [
-    'Fasse Dokument(e) zusammen...',
-    'Koche die Dokumente auf das Wichtigste ein...',
-    'Bündele den Inhalt...',
-  ],
-  chart: ['Erstelle Diagramm...', 'Bringe die Zahlen in Form...', 'Zeichne das Diagramm...'],
-  save_as_doc: ['Erstelle Dokument aus Antwort...', 'Gieße die Antwort in ein Dokument...'],
-  modify_doc: ['Bearbeite Dokument...', 'Feile am Dokument...'],
-  edit_current_doc: ['Bearbeite das aktuelle Dokument...', 'Lege im offenen Dokument Hand an...'],
-  modify_board: ['Aktualisiere Board...', 'Bringe das Board auf Stand...'],
-  share_doc: ['Teile Dokument mit Gruppe...', 'Reiche das Dokument an die Gruppe weiter...'],
-  direct: ['Beantworte direkt...', 'Antworte aus dem Stand...', 'Lege direkt los...'],
+  web: ['Surfe...', 'Suche im Netz...', 'Recherchiere online...'],
+  examples: ['Krame...', 'Hole Beispiele...', 'Suche Inspiration...'],
+  pressemitteilung_examples: ['Suche Pressemitteilungen...', 'Blättere...', 'Hole Vorlagen...'],
+  image: ['Generiere...', 'Male...', 'Zeichne...'],
+  image_edit: ['Bearbeite...', 'Pinsele...', 'Retuschiere...'],
+  sharepic: ['Gestalte...', 'Baue...', 'Erstelle...'],
+  summary: ['Fasse zusammen...', 'Verdichte...', 'Bündele...'],
+  chart: ['Zeichne...', 'Plotte...', 'Erstelle...'],
+  save_as_doc: ['Speichere...', 'Sichere...', 'Archiviere...'],
+  modify_doc: ['Bearbeite...', 'Ändere...', 'Überarbeite...'],
+  edit_current_doc: ['Passe an...', 'Bearbeite...', 'Ändere...'],
+  modify_board: ['Aktualisiere...', 'Ergänze...', 'Pflege...'],
+  share_doc: ['Teile...', 'Sende...', 'Reiche weiter...'],
+  direct: ['Antworte...', 'Schreibe...', 'Formuliere...'],
 };
 
 /**

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -242,7 +242,7 @@ function pickOne<T>(pool: readonly T[]): T {
 export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
   research: [
     'Recherchiere im Web und in den Dokumenten...',
-    'Grabe mich durch Quellen und Programme...',
+    'Grabe mich durch Quellen und Dokumente...',
     'Sammle Fakten von überall her...',
   ],
   compare: [
@@ -252,8 +252,8 @@ export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
   ],
   search: [
     'Durchsuche Grüne Positionen und Programme...',
-    'Wälze die Parteiprogramme...',
-    'Stöbere in den Beschlüssen...',
+    'Wälze die Unterlagen...',
+    'Stöbere in den Grünen Dokumenten...',
   ],
   // person: 'Suche Informationen zur Person...', // DISABLED: Person search not production ready
   web: [

--- a/packages/chat/src/lib/progressLabels.ts
+++ b/packages/chat/src/lib/progressLabels.ts
@@ -27,12 +27,12 @@ export const STAGE_LABEL_POOLS: Record<LabelledStage, readonly string[]> = {
   ],
   searching: [
     'Stöbere im Archiv …',
-    'Wälze die Parteiprogramme …',
+    'Wälze die Unterlagen …',
     'Durchforste die Quellen …',
-    'Blättere durch die Anträge …',
+    'Blättere durch die Dokumente …',
   ],
   summarizing: [
-    'Bündele die Argumente …',
+    'Bündele die Kernpunkte …',
     'Koche es auf den Punkt ein …',
     'Fasse das Wichtigste zusammen …',
   ],
@@ -40,7 +40,7 @@ export const STAGE_LABEL_POOLS: Record<LabelledStage, readonly string[]> = {
     'Mische die Farben …',
     'Werfe Farbbeutel auf die Leinwand …',
     'Spanne die Leinwand auf …',
-    'Male dein Sharepic …',
+    'Male das Motiv …',
   ],
   generating: ['Formuliere die Antwort …', 'Feile an den Worten …', 'Bringe es aufs Papier …'],
 };

--- a/packages/chat/src/lib/progressLabels.ts
+++ b/packages/chat/src/lib/progressLabels.ts
@@ -19,30 +19,11 @@ type LabelledStage = Extract<
 >;
 
 export const STAGE_LABEL_POOLS: Record<LabelledStage, readonly string[]> = {
-  classifying: [
-    'Sortiere dein Anliegen …',
-    'Stricke einen Plan …',
-    'Lese zwischen den Zeilen …',
-    'Denke kurz nach …',
-  ],
-  searching: [
-    'Stöbere im Archiv …',
-    'Wälze die Unterlagen …',
-    'Durchforste die Quellen …',
-    'Blättere durch die Dokumente …',
-  ],
-  summarizing: [
-    'Bündele die Kernpunkte …',
-    'Koche es auf den Punkt ein …',
-    'Fasse das Wichtigste zusammen …',
-  ],
-  generating_image: [
-    'Mische die Farben …',
-    'Werfe Farbbeutel auf die Leinwand …',
-    'Spanne die Leinwand auf …',
-    'Male das Motiv …',
-  ],
-  generating: ['Formuliere die Antwort …', 'Feile an den Worten …', 'Bringe es aufs Papier …'],
+  classifying: ['Sortiere …', 'Stricke …', 'Überlege …', 'Verstehe …'],
+  searching: ['Durchsuche …', 'Stöbere …', 'Wälze …', 'Blättere …'],
+  summarizing: ['Verdichte …', 'Bündele …', 'Fasse zusammen …'],
+  generating_image: ['Male …', 'Zeichne …', 'Pinsele …', 'Mische …'],
+  generating: ['Formuliere …', 'Schreibe …', 'Feile …', 'Tippe …'],
 };
 
 /**


### PR DESCRIPTION
The themed progress labels from #863 were too long and contained specific nouns that overclaimed scope. This replaces all pools with terse bare-verb forms — "Durchsuche …", "Stricke …", "Verdichte …", "Male …", "Formuliere …" — that stay accurate (a verb alone asserts no false fact about what's searched) and read immediately at a glance.

Frontend `/chat` stages get the confirmed preview set. Backend intent pools (Notebook QA) are shortened to match, keeping a distinguishing word only where two intents would otherwise collapse to the same bare verb (e.g. `web` → "Surfe..." vs `search` → "Durchsuche...").

Verified: `intentPipeline.vitest.ts` 48/48 green.