### PR TITLE
feat(chat): mention personal notebooks with @ and scope search to them

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -98,6 +98,9 @@ const ChatStateAnnotation = Annotation.Root({
   notebookCollectionIds: Annotation<string[]>({
     reducer: (x, y) => y ?? x ?? [],
   }),
+  notebookDocumentIds: Annotation<string[]>({
+    reducer: (x, y) => y ?? x ?? [],
+  }),
   // Default notebook scoping (from persistent UI selection)
   defaultNotebookCollectionIds: Annotation<string[]>({
     reducer: (x, y) => y ?? x ?? [],
@@ -642,6 +645,7 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     // Notebook scoping
     notebookIds: input.notebookIds || [],
     notebookCollectionIds: input.notebookIds ? resolveNotebookCollections(input.notebookIds) : [],
+    notebookDocumentIds: input.notebookDocumentIds ?? [],
 
     // Default notebook scoping (from persistent UI selection)
     defaultNotebookCollectionIds: input.defaultNotebookId

--- a/apps/api/agents/langgraph/ChatGraph/compoundPipeline.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/compoundPipeline.vitest.ts
@@ -96,6 +96,7 @@ function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
     threadAttachments: [],
     notebookIds: ['hamburg-notebook'],
     notebookCollectionIds: ['hamburg'],
+    notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
     documentIds: [],
     documentChatIds: [],
@@ -278,6 +279,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
     it('searches only in notebook-scoped collections', async () => {
       const state = makeState({
         notebookCollectionIds: ['hamburg'],
+        notebookDocumentIds: [],
         searchQuery: 'Klimapolitik',
         intent: 'search',
       });
@@ -291,6 +293,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
     it('returns results from the scoped collection', async () => {
       const state = makeState({
         notebookCollectionIds: ['hamburg'],
+        notebookDocumentIds: [],
         searchQuery: 'Klimapolitik',
         intent: 'search',
       });
@@ -336,6 +339,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
         ],
         notebookIds: ['hamburg-notebook'],
         notebookCollectionIds: ['hamburg'],
+        notebookDocumentIds: [],
         agentConfig: makeAgentConfig(),
         aiWorkerPool,
       });
@@ -392,6 +396,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
         messages: [{ role: 'user' as const, content: '' }],
         notebookIds: ['hamburg-notebook'],
         notebookCollectionIds: ['hamburg'],
+        notebookDocumentIds: [],
         agentConfig: makeAgentConfig(),
         aiWorkerPool,
         searchQuery: null,
@@ -427,6 +432,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
         messages: [{ role: 'user' as const, content: 'Klimapolitik Hamburg' }],
         notebookIds: ['hamburg-notebook'],
         notebookCollectionIds: ['hamburg'],
+        notebookDocumentIds: [],
         agentConfig: makeUniversalAgentConfig(),
         aiWorkerPool: {
           processRequest: vi.fn().mockResolvedValue({
@@ -452,6 +458,7 @@ describe('Compound Pipeline: @notebook + @skill', () => {
         ],
         notebookIds: [],
         notebookCollectionIds: [],
+        notebookDocumentIds: [],
         agentConfig: makeAgentConfig(),
         aiWorkerPool: {
           processRequest: vi.fn().mockResolvedValue({

--- a/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/briefGeneratorNode.vitest.ts
@@ -41,6 +41,7 @@ function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
     searchSources: [],
     notebookIds: [],
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     ...overrides,
   } as unknown as ChatGraphState;
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierForcedIntent.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierForcedIntent.vitest.ts
@@ -52,6 +52,7 @@ function buildState(overrides: Partial<ChatGraphState> & { userMessage: string }
     threadAttachments: [],
     notebookIds: [],
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
     documentIds: [],
     documentChatIds: [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/defaultNotebook.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/defaultNotebook.vitest.ts
@@ -93,6 +93,7 @@ function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
     threadAttachments: [],
     notebookIds: [],
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
     documentIds: [],
     memoryContext: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -188,6 +188,7 @@ async function testExpandedContextWindow() {
     chatHistoryContext: null,
     notebookIds: [],
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
     documentIds: [],
     documentChatIds: [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -229,6 +229,7 @@ async function evaluateBudgetAllocation() {
     chatHistoryContext: null,
     notebookIds: [],
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
     documentIds: [],
     documentChatIds: [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -33,7 +33,8 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
   const { searchResults, searchQuery, hasTemporal, researchBrief } = state;
   const rerankCfg = vectorConfig.get('rerank');
 
-  const isNotebookScoped = (state.notebookCollectionIds?.length ?? 0) > 0;
+  const isNotebookScoped =
+    (state.notebookCollectionIds?.length ?? 0) > 0 || (state.notebookDocumentIds?.length ?? 0) > 0;
   const inputLimit = isNotebookScoped ? 20 : rerankCfg.inputLimit;
   const outputLimit = isNotebookScoped ? 12 : rerankCfg.outputLimit;
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.vitest.ts
@@ -51,6 +51,7 @@ function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
     researchBrief: null,
     researchMeta: null,
     notebookCollectionIds: [],
+    notebookDocumentIds: [],
     ...overrides,
   } as unknown as ChatGraphState;
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
@@ -212,7 +212,8 @@ async function formatSearchContext(state: ChatGraphState): Promise<string> {
 
   // Default: budget-based truncation
   // Notebook-scoped searches get more results and higher budget for deeper answers
-  const isNotebookScoped = (state.notebookCollectionIds?.length ?? 0) > 0;
+  const isNotebookScoped =
+    (state.notebookCollectionIds?.length ?? 0) > 0 || (state.notebookDocumentIds?.length ?? 0) > 0;
   const maxResults = isNotebookScoped ? 12 : MAX_SEARCH_RESULTS;
   const topResults = state.searchResults.slice(0, maxResults);
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -739,9 +739,20 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
           break;
         }
 
-        // If specific documents are referenced, use document-scoped search
-        if (state.documentIds && state.documentIds.length > 0) {
-          log.info(`[Search] Using document-scoped search: ${state.documentIds.length} doc(s)`);
+        // Union of @datei picks and @user-notebook resolved doc IDs. Both reach
+        // the same Qdrant filter — a personal notebook is effectively a saved
+        // set of @datei picks.
+        const explicitDocIds = state.documentIds ?? [];
+        const userNotebookDocIds = state.notebookDocumentIds ?? [];
+        const scopeDocIds = [...new Set([...explicitDocIds, ...userNotebookDocIds])];
+
+        if (scopeDocIds.length > 0) {
+          const fromUserNotebook = userNotebookDocIds.length > 0;
+          log.info(
+            `[Search] Using document-scoped search: ${scopeDocIds.length} doc(s)${
+              fromUserNotebook ? ` (incl. ${userNotebookDocIds.length} from user notebook)` : ''
+            }`
+          );
           try {
             const documentSearchService = (
               await import('../../../../services/document-services/DocumentSearchService/index.js')
@@ -755,7 +766,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
                 threshold: 0.2,
               },
               filters: {
-                documentIds: state.documentIds,
+                documentIds: scopeDocIds,
               },
             });
 
@@ -768,7 +779,7 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
                 relevance: r.similarity_score ?? 0.5,
               });
             }
-            searchedCollections.push('user-documents');
+            searchedCollections.push(fromUserNotebook ? 'user-notebook' : 'user-documents');
           } catch (err: unknown) {
             log.warn(
               `[Search] Document-scoped search failed: ${err instanceof Error ? err.message : String(err)}`

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -280,6 +280,12 @@ export interface ChatGraphInput {
   imageAttachments?: ImageAttachment[] | undefined;
   threadAttachments?: ThreadAttachment[] | undefined;
   notebookIds?: string[] | undefined;
+  /**
+   * Document IDs already resolved from user-owned notebook UUIDs. The controller
+   * resolves UUID notebook mentions to their backing document IDs (ownership
+   * enforced there) so the graph can stay synchronous in init.
+   */
+  notebookDocumentIds?: string[] | undefined;
   defaultNotebookId?: string | undefined;
   documentIds?: string[] | undefined;
   textIds?: string[] | undefined;
@@ -323,6 +329,12 @@ export interface ChatGraphState {
   // Notebook scoping (from @notebook mentions)
   notebookIds: string[];
   notebookCollectionIds: string[];
+  /**
+   * Document IDs scoped from user-owned notebook (UUID) mentions. Used by
+   * searchNode to filter Qdrant hits to documents inside the mentioned
+   * personal notebook(s). Ownership is verified upstream in the controller.
+   */
+  notebookDocumentIds: string[];
 
   // Default notebook scoping (from persistent UI selection)
   defaultNotebookCollectionIds: string[];

--- a/apps/api/config/notebookCollectionMap.ts
+++ b/apps/api/config/notebookCollectionMap.ts
@@ -72,3 +72,46 @@ export function getAllCollectionIds(): string[] {
   }
   return [...all];
 }
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Heuristic to distinguish user-notebook IDs (UUIDs from `notebook_collections`)
+ * from system-notebook slugs (e.g. `hamburg-notebook`). Used by chat routing to
+ * split mentioned notebook IDs onto the right resolution path.
+ */
+export function isUserNotebookId(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
+/**
+ * Resolve user-mentioned notebook UUIDs into the document IDs that scope chat
+ * search. Ownership is enforced here — UUIDs not owned by `userId` are
+ * silently dropped so a forged or stale ID returns no documents.
+ *
+ * Imported lazily inside the function body to avoid a Qdrant-helper boot
+ * dependency at module load time (the helper initialises its Qdrant client).
+ */
+export async function resolveUserNotebookDocumentIds(
+  userId: string,
+  notebookIds: string[]
+): Promise<{ documentIds: string[]; resolvedUserNotebookIds: string[] }> {
+  const uuids = notebookIds.filter(isUserNotebookId);
+  if (uuids.length === 0 || !userId) {
+    return { documentIds: [], resolvedUserNotebookIds: [] };
+  }
+  const { NotebookQdrantHelper } = await import('../database/services/NotebookQdrantHelper.js');
+  const helper = new NotebookQdrantHelper();
+  const documentIds = new Set<string>();
+  const resolved: string[] = [];
+  for (const uuid of uuids) {
+    const collection = await helper.getNotebookCollection(uuid);
+    if (!collection || collection.user_id !== userId) continue;
+    resolved.push(uuid);
+    const docs = await helper.getCollectionDocuments(uuid);
+    for (const d of docs) {
+      if (d.document_id) documentIds.add(d.document_id);
+    }
+  }
+  return { documentIds: [...documentIds], resolvedUserNotebookIds: resolved };
+}

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -27,7 +27,11 @@ import {
   rerankNode,
   buildCitations,
 } from '../../agents/langgraph/ChatGraph/index.js';
-import { isKnownNotebook } from '../../config/notebookCollectionMap.js';
+import {
+  isKnownNotebook,
+  isUserNotebookId,
+  resolveUserNotebookDocumentIds,
+} from '../../config/notebookCollectionMap.js';
 import { isRegoloReasoningModel } from '../../services/ai/regoloReasoningStream.js';
 import {
   getMem0Instance,
@@ -140,7 +144,13 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         return { status: 200 as const, body: undefined };
       }
 
-      const notebookIds = rawNotebookIds?.filter(isKnownNotebook) ?? [];
+      const systemNotebookIds = rawNotebookIds?.filter(isKnownNotebook) ?? [];
+      const userNotebookUuids = rawNotebookIds?.filter(isUserNotebookId) ?? [];
+      const { documentIds: notebookDocumentIds, resolvedUserNotebookIds } =
+        userNotebookUuids.length > 0
+          ? await resolveUserNotebookDocumentIds(userId, userNotebookUuids)
+          : { documentIds: [], resolvedUserNotebookIds: [] };
+      const notebookIds = [...systemNotebookIds, ...resolvedUserNotebookIds];
       const defaultNotebookId =
         rawDefaultNotebookId && isKnownNotebook(rawDefaultNotebookId)
           ? rawDefaultNotebookId
@@ -149,6 +159,11 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       log.info(`[ChatGraph] Processing request for user ${userId}, agent ${agentId ?? 'default'}`);
       if (notebookIds.length > 0) {
         log.info(`[ChatGraph] Notebook scoping: ${notebookIds.join(', ')}`);
+      }
+      if (resolvedUserNotebookIds.length > 0) {
+        log.info(
+          `[ChatGraph] User-notebook scoping: ${resolvedUserNotebookIds.length} notebook(s) → ${notebookDocumentIds.length} document(s)`
+        );
       }
 
       // === Convert messages ===
@@ -331,6 +346,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         imageAttachments: imageAttachments.length > 0 ? imageAttachments : undefined,
         threadAttachments: previousAttachments.length > 0 ? previousAttachments : undefined,
         notebookIds: notebookIds.length > 0 ? notebookIds : undefined,
+        notebookDocumentIds: notebookDocumentIds.length > 0 ? notebookDocumentIds : undefined,
         defaultNotebookId,
         documentIds: rawDocumentIds?.length ? rawDocumentIds : undefined,
         documentChatIds: rawDocumentChatIds?.length

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -13,10 +13,11 @@ interface MentionPopoverProps {
   anchorRect: { x: number; y: number } | null;
 }
 
-interface MentionSection {
-  label: string;
-  items: Mentionable[];
-}
+type MentionSubgroup = { sublabel: string; items: Mentionable[] };
+
+type MentionSection =
+  | { kind: 'flat'; label: string; items: Mentionable[] }
+  | { kind: 'grouped'; label: string; groups: MentionSubgroup[] };
 
 export function MentionPopover({
   query,
@@ -27,21 +28,37 @@ export function MentionPopover({
   anchorRect,
 }: MentionPopoverProps) {
   const listRef = useRef<HTMLDivElement>(null);
-  const { notebooks, tools, boards, docs, documents } = filterMentionables(query);
+  const { notebooks, userNotebooks, tools, boards, docs, documents } = filterMentionables(query);
 
-  const sections: MentionSection[] = useMemo(
-    () =>
-      [
-        { label: 'Werkzeuge', items: tools },
-        { label: 'Boards', items: boards },
-        { label: 'Dokumente', items: docs },
-        { label: 'Dateien', items: documents },
-        { label: 'Notizbücher', items: notebooks },
-      ].filter((s) => s.items.length > 0),
-    [tools, boards, docs, documents, notebooks]
+  const sections: MentionSection[] = useMemo(() => {
+    const notebookGroups: MentionSubgroup[] = [];
+    if (userNotebooks.length > 0) {
+      notebookGroups.push({ sublabel: 'meine', items: userNotebooks });
+    }
+    if (notebooks.length > 0) {
+      notebookGroups.push({ sublabel: 'system', items: notebooks });
+    }
+
+    const all: MentionSection[] = [
+      { kind: 'flat', label: 'Werkzeuge', items: tools },
+      { kind: 'flat', label: 'Boards', items: boards },
+      { kind: 'flat', label: 'Dokumente', items: docs },
+      { kind: 'flat', label: 'Dateien', items: documents },
+      ...(notebookGroups.length > 0
+        ? [{ kind: 'grouped' as const, label: 'Notizbücher', groups: notebookGroups }]
+        : []),
+    ];
+
+    return all.filter((s) =>
+      s.kind === 'flat' ? s.items.length > 0 : s.groups.some((g) => g.items.length > 0)
+    );
+  }, [tools, boards, docs, documents, notebooks, userNotebooks]);
+
+  const totalItems = sections.reduce(
+    (sum, s) =>
+      sum + (s.kind === 'flat' ? s.items.length : s.groups.reduce((n, g) => n + g.items.length, 0)),
+    0
   );
-
-  const totalItems = sections.reduce((sum, s) => sum + s.items.length, 0);
 
   useEffect(() => {
     if (!visible) return;
@@ -69,17 +86,36 @@ export function MentionPopover({
           <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
             {section.label}
           </div>
-          {section.items.map((item) => {
-            const idx = itemIndex++;
-            return (
-              <MentionItem
-                key={item.identifier}
-                mentionable={item}
-                isSelected={idx === selectedIndex}
-                onSelect={onSelect}
-              />
-            );
-          })}
+          {section.kind === 'flat'
+            ? section.items.map((item) => {
+                const idx = itemIndex++;
+                return (
+                  <MentionItem
+                    key={item.identifier}
+                    mentionable={item}
+                    isSelected={idx === selectedIndex}
+                    onSelect={onSelect}
+                  />
+                );
+              })
+            : section.groups.map((group) => (
+                <div key={group.sublabel}>
+                  <div className="px-3 pt-1 text-[9px] uppercase tracking-wider text-foreground-muted/50">
+                    {group.sublabel}
+                  </div>
+                  {group.items.map((item) => {
+                    const idx = itemIndex++;
+                    return (
+                      <MentionItem
+                        key={item.identifier}
+                        mentionable={item}
+                        isSelected={idx === selectedIndex}
+                        onSelect={onSelect}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
         </div>
       ))}
     </div>

--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -18,6 +18,7 @@ import {
   setBoardMentionables,
   setCustomAgents,
   setDocMentionables,
+  setUserNotebookMentionables,
   type CustomAgentMentionable,
   type Mentionable,
 } from '../lib/mentionables';
@@ -31,6 +32,11 @@ interface DocListItem {
   id: string;
   title: string;
   document_subtype?: string;
+}
+
+interface UserNotebookListItem {
+  id: string;
+  name: string;
 }
 
 const STALE_TIME = 60_000;
@@ -107,14 +113,35 @@ export function useDocsQuery() {
   });
 }
 
+export function useUserNotebooksQuery() {
+  const apiClient = useApiClient();
+  return useQuery<UserNotebookListItem[]>({
+    queryKey: ['mention-user-notebooks'],
+    queryFn: async () => {
+      const res = await apiClient
+        .get<{ collections?: UserNotebookListItem[] }>('/auth/notebook-collections')
+        .catch(() => ({ collections: [] }));
+      const list = Array.isArray(res?.collections) ? res.collections : [];
+      setUserNotebookMentionables(
+        list.map((n) => ({ id: n.id, title: n.name, slug: slugify(n.name) }))
+      );
+      return list;
+    },
+    staleTime: STALE_TIME,
+    retry: 1,
+  });
+}
+
 /**
- * Convenience hook that triggers all three queries — call from the chat
- * composer so dynamic mentionables are warm by the time @-popovers open.
+ * Convenience hook that triggers all dynamic-mentionable queries — call from
+ * the chat composer so dynamic mentionables are warm by the time @-popovers
+ * open.
  */
 export function useMentionablesQuery(): void {
   useCustomAgentsQuery();
   useBoardsQuery();
   useDocsQuery();
+  useUserNotebooksQuery();
 }
 
 /**
@@ -138,4 +165,3 @@ export function useDocMentionables(): Mentionable[] {
     }));
   }, [data]);
 }
-

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -24,6 +24,7 @@ import {
   PiFileText,
   PiPaperclip,
   PiSparkle,
+  PiNotePencil,
 } from 'react-icons/pi';
 import { MdDiversity1 } from 'react-icons/md';
 import { agentsList, type AgentListItem } from './agents';
@@ -500,6 +501,34 @@ export function getDocMentionables(): Mentionable[] {
   return [...docToolMentionables, ...dynamicDocMentionables];
 }
 
+export interface UserNotebookMentionable {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+let dynamicUserNotebookMentionables: Mentionable[] = [];
+
+export function setUserNotebookMentionables(notebooks: UserNotebookMentionable[]): void {
+  dynamicUserNotebookMentionables = notebooks.map((n) => ({
+    type: 'notebook' as const,
+    category: 'function' as const,
+    trigger: '@' as const,
+    identifier: n.id,
+    title: n.title,
+    description: `Mein Notizbuch: ${n.title}`,
+    avatar: '📓',
+    icon: PiNotePencil,
+    backgroundColor: '#316049',
+    mention: n.slug,
+  }));
+  rebuildMentionableMap();
+}
+
+export function getUserNotebookMentionables(): Mentionable[] {
+  return dynamicUserNotebookMentionables;
+}
+
 export const documentMentionables: Mentionable[] = [
   {
     type: 'document',
@@ -519,6 +548,7 @@ export function getAllMentionables(): Mentionable[] {
   return [
     ...agentMentionables,
     ...customAgentMentionables,
+    ...dynamicUserNotebookMentionables,
     ...notebookMentionables,
     ...toolMentionables,
     ...boardToolMentionables,
@@ -536,6 +566,7 @@ function rebuildMentionableMap(): void {
   const orderedSources = [
     agentMentionables,
     customAgentMentionables,
+    dynamicUserNotebookMentionables,
     notebookMentionables,
     toolMentionables,
     boardToolMentionables,
@@ -565,6 +596,7 @@ export function filterMentionables(query: string): {
   agents: Mentionable[];
   customAgents: Mentionable[];
   notebooks: Mentionable[];
+  userNotebooks: Mentionable[];
   tools: Mentionable[];
   boards: Mentionable[];
   docs: Mentionable[];
@@ -577,6 +609,7 @@ export function filterMentionables(query: string): {
       agents: agentMentionables,
       customAgents: customAgentMentionables,
       notebooks: notebookMentionables,
+      userNotebooks: dynamicUserNotebookMentionables,
       tools: toolMentionables,
       boards: allBoards,
       docs: allDocs,
@@ -593,6 +626,7 @@ export function filterMentionables(query: string): {
     agents: agentMentionables.filter(matchFn),
     customAgents: customAgentMentionables.filter(matchFn),
     notebooks: notebookMentionables.filter(matchFn),
+    userNotebooks: dynamicUserNotebookMentionables.filter(matchFn),
     tools: toolMentionables.filter(matchFn),
     boards: 'board'.startsWith(q) || q.startsWith('board') ? allBoards : allBoards.filter(matchFn),
     docs: 'dok'.startsWith(q) || q.startsWith('dok') ? allDocs : allDocs.filter(matchFn),
@@ -608,5 +642,12 @@ export function filterMentionablesByCategory(
   if (category === 'skill') {
     return [...all.agents, ...all.customAgents];
   }
-  return [...all.tools, ...all.boards, ...all.docs, ...all.documents, ...all.notebooks];
+  return [
+    ...all.tools,
+    ...all.boards,
+    ...all.docs,
+    ...all.documents,
+    ...all.userNotebooks,
+    ...all.notebooks,
+  ];
 }

--- a/packages/chat/tsconfig.json
+++ b/packages/chat/tsconfig.json
@@ -3,13 +3,10 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@gruenerator/contracts": ["../contracts/src/index.ts"]
     },
     "noUncheckedIndexedAccess": false,
     "noPropertyAccessFromIndexSignature": false


### PR DESCRIPTION
## Summary

Personal notebooks (the ones users curate on `/notebooks/meine`) now appear in the chat `@`-menu under a `meine` sub-header above the system `Notizbücher`. Picking one scopes the next message's RAG search to that notebook's documents — mirroring how a system notebook mention scopes to its Qdrant collection.

Until now the `@`-menu was hardcoded to the 15 system notebooks; user notebooks existed as data but couldn't be referenced from chat. This closes that gap so users can chat against their own curated sets the same way they chat against Hamburg / Bayern / etc.

## Behaviour

- Empty user list: `meine` sub-header is suppressed; popover shows system notebooks only.
- Unauth chat: the user-notebooks query 401s silently, list stays empty, system notebooks still render.
- Forged or stale UUID: `resolveUserNotebookDocumentIds` enforces ownership, returns zero documents — no info leak across users.
- Mixed `@datei` + personal notebook: doc-IDs are unioned before the Qdrant search.

## Test plan

- [ ] `@`-menu shows `meine` then `system` sub-headers
- [ ] Filtering by query hides empty sub-groups
- [ ] Selecting a personal notebook scopes next reply to its docs (backend log: `[ChatGraph] User-notebook scoping: N notebook(s) → M document(s)`)
- [ ] Unauthorised UUID returns zero results (no leak)
- [ ] Mention parser still extracts both system + UUID notebooks into `notebookIds`

A second small commit (`chore(chat): resolve @gruenerator/contracts from source in tsconfig`) removes dead emit-only options from `packages/chat/tsconfig.json` and adds the `paths` entry consumers already use elsewhere — cold chat typechecks no longer need contracts to be pre-built.