### PR TITLE
fix(auth): collapse three caches to one, single guard source

### DIFF
--- a/apps/web/src/components/routing/HomeRedirect.tsx
+++ b/apps/web/src/components/routing/HomeRedirect.tsx
@@ -1,6 +1,6 @@
 import { Navigate } from 'react-router-dom';
 
-import { useAuthBootstrapped } from '../../hooks/useAuthBootstrapped';
+import { useAuthBootstrap } from '../../hooks/useAuthBootstrapped';
 import { useAuthStore } from '../../stores/authStore';
 
 import AuthSplash from './AuthSplash';
@@ -20,9 +20,8 @@ interface HomeRedirectProps {
  * guard simple and the special case visible at the call site in App.tsx.
  */
 const HomeRedirect = ({ children }: HomeRedirectProps) => {
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
-  const isBootstrapped = useAuthBootstrapped();
+  const { isBootstrapped, isAuthenticated } = useAuthBootstrap();
 
   if (isLoggingOut) return <>{children}</>;
   if (!isBootstrapped) return <AuthSplash />;

--- a/apps/web/src/components/routing/RequireAuth.tsx
+++ b/apps/web/src/components/routing/RequireAuth.tsx
@@ -17,13 +17,14 @@ import AuthSplash from './AuthSplash';
  * this guard entirely — they are mounted bare in `App.tsx`. The list of
  * public routes is `routes.filter((r) => r.public)` from `config/routes.ts`.
  *
- * Bootstrap state is read from React Query via `useAuthBootstrap()`, not
- * from a mirrored Zustand flag — see that hook for why.
+ * Both the bootstrap signal AND `isAuthenticated` are read from the single
+ * `authStatus` React Query via `useAuthBootstrap()`, not from a mirrored
+ * Zustand flag — see that hook for why. `isLoggingOut` stays on the store: it
+ * is a transient action-flag, not a cached truth.
  */
 const RequireAuth = () => {
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
-  const { isBootstrapped, isError } = useAuthBootstrap();
+  const { isBootstrapped, isError, isAuthenticated } = useAuthBootstrap();
   const location = useLocation();
 
   // During logout the store may momentarily show authenticated from stale

--- a/apps/web/src/components/utils/apiClient.ts
+++ b/apps/web/src/components/utils/apiClient.ts
@@ -130,11 +130,11 @@ async function shouldRedirectOn401(): Promise<boolean> {
 // ─────────────────────────────────────────────────────────────────────
 //
 // Background: backend-detected dead sessions used to leave the frontend's
-// `localStorage['authState']` and Zustand-persisted `gruenerator_auth_state`
-// claiming the user was authenticated. After `performLoginRedirect()`
-// triggered a full-page navigation to /login, the next mount read those
-// stale caches and `GuestRoute` bounced the user straight back to
-// /workplace — where the next API call 401'd again. Infinite loop.
+// `localStorage['authState']` instant-auth cache claiming the user was
+// authenticated. After `performLoginRedirect()` triggered a full-page
+// navigation to /login, the next mount read that stale cache and `GuestRoute`
+// bounced the user straight back to /workplace — where the next API call
+// 401'd again. Infinite loop.
 //
 // Two defenses are applied here, in order:
 //   1. Before redirecting, wipe the caches AND set `LOGOUT_TIMESTAMP` so

--- a/apps/web/src/features/auth/storageKeys.ts
+++ b/apps/web/src/features/auth/storageKeys.ts
@@ -1,18 +1,15 @@
 /**
  * Central registry of all storage keys touched by the auth flow.
  *
- * Auth state is duplicated across multiple storage layers (Zustand persist,
- * useAuth instant-cache, logout/login intent timestamps, redirect counter).
+ * Auth state touches multiple storage layers (useAuth instant-cache,
+ * logout/login intent timestamps, redirect counter).
  * Spreading the literal key strings across files invites typo divergence —
  * one file removes `authState`, another reads `authstate`, neither errors.
  * Anything that reads or writes these keys must import from here.
  */
 
-// Zustand-persisted full auth snapshot (user + flags). 15min TTL.
-export const PERSISTED_AUTH_STATE = 'gruenerator_auth_state';
-export const PERSISTED_AUTH_VERSION = 'gruenerator_auth_cache_version';
-
 // useInstantAuth synchronous-seed cache (just isAuthenticated + minimal user). 5min TTL.
+// This is the single persisted auth cache — React Query seeds `initialData` from it.
 export const INSTANT_AUTH_CACHE = 'authState';
 
 // Cooldown markers — gates `useAuth` from auto-re-authing right after a logout/dead session.
@@ -30,10 +27,16 @@ export const REDIRECT_TIMESTAMPS = 'gruenerator_redirect_timestamps';
  * All localStorage keys that hold any form of "user is authenticated" hint.
  * Use this when nuking auth state in defensive paths (circuit breaker, dead
  * session detection): iterate and remove rather than risking a typo.
+ *
+ * The two `gruenerator_auth_state*` entries are LEGACY — the Zustand-persisted
+ * snapshot was removed (auth state now lives solely in React Query's
+ * instant-auth cache). They are kept here as literals only so the defensive
+ * wipe still purges stale copies left in returning users' browsers; no live
+ * code reads or writes them.
  */
 export const ALL_AUTH_LOCAL_KEYS = [
-  PERSISTED_AUTH_STATE,
-  PERSISTED_AUTH_VERSION,
+  'gruenerator_auth_state',
+  'gruenerator_auth_cache_version',
   INSTANT_AUTH_CACHE,
   LOGOUT_TIMESTAMP,
   LOGIN_INTENT,

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -63,7 +63,7 @@ interface AuthOptions {
   instant?: boolean;
 }
 
-interface AuthData {
+export interface AuthData {
   isAuthenticated: boolean;
   user?: UserProfile;
 }

--- a/apps/web/src/hooks/useAuthBootstrapped.ts
+++ b/apps/web/src/hooks/useAuthBootstrapped.ts
@@ -1,32 +1,46 @@
 import { useQuery } from '@tanstack/react-query';
 
-/**
- * Returns `true` once the canonical `authStatus` query has answered at least
- * once this page load — whether the answer was "authenticated" or "guest".
- * Returns `false` only while the query is still pending its first resolution.
- *
- * Why this exists as its own hook instead of a Zustand flag: the source of
- * truth for "have we asked the server yet?" already lives in the React Query
- * cache. Mirroring it into a Zustand store via `useEffect` was the pattern
- * that hid the cold-start splash hang in PR #782 — guards inside the mirror
- * forgot to flip the bit on the "already-guest" branch. Reading the query
- * status directly removes the mirror, removes the guards, removes the bug.
- *
- * `enabled: false` makes this consumer read-only. It subscribes to the cache
- * populated by `AuthBootstrap`'s active fetch (or by React Query's
- * `initialData` from the instant-auth cache). React Query dedupes by
- * `queryKey`, so both subscribers see the same status.
- */
-/**
- * Same read-only subscription as `useAuthBootstrapped`, but also surfaces
- * whether the probe *errored* (server unreachable / transient failure) rather
- * than answering. `RequireAuth` needs this distinction: an errored probe with
- * no cached session must not bounce the user to `/login` — login can't reach
- * the server either. A `success` status with a guest answer still redirects.
- */
-export const useAuthBootstrap = (): { isBootstrapped: boolean; isError: boolean } => {
-  const { status } = useQuery({ queryKey: ['authStatus'], enabled: false });
-  return { isBootstrapped: status !== 'pending', isError: status === 'error' };
-};
+import { type AuthData } from './useAuth';
 
-export const useAuthBootstrapped = (): boolean => useAuthBootstrap().isBootstrapped;
+/**
+ * Read-only subscription to the canonical `authStatus` query — the single
+ * source of truth for the app's auth gate. Returns three derived signals:
+ *
+ *   - `isBootstrapped` — `true` once the query has answered at least once this
+ *     page load (whether "authenticated", "guest", or "errored"); `false` only
+ *     while still pending its first resolution. With `initialData` from the
+ *     instant-auth cache the query resolves synchronously on the warm path, so
+ *     the splash never flashes.
+ *   - `isError` — the probe errored (server unreachable / transient failure)
+ *     rather than answering. `RequireAuth` uses this so an errored probe with
+ *     no cached session holds the splash instead of bouncing to `/login` —
+ *     login can't reach the server either. A `success` answer of "guest" still
+ *     redirects.
+ *   - `isAuthenticated` — derived from the query's `data`, NOT a mirrored
+ *     Zustand flag. Sourcing both "have we resolved?" and "are we authed?" from
+ *     the *same* query is what removes the two-clock desync: a stale Zustand
+ *     cache and a fresh React Query state could otherwise disagree
+ *     mid-navigation and bounce a logged-in user to `/login`.
+ *
+ * Why read the query directly instead of a Zustand mirror: mirroring "have we
+ * asked the server yet?" into a store via `useEffect` was the pattern that hid
+ * the cold-start splash hang in PR #782 — guards inside the mirror forgot to
+ * flip the bit on the "already-guest" branch. Reading the query status removes
+ * the mirror, the guards, and the bug.
+ *
+ * `enabled: false` makes this consumer read-only — it subscribes to the cache
+ * populated by `AuthBootstrap`'s active fetch (or by `initialData`). React
+ * Query dedupes by `queryKey`, so every subscriber sees the same state.
+ */
+export const useAuthBootstrap = (): {
+  isBootstrapped: boolean;
+  isError: boolean;
+  isAuthenticated: boolean;
+} => {
+  const { status, data } = useQuery<AuthData>({ queryKey: ['authStatus'], enabled: false });
+  return {
+    isBootstrapped: status !== 'pending',
+    isError: status === 'error',
+    isAuthenticated: data?.isAuthenticated === true,
+  };
+};

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -3,13 +3,7 @@ import { type UserProfile } from '@gruenerator/contracts';
 import { create } from 'zustand';
 
 import apiClient, { setLoggingOutFlag } from '../components/utils/apiClient';
-import {
-  INSTANT_AUTH_CACHE,
-  LOGIN_INTENT,
-  LOGOUT_TIMESTAMP,
-  PERSISTED_AUTH_STATE,
-  PERSISTED_AUTH_VERSION,
-} from '../features/auth/storageKeys';
+import { INSTANT_AUTH_CACHE, LOGIN_INTENT, LOGOUT_TIMESTAMP } from '../features/auth/storageKeys';
 import { authClient } from '../lib/authClient';
 import { openDesktopLogin, type AuthSource } from '../utils/desktopAuth';
 import { isDesktopApp } from '../utils/platform';
@@ -52,14 +46,6 @@ export interface ApiResponse<T = unknown> {
   error?: string;
   data?: T;
   [key: string]: unknown;
-}
-
-interface PersistedAuthState {
-  user: User | null;
-  isAuthenticated: boolean;
-  selectedMessageColor: string;
-  locale: SupportedLocale;
-  isLoading: boolean;
 }
 
 export interface AuthStore {
@@ -109,15 +95,10 @@ function detectBrowserLocale(): SupportedLocale {
   return 'de-DE';
 }
 
-// Cache version + TTL config. Storage key constants live in `features/auth/storageKeys.ts`
-// so every read/write site shares the same literal — see that file for the rationale.
-const AUTH_STORAGE_KEY = PERSISTED_AUTH_STATE;
-const AUTH_VERSION_KEY = PERSISTED_AUTH_VERSION;
+// Storage key aliases. The literals live in `features/auth/storageKeys.ts` so every
+// read/write site shares the same string — see that file for the rationale.
 const LOGOUT_TIMESTAMP_KEY = LOGOUT_TIMESTAMP;
 const LOGIN_INTENT_KEY = LOGIN_INTENT;
-const AUTH_CACHE_VERSION = '1.2'; // Increment to invalidate old cache
-const AUTH_EXPIRY_TIME = 15 * 60 * 1000; // 15 minutes (increased from 10)
-const LOGOUT_COOLDOWN_TIME = 60 * 1000; // 1 minute cooldown after logout
 
 // Helper functions for legacy compatibility (deprecated)
 const legacyHelpers = {
@@ -146,103 +127,26 @@ const legacyHelpers = {
   },
 };
 
-// Helper to load persisted auth state
-const loadPersistedAuthState = (): PersistedAuthState | null => {
-  try {
-    // Check if user recently logged out
-    const logoutTimestamp = localStorage.getItem(LOGOUT_TIMESTAMP_KEY);
-    if (logoutTimestamp && Date.now() - parseInt(logoutTimestamp) < LOGOUT_COOLDOWN_TIME) {
-      return null;
-    }
-
-    // Check cache version first
-    const storedVersion = localStorage.getItem(AUTH_VERSION_KEY);
-    if (storedVersion !== AUTH_CACHE_VERSION) {
-      localStorage.removeItem(AUTH_STORAGE_KEY);
-      localStorage.setItem(AUTH_VERSION_KEY, AUTH_CACHE_VERSION);
-      return null;
-    }
-
-    const stored = localStorage.getItem(AUTH_STORAGE_KEY);
-    if (stored) {
-      const { authState, timestamp, cacheVersion } = JSON.parse(stored) as {
-        authState: PersistedAuthState;
-        timestamp: number;
-        cacheVersion: string;
-      };
-
-      // Double-check cache version in stored data
-      if (cacheVersion !== AUTH_CACHE_VERSION) {
-        localStorage.removeItem(AUTH_STORAGE_KEY);
-        return null;
-      }
-
-      // Check if stored state is still valid (not expired)
-      if (timestamp && Date.now() - timestamp < AUTH_EXPIRY_TIME) {
-        return {
-          user: authState.user,
-          isAuthenticated: authState.isAuthenticated,
-          selectedMessageColor: authState.selectedMessageColor || '#008939',
-          locale: authState.locale || 'de-DE',
-          isLoading: false, // Don't start in loading state if we have persisted data
-        };
-      } else {
-        // Remove expired data
-        localStorage.removeItem(AUTH_STORAGE_KEY);
-      }
-    }
-  } catch {
-    localStorage.removeItem(AUTH_STORAGE_KEY);
-    localStorage.removeItem(AUTH_VERSION_KEY);
-  }
-  return null;
-};
-
-// Helper to persist auth state
-const persistAuthState = (authState: Partial<AuthStore>): void => {
-  try {
-    const dataToStore = {
-      authState: {
-        user: authState.user,
-        isAuthenticated: authState.isAuthenticated,
-        selectedMessageColor: authState.selectedMessageColor,
-        locale: authState.locale,
-      },
-      timestamp: Date.now(),
-      cacheVersion: AUTH_CACHE_VERSION,
-    };
-
-    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(dataToStore));
-    localStorage.setItem(AUTH_VERSION_KEY, AUTH_CACHE_VERSION);
-  } catch (error) {
-    // If storage is full, try to clear some space
-    if (error instanceof Error && error.name === 'QuotaExceededError') {
-      localStorage.removeItem(AUTH_STORAGE_KEY);
-      localStorage.removeItem(AUTH_VERSION_KEY);
-    }
-  }
-};
-
-// Load initial state from localStorage if available
-const persistedState = loadPersistedAuthState();
-
 /**
  * Zustand store for authentication state management
  */
 export const useAuthStore = create<AuthStore>((set, get) => ({
-  // Auth state - use persisted state if available, otherwise defaults
-  user: persistedState?.user || null,
-  isAuthenticated: persistedState?.isAuthenticated || false,
+  // Auth state — Zustand no longer persists to localStorage. React Query's
+  // instant-auth cache (seeded via `initialData` in useAuth) is the single
+  // source of truth for a warm start; this store is a pure in-memory mirror,
+  // populated by the queryFn's `applyAuthAnswer` → `setAuthState`.
+  user: null,
+  isAuthenticated: false,
   // Intentionally always false on init — server must reconfirm every load.
   hasServerConfirmed: false,
-  isLoading: persistedState ? false : true, // Don't start loading if we have persisted data
+  isLoading: true,
   error: null,
   isLoggingOut: false, // New state to track logout in progress
 
-  selectedMessageColor: persistedState?.selectedMessageColor || '#008939', // Default Klee
+  selectedMessageColor: '#008939', // Default Klee
 
   // Locale/language preference
-  locale: persistedState?.locale || detectBrowserLocale(),
+  locale: detectBrowserLocale(),
 
   // Main actions
   setAuthState: (data: AuthStateData) => {
@@ -279,10 +183,6 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
   clearAuth: () => {
     // CRITICAL: Set logout timestamp to prevent immediate re-auth
     localStorage.setItem(LOGOUT_TIMESTAMP_KEY, Date.now().toString());
-
-    // CRITICAL: Clear ALL persisted auth data to prevent data leakage
-    localStorage.removeItem(AUTH_STORAGE_KEY);
-    localStorage.removeItem(AUTH_VERSION_KEY);
 
     // Clear the instant-auth cache used by useInstantAuth() / getCachedAuthState()
     // Without this, LoginPage reads stale cached auth and causes redirect loops.
@@ -702,17 +602,6 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
 // Export legacy helpers for backward compatibility
 export { legacyHelpers };
-
-// Subscribe to changes and persist them to localStorage
-useAuthStore.subscribe((state) => {
-  // Only persist if the user is authenticated to avoid overwriting with null
-  if (state.isAuthenticated && state.user) {
-    persistAuthState(state);
-  }
-});
-
-// Legacy initialization - no longer needed with new auth system
-// Auth state is now managed via backend API calls in useAuth hook
 
 // Helper to set login intent (clears logout timestamp)
 const setLoginIntent = () => {

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -23,19 +23,6 @@ export interface AuthState {
   locale: 'de-DE' | 'de-AT';
 }
 
-export interface PersistedAuthState {
-  user: User | null;
-  isAuthenticated: boolean;
-  selectedMessageColor: string;
-  locale: 'de-DE' | 'de-AT';
-}
-
-export interface AuthStorageData {
-  authState: PersistedAuthState;
-  timestamp: number;
-  cacheVersion: string;
-}
-
 export interface ProfileData {
   display_name?: string;
   email?: string;


### PR DESCRIPTION
## Summary

Stabilizes the intermittent "Willkommen zurück" redirect that bounced
logged-in users to `/login?redirectTo=…` mid-navigation. Companion to
#854 — that PR fixed the *throw* path (`probeAuthStatus` + retry without
teardown); this PR removes the cache topology that made the
*success*-path desync still possible.

The bug was a two-axis desync, not a single line:

- **Three persistence caches** — Zustand-persisted `gruenerator_auth_state`
  (15 min, with its own version key, expiry, and `subscribe` write
  trigger), React Query's `INSTANT_AUTH_CACHE` (5 min, only-positive
  caching), and Better Auth's 300 s cookie cache. Cache 1 could expire
  while cache 2 still seeded `initialData`.
- **Two runtime decision sources** — `RequireAuth` read `isAuthenticated`
  from Zustand and `isBootstrapped` from React Query. In the desync
  window above, the guard saw `isBootstrapped=true` AND
  `isAuthenticated=false` in the same render → immediate redirect with
  `?redirectTo=`.

This change collapses both axes:

- `authStore.ts` — delete `loadPersistedAuthState` / `persistAuthState`
  / the `subscribe` block / the entire 15 min Zustand cache. `user` and
  `isAuthenticated` become a pure in-memory mirror written only by
  `applyAuthAnswer`.
- `useAuthBootstrap()` now also returns `isAuthenticated`, typed off
  the exported `AuthData` via `useQuery<AuthData>`. The orphan
  `useAuthBootstrapped` boolean is removed.
- `RequireAuth` and `HomeRedirect` read `isAuthenticated` from the
  hook, not Zustand. `isLoggingOut` stays on the store (transient
  action-flag, not cached truth). `RequireAuth` keeps master's
  `isError` branch as defense-in-depth.
- `storageKeys.ts` / `types/auth.ts` / `apiClient.ts` — drop the dead
  `PERSISTED_AUTH_*` keys and orphan `PersistedAuthState` /
  `AuthStorageData` types; legacy literals kept inline in
  `ALL_AUTH_LOCAL_KEYS` so the defensive wipe still purges stale
  localStorage on returning users' browsers.

100 % typesafe — no new casts, no `as unknown`, no `@ts-expect-error`;
`UserProfile` from `@gruenerator/contracts` stays the single source of
truth for the user shape.

## Test plan

- [x] `pnpm --filter @gruenerator/web typecheck` — passes locally
- [ ] **Repro pre-fix** — mock `authClient.getSession()` to return
      `{ data: null, error: null }` from a reachable server; on master
      this redirects to `/login` mid-navigation, on this branch it does
      not (success-path desync gone).
- [ ] Genuine logout still redirects to `/login`
- [ ] OAuth (Keycloak/Authentik) callback still lands directly on
      `/workplace` — no bounce
- [ ] Idle-tab session expiry — delete the session cookie in devtools,
      focus the tab, `refetchOnWindowFocus` → `200+null` definitive
      guest → redirect
- [ ] Returning user with stale `gruenerator_auth_state` in localStorage
      from a pre-PR session: app loads cleanly; if the circuit breaker
      ever trips, `wipeAllAuthCaches` still removes the legacy key via
      `ALL_AUTH_LOCAL_KEYS`