### PR TITLE
refactor(notebook): flatten editor page, use @gruenerator/ui primitives

### DIFF
--- a/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
+++ b/apps/web/src/features/notebook/components/MyNotebooksPage.tsx
@@ -10,17 +10,11 @@ import {
   Badge,
   Button,
   Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Input,
   toast,
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -43,6 +37,8 @@ import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+
+import { RenameNotebookDialog } from './RenameNotebookDialog';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
@@ -202,64 +198,6 @@ const NotebookManagementCard = memo(function NotebookManagementCard({
     </div>
   );
 });
-
-function RenameDialog({
-  collection,
-  isUpdating,
-  onCancel,
-  onSubmit,
-}: {
-  collection: NotebookCollection;
-  isUpdating: boolean;
-  onCancel: () => void;
-  onSubmit: (name: string, description: string) => void;
-}) {
-  const [name, setName] = useState(collection.name);
-  const [description, setDescription] = useState(collection.description ?? '');
-  const canSave = name.trim().length > 0 && !isUpdating;
-
-  return (
-    <DialogContent className="sm:max-w-[480px]">
-      <DialogHeader>
-        <DialogTitle>Notebook umbenennen</DialogTitle>
-        <DialogDescription>
-          Ändere den Namen und die Beschreibung deines Notebooks.
-        </DialogDescription>
-      </DialogHeader>
-      <div className="flex flex-col gap-md py-sm">
-        <div className="flex flex-col gap-xs">
-          <label htmlFor="rename-name" className="text-sm font-medium">
-            Name
-          </label>
-          <Input
-            id="rename-name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            autoFocus
-          />
-        </div>
-        <div className="flex flex-col gap-xs">
-          <label htmlFor="rename-description" className="text-sm font-medium">
-            Beschreibung
-          </label>
-          <Input
-            id="rename-description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-          />
-        </div>
-      </div>
-      <DialogFooter>
-        <Button variant="ghost" onClick={onCancel} disabled={isUpdating}>
-          Abbrechen
-        </Button>
-        <Button onClick={() => onSubmit(name.trim(), description.trim())} disabled={!canSave}>
-          Speichern
-        </Button>
-      </DialogFooter>
-    </DialogContent>
-  );
-}
 
 function MyNotebooksPageInner() {
   const navigate = useNavigate();
@@ -440,7 +378,7 @@ function MyNotebooksPageInner() {
           }}
         >
           {phase.kind === 'rename' ? (
-            <RenameDialog
+            <RenameNotebookDialog
               collection={phase.collection}
               isUpdating={isUpdating}
               onCancel={closeDialog}

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,5 +1,5 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
-import { Badge, Button } from '@gruenerator/ui';
+import { Badge, Button, Input, Separator } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
@@ -283,12 +283,7 @@ const NotebookEditor = ({
   };
 
   return (
-    <motion.div
-      className="relative p-lg sm:p-xl"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.3 }}
-    >
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
       <div>
         {!editingCollection && (
           <div className="flex items-center justify-center gap-2 pb-md">
@@ -372,166 +367,167 @@ const NotebookEditor = ({
               transition={{ duration: 0.2 }}
             >
               <form onSubmit={handleSubmit(onSubmit)} className="space-y-lg">
-                <section className="rounded-xl bg-background-alt/50 px-md py-md">
-                  {editing === 'name' ? (
-                    <input
-                      type="text"
-                      defaultValue={watchedName}
-                      autoFocus
-                      maxLength={100}
-                      placeholder="Name des Notebooks"
-                      onBlur={(e) => commitName(e.currentTarget.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          commitName(e.currentTarget.value);
-                        } else if (e.key === 'Escape') {
-                          e.preventDefault();
-                          setEditing(null);
-                        }
-                      }}
-                      className="w-full bg-transparent text-xl font-semibold text-foreground outline-none placeholder:text-grey-400"
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => setEditing('name')}
-                      className="group flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background"
-                      aria-label="Name bearbeiten"
-                    >
-                      <span
-                        className={cn(
-                          'truncate text-xl font-semibold leading-tight',
-                          watchedName ? 'text-foreground' : 'italic text-grey-400'
-                        )}
-                      >
-                        {watchedName || 'Notebook benennen…'}
-                      </span>
-                      <HiPencil
-                        size={12}
-                        className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
+                {!editingCollection && (
+                  <section className="space-y-xs">
+                    {editing === 'name' ? (
+                      <input
+                        type="text"
+                        defaultValue={watchedName}
+                        autoFocus
+                        maxLength={100}
+                        placeholder="Name des Notebooks"
+                        onBlur={(e) => commitName(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            commitName(e.currentTarget.value);
+                          } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            setEditing(null);
+                          }
+                        }}
+                        className="w-full bg-transparent text-2xl font-semibold text-foreground outline-none placeholder:text-grey-400"
                       />
-                    </button>
-                  )}
-
-                  {editing === 'desc' ? (
-                    <textarea
-                      defaultValue={watchedDesc}
-                      autoFocus
-                      rows={3}
-                      maxLength={500}
-                      placeholder="Kurze Beschreibung…"
-                      onBlur={(e) => commitDesc(e.currentTarget.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                          e.preventDefault();
-                          commitDesc(e.currentTarget.value);
-                        } else if (e.key === 'Escape') {
-                          e.preventDefault();
-                          setEditing(null);
-                        }
-                      }}
-                      className="mt-xs w-full resize-none rounded-md border border-grey-200 bg-background px-sm py-xs text-sm text-foreground outline-none placeholder:text-grey-400 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-grey-700"
-                    />
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => setEditing('desc')}
-                      className="group mt-[2px] flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background"
-                      aria-label="Beschreibung bearbeiten"
-                    >
-                      <span
-                        className={cn(
-                          'line-clamp-2 text-sm leading-relaxed',
-                          watchedDesc ? 'text-grey-600 dark:text-grey-300' : 'italic text-grey-400'
-                        )}
-                      >
-                        {watchedDesc || 'Beschreibung hinzufügen…'}
-                      </span>
-                      <HiPencil
-                        size={11}
-                        className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
-                      />
-                    </button>
-                  )}
-
-                  <div className="mt-md flex flex-wrap items-center gap-xs">
-                    {labels.map((label) => (
-                      <Badge
-                        key={label}
-                        variant="secondary"
-                        className="gap-1 border-transparent bg-secondary-600 text-xs text-white"
-                      >
-                        {label}
-                        <button
-                          type="button"
-                          className="ml-0.5 inline-flex items-center hover:text-grey-200"
-                          onClick={() => handleRemoveLabel(label)}
-                          aria-label={`Label "${label}" entfernen`}
-                        >
-                          <HiX size={11} />
-                        </button>
-                      </Badge>
-                    ))}
-                    {editing === 'labels' ? (
-                      <div className="flex items-center gap-xs">
-                        <input
-                          type="text"
-                          value={newLabel}
-                          autoFocus
-                          onChange={(e) => setNewLabel(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                              e.preventDefault();
-                              handleAddLabel();
-                            } else if (e.key === 'Escape') {
-                              e.preventDefault();
-                              setNewLabel('');
-                              setEditing(null);
-                            }
-                          }}
-                          onBlur={() => {
-                            if (!newLabel.trim()) setEditing(null);
-                          }}
-                          placeholder="Label…"
-                          maxLength={30}
-                          disabled={loading || labels.length >= 10}
-                          className="w-32 rounded-md border border-grey-300 bg-background px-sm py-[2px] text-xs text-foreground placeholder:text-grey-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-grey-600"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          onClick={handleAddLabel}
-                          disabled={loading || !newLabel.trim() || labels.length >= 10}
-                          aria-label="Label hinzufügen"
-                        >
-                          <HiPlus size={12} />
-                        </Button>
-                      </div>
                     ) : (
-                      labels.length < 10 && (
-                        <button
-                          type="button"
-                          onClick={() => setEditing('labels')}
-                          className="inline-flex items-center gap-1 rounded-full border border-dashed border-grey-300 px-2 py-[2px] text-xs text-grey-500 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-grey-600"
+                      <button
+                        type="button"
+                        onClick={() => setEditing('name')}
+                        className="group flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background-alt/50"
+                        aria-label="Name bearbeiten"
+                      >
+                        <span
+                          className={cn(
+                            'truncate text-2xl font-semibold leading-tight',
+                            watchedName ? 'text-foreground-heading' : 'italic text-grey-400'
+                          )}
                         >
-                          <HiPlus size={10} />
-                          {labels.length === 0 ? 'Label hinzufügen' : 'Weiteres Label'}
-                        </button>
-                      )
+                          {watchedName || 'Notebook benennen…'}
+                        </span>
+                        <HiPencil
+                          size={14}
+                          className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
+                        />
+                      </button>
                     )}
-                  </div>
+
+                    {editing === 'desc' ? (
+                      <textarea
+                        defaultValue={watchedDesc}
+                        autoFocus
+                        rows={3}
+                        maxLength={500}
+                        placeholder="Kurze Beschreibung…"
+                        onBlur={(e) => commitDesc(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                            e.preventDefault();
+                            commitDesc(e.currentTarget.value);
+                          } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            setEditing(null);
+                          }
+                        }}
+                        className="w-full resize-none rounded-md border border-grey-200 bg-background px-sm py-xs text-sm text-foreground outline-none placeholder:text-grey-400 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 dark:border-grey-700"
+                      />
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => setEditing('desc')}
+                        className="group flex w-full items-center gap-xs rounded-md px-1 py-[2px] text-left transition-colors hover:bg-background-alt/50"
+                        aria-label="Beschreibung bearbeiten"
+                      >
+                        <span
+                          className={cn(
+                            'line-clamp-2 text-base leading-relaxed',
+                            watchedDesc
+                              ? 'text-grey-600 dark:text-grey-300'
+                              : 'italic text-grey-400'
+                          )}
+                        >
+                          {watchedDesc || 'Beschreibung hinzufügen…'}
+                        </span>
+                        <HiPencil
+                          size={12}
+                          className="ml-auto shrink-0 text-grey-400 opacity-0 transition-opacity group-hover:opacity-60"
+                        />
+                      </button>
+                    )}
+                  </section>
+                )}
+
+                <section className="flex flex-wrap items-center gap-xs">
+                  {labels.map((label) => (
+                    <Badge
+                      key={label}
+                      variant="secondary"
+                      className="gap-1 border-transparent bg-secondary-600 text-xs text-white"
+                    >
+                      {label}
+                      <button
+                        type="button"
+                        className="ml-0.5 inline-flex items-center hover:text-grey-200"
+                        onClick={() => handleRemoveLabel(label)}
+                        aria-label={`Label "${label}" entfernen`}
+                      >
+                        <HiX size={11} />
+                      </button>
+                    </Badge>
+                  ))}
+                  {editing === 'labels' ? (
+                    <div className="flex items-center gap-xs">
+                      <Input
+                        type="text"
+                        value={newLabel}
+                        autoFocus
+                        onChange={(e) => setNewLabel(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            handleAddLabel();
+                          } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            setNewLabel('');
+                            setEditing(null);
+                          }
+                        }}
+                        onBlur={() => {
+                          if (!newLabel.trim()) setEditing(null);
+                        }}
+                        placeholder="Label…"
+                        maxLength={30}
+                        disabled={loading || labels.length >= 10}
+                        className="h-7 w-32 text-xs"
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={handleAddLabel}
+                        disabled={loading || !newLabel.trim() || labels.length >= 10}
+                        aria-label="Label hinzufügen"
+                      >
+                        <HiPlus size={12} />
+                      </Button>
+                    </div>
+                  ) : (
+                    labels.length < 10 && (
+                      <button
+                        type="button"
+                        onClick={() => setEditing('labels')}
+                        className="inline-flex items-center gap-1 rounded-full border border-dashed border-grey-300 px-2 py-[2px] text-xs text-grey-500 transition-colors hover:border-primary-500 hover:text-primary-600 dark:border-grey-600"
+                      >
+                        <HiPlus size={10} />
+                        {labels.length === 0 ? 'Label hinzufügen' : 'Weiteres Label'}
+                      </button>
+                    )
+                  )}
                 </section>
 
