### PR TITLE
refactor(notebook): inline-edit hero, drag overlay, corner-accent tiles

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Input, Separator } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { HiCheckCircle, HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
+import { HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
@@ -31,29 +31,33 @@ interface UploadedDocument {
 const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.odt', '.rtf'];
 const MAX_DOCUMENTS = 100;
 
-function getFileTypeStyle(filename: string): { label: string; borderClass: string } {
+function getFileTypeStyle(filename: string): { label: string; cornerClass: string } {
   const ext = filename.toLowerCase().split('.').pop() ?? '';
   switch (ext) {
     case 'pdf':
-      return { label: 'PDF', borderClass: 'border-red-300 dark:border-red-900/50' };
+      return { label: 'PDF', cornerClass: 'bg-red-400 dark:bg-red-700' };
     case 'docx':
-      return { label: 'DOCX', borderClass: 'border-blue-300 dark:border-blue-900/50' };
+      return { label: 'DOCX', cornerClass: 'bg-blue-400 dark:bg-blue-700' };
     case 'doc':
-      return { label: 'DOC', borderClass: 'border-blue-300 dark:border-blue-900/50' };
+      return { label: 'DOC', cornerClass: 'bg-blue-400 dark:bg-blue-700' };
     case 'odt':
-      return { label: 'ODT', borderClass: 'border-emerald-300 dark:border-emerald-900/50' };
+      return { label: 'ODT', cornerClass: 'bg-emerald-400 dark:bg-emerald-700' };
     case 'rtf':
-      return { label: 'RTF', borderClass: 'border-orange-300 dark:border-orange-900/50' };
+      return { label: 'RTF', cornerClass: 'bg-orange-400 dark:bg-orange-700' };
     case 'md':
-      return { label: 'MD', borderClass: 'border-slate-300 dark:border-slate-700' };
+      return { label: 'MD', cornerClass: 'bg-slate-400 dark:bg-slate-600' };
     case 'txt':
-      return { label: 'TXT', borderClass: 'border-slate-300 dark:border-slate-700' };
+      return { label: 'TXT', cornerClass: 'bg-slate-400 dark:bg-slate-600' };
     default:
       return {
         label: ext.slice(0, 4).toUpperCase() || 'FILE',
-        borderClass: 'border-grey-300 dark:border-grey-700',
+        cornerClass: 'bg-grey-400 dark:bg-grey-600',
       };
   }
+}
+
+function hasFileDrag(e: DragEvent): boolean {
+  return Array.from(e.dataTransfer.types).includes('Files');
 }
 
 interface NotebookEditorProps {
@@ -202,7 +206,8 @@ const NotebookEditor = ({
   );
 
   const handleDrop = useCallback(
-    (e: DragEvent<HTMLDivElement>) => {
+    (e: DragEvent<HTMLElement>) => {
+      if (!hasFileDrag(e)) return;
       e.preventDefault();
       setIsDragOver(false);
       const files = Array.from(e.dataTransfer.files ?? []);
@@ -211,13 +216,20 @@ const NotebookEditor = ({
     [handleFilesUpload]
   );
 
-  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+  const handleDragEnter = useCallback((e: DragEvent<HTMLElement>) => {
+    if (!hasFileDrag(e)) return;
     e.preventDefault();
     setIsDragOver(true);
   }, []);
 
-  const handleDragLeave = useCallback((e: DragEvent<HTMLDivElement>) => {
+  const handleDragOver = useCallback((e: DragEvent<HTMLElement>) => {
+    if (!hasFileDrag(e)) return;
     e.preventDefault();
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLElement>) => {
+    if (!hasFileDrag(e)) return;
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
     setIsDragOver(false);
   }, []);
 
@@ -322,6 +334,7 @@ const NotebookEditor = ({
                       isUploading && 'cursor-default opacity-85'
                     )}
                     onDrop={handleDrop}
+                    onDragEnter={handleDragEnter}
                     onDragOver={handleDragOver}
                     onDragLeave={handleDragLeave}
                     onClick={() => !isUploading && fileInputRef.current?.click()}
@@ -523,14 +536,39 @@ const NotebookEditor = ({
                   )}
                 </section>
 
-                {uploadedDocuments.length > 0 && (
-                  <div className="space-y-md">
-                    <div className="flex items-baseline justify-between">
-                      <h2 className="text-xl font-semibold text-foreground-heading">Dokumente</h2>
+                <section
+                  className="relative space-y-md"
+                  onDragEnter={handleDragEnter}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                >
+                  <div className="flex items-center justify-between gap-md">
+                    <h2 className="text-xl font-semibold text-foreground-heading">Dokumente</h2>
+                    <div className="flex items-center gap-sm">
                       <span className="text-sm text-grey-500">
                         {uploadedDocuments.length}/{MAX_DOCUMENTS}
                       </span>
+                      <Button
+                        type="button"
+                        size="icon-sm"
+                        variant="outline"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={
+                          loading || isUploading || uploadedDocuments.length >= MAX_DOCUMENTS
+                        }
+                        aria-label="Dokumente hinzufügen"
+                      >
+                        <HiPlus size={16} />
+                      </Button>
                     </div>
+                  </div>
+
+                  {uploadedDocuments.length === 0 ? (
+                    <p className="py-lg text-center text-sm text-grey-500">
+                      Noch keine Dokumente. Ziehe Dateien hierher oder klicke auf +.
+                    </p>
+                  ) : (
                     <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
                       {uploadedDocuments.map((doc) => {
                         const isIndexing = indexingDocIds.has(doc.id);
@@ -539,12 +577,18 @@ const NotebookEditor = ({
                           <div
                             key={doc.id}
                             className={cn(
-                              'group relative flex min-h-[112px] min-w-0 flex-col gap-xs rounded-xl border-2 bg-background p-md transition-all duration-200',
-                              fileType.borderClass,
+                              'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
                               isIndexing ? 'opacity-90' : 'hover:shadow-sm'
                             )}
                             aria-label={`${fileType.label}: ${doc.filename || doc.title}`}
                           >
+                            <div
+                              className={cn(
+                                'pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md',
+                                fileType.cornerClass
+                              )}
+                              aria-hidden
+                            />
                             <Button
                               type="button"
                               variant="ghost"
@@ -567,69 +611,37 @@ const NotebookEditor = ({
                             >
                               {doc.filename || doc.title}
                             </div>
-                            <div className="mt-auto flex items-center gap-xs text-xs text-grey-500">
-                              {isIndexing ? (
-                                <>
-                                  <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                                  <span>Wird verarbeitet…</span>
-                                </>
-                              ) : (
-                                <>
-                                  <HiCheckCircle size={12} className="text-green-600" />
-                                  <span>Bereit</span>
-                                </>
-                              )}
-                            </div>
+                            {isIndexing ? (
+                              <div className="mt-auto flex items-center gap-xs text-xs text-grey-500">
+                                <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                                <span>Wird verarbeitet…</span>
+                              </div>
+                            ) : null}
                           </div>
                         );
                       })}
                     </div>
-                    {uploadedDocuments.length < MAX_DOCUMENTS && (
-                      <div
-                        className={cn(
-                          'flex min-h-[64px] cursor-pointer items-center justify-center gap-sm rounded-lg border-2 border-dashed bg-background-alt px-md py-sm transition-colors duration-200',
-                          isDragOver
-                            ? 'border-primary-500 bg-green-50 dark:bg-secondary-900'
-                            : 'border-grey-300 hover:border-primary-500 hover:bg-background dark:border-grey-600',
-                          (isUploading || loading) && 'cursor-default opacity-60'
-                        )}
-                        onDrop={handleDrop}
-                        onDragOver={handleDragOver}
-                        onDragLeave={handleDragLeave}
-                        onClick={() => {
-                          if (isUploading || loading) return;
-                          fileInputRef.current?.click();
-                        }}
-                      >
-                        {isUploading ? (
-                          <>
-                            <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                            <span className="text-sm text-grey-500">Wird hochgeladen…</span>
-                          </>
-                        ) : (
-                          <>
-                            <HiUpload className="text-grey-400" />
-                            <span className="text-sm font-medium text-foreground">
-                              Weitere Dateien ablegen oder klicken
-                            </span>
-                            <span className="text-xs text-grey-500">
-                              ({MAX_DOCUMENTS - uploadedDocuments.length} verbleibend)
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    )}
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      multiple
-                      accept={ACCEPTED_EXTENSIONS.join(',')}
-                      onChange={handleFileSelect}
-                      style={{ display: 'none' }}
-                    />
-                    {uploadError && <p className="mt-xs text-sm text-red-600">{uploadError}</p>}
-                  </div>
-                )}
+                  )}
+
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    accept={ACCEPTED_EXTENSIONS.join(',')}
+                    onChange={handleFileSelect}
+                    style={{ display: 'none' }}
+                  />
+                  {uploadError && <p className="text-sm text-red-600">{uploadError}</p>}
+
+                  {isDragOver && (
+                    <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center gap-sm rounded-xl border-2 border-dashed border-primary-500 bg-primary-500/10 backdrop-blur-[2px]">
+                      <HiUpload className="text-primary-700 dark:text-primary-300" />
+                      <span className="text-sm font-medium text-primary-700 dark:text-primary-300">
+                        Dateien hier ablegen
+                      </span>
+                    </div>
+                  )}
+                </section>
 
                 <Separator />
                 <div className="flex flex-wrap justify-end gap-sm">

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -1,7 +1,6 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import {
   Button,
-  Dialog,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -11,17 +10,17 @@ import {
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
-import { HiArrowLeft, HiPencil } from 'react-icons/hi';
+import { HiArrowLeft } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import PageContainer from '../../../components/common/PageContainer';
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useDocumentsStore } from '../../../stores/documentsStore';
+import { cn } from '../../../utils/cn';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
-import { RenameNotebookDialog } from './RenameNotebookDialog';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
@@ -36,7 +35,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
   const { query, createQACollection, updateQACollection, isCreating, isUpdating } =
     useNotebookCollections({ isActive: true });
-  const [renameOpen, setRenameOpen] = useState(false);
+  const [editingField, setEditingField] = useState<'name' | 'desc' | null>(null);
 
   const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
   const editingCollection = useMemo<NotebookCollection | null>(() => {
@@ -88,31 +87,46 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
     [createQACollection, goBack]
   );
 
-  const handleRenameSubmit = useCallback(
-    async (collection: NotebookCollection, name: string, description: string) => {
-      if (!name) return;
-      await updateQACollection(collection.id, {
-        name,
-        description: description || undefined,
-        custom_prompt: collection.custom_prompt,
-        selectionMode: collection.selection_mode,
-        labels: collection.labels,
+  const commitHeroName = useCallback(
+    async (raw: string) => {
+      setEditingField(null);
+      if (!editingCollection) return;
+      const trimmed = raw.trim().slice(0, 100);
+      if (!trimmed || trimmed === editingCollection.name) return;
+      await updateQACollection(editingCollection.id, {
+        name: trimmed,
+        description: editingCollection.description ?? undefined,
+        custom_prompt: editingCollection.custom_prompt,
+        selectionMode: editingCollection.selection_mode,
+        labels: editingCollection.labels,
       });
-      setRenameOpen(false);
     },
-    [updateQACollection]
+    [editingCollection, updateQACollection]
+  );
+
+  const commitHeroDesc = useCallback(
+    async (raw: string) => {
+      setEditingField(null);
+      if (!editingCollection) return;
+      const trimmed = raw.trim().slice(0, 500);
+      if (trimmed === (editingCollection.description ?? '')) return;
+      await updateQACollection(editingCollection.id, {
+        name: editingCollection.name,
+        description: trimmed || undefined,
+        custom_prompt: editingCollection.custom_prompt,
+        selectionMode: editingCollection.selection_mode,
+        labels: editingCollection.labels,
+      });
+    },
+    [editingCollection, updateQACollection]
   );
 
   const isEditMissing = mode === 'edit' && !query.isLoading && !editingCollection;
 
-  const pageTitle = mode === 'edit' ? (editingCollection?.name ?? 'Notebook') : 'Neues Notebook';
-  const pageSubtitle =
-    mode === 'edit' && editingCollection?.description ? editingCollection.description : undefined;
-
   return (
     <ErrorBoundary>
       <PageContainer maxWidth="lg" noPadTop>
-        <div className="mb-md flex items-center justify-between">
+        <div className="mb-md">
           <Button
             variant="ghost"
             size="sm"
@@ -122,27 +136,80 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
             <HiArrowLeft size={14} />
             Meine Notebooks
           </Button>
-          {mode === 'edit' && editingCollection ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setRenameOpen(true)}
-              className="gap-xs text-grey-500 hover:text-foreground"
-            >
-              <HiPencil size={14} />
-              Umbenennen
-            </Button>
-          ) : null}
         </div>
 
         {mode === 'edit' && editingCollection ? (
           <div className="mb-xl text-center">
-            <h1 className="mb-xs text-4xl font-semibold text-foreground-heading max-md:text-2xl">
-              {pageTitle}
-            </h1>
-            {pageSubtitle ? (
-              <p className="text-lg text-grey-500 dark:text-grey-400">{pageSubtitle}</p>
-            ) : null}
+            {editingField === 'name' ? (
+              <input
+                autoFocus
+                defaultValue={editingCollection.name}
+                maxLength={100}
+                onBlur={(e) => void commitHeroName(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void commitHeroName(e.currentTarget.value);
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setEditingField(null);
+                  }
+                }}
+                className="mb-xs w-full bg-transparent text-center text-4xl font-semibold text-foreground-heading outline-none max-md:text-2xl"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditingField('name')}
+                disabled={isUpdating}
+                className="mb-xs block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
+                aria-label="Name bearbeiten"
+              >
+                <h1 className="text-4xl font-semibold text-foreground-heading max-md:text-2xl">
+                  {editingCollection.name}
+                </h1>
+              </button>
+            )}
+
+            {editingField === 'desc' ? (
+              <textarea
+                autoFocus
+                rows={2}
+                defaultValue={editingCollection.description ?? ''}
+                maxLength={500}
+                placeholder="Beschreibung hinzufügen…"
+                onBlur={(e) => void commitHeroDesc(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    void commitHeroDesc(e.currentTarget.value);
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setEditingField(null);
+                  }
+                }}
+                className="w-full resize-none bg-transparent text-center text-lg text-grey-500 outline-none placeholder:text-grey-400 dark:text-grey-400"
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setEditingField('desc')}
+                disabled={isUpdating}
+                className="block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
+                aria-label="Beschreibung bearbeiten"
+              >
+                <p
+                  className={cn(
+                    'text-lg',
+                    editingCollection.description
+                      ? 'text-grey-500 dark:text-grey-400'
+                      : 'italic text-grey-400'
+                  )}
+                >
+                  {editingCollection.description || 'Beschreibung hinzufügen…'}
+                </p>
+              </button>
+            )}
           </div>
         ) : null}
 
@@ -179,24 +246,6 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
             onSave={handleCreateSave}
           />
         )}
-
-        <Dialog
-          open={renameOpen}
-          onOpenChange={(open) => {
-            if (!isUpdating) setRenameOpen(open);
-          }}
-        >
-          {renameOpen && editingCollection ? (
-            <RenameNotebookDialog
-              collection={editingCollection}
-              isUpdating={isUpdating}
-              onCancel={() => setRenameOpen(false)}
-              onSubmit={(name, description) =>
-                void handleRenameSubmit(editingCollection, name, description)
-              }
-            />
-          ) : null}
-        </Dialog>
       </PageContainer>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Follow-up tweaks after the redesign in #872. Four polish-passes:

1. **Inline-edit hero** — clicking the centered notebook name or description on the editor page swaps it for an input/textarea wired directly to `updateQACollection`. The previous "Umbenennen" button + dialog flow is gone; `RenameNotebookDialog.tsx` stays for `MyNotebooksPage`'s list-view rename.
2. **Drag overlay instead of always-visible dropzone** — the "Weitere Dateien ablegen oder klicken (98 verbleibend)" box is gone. Drop handlers move to the documents section; a primary-tinted overlay appears only while a file drag is over it. Text drags ignored via `dataTransfer.types.includes('Files')` guard.
3. **Plus button next to "Dokumente"** — icon button to the right of the heading opens the native file picker, matching the WorkplacePage SectionHeader-with-action pattern. Section now renders even at 0 documents so users can re-add after clearing.
4. **Corner-accent tiles** — the 2px filetype-colored border becomes a neutral grey border; a small colored bar in the top-right corner now signals filetype. The "✓ Bereit" status row is gone — status only renders while a doc is still indexing (the more useful state).

## Test plan
- [ ] `/notebooks/meine/:id/bearbeiten` — click the h1 name → input takes over; type a new value → Enter (or blur) saves via PATCH; Esc cancels. Same for the description (Cmd/Ctrl+Enter saves)
- [ ] No "Umbenennen" button in the top row anymore
- [ ] Document tiles: neutral grey border, colored bar in top-right corner per filetype (PDF red, DOCX blue, ODT emerald, RTF orange, MD/TXT slate), no "Bereit" text
- [ ] Drag a file from the OS into the page → dashed primary overlay appears over the documents section, drop uploads, overlay disappears
- [ ] Click the + button next to "Dokumente" → native file picker opens
- [ ] Delete all docs (X on each tile) — "Noch keine Dokumente. Ziehe Dateien hierher oder klicke auf +." renders; + button still works to re-add
- [ ] `/notebooks/meine/neu` create flow still works (step 1 dropzone → step 2 form unchanged in create mode)
- [ ] Newly uploaded doc shows "Wird verarbeitet…" status until indexed, then status row disappears