### PR TITLE
fix(api): populate req.user on notebook contract router

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -308,9 +308,13 @@ export async function setupRoutes(app: Application): Promise<void> {
   mountNotebookCollectionsContractRouter(app);
   app.use('/api/auth/notebook-collections', authenticatedReadLimiter, notebookCollectionsRouter);
   // ts-rest contract router for notebook interaction — mounts BEFORE the
-  // legacy router so contract-modeled routes match first. Mixed auth: the
-  // contract checks req.user per-handler where needed (no requireAuth at
-  // the prefix, which would break the public/:token routes).
+  // legacy router so contract-modeled routes match first. Mixed auth: some
+  // routes are public (`/public/:token`), others require auth. `optionalAuth`
+  // populates `req.user` for valid sessions WITHOUT rejecting unauthenticated
+  // requests, so per-handler `requireAuthUser()` checks can do the actual
+  // gating. Without this middleware `req.user` would always be undefined and
+  // authenticated routes (askMulti, askSingle, researchSearch) would 401.
+  app.use('/api/auth/notebook', optionalAuth);
   mountNotebookContractRouter(app);
   app.use('/api/auth/notebook', authenticatedReadLimiter, notebookInteractionRouter);
   app.use('/api/auth/notebook', authenticatedReadLimiter, notebookRecentDocumentsRouter);


### PR DESCRIPTION
## Why

#871 introduced `POST /api/auth/notebook/:id/research-search`, but every call from the new user-notebook manual research tab 401s. The handler runs (the URL is correct), but `req.user` is undefined because no auth middleware ran upstream.

`askMulti` and `askSingle` have the same bug — they just weren't reached from the production UI before now (chat streams through `/api/chat-graph` instead), so it was latent.

## What

One line on the prefix:

```ts
app.use('/api/auth/notebook', optionalAuth);
mountNotebookContractRouter(app);
```

`optionalAuth` resolves the session and sets `req.user` when valid, but never rejects — so the public `/public/:token` contract routes still work. Per-handler `requireAuthUser()` continues to enforce auth where needed.

This pattern matches what `mountNotebookCollectionsContractRouter` does (line 307) — that one uses `requireAuth` because all its routes are auth'd. The notebook router can't because of the public-token routes, but `optionalAuth` is the right tool for "populate user when present, don't reject when absent."

## Test plan

- [ ] Authenticated `POST /api/auth/notebook/<my-uuid>/research-search` returns 200 (was 401)
- [ ] Unauthenticated request to the same path still 401s (handler enforces it)
- [ ] `GET /api/auth/notebook/public/<token>` still works without auth (public route)
- [ ] System manual search (`/api/research/search`) still works (unchanged)