-                {/* Documents: cards + dropzone */}
                 {uploadedDocuments.length > 0 && (
-                  <div className="space-y-sm">
-                    <div className="flex items-baseline justify-between px-1">
-                      <label className="text-xs font-medium uppercase tracking-wide text-grey-500">
-                        Dokumente
-                      </label>
-                      <span className="text-xs text-grey-500">
+                  <div className="space-y-md">
+                    <div className="flex items-baseline justify-between">
+                      <h2 className="text-xl font-semibold text-foreground-heading">Dokumente</h2>
+                      <span className="text-sm text-grey-500">
                         {uploadedDocuments.length}/{MAX_DOCUMENTS}
                       </span>
                     </div>
@@ -635,7 +631,8 @@ const NotebookEditor = ({
                   </div>
                 )}
 
-                <div className="flex flex-wrap justify-end gap-sm pt-lg border-t border-grey-200 dark:border-grey-700">
+                <Separator />
+                <div className="flex flex-wrap justify-end gap-sm">
                   {!editingCollection && (
                     <Button
                       type="button"

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -1,8 +1,17 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
-import { Button, toast } from '@gruenerator/ui';
+import {
+  Button,
+  Dialog,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  toast,
+} from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
-import { HiArrowLeft } from 'react-icons/hi';
+import { useCallback, useMemo, useState } from 'react';
+import { HiArrowLeft, HiPencil } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
@@ -12,6 +21,7 @@ import { useDocumentsStore } from '../../../stores/documentsStore';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
+import { RenameNotebookDialog } from './RenameNotebookDialog';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
@@ -26,6 +36,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
   const { query, createQACollection, updateQACollection, isCreating, isUpdating } =
     useNotebookCollections({ isActive: true });
+  const [renameOpen, setRenameOpen] = useState(false);
 
   const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
   const editingCollection = useMemo<NotebookCollection | null>(() => {
@@ -77,12 +88,31 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
     [createQACollection, goBack]
   );
 
+  const handleRenameSubmit = useCallback(
+    async (collection: NotebookCollection, name: string, description: string) => {
+      if (!name) return;
+      await updateQACollection(collection.id, {
+        name,
+        description: description || undefined,
+        custom_prompt: collection.custom_prompt,
+        selectionMode: collection.selection_mode,
+        labels: collection.labels,
+      });
+      setRenameOpen(false);
+    },
+    [updateQACollection]
+  );
+
   const isEditMissing = mode === 'edit' && !query.isLoading && !editingCollection;
+
+  const pageTitle = mode === 'edit' ? (editingCollection?.name ?? 'Notebook') : 'Neues Notebook';
+  const pageSubtitle =
+    mode === 'edit' && editingCollection?.description ? editingCollection.description : undefined;
 
   return (
     <ErrorBoundary>
       <PageContainer maxWidth="lg" noPadTop>
-        <div className="mb-md">
+        <div className="mb-md flex items-center justify-between">
           <Button
             variant="ghost"
             size="sm"
@@ -92,47 +122,81 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
             <HiArrowLeft size={14} />
             Meine Notebooks
           </Button>
+          {mode === 'edit' && editingCollection ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setRenameOpen(true)}
+              className="gap-xs text-grey-500 hover:text-foreground"
+            >
+              <HiPencil size={14} />
+              Umbenennen
+            </Button>
+          ) : null}
         </div>
 
+        {mode === 'edit' && editingCollection ? (
+          <div className="mb-xl text-center">
+            <h1 className="mb-xs text-4xl font-semibold text-foreground-heading max-md:text-2xl">
+              {pageTitle}
+            </h1>
+            {pageSubtitle ? (
+              <p className="text-lg text-grey-500 dark:text-grey-400">{pageSubtitle}</p>
+            ) : null}
+          </div>
+        ) : null}
+
         {mode === 'edit' && query.isLoading ? (
-          <div className="rounded-2xl border border-grey-200 bg-background p-xl dark:border-grey-800">
-            <div className="h-7 w-1/3 animate-pulse rounded bg-grey-100 dark:bg-grey-900" />
-            <div className="mt-md h-4 w-2/3 animate-pulse rounded bg-grey-100 dark:bg-grey-900" />
-            <div className="mt-xl grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-              {Array.from({ length: 8 }).map((_, i) => (
-                <div
-                  key={i}
-                  className="h-28 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900"
-                />
-              ))}
-            </div>
+          <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-28 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900" />
+            ))}
           </div>
         ) : isEditMissing ? (
-          <div className="flex flex-col items-center gap-md rounded-2xl border border-dashed border-grey-300 p-xl text-center dark:border-grey-700">
-            <div className="text-base font-medium text-foreground-heading">
-              Dieses Notebook existiert nicht oder wurde gelöscht.
-            </div>
-            <Button onClick={goBack}>Zurück zu Meine Notebooks</Button>
-          </div>
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>Notebook nicht gefunden</EmptyTitle>
+              <EmptyDescription>
+                Dieses Notebook existiert nicht oder wurde gelöscht.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button onClick={goBack}>Zurück zu Meine Notebooks</Button>
+            </EmptyContent>
+          </Empty>
+        ) : mode === 'edit' && editingCollection ? (
+          <NotebookEditor
+            editingCollection={editingCollection}
+            loading={isUpdating}
+            onCancel={goBack}
+            onSave={(data) => handleEditSave(editingCollection, data)}
+          />
         ) : (
-          <div className="rounded-2xl border border-grey-200 bg-background dark:border-grey-800">
-            {mode === 'edit' && editingCollection ? (
-              <NotebookEditor
-                editingCollection={editingCollection}
-                loading={isUpdating}
-                onCancel={goBack}
-                onSave={(data) => handleEditSave(editingCollection, data)}
-              />
-            ) : (
-              <NotebookEditor
-                editingCollection={null}
-                loading={isCreating}
-                onCancel={goBack}
-                onSave={handleCreateSave}
-              />
-            )}
-          </div>
+          <NotebookEditor
+            editingCollection={null}
+            loading={isCreating}
+            onCancel={goBack}
+            onSave={handleCreateSave}
+          />
         )}
