### PR TITLE
feat(notebook): opt-in search button on SectionHeader, migrate notebook headers

### DIFF
--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  SectionHeader,
   Skeleton,
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
@@ -20,7 +21,6 @@ import {
   HiDotsVertical,
   HiOutlineTrash,
   HiPencil,
-  HiPlus,
   HiShare,
   HiUserGroup,
 } from 'react-icons/hi';
@@ -157,8 +157,8 @@ const NotebookSection = memo(
     if (filtered.length === 0) return null;
 
     return (
-      <>
-        <h2 className="text-xl font-semibold text-foreground-heading mt-xl mb-md">{title}</h2>
+      <section className="mt-xl">
+        <SectionHeader title={title} />
         <div
           className={
             columns === 2
@@ -170,7 +170,7 @@ const NotebookSection = memo(
             <NotebookCard key={notebook.id} notebook={notebook} groups={groups} />
           ))}
         </div>
-      </>
+      </section>
     );
   }
 );
@@ -241,27 +241,23 @@ const EigeneNotebooks = memo(
     const shouldCollapse = qaCollections.length > COLLAPSE_THRESHOLD;
 
     return (
-      <div>
-        <div className="flex items-center gap-xs mt-xl mb-md">
-          <h2 className="text-xl font-semibold text-foreground-heading m-0">Eigene</h2>
-          <button
-            type="button"
-            onClick={onCreate}
-            className="flex items-center justify-center w-7 h-7 rounded-full text-primary-600 hover:bg-primary-600/10 transition-colors cursor-pointer"
-            aria-label="Notebook erstellen"
-          >
-            <HiPlus size={18} />
-          </button>
-          <button
-            type="button"
-            onClick={() => void navigate('/notebooks/meine')}
-            className="flex items-center justify-center w-7 h-7 rounded-full text-grey-500 hover:text-foreground hover:bg-grey-200/40 dark:hover:bg-grey-700/40 transition-colors cursor-pointer"
-            aria-label="Meine Notebooks verwalten"
-            title="Meine Notebooks verwalten"
-          >
-            <HiCog size={16} />
-          </button>
-        </div>
+      <div className="mt-xl">
+        <SectionHeader
+          title="Eigene"
+          onCreate={onCreate}
+          createLabel="Notebook erstellen"
+          actions={
+            <button
+              type="button"
+              onClick={() => void navigate('/notebooks/meine')}
+              className="flex h-7 w-7 items-center justify-center rounded-full text-grey-500 transition-colors hover:bg-grey-200/40 hover:text-foreground dark:hover:bg-grey-700/40"
+              aria-label="Meine Notebooks verwalten"
+              title="Meine Notebooks verwalten"
+            >
+              <HiCog size={16} />
+            </button>
+          }
+        />
         {loading ? (
           <div className="flex flex-col gap-sm">
             {Array.from({ length: 3 }, (_, i) => (
@@ -484,6 +480,7 @@ function NotebooksIndexFooter() {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
       } else {
         const result = await createQACollection({
@@ -492,6 +489,7 @@ function NotebooksIndexFooter() {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
 
         if (result?.id && data.documents.length) {

--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -1,5 +1,5 @@
-import { Skeleton } from '@gruenerator/ui';
-import { memo } from 'react';
+import { Skeleton, SectionHeader } from '@gruenerator/ui';
+import { memo, useMemo, useState } from 'react';
 import { HiBookOpen } from 'react-icons/hi';
 import { useNavigate } from 'react-router-dom';
 
@@ -43,11 +43,25 @@ const VonDerBasisCard = memo(function VonDerBasisCard({
 
 export function VonDerBasisSection() {
   const { data, isLoading } = usePublicNotebookCollections({ enabled: true });
+  const [query, setQuery] = useState('');
+
   const collections = data ?? [];
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return collections;
+    return collections.filter(
+      (c) => c.name.toLowerCase().includes(q) || (c.description ?? '').toLowerCase().includes(q)
+    );
+  }, [collections, query]);
 
   return (
     <section className="mt-xl">
-      <h2 className="mb-md text-xl font-semibold text-foreground-heading">Von der Basis</h2>
+      <SectionHeader
+        title="Von der Basis"
+        searchQuery={query}
+        onSearchChange={setQuery}
+        searchPlaceholder="Notizbücher durchsuchen…"
+      />
 
       {isLoading ? (
         <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
@@ -66,9 +80,13 @@ export function VonDerBasisSection() {
           Noch keine öffentlichen Notebooks. Sei der oder die Erste — veröffentliche eines deiner
           Notebooks im Editor.
         </p>
+      ) : filtered.length === 0 ? (
+        <p className="rounded-md border border-dashed border-grey-300 px-md py-lg text-center text-sm text-grey-500 dark:border-grey-700 dark:text-grey-400">
+          Keine Treffer für „{query}".
+        </p>
       ) : (
         <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
-          {collections.map((c) => (
+          {filtered.map((c) => (
             <VonDerBasisCard key={c.id} collection={c} />
           ))}
         </div>

--- a/packages/ui/src/components/section-header.tsx
+++ b/packages/ui/src/components/section-header.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { PlusIcon } from 'lucide-react';
+import { PlusIcon, SearchIcon, XIcon } from 'lucide-react';
 
 import { cn } from '../lib/cn';
 
@@ -19,6 +19,9 @@ const sectionHeaderVariants = cva('flex items-center justify-between', {
 const plusButtonClass =
   'flex items-center justify-center w-7 h-7 rounded-full text-primary-600 hover:bg-primary-600/10 transition-colors cursor-pointer border-none bg-transparent';
 
+const iconButtonClass =
+  'flex items-center justify-center w-7 h-7 rounded-full text-grey-500 hover:text-foreground hover:bg-grey-200/40 dark:hover:bg-grey-700/40 transition-colors cursor-pointer border-none bg-transparent';
+
 function SectionHeader({
   className,
   size = 'default',
@@ -28,6 +31,10 @@ function SectionHeader({
   createLabel,
   createMenu,
   actions,
+  searchQuery,
+  onSearchChange,
+  searchPlaceholder,
+  searchLabel,
   ...props
 }: React.ComponentProps<'div'> &
   VariantProps<typeof sectionHeaderVariants> & {
@@ -38,6 +45,15 @@ function SectionHeader({
     /** Wraps the plus button as a dropdown trigger. Receives the button as children. */
     createMenu?: (trigger: React.ReactNode) => React.ReactNode;
     actions?: React.ReactNode;
+    /**
+     * Search affordance. Pass `onSearchChange` to opt in — renders a magnifier
+     * icon that expands to an inline input. The query value is controlled by
+     * the consumer via `searchQuery`.
+     */
+    searchQuery?: string;
+    onSearchChange?: (q: string) => void;
+    searchPlaceholder?: string;
+    searchLabel?: string;
   }) {
   const Heading = size === 'sm' ? 'h3' : 'h2';
   const headingClass =
@@ -56,6 +72,60 @@ function SectionHeader({
         <PlusIcon className="size-[18px]" />
       </button>
     ) : null;
+
+  const searchable = typeof onSearchChange === 'function';
+  const [searchOpen, setSearchOpen] = React.useState(false);
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+  const isExpanded = searchOpen || (searchQuery?.length ?? 0) > 0;
+
+  React.useEffect(() => {
+    if (searchOpen) {
+      searchInputRef.current?.focus();
+    }
+  }, [searchOpen]);
+
+  const searchControl = searchable ? (
+    isExpanded ? (
+      <div className="flex items-center gap-1 rounded-full border border-grey-200 bg-background pl-2 pr-1 py-0.5 dark:border-grey-700">
+        <SearchIcon className="size-3.5 text-grey-500" aria-hidden />
+        <input
+          ref={searchInputRef}
+          type="search"
+          value={searchQuery ?? ''}
+          onChange={(e) => onSearchChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              onSearchChange('');
+              setSearchOpen(false);
+            }
+          }}
+          placeholder={searchPlaceholder ?? 'Suchen…'}
+          aria-label={searchLabel ?? 'Suchen'}
+          className="h-6 w-32 border-none bg-transparent text-sm text-foreground placeholder:text-grey-400 focus:outline-none focus:ring-0"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            onSearchChange('');
+            setSearchOpen(false);
+          }}
+          className="flex h-5 w-5 items-center justify-center rounded-full text-grey-500 hover:bg-grey-200/40 dark:hover:bg-grey-700/40"
+          aria-label="Suche schließen"
+        >
+          <XIcon className="size-3" />
+        </button>
+      </div>
+    ) : (
+      <button
+        type="button"
+        onClick={() => setSearchOpen(true)}
+        className={iconButtonClass}
+        aria-label={searchLabel ?? 'Suchen'}
+      >
+        <SearchIcon className="size-4" />
+      </button>
+    )
+  ) : null;
 
   return (
     <div
@@ -76,7 +146,12 @@ function SectionHeader({
         )}
         {createMenu && plusButton ? createMenu(plusButton) : plusButton}
       </div>
-      {actions && <div className="flex items-center gap-xs">{actions}</div>}
+      {(actions || searchControl) && (
+        <div className="flex items-center gap-xs">
+          {actions}
+          {searchControl}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The notebook index page had three near-identical inlined `<h2>` headers (Bundesebene/Landesebene/Weitere via `NotebookSection`, `Eigene` with plus + cog, `Von der Basis` with nothing) — meanwhile `WorkplacePage` was already consuming a reusable `SectionHeader` from `@gruenerator/ui`. Migrating the notebook headers onto the same component consolidates styling and unlocks the requested search affordance without scattering filter state across sections.

`SectionHeader` gains an optional search slot (`searchQuery` + `onSearchChange`). It's off by default — passing `onSearchChange` opts in and renders a magnifier-icon button that expands to an inline input (with X to clear, ESC to close). Existing call sites (`WorkplacePage`) render unchanged.

"Von der Basis" turns the search on and filters its public-collection list locally. The same prop is ready to enable on a future user-shared-notebooks section without further changes to the header component.

## Test plan

- [ ] `/notebooks` renders Bundesebene/Landesebene/Eigene/Von der Basis exactly as before (spacing, alignment, plus + cog still work)
- [ ] Click magnifier on "Von der Basis" → input appears, typing filters the cards, X clears + collapses
- [ ] Empty filter result shows the "Keine Treffer" message
- [ ] WorkplacePage's "Weitere Tools" / "Grünerators Favoriten" headers unchanged
- [ ] `pnpm --filter @gruenerator/ui typecheck` green; `@gruenerator/web` typecheck shows only the pre-existing `NotebookEditor.tsx:281` error from master (unrelated)