### PR TITLE
feat(notebook): public notebooks + Von der Basis section

### DIFF
--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -22,6 +22,8 @@ const logger = createLogger('NotebookQdrantHelper');
 // Type Interfaces
 // =============================================================================
 
+type PublicOwnership = 'owner' | 'public_data';
+
 interface NotebookCollectionData {
   id?: string;
   user_id: string;
@@ -38,6 +40,8 @@ interface NotebookCollectionData {
   last_used_at?: string | null;
   created_at?: string;
   updated_at?: string;
+  is_public?: boolean;
+  public_ownership?: PublicOwnership | null;
 }
 
 interface NotebookCollection {
@@ -56,6 +60,8 @@ interface NotebookCollection {
   settings: Record<string, unknown>;
   document_count: number;
   last_used_at: string | null;
+  is_public: boolean;
+  public_ownership: PublicOwnership | null;
   notebook_collection_documents?: CollectionDocument[];
 }
 
@@ -193,6 +199,8 @@ class NotebookQdrantHelper {
           settings: collectionData.settings || {},
           document_count: collectionData.document_count || 0,
           last_used_at: collectionData.last_used_at || null,
+          is_public: collectionData.is_public === true,
+          public_ownership: collectionData.public_ownership ?? null,
         },
       };
 
@@ -603,6 +611,10 @@ class NotebookQdrantHelper {
    * Format collection data from Qdrant payload
    */
   formatCollectionFromPayload(payload: Record<string, unknown>): NotebookCollection {
+    const rawOwnership = payload.public_ownership;
+    const publicOwnership: PublicOwnership | null =
+      rawOwnership === 'owner' || rawOwnership === 'public_data' ? rawOwnership : null;
+
     return {
       id: payload.collection_id as string,
       user_id: payload.user_id as string,
@@ -619,7 +631,39 @@ class NotebookQdrantHelper {
       settings: (payload.settings as Record<string, unknown>) || {},
       document_count: (payload.document_count as number) || 0,
       last_used_at: payload.last_used_at as string | null,
+      is_public: payload.is_public === true,
+      public_ownership: publicOwnership,
     };
+  }
+
+  /**
+   * List all notebook collections marked is_public=true across all users.
+   * Powers the "Von der Basis" community section on /notebooks.
+   */
+  async getPublicNotebookCollections(
+    options: GetCollectionsOptions = {}
+  ): Promise<NotebookCollection[]> {
+    await this.ensureInitialized();
+
+    try {
+      const { limit = 200, offset = 0 } = options;
+
+      const filter: QdrantFilter = {
+        must: [{ key: 'is_public', match: { value: true } }],
+      };
+
+      const results = await this.qdrantOps!.scrollDocuments(
+        this.qdrant.collections.notebook_collections,
+        filter,
+        { limit, offset, withPayload: true }
+      );
+
+      return results.map((result) => this.formatCollectionFromPayload(result.payload));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error listing public Notebook collections: ${message}`);
+      throw new Error(`Failed to list public Notebook collections: ${message}`);
+    }
   }
 
   /**

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -120,6 +120,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         updated_at: string;
         settings?: Record<string, unknown> | undefined;
         notebook_collection_documents?: Array<{ document_id: string }>;
+        is_public?: boolean;
+        public_ownership?: 'owner' | 'public_data' | null;
       };
 
       const collections = (await notebookHelper.getUserNotebookCollections(
@@ -163,6 +165,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             auto_sync: !!collection.auto_sync,
             remove_missing_on_sync: !!collection.remove_missing_on_sync,
             labels,
+            is_public: collection.is_public === true,
+            public_ownership: collection.public_ownership ?? null,
           };
         })
       );
@@ -173,6 +177,74 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       };
     } catch (error) {
       log.error('[notebookCollectionsContract.listCollections] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  listPublicCollections: async () => {
+    try {
+      type NotebookCollectionFromQdrantRaw = {
+        id: string;
+        user_id: string;
+        name: string;
+        description: string | null;
+        custom_prompt: string | null;
+        selection_mode?: string | undefined;
+        wolke_share_link_ids?: string[] | null | undefined;
+        auto_sync?: boolean | undefined;
+        remove_missing_on_sync?: boolean | undefined;
+        created_at: string;
+        updated_at: string;
+        settings?: Record<string, unknown> | undefined;
+        notebook_collection_documents?: Array<{ document_id: string }>;
+        is_public?: boolean;
+        public_ownership?: 'owner' | 'public_data' | null;
+      };
+
+      const postgres = getPostgresInstance();
+      const collections =
+        (await notebookHelper.getPublicNotebookCollections()) as NotebookCollectionFromQdrantRaw[];
+
+      const transformedData = await Promise.all(
+        collections.map(async (collection) => {
+          const documentIds = (collection.notebook_collection_documents || []).map(
+            (qcd) => qcd.document_id
+          );
+
+          let documents: DocumentRecord[] = [];
+          if (documentIds.length > 0) {
+            documents = await postgres.query<DocumentRecord>(
+              'SELECT id, title, page_count, created_at, source_type, wolke_share_link_id FROM documents WHERE id = ANY($1)',
+              [documentIds]
+            );
+          }
+
+          const settings = (collection.settings as Record<string, unknown>) || {};
+          const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+
+          return {
+            ...collection,
+            documents,
+            document_count: documents.length,
+            selection_mode: collection.selection_mode || 'documents',
+            wolke_share_links: [] as WolkeShareLink[],
+            has_wolke_sources: false,
+            documents_from_wolke: 0,
+            auto_sync: !!collection.auto_sync,
+            remove_missing_on_sync: !!collection.remove_missing_on_sync,
+            labels,
+            is_public: collection.is_public === true,
+            public_ownership: collection.public_ownership ?? null,
+          };
+        })
+      );
+
+      return {
+        status: 200 as const,
+        body: { success: true, collections: transformedData },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.listPublicCollections] Error:', error);
       return { status: 500 as const, body: { error: 'Internal server error' } };
     }
   },
@@ -192,6 +264,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         auto_sync,
         remove_missing_on_sync,
         labels,
+        is_public,
+        public_ownership,
       } = args.body;
 
       const selection_mode = selectionModeRaw ?? 'documents';
@@ -206,6 +280,15 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return {
           status: 400 as const,
           body: { error: 'A notebook can contain at most 100 documents' },
+        };
+      }
+
+      if (is_public === true && !public_ownership) {
+        return {
+          status: 400 as const,
+          body: {
+            error: 'public_ownership is required when is_public is true (owner | public_data)',
+          },
         };
       }
 
@@ -277,6 +360,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         settings: {
           ...(Array.isArray(labels) ? { labels: labels.map((l) => l.trim()).filter(Boolean) } : {}),
         },
+        is_public: is_public === true,
+        public_ownership: is_public === true ? (public_ownership ?? null) : null,
       };
 
       const result = await notebookHelper.storeNotebookCollection(collectionData);
@@ -351,6 +436,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         auto_sync,
         remove_missing_on_sync,
         labels,
+        is_public,
+        public_ownership,
       } = args.body;
 
       const selection_mode = selectionModeRaw ?? 'documents';
@@ -365,6 +452,15 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return {
           status: 400 as const,
           body: { error: 'A notebook can contain at most 100 documents' },
+        };
+      }
+
+      if (is_public === true && !public_ownership) {
+        return {
+          status: 400 as const,
+          body: {
+            error: 'public_ownership is required when is_public is true (owner | public_data)',
+          },
         };
       }
 
@@ -451,6 +547,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       } else {
         updateData.auto_sync = false;
         updateData.remove_missing_on_sync = false;
+      }
+
+      if (typeof is_public === 'boolean') {
+        updateData.is_public = is_public;
+        updateData.public_ownership = is_public ? (public_ownership ?? null) : null;
       }
 
       await notebookHelper.updateNotebookCollection(collectionId, updateData);

--- a/apps/web/src/features/auth/services/profileApiService.ts
+++ b/apps/web/src/features/auth/services/profileApiService.ts
@@ -479,6 +479,13 @@ export const profileApiService = {
       auto_sync: selectionMode === 'wolke' ? !!collectionData.auto_sync : false,
       remove_missing_on_sync:
         selectionMode === 'wolke' ? !!collectionData.remove_missing_on_sync : false,
+      ...(Array.isArray(collectionData.labels) ? { labels: collectionData.labels } : {}),
+      ...(typeof collectionData.is_public === 'boolean'
+        ? { is_public: collectionData.is_public }
+        : {}),
+      ...(collectionData.public_ownership
+        ? { public_ownership: collectionData.public_ownership }
+        : {}),
     };
 
     const response = await apiClient.post<NotebookCollectionMutationResponse>(
@@ -513,6 +520,13 @@ export const profileApiService = {
       auto_sync: selectionMode === 'wolke' ? !!collectionData.auto_sync : undefined,
       remove_missing_on_sync:
         selectionMode === 'wolke' ? !!collectionData.remove_missing_on_sync : undefined,
+      ...(Array.isArray(collectionData.labels) ? { labels: collectionData.labels } : {}),
+      ...(typeof collectionData.is_public === 'boolean'
+        ? { is_public: collectionData.is_public }
+        : {}),
+      ...(collectionData.public_ownership
+        ? { public_ownership: collectionData.public_ownership }
+        : {}),
     };
 
     const response = await apiClient.put<NotebookCollectionUpdateResponse>(

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,5 +1,5 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
-import { Badge, Button, Input, Separator } from '@gruenerator/ui';
+import { Badge, Button, Input, Label, Separator, Switch } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
@@ -8,12 +8,16 @@ import { HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
 
+type PublicOwnership = 'owner' | 'public_data';
+
 interface NotebookCollection {
   id?: string;
   name: string;
   description?: string;
   documents?: { id: string; title?: string }[];
   labels?: string[];
+  is_public?: boolean;
+  public_ownership?: PublicOwnership | null;
 }
 
 interface NotebookEditorFormData {
@@ -82,6 +86,8 @@ const NotebookEditor = ({
   const [newLabel, setNewLabel] = useState('');
   const [indexingDocIds, setIndexingDocIds] = useState<Set<string>>(() => new Set());
   const [editing, setEditing] = useState<null | 'name' | 'desc' | 'labels'>(null);
+  const [isPublic, setIsPublic] = useState(false);
+  const [publicOwnership, setPublicOwnership] = useState<PublicOwnership | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { uploadFileOnly, pollDocumentStatus } = useDocumentsStore();
@@ -122,6 +128,8 @@ const NotebookEditor = ({
         description: editingCollection.description || '',
       });
       setLabels(editingCollection.labels || []);
+      setIsPublic(editingCollection.is_public === true);
+      setPublicOwnership(editingCollection.public_ownership ?? null);
       if (editingCollection.documents?.length) {
         setUploadedDocuments(
           editingCollection.documents.map((doc) => ({
@@ -134,6 +142,8 @@ const NotebookEditor = ({
     } else {
       reset({ name: '', description: '' });
       setLabels([]);
+      setIsPublic(false);
+      setPublicOwnership(null);
       setUploadedDocuments([]);
       setStep(1);
     }
@@ -271,6 +281,7 @@ const NotebookEditor = ({
 
   const onSubmit = async (data: NotebookEditorFormData): Promise<void> => {
     if (uploadedDocuments.length === 0) return;
+    if (isPublic && !publicOwnership) return;
 
     const payload: NotebookEditorSavePayload = {
       ...(editingCollection?.id ? { id: editingCollection.id } : {}),
@@ -280,6 +291,8 @@ const NotebookEditor = ({
       documents: uploadedDocuments.map((doc) => doc.id),
       documentMeta: uploadedDocuments.map((doc) => ({ id: doc.id, title: doc.title })),
       labels,
+      isPublic,
+      publicOwnership: isPublic ? publicOwnership : null,
     };
 
     await onSave(payload);
@@ -290,6 +303,8 @@ const NotebookEditor = ({
     setUploadedDocuments([]);
     setLabels([]);
     setNewLabel('');
+    setIsPublic(false);
+    setPublicOwnership(null);
     setStep(1);
     if (onCancel) onCancel();
   };
@@ -644,6 +659,67 @@ const NotebookEditor = ({
                 </section>
 
                 <Separator />
+
+                <section className="space-y-md">
+                  <div className="flex items-center justify-between gap-md">
+                    <div className="space-y-xs">
+                      <Label htmlFor="notebook-public-toggle" className="text-base">
+                        Notebook öffentlich machen
+                      </Label>
+                      <p className="text-sm text-grey-500 dark:text-grey-400">
+                        Dein Notebook wird unter „Von der Basis" auf der Notebooks-Seite sichtbar.
+                      </p>
+                    </div>
+                    <Switch
+                      id="notebook-public-toggle"
+                      checked={isPublic}
+                      onCheckedChange={(checked) => {
+                        setIsPublic(checked);
+                        if (!checked) setPublicOwnership(null);
+                      }}
+                      disabled={loading}
+                    />
+                  </div>
+
+                  {isPublic && (
+                    <fieldset className="space-y-xs rounded-md border border-grey-200 p-md dark:border-grey-700">
+                      <legend className="px-1 text-xs font-medium uppercase tracking-wide text-grey-500">
+                        Bitte bestätige
+                      </legend>
+                      <label className="flex cursor-pointer items-start gap-sm rounded-md px-1 py-xs transition-colors hover:bg-background-alt/50">
+                        <input
+                          type="radio"
+                          name="public-ownership"
+                          value="owner"
+                          checked={publicOwnership === 'owner'}
+                          onChange={() => setPublicOwnership('owner')}
+                          disabled={loading}
+                          className="mt-0.5 accent-primary-500"
+                        />
+                        <span className="text-sm text-foreground">
+                          Ich besitze die Daten oder habe die Rechte zur Veröffentlichung
+                        </span>
+                      </label>
+                      <label className="flex cursor-pointer items-start gap-sm rounded-md px-1 py-xs transition-colors hover:bg-background-alt/50">
+                        <input
+                          type="radio"
+                          name="public-ownership"
+                          value="public_data"
+                          checked={publicOwnership === 'public_data'}
+                          onChange={() => setPublicOwnership('public_data')}
+                          disabled={loading}
+                          className="mt-0.5 accent-primary-500"
+                        />
+                        <span className="text-sm text-foreground">
+                          Die Daten sind öffentlich verfügbar (z.B. offizielle Dokumente,
+                          Pressemitteilungen)
+                        </span>
+                      </label>
+                    </fieldset>
+                  )}
+                </section>
+
+                <Separator />
                 <div className="flex flex-wrap justify-end gap-sm">
                   {!editingCollection && (
                     <Button
@@ -658,7 +734,12 @@ const NotebookEditor = ({
                   )}
                   <Button
                     type="submit"
-                    disabled={loading || uploadedDocuments.length === 0 || !watchedName.trim()}
+                    disabled={
+                      loading ||
+                      uploadedDocuments.length === 0 ||
+                      !watchedName.trim() ||
+                      (isPublic && !publicOwnership)
+                    }
                   >
                     {loading
                       ? 'Wird gespeichert...'

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -59,6 +59,8 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         labels: data.labels,
         selectionMode: collection.selection_mode,
         custom_prompt: collection.custom_prompt,
+        is_public: data.isPublic,
+        public_ownership: data.publicOwnership,
       });
 
       toast.success(`Notebook „${data.name}" gespeichert`);
@@ -80,6 +82,8 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         description: data.description,
         documents: data.documents,
         labels: data.labels,
+        is_public: data.isPublic,
+        public_ownership: data.publicOwnership,
       });
       toast.success(`Notebook „${data.name}" erstellt`);
       goBack();

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -84,6 +84,8 @@ interface NotebookPageContentProps {
   showStats?: boolean;
   /** Disable the built-in "Zuletzt hinzugefügt" section (caller renders its own). Defaults to true. */
   showLastAdded?: boolean;
+  /** Disable the example-question chip grid below the composer. Defaults to true. */
+  showExamples?: boolean;
   /** Disable the manual research tab (dynamic user notebooks have no system collection scope). Defaults to true. */
   showManualSearch?: boolean;
   /** Hide filter UI on the manual research tab. For user notebooks: no facets. */
@@ -133,6 +135,7 @@ export const NotebookPageContent = ({
   startpageFooter,
   showStats = true,
   showLastAdded = true,
+  showExamples = true,
   showManualSearch = true,
   hideManualSearchFilters = false,
   manualSearchEndpoint,
@@ -343,7 +346,7 @@ export const NotebookPageContent = ({
                   subtitle={config.infoPanelDescription}
                   sources={config.sources}
                   placeholder={config.placeholder}
-                  exampleQuestions={config.exampleQuestions ?? []}
+                  exampleQuestions={showExamples ? (config.exampleQuestions ?? []) : []}
                   composerSourceFilters={sourceFilters}
                   composerCategoryFilters={categoryFilters}
                   mode={mode}

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -42,10 +42,9 @@ import {
   type NotebookConfigEntry,
 } from '../config/notebooksConfig';
 
-import { LastAddedSection } from './LastAddedSection';
 import NotebookEditor from './NotebookEditor';
 import { NotebookPageContent } from './NotebookPage';
-import { StatisticsSection } from './StatisticsSection';
+import { VonDerBasisSection } from './VonDerBasisSection';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
@@ -403,11 +402,6 @@ function NotebooksIndexFooter() {
     [isAustrian]
   );
 
-  const systemCollectionIds = useMemo(() => {
-    const config = getNotebookConfig('gruenerator');
-    return config.collections.filter((c) => !c.locale || c.locale === locale).map((c) => c.id);
-  }, [locale]);
-
   const queryClient = useQueryClient();
   const {
     query: collectionsQuery,
@@ -540,11 +534,7 @@ function NotebooksIndexFooter() {
         </div>
       </div>
 
-      {systemCollectionIds.length > 0 && (
-        <LastAddedSection collectionIds={systemCollectionIds} showSourceLabel />
-      )}
-
-      {systemCollectionIds.length > 0 && <StatisticsSection collectionIds={systemCollectionIds} />}
+      <VonDerBasisSection />
 
       {/* Tools section commented out per request — chat composer at the top covers Suche. */}
 
@@ -576,6 +566,7 @@ function NotebooksIndexPage() {
       startpageFooter={<NotebooksIndexFooter />}
       showLastAdded={false}
       showStats={false}
+      showExamples={false}
     />
   );
 }

--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -1,0 +1,80 @@
+import { Skeleton } from '@gruenerator/ui';
+import { memo } from 'react';
+import { HiBookOpen } from 'react-icons/hi';
+import { useNavigate } from 'react-router-dom';
+
+import { usePublicNotebookCollections } from '../hooks/usePublicNotebookCollections';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+const VonDerBasisCard = memo(function VonDerBasisCard({
+  collection,
+}: {
+  collection: NotebookCollection;
+}) {
+  const navigate = useNavigate();
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => void navigate(`/notebook/${collection.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          void navigate(`/notebook/${collection.id}`);
+        }
+      }}
+      className="group flex min-h-[4rem] cursor-pointer items-center gap-sm rounded-md border border-grey-200 bg-background px-md py-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700"
+    >
+      <HiBookOpen className="shrink-0 text-base text-secondary-600" />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-foreground-heading">
+          {collection.name}
+        </div>
+        {collection.description ? (
+          <div className="truncate text-xs text-grey-500 dark:text-grey-400">
+            {collection.description}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+export function VonDerBasisSection() {
+  const { data, isLoading } = usePublicNotebookCollections({ enabled: true });
+  const collections = data ?? [];
+
+  return (
+    <section className="mt-xl">
+      <h2 className="mb-md text-xl font-semibold text-foreground-heading">Von der Basis</h2>
+
+      {isLoading ? (
+        <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex min-h-[4rem] items-center gap-sm rounded-md border border-grey-200 px-md py-md dark:border-grey-700"
+            >
+              <Skeleton className="size-5 shrink-0 rounded" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          ))}
+        </div>
+      ) : collections.length === 0 ? (
+        <p className="rounded-md border border-dashed border-grey-300 px-md py-lg text-center text-sm text-grey-500 dark:border-grey-700 dark:text-grey-400">
+          Noch keine öffentlichen Notebooks. Sei der oder die Erste — veröffentliche eines deiner
+          Notebooks im Editor.
+        </p>
+      ) : (
+        <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
+          {collections.map((c) => (
+            <VonDerBasisCard key={c.id} collection={c} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default VonDerBasisSection;

--- a/apps/web/src/features/notebook/hooks/usePublicNotebookCollections.ts
+++ b/apps/web/src/features/notebook/hooks/usePublicNotebookCollections.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import apiClient from '../../../components/utils/apiClient';
+
+import type { NotebookCollection, NotebookCollectionsResponse } from '../../../types/notebook';
+
+const QUERY_KEY = ['notebookCollections', 'public'] as const;
+
+async function fetchPublicNotebookCollections(): Promise<NotebookCollection[]> {
+  const response = await apiClient.get<NotebookCollectionsResponse>(
+    '/auth/notebook-collections/public'
+  );
+  if (!response.data.success) {
+    throw new Error(response.data.message ?? 'Failed to fetch public notebook collections');
+  }
+  return response.data.collections ?? [];
+}
+
+export function usePublicNotebookCollections({ enabled = true }: { enabled?: boolean } = {}) {
+  return useQuery<NotebookCollection[], Error>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchPublicNotebookCollections,
+    enabled,
+    staleTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+}

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -17,6 +17,11 @@ export interface WolkeShareLink {
 }
 
 /**
+ * Discloses why a notebook was published. Captured alongside the is_public flag.
+ */
+export type NotebookPublicOwnership = 'owner' | 'public_data';
+
+/**
  * Base notebook collection type representing a Q&A collection
  */
 export interface NotebookCollection {
@@ -26,6 +31,7 @@ export interface NotebookCollection {
   description?: string;
   custom_prompt?: string;
   is_public: boolean;
+  public_ownership?: NotebookPublicOwnership | null;
   public_url_token?: string | null;
   view_count: number;
   last_accessed?: string;
@@ -68,6 +74,8 @@ export interface NotebookCollectionInput {
   labels?: string[];
   auto_sync?: boolean;
   remove_missing_on_sync?: boolean;
+  is_public?: boolean;
+  public_ownership?: NotebookPublicOwnership | null;
 }
 
 /**

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -43,6 +43,22 @@ export const notebookCollectionsContract = c.router(
     },
 
     /**
+     * GET /api/auth/notebook-collections/public
+     * List all notebook collections marked is_public=true across all users.
+     * Powers the "Von der Basis" section on /notebooks.
+     */
+    listPublicCollections: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/public',
+      responses: {
+        200: collectionsListResponseSchema,
+        401: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'List publicly published notebook collections',
+    },
+
+    /**
      * POST /api/auth/notebook-collections
      * Create a new notebook collection.
      */

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -10,6 +10,9 @@ import { z } from 'zod';
 
 // ── Request bodies ──────────────────────────────────────────────────────────
 
+export const publicOwnershipSchema = z.enum(['owner', 'public_data']);
+export type PublicOwnership = z.infer<typeof publicOwnershipSchema>;
+
 export const createCollectionBodySchema = z.object({
   name: z.string(),
   description: z.string().nullish(),
@@ -20,6 +23,8 @@ export const createCollectionBodySchema = z.object({
   auto_sync: z.boolean().nullish(),
   remove_missing_on_sync: z.boolean().nullish(),
   labels: z.array(z.string()).nullish(),
+  is_public: z.boolean().nullish(),
+  public_ownership: publicOwnershipSchema.nullish(),
 });
 
 export const updateCollectionBodySchema = z.object({
@@ -32,6 +37,8 @@ export const updateCollectionBodySchema = z.object({
   auto_sync: z.boolean().nullish(),
   remove_missing_on_sync: z.boolean().nullish(),
   labels: z.array(z.string()).nullish(),
+  is_public: z.boolean().nullish(),
+  public_ownership: publicOwnershipSchema.nullish(),
 });
 
 export const bulkDeleteBodySchema = z.object({
@@ -57,6 +64,8 @@ export const notebookEditorSavePayloadSchema = z.object({
   documents: z.array(z.string()),
   documentMeta: z.array(z.object({ id: z.string(), title: z.string() })),
   labels: z.array(z.string()),
+  isPublic: z.boolean(),
+  publicOwnership: publicOwnershipSchema.nullable(),
 });
 
 export type NotebookEditorSavePayload = z.infer<typeof notebookEditorSavePayloadSchema>;
@@ -102,6 +111,8 @@ export const transformedCollectionSchema = z.object({
   settings: z.unknown().nullish(),
   notebook_collection_documents: z.array(z.object({ document_id: z.string() })).nullish(),
   labels: z.array(z.string()).nullish(),
+  is_public: z.boolean().nullish(),
+  public_ownership: publicOwnershipSchema.nullable().optional(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────


### PR DESCRIPTION
Make notebook collections publishable to a new "Von der Basis" section on `/notebooks`.

## What lands end-to-end

**Editor** — below the documents section, a `Switch` from `@gruenerator/ui` ("Notebook öffentlich machen"). Flipping it on reveals two radio options: "Ich besitze die Daten" or "Die Daten sind öffentlich verfügbar". Save is blocked until one is selected.

**Persistence** — `is_public: boolean` and `public_ownership: 'owner' | 'public_data' | null` are added to the create/update Zod body schemas, threaded through `notebookCollectionsContractRouter`, and written to the Qdrant payload alongside the rest of the collection. The contract router validates that `public_ownership` is required when `is_public=true`.

**New endpoint** — `GET /api/auth/notebook-collections/public` (added to `notebookCollectionsContract` as `listPublicCollections`). Fetches all collections with `is_public=true` across all users; the new `usePublicNotebookCollections` hook calls it.

**`/notebooks` redesign**:
- `LastAddedSection` ("Zuletzt hinzugefügt") removed from `NotebooksIndexFooter`
- `StatisticsSection` removed alongside
- example-prompt chips hidden via a new `showExamples={false}` prop on `NotebookPageContent` (the prop falls back to `true` everywhere else)
- new `<VonDerBasisSection>` renders cards for every public notebook (empty-state placeholder when none exist yet)

**Side-effect fix** — `profileApiService.createQACollection` and `updateQACollection` were silently dropping `labels` from the request body. The same spread-guard pattern I used for `is_public` also includes `labels` now, so labels actually persist via the React Query mutation path (matching the long-standing behavior of the parallel `notebookStore.ts` path).

## Test plan
- [ ] Open a notebook in `/notebooks/meine/:id/bearbeiten` → toggle the new "Notebook öffentlich machen" switch on → two radios appear, save button disabled until one selected
- [ ] Pick "Ich besitze die Daten" → Aktualisieren → toast confirms, navigate to `/notebooks`
- [ ] "Von der Basis" section shows the newly-published notebook; clicking the card opens `/notebook/:id`
- [ ] Toggle off in the editor → save → notebook no longer appears in "Von der Basis"
- [ ] Save with `is_public=true` but no ownership selected → frontend Aktualisieren stays disabled; if bypassed at API layer, backend returns 400 "public_ownership is required"
- [ ] `/notebooks` no longer shows "Zuletzt hinzugefügt" + "Statistiken" + example-prompt chips
- [ ] Add a label to a notebook and reload — label persists (this was previously dropped via the React Query path)
- [ ] Existing notebooks (created before this PR) show `is_public=false` by default; toggling persists

## Architecture notes
- Qdrant payload is schemaless; no SQL migration. The fields are read back via `formatCollectionFromPayload` with a guard that rejects unknown ownership values.
- `is_public` was previously declared on the frontend `NotebookCollection` type but was a stub. This PR makes it real, end-to-end. The existing `Geteilt` badge in `MyNotebooksPage` (which checks `collection.is_public`) will now light up correctly.