### PR TITLE
fix(chat): resolve system-agent icons in WelcomeScreen

### DIFF
--- a/packages/chat/src/lib/agentIcons.ts
+++ b/packages/chat/src/lib/agentIcons.ts
@@ -1,0 +1,32 @@
+import {
+  PiBird,
+  PiBookOpenText,
+  PiBuildings,
+  PiChatsCircle,
+  PiFileText,
+  PiHandHeart,
+  PiMagnifyingGlass,
+  PiMegaphone,
+  PiMicrophone,
+  PiSparkle,
+} from 'react-icons/pi';
+import type { SkillIcon } from '@gruenerator/shared/agents';
+
+const AGENT_ICON_REGISTRY: Record<string, SkillIcon> = {
+  sparkle: PiSparkle,
+  megaphone: PiMegaphone,
+  buildings: PiBuildings,
+  'magnifying-glass': PiMagnifyingGlass,
+  'chats-circle': PiChatsCircle,
+  microphone: PiMicrophone,
+  'book-open-text': PiBookOpenText,
+  'hand-heart': PiHandHeart,
+  'file-text': PiFileText,
+  bird: PiBird,
+};
+
+export function resolveAgentIcon(identifier: string, iconKey?: string): SkillIcon | undefined {
+  if (identifier.startsWith('gruenerator-oeffentlichkeitsarbeit')) return PiMegaphone;
+  if (!iconKey) return undefined;
+  return AGENT_ICON_REGISTRY[iconKey];
+}

--- a/packages/chat/src/lib/useActiveAgentMeta.ts
+++ b/packages/chat/src/lib/useActiveAgentMeta.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { SKILLS, getSystemAgent, localizeAgent, type SkillIcon } from '@gruenerator/shared/agents';
 import { agentsList } from './agents';
+import { resolveAgentIcon } from './agentIcons';
 import { useScopedAgentId } from './useScopedAgentState';
 
 export interface ActiveAgentMeta {
@@ -28,7 +29,7 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
     if (!selectedAgentId) return null;
     // The resolved icon component lives on the skills catalog; system agents
     // and skills that share an identifier reuse the same branding.
-    const icon = agentsList.find((a) => a.identifier === selectedAgentId)?.icon;
+    const skillIcon = agentsList.find((a) => a.identifier === selectedAgentId)?.icon;
     const rawAgent = getSystemAgent(selectedAgentId);
     if (rawAgent) {
       // Prefer the canonical system-agent metadata when navigating via URL or
@@ -36,6 +37,11 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
       // (e.g. "Pressemitteilung" instead of "Öffentlichkeitsarbeit") when
       // multiple skills share an identifier.
       const agent = localizeAgent(rawAgent, userLocale);
+      // System agents that aren't in the skills catalog (e.g. `gruenerator-suche`)
+      // still carry their own `iconKey` — resolve it here so WelcomeScreen
+      // doesn't silently fall back to the emoji avatar.
+      const icon: SkillIcon | undefined =
+        skillIcon ?? resolveAgentIcon(selectedAgentId, agent.iconKey);
       return {
         identifier: selectedAgentId,
         avatar: agent.avatar,
@@ -52,7 +58,7 @@ export function useActiveAgentMeta(userLocale: string = 'de-DE'): ActiveAgentMet
     return {
       identifier: selectedAgentId,
       avatar: skill.avatar,
-      ...(icon ? { icon } : {}),
+      ...(skillIcon ? { icon: skillIcon } : {}),
       title: skill.title,
       description: skill.description,
     };


### PR DESCRIPTION
After PR #860 fixed the per-skill icon rendering, one path still silently fell back to the emoji avatar: `useActiveAgentMeta` only resolved the icon component via the skills catalog (`agentsList.find(...)?.icon`). Non-skill system agents (e.g. `gruenerator-suche`) carry their own `iconKey: 'magnifying-glass'`, but the hook never read it — so `WelcomeScreen` showed the legacy emoji when you opened a fresh chat with one of those agents.

This adds a chat-package-local registry mirroring `apps/web/.../sidebarAgentConfig.ts:getAgentIcon`'s shorthand→Phosphor mapping, and threads it through as the system-agent fallback. The skills branch is unchanged — skill icons keep coming from the catalog. The two registries duplicate 10 entries today; deduping across the package boundary is a separate follow-up.