### PR TITLE
feat(notebook): redesign editor as dedicated page, raise doc cap to 100

### DIFF
--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -202,10 +202,10 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return { status: 400 as const, body: { error: 'Name is required' } };
       }
 
-      if (Array.isArray(document_ids) && document_ids.length > 20) {
+      if (Array.isArray(document_ids) && document_ids.length > 100) {
         return {
           status: 400 as const,
-          body: { error: 'A notebook can contain at most 20 documents' },
+          body: { error: 'A notebook can contain at most 100 documents' },
         };
       }
 
@@ -361,10 +361,10 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return { status: 400 as const, body: { error: 'Name is required' } };
       }
 
-      if (Array.isArray(document_ids) && document_ids.length > 20) {
+      if (Array.isArray(document_ids) && document_ids.length > 100) {
         return {
           status: 400 as const,
-          body: { error: 'A notebook can contain at most 20 documents' },
+          body: { error: 'A notebook can contain at most 100 documents' },
         };
       }
 

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -144,6 +144,16 @@ const MyNotebooksPage = lazy(() =>
     default: m.MyNotebooksPage,
   }))
 );
+const NotebookCreatePage = lazy(() =>
+  import('../features/notebook/components/NotebookEditorPage').then((m) => ({
+    default: m.NotebookCreatePage,
+  }))
+);
+const NotebookEditPage = lazy(() =>
+  import('../features/notebook/components/NotebookEditorPage').then((m) => ({
+    default: m.NotebookEditPage,
+  }))
+);
 const DocumentViewPage = lazy(() => import('../features/documents/DocumentViewPage'));
 const Reel = lazy(() => import('../features/subtitler/components/SubtitlerPage'));
 const SubtitlerBetaPage = lazy(
@@ -289,6 +299,16 @@ const standardRoutes: RouteConfig[] = [
     path: '/notebooks/meine',
     component: GrueneratorenBundle.MyNotebooks,
     withForm: true,
+    layoutMode: 'sidebarOnly',
+  },
+  {
+    path: '/notebooks/meine/neu',
+    component: NotebookCreatePage,
+    layoutMode: 'sidebarOnly',
+  },
+  {
+    path: '/notebooks/meine/:id/bearbeiten',
+    component: NotebookEditPage,
     layoutMode: 'sidebarOnly',
   },
   {

--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -1,4 +1,3 @@
-import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,19 +44,15 @@ import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
-import NotebookEditor from './NotebookEditor';
-
 import type { NotebookCollection } from '../../../types/notebook';
 
 type DialogPhase =
   | { kind: 'closed' }
-  | { kind: 'create' }
-  | { kind: 'edit'; collection: NotebookCollection }
   | { kind: 'rename'; collection: NotebookCollection }
   | { kind: 'delete'; collection: NotebookCollection };
 
 const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.odt', '.rtf'];
-const MAX_DOCUMENTS_PER_NOTEBOOK = 20;
+const MAX_DOCUMENTS_PER_NOTEBOOK = 100;
 
 function hasFileDrag(e: DragEvent): boolean {
   return Array.from(e.dataTransfer.types).includes('Files');
@@ -271,14 +266,9 @@ function MyNotebooksPageInner() {
   const queryClient = useQueryClient();
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
   const uploadFileOnly = useDocumentsStore((s) => s.uploadFileOnly);
-  const {
-    query,
-    createQACollection,
-    updateQACollection,
-    deleteQACollection,
-    isCreating,
-    isUpdating,
-  } = useNotebookCollections({ isActive: true });
+  const { query, updateQACollection, deleteQACollection, isUpdating } = useNotebookCollections({
+    isActive: true,
+  });
   const [phase, setPhase] = useState<DialogPhase>({ kind: 'closed' });
   const [processingCollectionIds, setProcessingCollectionIds] = useState<Set<string>>(
     () => new Set()
@@ -312,50 +302,6 @@ function MyNotebooksPageInner() {
       closeDialog();
     },
     [updateQACollection, closeDialog]
-  );
-
-  const handleEditSave = useCallback(
-    async (collection: NotebookCollection, data: NotebookEditorSavePayload) => {
-      const originalIds = new Set((collection.documents ?? []).map((doc) => String(doc.id)));
-      const addedIds = data.documents.filter((id) => !originalIds.has(id));
-
-      await updateQACollection(collection.id, {
-        name: data.name,
-        description: data.description,
-        documents: data.documents,
-        labels: data.labels,
-        selectionMode: collection.selection_mode,
-        custom_prompt: collection.custom_prompt,
-      });
-      closeDialog();
-
-      if (addedIds.length > 0) {
-        setProcessingCollectionIds((prev) => new Set(prev).add(collection.id));
-        void Promise.all(addedIds.map((id) => pollDocumentStatus(id))).finally(() => {
-          setProcessingCollectionIds((prev) => {
-            if (!prev.has(collection.id)) return prev;
-            const next = new Set(prev);
-            next.delete(collection.id);
-            return next;
-          });
-          void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
-        });
-      }
-    },
-    [updateQACollection, closeDialog, pollDocumentStatus, queryClient]
-  );
-
-  const handleCreateSave = useCallback(
-    async (data: NotebookEditorSavePayload) => {
-      await createQACollection({
-        name: data.name,
-        description: data.description,
-        documents: data.documents,
-        labels: data.labels,
-      });
-      closeDialog();
-    },
-    [createQACollection, closeDialog]
   );
 
   const handleDeleteConfirm = useCallback(
@@ -439,7 +385,7 @@ function MyNotebooksPageInner() {
         subtitle="Verwalte deine eigenen Notebooks. Ziehe Dateien direkt auf eine Karte, um sie hinzuzufügen."
       >
         <div className="mb-lg flex justify-end">
-          <Button onClick={() => setPhase({ kind: 'create' })}>
+          <Button onClick={() => void navigate('/notebooks/meine/neu')}>
             <HiPlus className="mr-1" /> Neues Notebook
           </Button>
         </div>
@@ -464,7 +410,7 @@ function MyNotebooksPageInner() {
                 Erstelle dein erstes Notebook, um Dokumente und Quellen zu bündeln.
               </div>
             </div>
-            <Button onClick={() => setPhase({ kind: 'create' })}>
+            <Button onClick={() => void navigate('/notebooks/meine/neu')}>
               <HiPlus className="mr-1" /> Eigenes Notebook erstellen
             </Button>
           </div>
@@ -477,7 +423,7 @@ function MyNotebooksPageInner() {
                 isProcessing={processingCollectionIds.has(c.id)}
                 onOpen={handleOpen}
                 onRename={(col) => setPhase({ kind: 'rename', collection: col })}
-                onEdit={(col) => setPhase({ kind: 'edit', collection: col })}
+                onEdit={(col) => void navigate(`/notebooks/meine/${col.id}/bearbeiten`)}
                 onShare={handleShare}
                 onDelete={(col) => setPhase({ kind: 'delete', collection: col })}
                 onAddFiles={handleAddFilesToCard}
@@ -503,38 +449,6 @@ function MyNotebooksPageInner() {
               }
             />
           ) : null}
-        </Dialog>
-
-        {/* Full editor dialog (create or edit) */}
-        <Dialog
-          open={phase.kind === 'create' || phase.kind === 'edit'}
-          onOpenChange={(open) => {
-            if (!open && !isCreating && !isUpdating) closeDialog();
-          }}
-        >
-          <DialogContent
-            className="sm:max-w-[min(1200px,calc(100%-2rem))] w-[calc(100%-1rem)] max-h-[90dvh] overflow-y-auto p-0 [&>[data-slot=dialog-close]]:hidden"
-            aria-describedby={undefined}
-          >
-            <DialogTitle className="sr-only">
-              {phase.kind === 'edit' ? 'Notebook bearbeiten' : 'Notebook erstellen'}
-            </DialogTitle>
-            {phase.kind === 'edit' ? (
-              <NotebookEditor
-                editingCollection={phase.collection}
-                loading={isUpdating}
-                onCancel={closeDialog}
-                onSave={(data) => handleEditSave(phase.collection, data)}
-              />
-            ) : phase.kind === 'create' ? (
-              <NotebookEditor
-                editingCollection={null}
-                loading={isCreating}
-                onCancel={closeDialog}
-                onSave={handleCreateSave}
-              />
-            ) : null}
-          </DialogContent>
         </Dialog>
 
         {/* Delete confirmation */}

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -29,50 +29,29 @@ interface UploadedDocument {
 }
 
 const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.odt', '.rtf'];
-const MAX_DOCUMENTS = 20;
+const MAX_DOCUMENTS = 100;
 
-function getFileTypeBadge(filename: string): { label: string; tagClass: string } {
+function getFileTypeStyle(filename: string): { label: string; borderClass: string } {
   const ext = filename.toLowerCase().split('.').pop() ?? '';
   switch (ext) {
     case 'pdf':
-      return {
-        label: 'PDF',
-        tagClass: 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300',
-      };
+      return { label: 'PDF', borderClass: 'border-red-300 dark:border-red-900/50' };
     case 'docx':
-      return {
-        label: 'DOCX',
-        tagClass: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
-      };
+      return { label: 'DOCX', borderClass: 'border-blue-300 dark:border-blue-900/50' };
     case 'doc':
-      return {
-        label: 'DOC',
-        tagClass: 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300',
-      };
+      return { label: 'DOC', borderClass: 'border-blue-300 dark:border-blue-900/50' };
     case 'odt':
-      return {
-        label: 'ODT',
-        tagClass: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300',
-      };
+      return { label: 'ODT', borderClass: 'border-emerald-300 dark:border-emerald-900/50' };
     case 'rtf':
-      return {
-        label: 'RTF',
-        tagClass: 'bg-orange-100 text-orange-700 dark:bg-orange-950/40 dark:text-orange-300',
-      };
+      return { label: 'RTF', borderClass: 'border-orange-300 dark:border-orange-900/50' };
     case 'md':
-      return {
-        label: 'MD',
-        tagClass: 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-      };
+      return { label: 'MD', borderClass: 'border-slate-300 dark:border-slate-700' };
     case 'txt':
-      return {
-        label: 'TXT',
-        tagClass: 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-      };
+      return { label: 'TXT', borderClass: 'border-slate-300 dark:border-slate-700' };
     default:
       return {
         label: ext.slice(0, 4).toUpperCase() || 'FILE',
-        tagClass: 'bg-grey-200 text-grey-700 dark:bg-grey-800 dark:text-grey-300',
+        borderClass: 'border-grey-300 dark:border-grey-700',
       };
   }
 }
@@ -305,50 +284,28 @@ const NotebookEditor = ({
 
   return (
     <motion.div
-      className="p-md sm:p-lg"
+      className="relative p-lg sm:p-xl"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
     >
       <div>
-        {/* Header: title - dots - close */}
-        <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-sm pb-md">
-          <span className="text-base font-semibold text-foreground truncate">
-            {editingCollection
-              ? 'Notebook bearbeiten'
-              : step === 1
-                ? 'Dokument hochladen'
-                : 'Notebook erstellen'}
-          </span>
-
-          {!editingCollection && (
-            <div className="flex items-center justify-center gap-2">
-              <div
-                className={cn(
-                  'size-2 rounded-full transition-all duration-250',
-                  step === 1 ? 'bg-primary-500 scale-125' : 'bg-primary-500 opacity-45'
-                )}
-              />
-              <div
-                className={cn(
-                  'size-2 rounded-full transition-all duration-250',
-                  step === 2 ? 'bg-primary-500 scale-125' : 'bg-grey-300'
-                )}
-              />
-            </div>
-          )}
-
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="justify-self-end rounded-full"
-            onClick={handleCancel}
-            disabled={isUploading || loading}
-            aria-label="Schließen"
-          >
-            <HiX size={18} />
-          </Button>
-        </div>
+        {!editingCollection && (
+          <div className="flex items-center justify-center gap-2 pb-md">
+            <div
+              className={cn(
+                'size-2 rounded-full transition-all duration-250',
+                step === 1 ? 'bg-primary-500 scale-125' : 'bg-primary-500 opacity-45'
+              )}
+            />
+            <div
+              className={cn(
+                'size-2 rounded-full transition-all duration-250',
+                step === 2 ? 'bg-primary-500 scale-125' : 'bg-grey-300'
+              )}
+            />
+          </div>
+        )}
 
         <AnimatePresence mode="wait">
           {step === 1 && !editingCollection ? (
@@ -414,9 +371,8 @@ const NotebookEditor = ({
               exit={{ opacity: 0, x: 20 }}
               transition={{ duration: 0.2 }}
             >
-              <form onSubmit={handleSubmit(onSubmit)} className="space-y-md">
-                {/* Compact header: name / description / labels — click to edit */}
-                <section className="rounded-xl bg-background-alt/50 px-sm py-sm">
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-lg">
+                <section className="rounded-xl bg-background-alt/50 px-md py-md">
                   {editing === 'name' ? (
                     <input
                       type="text"
@@ -434,7 +390,7 @@ const NotebookEditor = ({
                           setEditing(null);
                         }
                       }}
-                      className="w-full bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-grey-400"
+                      className="w-full bg-transparent text-xl font-semibold text-foreground outline-none placeholder:text-grey-400"
                     />
                   ) : (
                     <button
@@ -445,7 +401,7 @@ const NotebookEditor = ({
                     >
                       <span
                         className={cn(
-                          'truncate text-lg font-semibold leading-tight',
+                          'truncate text-xl font-semibold leading-tight',
                           watchedName ? 'text-foreground' : 'italic text-grey-400'
                         )}
                       >
@@ -486,7 +442,7 @@ const NotebookEditor = ({
                     >
                       <span
                         className={cn(
-                          'line-clamp-1 text-sm',
+                          'line-clamp-2 text-sm leading-relaxed',
                           watchedDesc ? 'text-grey-600 dark:text-grey-300' : 'italic text-grey-400'
                         )}
                       >
@@ -499,7 +455,7 @@ const NotebookEditor = ({
                     </button>
                   )}
 
-                  <div className="mt-sm flex flex-wrap items-center gap-xs">
+                  <div className="mt-md flex flex-wrap items-center gap-xs">
                     {labels.map((label) => (
                       <Badge
                         key={label}
@@ -570,7 +526,7 @@ const NotebookEditor = ({
 
                 {/* Documents: cards + dropzone */}
                 {uploadedDocuments.length > 0 && (
-                  <div className="space-y-xs">
+                  <div className="space-y-sm">
                     <div className="flex items-baseline justify-between px-1">
                       <label className="text-xs font-medium uppercase tracking-wide text-grey-500">
                         Dokumente
@@ -579,57 +535,26 @@ const NotebookEditor = ({
                         {uploadedDocuments.length}/{MAX_DOCUMENTS}
                       </span>
                     </div>
-                    <div className="grid grid-cols-1 gap-sm md:grid-cols-2 xl:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
                       {uploadedDocuments.map((doc) => {
                         const isIndexing = indexingDocIds.has(doc.id);
-                        const fileType = getFileTypeBadge(doc.filename || doc.title);
+                        const fileType = getFileTypeStyle(doc.filename || doc.title);
                         return (
                           <div
                             key={doc.id}
                             className={cn(
-                              'group relative flex items-center gap-sm rounded-xl border border-grey-200 bg-background p-sm min-w-0 transition-all duration-200 dark:border-grey-800',
-                              isIndexing
-                                ? 'opacity-90'
-                                : 'hover:border-grey-300 hover:shadow-sm dark:hover:border-grey-700'
+                              'group relative flex min-h-[112px] min-w-0 flex-col gap-xs rounded-xl border-2 bg-background p-md transition-all duration-200',
+                              fileType.borderClass,
+                              isIndexing ? 'opacity-90' : 'hover:shadow-sm'
                             )}
+                            aria-label={`${fileType.label}: ${doc.filename || doc.title}`}
                           >
-                            <span
-                              className={cn(
-                                'shrink-0 rounded-md px-1.5 py-[3px] text-[10px] font-semibold uppercase tracking-wide',
-                                fileType.tagClass,
-                                isIndexing && 'opacity-60'
-                              )}
-                              aria-hidden
-                            >
-                              {fileType.label}
-                            </span>
-                            <div className="min-w-0 flex-1">
-                              <div
-                                className="truncate text-sm font-medium text-foreground"
-                                title={doc.filename || doc.title}
-                              >
-                                {doc.filename || doc.title}
-                              </div>
-                              <div className="mt-[2px] flex items-center gap-xs text-xs text-grey-500">
-                                {isIndexing ? (
-                                  <>
-                                    <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                                    <span>Wird verarbeitet…</span>
-                                  </>
-                                ) : (
-                                  <>
-                                    <HiCheckCircle size={12} className="text-green-600" />
-                                    <span>Bereit</span>
-                                  </>
-                                )}
-                              </div>
-                            </div>
                             <Button
                               type="button"
                               variant="ghost"
                               size="icon-xs"
                               className={cn(
-                                'shrink-0 transition-opacity',
+                                'absolute right-1 top-1 transition-opacity',
                                 isIndexing
                                   ? 'opacity-60'
                                   : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
@@ -640,6 +565,25 @@ const NotebookEditor = ({
                             >
                               <HiX size={12} />
                             </Button>
+                            <div
+                              className="line-clamp-3 break-words pr-6 text-sm font-medium leading-snug text-foreground"
+                              title={doc.filename || doc.title}
+                            >
+                              {doc.filename || doc.title}
+                            </div>
+                            <div className="mt-auto flex items-center gap-xs text-xs text-grey-500">
+                              {isIndexing ? (
+                                <>
+                                  <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                                  <span>Wird verarbeitet…</span>
+                                </>
+                              ) : (
+                                <>
+                                  <HiCheckCircle size={12} className="text-green-600" />
+                                  <span>Bereit</span>
+                                </>
+                              )}
+                            </div>
                           </div>
                         );
                       })}
@@ -647,7 +591,7 @@ const NotebookEditor = ({
                     {uploadedDocuments.length < MAX_DOCUMENTS && (
                       <div
                         className={cn(
-                          'flex min-h-[52px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-sm transition-colors duration-200',
+                          'flex min-h-[64px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-md py-sm transition-colors duration-200',
                           isDragOver
                             ? 'border-primary-500 bg-green-50 dark:bg-secondary-900'
                             : 'border-grey-300 hover:border-primary-500 hover:bg-background dark:border-grey-600',
@@ -691,7 +635,7 @@ const NotebookEditor = ({
                   </div>
                 )}
 
-                <div className="flex flex-wrap justify-end gap-sm pt-md border-t border-grey-200 dark:border-grey-700">
+                <div className="flex flex-wrap justify-end gap-sm pt-lg border-t border-grey-200 dark:border-grey-700">
                   {!editingCollection && (
                     <Button
                       type="button"

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -1,0 +1,157 @@
+import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
+import { Button, toast } from '@gruenerator/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { HiArrowLeft } from 'react-icons/hi';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
+import PageContainer from '../../../components/common/PageContainer';
+import ErrorBoundary from '../../../components/ErrorBoundary';
+import { useDocumentsStore } from '../../../stores/documentsStore';
+import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+
+import NotebookEditor from './NotebookEditor';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+interface NotebookEditorPageProps {
+  mode: 'create' | 'edit';
+}
+
+function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const params = useParams<{ id: string }>();
+  const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
+  const { query, createQACollection, updateQACollection, isCreating, isUpdating } =
+    useNotebookCollections({ isActive: true });
+
+  const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
+  const editingCollection = useMemo<NotebookCollection | null>(() => {
+    if (mode !== 'edit' || !params.id) return null;
+    return collections.find((c) => c.id === params.id) ?? null;
+  }, [collections, mode, params.id]);
+
+  const goBack = useCallback(() => {
+    void navigate('/notebooks/meine');
+  }, [navigate]);
+
+  const handleEditSave = useCallback(
+    async (collection: NotebookCollection, data: NotebookEditorSavePayload) => {
+      const originalIds = new Set((collection.documents ?? []).map((doc) => String(doc.id)));
+      const addedIds = data.documents.filter((id) => !originalIds.has(id));
+
+      await updateQACollection(collection.id, {
+        name: data.name,
+        description: data.description,
+        documents: data.documents,
+        labels: data.labels,
+        selectionMode: collection.selection_mode,
+        custom_prompt: collection.custom_prompt,
+      });
+
+      toast.success(`Notebook „${data.name}" gespeichert`);
+      goBack();
+
+      if (addedIds.length > 0) {
+        void Promise.all(addedIds.map((id) => pollDocumentStatus(id))).finally(() => {
+          void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+        });
+      }
+    },
+    [updateQACollection, goBack, pollDocumentStatus, queryClient]
+  );
+
+  const handleCreateSave = useCallback(
+    async (data: NotebookEditorSavePayload) => {
+      await createQACollection({
+        name: data.name,
+        description: data.description,
+        documents: data.documents,
+        labels: data.labels,
+      });
+      toast.success(`Notebook „${data.name}" erstellt`);
+      goBack();
+    },
+    [createQACollection, goBack]
+  );
+
+  const isEditMissing = mode === 'edit' && !query.isLoading && !editingCollection;
+
+  return (
+    <ErrorBoundary>
+      <PageContainer maxWidth="lg" noPadTop>
+        <div className="mb-md">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={goBack}
+            className="-ml-2 gap-xs text-grey-500 hover:text-foreground"
+          >
+            <HiArrowLeft size={14} />
+            Meine Notebooks
+          </Button>
+        </div>
+
+        {mode === 'edit' && query.isLoading ? (
+          <div className="rounded-2xl border border-grey-200 bg-background p-xl dark:border-grey-800">
+            <div className="h-7 w-1/3 animate-pulse rounded bg-grey-100 dark:bg-grey-900" />
+            <div className="mt-md h-4 w-2/3 animate-pulse rounded bg-grey-100 dark:bg-grey-900" />
+            <div className="mt-xl grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-28 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900"
+                />
+              ))}
+            </div>
+          </div>
+        ) : isEditMissing ? (
+          <div className="flex flex-col items-center gap-md rounded-2xl border border-dashed border-grey-300 p-xl text-center dark:border-grey-700">
+            <div className="text-base font-medium text-foreground-heading">
+              Dieses Notebook existiert nicht oder wurde gelöscht.
+            </div>
+            <Button onClick={goBack}>Zurück zu Meine Notebooks</Button>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-grey-200 bg-background dark:border-grey-800">
+            {mode === 'edit' && editingCollection ? (
+              <NotebookEditor
+                editingCollection={editingCollection}
+                loading={isUpdating}
+                onCancel={goBack}
+                onSave={(data) => handleEditSave(editingCollection, data)}
+              />
+            ) : (
+              <NotebookEditor
+                editingCollection={null}
+                loading={isCreating}
+                onCancel={goBack}
+                onSave={handleCreateSave}
+              />
+            )}
+          </div>
+        )}
+      </PageContainer>
+    </ErrorBoundary>
+  );
+}
+
+function NotebookCreatePageInner() {
+  return <NotebookEditorPageInner mode="create" />;
+}
+
+function NotebookEditPageInner() {
+  return <NotebookEditorPageInner mode="edit" />;
+}
+
+export const NotebookCreatePage = withAuthRequired(NotebookCreatePageInner, {
+  title: 'Notebook erstellen',
+});
+
+export const NotebookEditPage = withAuthRequired(NotebookEditPageInner, {
+  title: 'Notebook bearbeiten',
+});
+
+export default NotebookEditPage;


### PR DESCRIPTION
The popup-based notebook editor crowded out filenames with PDF/DOCX badges and capped notebooks at 20 documents — too few for the real workflows users have built around it. Moving the editor onto its own page at `/notebooks/meine/neu` and `/notebooks/meine/:id/bearbeiten` (with the existing `sidebarOnly` layout) lets the notebook's own title/description/labels serve as the page hero instead of a static "Notebook bearbeiten" string, and gives the document grid room to breathe (vertical cards, colored borders by filetype, 4 columns at xl). The 20→100 cap rises symmetrically on both ends — frontend constant in `NotebookEditor.tsx` + `MyNotebooksPage.tsx` (drag-to-card uploader) and the two hardcoded `> 20` checks in `notebookCollectionsContractRouter.ts`.

`MyNotebooksPage` keeps the rename and delete dialogs but loses the create/edit dialog block (and `NotebookEditor` import) — its "Neues Notebook" buttons and the dropdown's "Bearbeiten" entry now navigate to the new routes.

## Test plan
- [ ] `/notebooks/meine` → "Neues Notebook" navigates to `/notebooks/meine/neu`, dropzone renders, uploads work, save returns to list
- [ ] `/notebooks/meine` → dropdown → "Bearbeiten" navigates to `/notebooks/meine/:id/bearbeiten`, edits persist, "← Meine Notebooks" returns
- [ ] Upload >20 files into one notebook — counter shows `21/100`, backend accepts; 101st triggers the "übersprungen — maximal 100 Dateien" toast
- [ ] Cards show colored borders matching filetype (PDF red, DOCX blue, ODT emerald, RTF orange, MD/TXT slate), no PDF/DOCX text badge
- [ ] Dark mode reads cleanly against `bg-background`
- [ ] xl viewport reflows the doc grid to 4 columns

## Note
`pnpm --filter @gruenerator/web lint` fails on a pre-existing reference to `apps/web/src/features/research/ResearchPage.tsx` that was deleted in `78af12e7b` — unrelated to this PR. Typecheck is clean.