+
+        <Dialog
+          open={renameOpen}
+          onOpenChange={(open) => {
+            if (!isUpdating) setRenameOpen(open);
+          }}
+        >
+          {renameOpen && editingCollection ? (
+            <RenameNotebookDialog
+              collection={editingCollection}
+              isUpdating={isUpdating}
+              onCancel={() => setRenameOpen(false)}
+              onSubmit={(name, description) =>
+                void handleRenameSubmit(editingCollection, name, description)
+              }
+            />
+          ) : null}
+        </Dialog>
       </PageContainer>
     </ErrorBoundary>
   );

--- a/apps/web/src/features/notebook/components/RenameNotebookDialog.tsx
+++ b/apps/web/src/features/notebook/components/RenameNotebookDialog.tsx
@@ -1,0 +1,71 @@
+import {
+  Button,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@gruenerator/ui';
+import { useState } from 'react';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+interface RenameNotebookDialogProps {
+  collection: NotebookCollection;
+  isUpdating: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string, description: string) => void;
+}
+
+export function RenameNotebookDialog({
+  collection,
+  isUpdating,
+  onCancel,
+  onSubmit,
+}: RenameNotebookDialogProps) {
+  const [name, setName] = useState(collection.name);
+  const [description, setDescription] = useState(collection.description ?? '');
+  const canSave = name.trim().length > 0 && !isUpdating;
+
+  return (
+    <DialogContent className="sm:max-w-[480px]">
+      <DialogHeader>
+        <DialogTitle>Notebook umbenennen</DialogTitle>
+        <DialogDescription>
+          Ändere den Namen und die Beschreibung deines Notebooks.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="flex flex-col gap-md py-sm">
+        <div className="flex flex-col gap-xs">
+          <Label htmlFor="rename-name">Name</Label>
+          <Input
+            id="rename-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+          />
+        </div>
+        <div className="flex flex-col gap-xs">
+          <Label htmlFor="rename-description">Beschreibung</Label>
+          <Input
+            id="rename-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </div>
+      </div>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onCancel} disabled={isUpdating}>
+          Abbrechen
+        </Button>
+        <Button onClick={() => onSubmit(name.trim(), description.trim())} disabled={!canSave}>
+          Speichern
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+}
+
+export default RenameNotebookDialog;


