### PR TITLE
refactor(notebook): simplify manual-research props and handler

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -307,13 +307,9 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/auth/notebook-collections', requireAuth);
   mountNotebookCollectionsContractRouter(app);
   app.use('/api/auth/notebook-collections', authenticatedReadLimiter, notebookCollectionsRouter);
-  // ts-rest contract router for notebook interaction — mounts BEFORE the
-  // legacy router so contract-modeled routes match first. Mixed auth: some
-  // routes are public (`/public/:token`), others require auth. `optionalAuth`
-  // populates `req.user` for valid sessions WITHOUT rejecting unauthenticated
-  // requests, so per-handler `requireAuthUser()` checks can do the actual
-  // gating. Without this middleware `req.user` would always be undefined and
-  // authenticated routes (askMulti, askSingle, researchSearch) would 401.
+  // Mixed-auth contract: `optionalAuth` populates req.user without rejecting,
+  // so per-handler `requireAuthUser()` gates the writes and the public/:token
+  // routes still work. Mounted before the legacy router so contract routes win.
   app.use('/api/auth/notebook', optionalAuth);
   mountNotebookContractRouter(app);
   app.use('/api/auth/notebook', authenticatedReadLimiter, notebookInteractionRouter);

--- a/apps/api/routes/notebook/notebookContractRouter.ts
+++ b/apps/api/routes/notebook/notebookContractRouter.ts
@@ -42,6 +42,12 @@ import type { Application, Request } from 'express';
 const log = createLogger('notebookContractRouter');
 const notebookHelper = new NotebookQdrantHelper();
 
+const MODE_WEIGHTS: Record<'hybrid' | 'vector' | 'text', readonly [number, number]> = {
+  hybrid: [0.7, 0.3],
+  vector: [1.0, 0.0],
+  text: [0.0, 1.0],
+};
+
 /**
  * Extract the authenticated user id or return a 401 contract response.
  * Used by `askMulti` / `askSingle` where req.user is required.
@@ -287,16 +293,7 @@ export const notebookContractRouter = s.router(notebookContract, {
       const effectiveLimit = Math.min(Math.max(limit ?? 30, 1), 100);
       const effectiveMode = mode ?? 'hybrid';
       const effectiveSort = sortBy ?? 'relevance';
-
-      let vectorWeight = 0.7;
-      let textWeight = 0.3;
-      if (effectiveMode === 'vector') {
-        vectorWeight = 1.0;
-        textWeight = 0.0;
-      } else if (effectiveMode === 'text') {
-        vectorWeight = 0.0;
-        textWeight = 1.0;
-      }
+      const [vectorWeight, textWeight] = MODE_WEIGHTS[effectiveMode];
 
       const documentSearchService = getQdrantDocumentService();
       const resp = await documentSearchService.search({

--- a/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
+++ b/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
@@ -102,28 +102,22 @@ function resultToCardProps(result: ResearchResult) {
 
 interface NotebookManualSearchProps {
   collectionIds: string[];
-  /** Hide type/category/region/sort/mode/filter-panel UI. Search input + results only. */
-  hideFilters?: boolean;
   /**
-   * Override the search transport. When `{ type: 'notebook' }`, routes to the
-   * per-notebook endpoint with ownership-scoped Qdrant search instead of the
-   * system-collection `/research/search`.
+   * When set, routes search to `/auth/notebook/:id/research-search` (ownership-scoped)
+   * AND hides the facet-filter UI. User notebooks have no Qdrant facets.
    */
-  searchEndpoint?: { type: 'notebook'; notebookId: string };
+  notebookId?: string;
 }
 