### PR DESCRIPTION
Follow-up to #870. The shipped page wrapped the editor body in a `rounded-2xl` card and used a soft green panel for the inline-edit name/description — both layers fought the visual rhythm of the rest of the app. This drops the card chrome, switches the page hero to a centered `<h1>` + subtitle pattern matching WorkplacePage / NotebooksIndexPage, and replaces ad-hoc inputs/dividers with `@gruenerator/ui` primitives (`Input`, `Separator`, `Empty` family).

`RenameDialog` lifted out of `MyNotebooksPage` into its own `RenameNotebookDialog.tsx` so the editor page can open it from a new "Umbenennen" button — that's how name/description are edited in edit mode (the in-form inline-edit is hidden there to avoid two sources of truth). Create mode keeps inline-edit name/description (no collection to rename yet) but without the green panel background.

## Test plan
- [ ] `/notebooks/meine/:id/bearbeiten` — back link top-left, "Umbenennen" top-right, centered h1 with notebook name + subtitle, no outer card border, labels row + Dokumente h2 with `n/100` counter + grid + dropzone + Separator + Aktualisieren button
- [ ] Click "Umbenennen" → RenameDialog opens, pre-filled. Submit invalidates the collections query and the hero refreshes with the new name on next paint
- [ ] `/notebooks/meine/neu` step 1 → just back link + dropzone (no centered hero). After upload, step 2 reveals inline-editable title/description without panel background, plus labels + docs + footer
- [ ] `/notebooks/meine/<bogus-uuid>/bearbeiten` → renders Empty primitive with "Zurück zu Meine Notebooks" CTA
- [ ] `/notebooks/meine` rename dialog still works (post-extraction regression)
- [ ] Dark mode: Separator and hover affordances readable