-export function NotebookManualSearch({
-  collectionIds,
-  hideFilters = false,
-  searchEndpoint,
-}: NotebookManualSearchProps) {
+export function NotebookManualSearch({ collectionIds, notebookId }: NotebookManualSearchProps) {
+  const hideFilters = !!notebookId;
   const [query, setQuery] = useState('');
   const [hasSearched, setHasSearched] = useState(false);
   const lastQueryRef = useRef('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   const { results, metadata, isLoading, error, search } = useResearch(
-    searchEndpoint?.type === 'notebook' ? { notebookId: searchEndpoint.notebookId } : undefined
+    notebookId ? { notebookId } : undefined
   );
   const {
     filterFields,
@@ -212,6 +206,148 @@ export function NotebookManualSearch({
   const sortIndicator = sortBy !== 'relevance' ? ` · sortiert nach ${SORT_LABELS[sortBy]}` : '';
   const modeLabel = MODE_OPTIONS.find((o) => o.value === searchMode)?.label ?? 'Hybrid';
 
+  const filterControls = hideFilters ? undefined : (
+    <div className="flex flex-wrap items-center gap-xs">
+      {contentTypeConfig && (contentTypeConfig.values ?? []).length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <HiBarsArrowDown className="size-4" />
+              {filtersLoading
+                ? 'Laden...'
+                : activeContentTypes.length > 0
+                  ? `${activeContentTypes.length} Typ${activeContentTypes.length > 1 ? 'en' : ''}`
+                  : 'Typ'}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            {(contentTypeConfig.values ?? []).map((v) => (
+              <DropdownMenuCheckboxItem
+                key={v.value}
+                checked={activeContentTypes.includes(v.value)}
+                onCheckedChange={(checked) => {
+                  setKeywordFilter(
+                    'content_type',
+                    checked
+                      ? [...activeContentTypes, v.value]
+                      : activeContentTypes.filter((t) => t !== v.value)
+                  );
+                }}
+                onSelect={(e) => e.preventDefault()}
+              >
+                {v.value} ({v.count})
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+
+      {(['primary_category', 'subcategories', 'region'] as const).map((field) => {
+        const config = getKeywordConfig(field);
+        const values = config?.values ?? [];
+        const active = getActiveValues(field);
+        if (!config || values.length === 0) return null;
+        return (
+          <DropdownMenu key={field}>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm">
+                <HiTag className="size-4" />
+                {filtersLoading
+                  ? 'Laden...'
+                  : active.length > 0
+                    ? `${active.length} ${config.label}`
+                    : config.label}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="max-h-[20rem] overflow-y-auto">
+              {values.map((v) => (
+                <DropdownMenuCheckboxItem
+                  key={v.value}
+                  checked={active.includes(v.value)}
+                  onCheckedChange={(checked) => {
+                    setKeywordFilter(
+                      field,
+                      checked ? [...active, v.value] : active.filter((t) => t !== v.value)
+                    );
+                  }}
+                  onSelect={(e) => e.preventDefault()}
+                >
+                  {v.value} ({v.count})
+                </DropdownMenuCheckboxItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        );
+      })}
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <HiArrowsUpDown className="size-4" />
+            {SORT_LABELS[sortBy] ?? 'Relevanz'}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuRadioGroup value={sortBy} onValueChange={(v) => setSortBy(v as SortOption)}>
+            {SORT_OPTIONS.map((opt) => (
+              <DropdownMenuRadioItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ResearchFilterPanel
+        filterFields={filterFields}
+        activeFilters={activeFilters}
+        dateFilterCount={dateFilterCount}
+        filtersLoading={filtersLoading}
+        onSetDateFilter={setDateFilter}
+        onClearDates={clearDateFilters}
+        onFiltersOpen={() => setFiltersEnabled(true)}
+      />
+
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant={searchMode !== 'hybrid' ? 'default' : 'outline'}
+            size="sm"
+            aria-label="Suchmodus"
+            title={`Suchmodus: ${modeLabel}`}
+          >
+            <HiCog6Tooth className="size-4" />
+            {modeLabel}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" sideOffset={8} className="w-auto p-2">
+          <div className="space-y-1.5">
+            <span className="block px-1 text-xs font-medium text-grey-500 dark:text-grey-400">
+              Suchmodus
+            </span>
+            <div className="flex flex-col gap-0.5">
+              {MODE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setSearchMode(opt.value)}
+                  className={cn(
+                    'rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+                    searchMode === opt.value
+                      ? 'bg-primary-500 text-white'
+                      : 'text-foreground hover:bg-background-alt'
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+
   return (
     <div className="flex flex-col gap-md">
       <SearchBar
@@ -223,152 +359,7 @@ export function NotebookManualSearch({
         hideDisclaimer
         variant="composer"
         submitPlacement="tray"
-        bottomContent={
-          hideFilters ? undefined : (
-            <div className="flex flex-wrap items-center gap-xs">
-              {contentTypeConfig && (contentTypeConfig.values ?? []).length > 0 && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" size="sm">
-                      <HiBarsArrowDown className="size-4" />
-                      {filtersLoading
-                        ? 'Laden...'
-                        : activeContentTypes.length > 0
-                          ? `${activeContentTypes.length} Typ${activeContentTypes.length > 1 ? 'en' : ''}`
-                          : 'Typ'}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    {(contentTypeConfig.values ?? []).map((v) => (
-                      <DropdownMenuCheckboxItem
-                        key={v.value}
-                        checked={activeContentTypes.includes(v.value)}
-                        onCheckedChange={(checked) => {
-                          setKeywordFilter(
-                            'content_type',
-                            checked
-                              ? [...activeContentTypes, v.value]
-                              : activeContentTypes.filter((t) => t !== v.value)
-                          );
-                        }}
-                        onSelect={(e) => e.preventDefault()}
-                      >
-                        {v.value} ({v.count})
-                      </DropdownMenuCheckboxItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-
-              {(['primary_category', 'subcategories', 'region'] as const).map((field) => {
-                const config = getKeywordConfig(field);
-                const values = config?.values ?? [];
-                const active = getActiveValues(field);
-                if (!config || values.length === 0) return null;
-                return (
-                  <DropdownMenu key={field}>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="outline" size="sm">
-                        <HiTag className="size-4" />
-                        {filtersLoading
-                          ? 'Laden...'
-                          : active.length > 0
-                            ? `${active.length} ${config.label}`
-                            : config.label}
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" className="max-h-[20rem] overflow-y-auto">
-                      {values.map((v) => (
-                        <DropdownMenuCheckboxItem
-                          key={v.value}
-                          checked={active.includes(v.value)}
-                          onCheckedChange={(checked) => {
-                            setKeywordFilter(
-                              field,
-                              checked ? [...active, v.value] : active.filter((t) => t !== v.value)
-                            );
-                          }}
-                          onSelect={(e) => e.preventDefault()}
-                        >
-                          {v.value} ({v.count})
-                        </DropdownMenuCheckboxItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                );
-              })}
-
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="outline" size="sm">
-                    <HiArrowsUpDown className="size-4" />
-                    {SORT_LABELS[sortBy] ?? 'Relevanz'}
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuRadioGroup
-                    value={sortBy}
-                    onValueChange={(v) => setSortBy(v as SortOption)}
-                  >
-                    {SORT_OPTIONS.map((opt) => (
-                      <DropdownMenuRadioItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </DropdownMenuRadioItem>
-                    ))}
-                  </DropdownMenuRadioGroup>
-                </DropdownMenuContent>
-              </DropdownMenu>
-
-              <ResearchFilterPanel
-                filterFields={filterFields}
-                activeFilters={activeFilters}
-                dateFilterCount={dateFilterCount}
-                filtersLoading={filtersLoading}
-                onSetDateFilter={setDateFilter}
-                onClearDates={clearDateFilters}
-                onFiltersOpen={() => setFiltersEnabled(true)}
-              />
-
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant={searchMode !== 'hybrid' ? 'default' : 'outline'}
-                    size="sm"
-                    aria-label="Suchmodus"
-                    title={`Suchmodus: ${modeLabel}`}
-                  >
-                    <HiCog6Tooth className="size-4" />
-                    {modeLabel}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent align="end" sideOffset={8} className="w-auto p-2">
-                  <div className="space-y-1.5">
-                    <span className="block px-1 text-xs font-medium text-grey-500 dark:text-grey-400">
-                      Suchmodus
-                    </span>
-                    <div className="flex flex-col gap-0.5">
-                      {MODE_OPTIONS.map((opt) => (
-                        <button
-                          key={opt.value}
-                          type="button"
-                          onClick={() => setSearchMode(opt.value)}
-                          className={cn(
-                            'rounded-md px-3 py-1.5 text-left text-sm transition-colors',
-                            searchMode === opt.value
-                              ? 'bg-primary-500 text-white'
-                              : 'text-foreground hover:bg-background-alt'
-                          )}
-                        >
-                          {opt.label}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </PopoverContent>
-              </Popover>
-            </div>
-          )
-        }
+        bottomContent={filterControls}
       />
 
       {!hideFilters && activeFilterCount > 0 && (

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -86,10 +86,11 @@ interface NotebookPageContentProps {
   showLastAdded?: boolean;
   /** Disable the manual research tab (dynamic user notebooks have no system collection scope). Defaults to true. */
   showManualSearch?: boolean;
-  /** Hide filter UI on the manual research tab. For user notebooks: no facets. */
-  hideManualSearchFilters?: boolean;
-  /** Route manual research to a per-notebook endpoint instead of /research/search. */
-  manualSearchEndpoint?: { type: 'notebook'; notebookId: string };
+  /**
+   * When set, the manual research tab scopes to a single user-owned notebook
+   * (ownership-checked, no facet filter UI). Forwarded to `NotebookManualSearch`.
+   */
+  manualSearchNotebookId?: string;
 }
 
 interface NotebookPageProps {
@@ -134,8 +135,7 @@ export const NotebookPageContent = ({
   showStats = true,
   showLastAdded = true,
   showManualSearch = true,
-  hideManualSearchFilters = false,
-  manualSearchEndpoint,
+  manualSearchNotebookId,
 }: NotebookPageContentProps): React.ReactElement => {
   const isMulti = config.collectionType === 'multi';
   const isSingleSystem = !isMulti && config.collections[0]?.id.endsWith('-system');
@@ -353,8 +353,7 @@ export const NotebookPageContent = ({
                   showStats={showStats}
                   showLastAdded={showLastAdded}
                   showManualSearch={showManualSearch}
-                  hideManualSearchFilters={hideManualSearchFilters}
-                  manualSearchEndpoint={manualSearchEndpoint}
+                  manualSearchNotebookId={manualSearchNotebookId}
                   notebookMention={notebookMention}
                   footer={startpageFooter}
                 />
@@ -486,8 +485,7 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
       showStats={false}
       showLastAdded={false}
       showManualSearch
-      hideManualSearchFilters
-      manualSearchEndpoint={{ type: 'notebook', notebookId: collection.id }}
+      manualSearchNotebookId={collection.id}
     />
   );
 };

--- a/apps/web/src/features/notebook/components/NotebookStartpage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookStartpage.tsx
@@ -39,10 +39,11 @@ interface NotebookStartpageProps {
   showStats?: boolean;
   showLastAdded?: boolean;
   showManualSearch?: boolean;
-  /** Hide the filter UI on the manual-research tab (user notebooks have no facets). */
-  hideManualSearchFilters?: boolean;
-  /** Route the manual-research tab to a per-notebook endpoint instead of /research/search. */
-  manualSearchEndpoint?: { type: 'notebook'; notebookId: string };
+  /**
+   * When set, the manual-research tab scopes search to a single user-owned notebook
+   * (ownership-checked, no facet filters). Forwarded to `NotebookManualSearch`.
+   */
+  manualSearchNotebookId?: string;
   /** Mention slug for the global-chat tab (e.g. 'berlin'). Null hides the tab. */
   notebookMention?: string | null;
   footer?: ReactNode;
@@ -84,8 +85,7 @@ export function NotebookStartpage({
   showStats = true,
   showLastAdded = true,
   showManualSearch = true,
-  hideManualSearchFilters = false,
-  manualSearchEndpoint,
+  manualSearchNotebookId,
   notebookMention,
   footer,
 }: NotebookStartpageProps) {
@@ -192,8 +192,7 @@ export function NotebookStartpage({
         <div className="mx-auto max-w-3xl">
           <NotebookManualSearch
             collectionIds={recentCollectionIds}
-            hideFilters={hideManualSearchFilters}
-            searchEndpoint={manualSearchEndpoint}
+            notebookId={manualSearchNotebookId}
           />
         </div>
       )}


### PR DESCRIPTION
## Why

A `/simplify` review of #871 + #875 surfaced a few small cleanups in code I wrote. Architectural duplication (e.g. `requireAuthUser` re-implemented across 4 contract routers, `requireOwnedNotebook` missing helper, dedup/sort/snippet pipeline) was flagged but explicitly out of scope — those touch unrelated files.

## Changes

- **One prop instead of two.** `hideManualSearchFilters` + `manualSearchEndpoint: { type: 'notebook'; notebookId }` collapsed into a single `manualSearchNotebookId?: string` (or `notebookId?` at the leaf). The two flags were perfectly correlated at every call site, and the discriminated union had only one variant — YAGNI.
- **Filter JSX lifted to a `filterControls` const** above `return` in `NotebookManualSearch`. The 130-line `bottomContent={ hideFilters ? undefined : (<div>...</div>) }` ternary was pushing every inner line one indent level deeper and making any future filter edit look like a giant diff. Now `bottomContent={filterControls}` and the JSX tree stays shallow.
- **MODE_WEIGHTS lookup table** replaces the three-branch if/else in the `researchSearch` handler. One line per mode, no branching.
- **Trimmed the narrative comment** in `routes.ts` from PR #875 — the "would 401" sentence narrated the bug fix, not the code. Down to the relevant WHY.

Net -19 LOC across 5 files. No behavior change.

## Test plan

- [ ] Typecheck (api + web) — already green locally
- [ ] User notebook overview at `/notebooks/<uuid>` still renders KI + Manuelle Recherche tabs
- [ ] Manual research on a user notebook still hits `/auth/notebook/:id/research-search` (Network tab)
- [ ] System notebook (`/notebooks/hamburg`) manual research still shows the full filter UI
- [ ] Backend handler still returns the same shape (mode/sort/limit/threshold unchanged)