### PR TITLE
feat(chat): add @wolke mentionable for attaching Nextcloud files

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -47,6 +47,7 @@ import type {
   ExamplesToolResult,
   DocumentSource,
   SynthesisMode,
+  WolkeFileRef,
 } from './types.js';
 import type { SubcategoryFilters } from '../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../routes/chat/agents/types.js';
@@ -120,6 +121,10 @@ const ChatStateAnnotation = Annotation.Root({
 
   // Collaborative document context (from @doc mentions)
   docMentionIds: Annotation<string[]>({
+    reducer: (x, y) => y ?? x ?? [],
+  }),
+  // Wolke (Nextcloud) file refs selected via @wolke mentionable.
+  wolkeFiles: Annotation<WolkeFileRef[]>({
     reducer: (x, y) => y ?? x ?? [],
   }),
   // Current open document in the docs editor (primary context for docs surface)
@@ -661,6 +666,9 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     // Collaborative document context (from @doc mentions, populated by controller)
     docMentionIds: input.docMentionIds || [],
     documentMentionContext: null,
+
+    // Wolke (Nextcloud) file refs (from @wolke mentionable, validated by controller)
+    wolkeFiles: input.wolkeFiles || [],
 
     // Current open document (docs editor surface)
     currentDocument: input.currentDocument || null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
@@ -13,7 +13,13 @@ import {
   resolveNotebookCollections,
 } from '../../../../config/notebookCollectionMap.js';
 
-import type { ChatGraphState, DocumentSource, SearchIntent, SynthesisMode } from '../types.js';
+import type {
+  ChatGraphState,
+  DocumentSource,
+  SearchIntent,
+  SynthesisMode,
+  WolkeFileRef,
+} from '../types.js';
 
 const COMPARE_VERB_PATTERN =
   /\b(vergleich|unterschied|pro\s+und\s+contra|gegenüber|im\s+vergleich|versus|vs\.?|gemeinsamkeit|abweichung|kontrast|stell.*gegenüber)/i;
@@ -48,6 +54,7 @@ interface BuildOpts {
   documentChatIds: string[];
   docMentionIds: string[];
   notebookIds: string[];
+  wolkeFiles: WolkeFileRef[];
   threadAttachments: ChatGraphState['threadAttachments'];
   currentDocument: ChatGraphState['currentDocument'];
 }
@@ -86,6 +93,15 @@ export function buildDocumentSources(opts: BuildOpts): DocumentSource[] {
       id,
       label: notebookLabel(id),
       ...(known ? { collectionIds } : {}),
+    });
+  }
+
+  for (const ref of opts.wolkeFiles) {
+    sources.push({
+      kind: 'wolke',
+      id: `wolke:${ref.shareLinkId}:${ref.path}`,
+      label: ref.name,
+      wolke: ref,
     });
   }
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -72,6 +72,7 @@ export async function classifierNode(state: ChatGraphState): Promise<Partial<Cha
     documentChatIds: state.documentChatIds ?? [],
     docMentionIds: state.docMentionIds ?? [],
     notebookIds: state.notebookIds ?? [],
+    wolkeFiles: state.wolkeFiles ?? [],
     threadAttachments: state.threadAttachments ?? [],
     currentDocument: state.currentDocument ?? null,
   });
@@ -137,6 +138,7 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
     const hasNotebooks = state.notebookIds && state.notebookIds.length > 0;
     const hasDocuments = state.documentIds && state.documentIds.length > 0;
     const hasDocumentChat = state.documentChatIds && state.documentChatIds.length > 0;
+    const hasWolkeFiles = state.wolkeFiles && state.wolkeFiles.length > 0;
     const hasBoards = state.boardIds && state.boardIds.length > 0;
     // Open document in the docs-editor is primary context, not retrieval scope.
     // Distinct from documentChatIds — we do NOT force-route to search for it.
@@ -326,6 +328,22 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
       return classifyWithForcedSearch({
         reason: 'Document',
         docCount: state.documentIds.length,
+        aiWorkerPool,
+        userContent,
+        conversationContext,
+        topicalContext,
+        temporal,
+        complexity,
+        startTime,
+      });
+    }
+
+    // @wolke selections force search intent — the wolke file content must reach
+    // respondNode via perSourceResults, and that only happens inside the search path.
+    if (hasWolkeFiles && userContent.length > 0) {
+      return classifyWithForcedSearch({
+        reason: 'Wolke',
+        docCount: state.wolkeFiles.length,
         aiWorkerPool,
         userContent,
         conversationContext,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -195,6 +195,7 @@ async function testExpandedContextWindow() {
     boardContext: null,
     docMentionIds: [],
     documentMentionContext: null,
+    wolkeFiles: [],
     currentDocument: null,
     searchSources: [],
     intent: 'search',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -236,6 +236,7 @@ async function evaluateBudgetAllocation() {
     boardContext: null,
     docMentionIds: [],
     documentMentionContext: null,
+    wolkeFiles: [],
     currentDocument: null,
     searchSources: [],
     intent: 'search',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -43,6 +43,7 @@ import {
   extractDomain,
   resolveCollectionName,
 } from './citationUtils.js';
+import { retrieveWolkeFile } from './wolkeRetrieval.js';
 
 import type { SubcategoryFilters } from '../../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../../routes/chat/agents/types.js';
@@ -354,6 +355,16 @@ export async function executeMultiDocFanout(
         return [src.id, results];
       }
 
+      if (src.kind === 'wolke') {
+        collections.add(`wolke:${src.wolke?.shareLinkId.slice(0, 8) ?? '?'}`);
+        if (!agentConfig.userId) {
+          log.warn(`[Search] Skipping wolke source ${src.id}: no userId on agentConfig`);
+          return [src.id, []];
+        }
+        const results = await retrieveWolkeFile(src, perSourceLimit, agentConfig.userId);
+        return [src.id, results];
+      }
+
       if (src.kind === 'notebook' && src.collectionIds && src.collectionIds.length > 0) {
         const collectionPromises = src.collectionIds.map((collection) => {
           collections.add(collection);
@@ -455,13 +466,17 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         s.kind === 'document' ||
         s.kind === 'document_chat' ||
         s.kind === 'doc_mention' ||
-        s.kind === 'notebook'
+        s.kind === 'notebook' ||
+        s.kind === 'wolke'
     );
+    const hasWolke = retrievableDocSources.some((s) => s.kind === 'wolke');
 
     // Multi-document fan-out: when the user references ≥2 retrievable doc sources,
     // run a doc-scoped retrieval per source so each gets its own evidence budget.
     // Prevents one denser/better-embedded doc from starving the others at rerank time.
-    if (retrievableDocSources.length >= 2) {
+    // Wolke sources always fan out (single or multiple) because they have no single-source
+    // retrieval path in the `case 'search'` block — they're only fetched via retrieveWolkeFile.
+    if (retrievableDocSources.length >= 2 || hasWolke) {
       const query = truncateQuery(searchQuery || '');
       log.info(
         `[Search] Multi-doc fan-out across ${retrievableDocSources.length} sources: ${retrievableDocSources.map((s) => `${s.kind}:${s.id.slice(0, 8)}`).join(', ')}`

--- a/apps/api/agents/langgraph/ChatGraph/nodes/wolkeRetrieval.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/wolkeRetrieval.ts
@@ -1,0 +1,121 @@
+/**
+ * Wolke file retrieval for the multi-doc fan-out.
+ *
+ * Downloads a single user-selected Wolke (Nextcloud) file via WebDAV at
+ * chat-send time, extracts its text via the shared OCR / text-extraction
+ * pipeline, and returns SearchResult chunks the respondNode can quote.
+ *
+ * No DB writes, no Qdrant indexing — purely inline-at-send-time. Stale or
+ * unsupported files yield an empty result set so the rest of the turn still
+ * succeeds.
+ */
+
+import NextcloudApiClient from '../../../../services/api-clients/nextcloudApiClient.js';
+import { extractTextFromFile } from '../../../../services/document-services/DocumentProcessingService/textExtraction.js';
+import { NextcloudShareManager } from '../../../../utils/integrations/nextcloud/shareManager.js';
+import { createLogger } from '../../../../utils/logger.js';
+import { SOURCE_PREFIX, type DocumentSource, type SearchResult } from '../types.js';
+
+const log = createLogger('WolkeRetrieval');
+
+const CHUNK_SIZE = 1500;
+const CHUNK_OVERLAP = 100;
+
+function chunkText(text: string, perSourceLimit: number): string[] {
+  const cleaned = text.trim();
+  if (!cleaned) return [];
+  if (cleaned.length <= CHUNK_SIZE) return [cleaned];
+  const chunks: string[] = [];
+  let pos = 0;
+  const stride = CHUNK_SIZE - CHUNK_OVERLAP;
+  while (pos < cleaned.length && chunks.length < perSourceLimit) {
+    chunks.push(cleaned.slice(pos, pos + CHUNK_SIZE));
+    pos += stride;
+  }
+  return chunks;
+}
+
+function mimeTypeFromName(name: string): string {
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.docx'))
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  if (lower.endsWith('.pptx'))
+    return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  if (lower.endsWith('.txt') || lower.endsWith('.md')) return 'text/plain';
+  return 'application/octet-stream';
+}
+
+interface ShareLinkRecord {
+  id: string;
+  share_link: string;
+  is_active?: boolean;
+}
+
+async function resolveShareLink(
+  userId: string,
+  shareLinkId: string
+): Promise<ShareLinkRecord | null> {
+  try {
+    const links = (await NextcloudShareManager.getShareLinks(userId)) as ShareLinkRecord[];
+    return links.find((l) => l.id === shareLinkId && l.is_active !== false) ?? null;
+  } catch (err) {
+    log.warn(`[Wolke] Share-link lookup failed for ${shareLinkId}`, err);
+    return null;
+  }
+}
+
+export async function retrieveWolkeFile(
+  src: DocumentSource,
+  perSourceLimit: number,
+  userId: string
+): Promise<SearchResult[]> {
+  if (src.kind !== 'wolke' || !src.wolke) return [];
+  const { shareLinkId, path: filePath, name } = src.wolke;
+
+  const shareLink = await resolveShareLink(userId, shareLinkId);
+  if (!shareLink) {
+    log.warn(`[Wolke] Skip ${name}: share link ${shareLinkId} not available`);
+    return [];
+  }
+
+  let client: NextcloudApiClient;
+  try {
+    client = await NextcloudApiClient.create(shareLink.share_link);
+  } catch (err) {
+    log.warn(`[Wolke] NextcloudApiClient init failed for ${shareLinkId}`, err);
+    return [];
+  }
+
+  let download: { buffer: Buffer; mimeType: string | null; size: number };
+  try {
+    download = await client.downloadFile(filePath);
+  } catch (err) {
+    log.warn(`[Wolke] downloadFile failed for ${filePath}`, err);
+    return [];
+  }
+
+  const mimetype = download.mimeType || mimeTypeFromName(name);
+  let text: string;
+  try {
+    text = await extractTextFromFile({
+      buffer: download.buffer,
+      mimetype,
+      originalname: name,
+      size: download.size,
+    });
+  } catch (err) {
+    log.warn(`[Wolke] text extraction skipped for ${name} (${mimetype})`, err);
+    return [];
+  }
+
+  const chunks = chunkText(text, perSourceLimit);
+  return chunks.map<SearchResult>((content, idx) => ({
+    source: `${SOURCE_PREFIX.WOLKE}${shareLinkId}:${filePath}`,
+    title: name,
+    content,
+    relevance: 0.7,
+    documentSourceId: src.id,
+    chunkIndex: idx,
+  }));
+}

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -13,7 +13,10 @@
 import type { SubcategoryFilters } from '../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../routes/chat/agents/types.js';
 import type { AIWorkerPool } from '../../../workers/types.js';
+import type { WolkeFileRef } from '@gruenerator/contracts';
 import type { ModelMessage } from 'ai';
+
+export type { WolkeFileRef };
 
 /**
  * Search source backends that can be queried in parallel.
@@ -108,6 +111,7 @@ export const SOURCE_PREFIX = {
   RESEARCH_SYNTHESIS: 'research_synthesis',
   DOCUMENT: 'document',
   DOCUMENT_CHAT: 'documentchat:',
+  WOLKE: 'wolke:',
 } as const;
 
 /**
@@ -161,7 +165,8 @@ export type DocumentSourceKind =
   | 'doc_mention' // docMentionIds (collab @doc)
   | 'notebook' // notebookIds (collection scope)
   | 'attachment' // threadAttachments (uploaded file context)
-  | 'current_doc'; // currentDocument (open in docs editor)
+  | 'current_doc' // currentDocument (open in docs editor)
+  | 'wolke'; // wolkeFiles (@wolke mentionable — Nextcloud file picker)
 
 /**
  * Normalized reference to a single document the user is working with this turn.
@@ -176,6 +181,9 @@ export interface DocumentSource {
   // For `notebook` kind: Qdrant collection keys for this notebook (a single
   // notebook can span multiple collections). Empty for non-notebook kinds.
   collectionIds?: string[] | undefined;
+  // For `wolke` kind: the original share-link + path so searchNode can fetch
+  // the file content via WebDAV at retrieval time.
+  wolke?: WolkeFileRef | undefined;
 }
 
 /**
@@ -286,6 +294,7 @@ export interface ChatGraphInput {
   documentChatIds?: string[] | undefined;
   boardIds?: string[] | undefined;
   docMentionIds?: string[] | undefined;
+  wolkeFiles?: WolkeFileRef[] | undefined;
   currentDocument?: CurrentDocument | undefined;
   userLocale?: UserLocale | undefined;
   customSystemPrompt?: string | undefined;
@@ -340,6 +349,10 @@ export interface ChatGraphState {
   // Collaborative document context (from @doc mentions)
   docMentionIds: string[];
   documentMentionContext: string | null;
+
+  // Wolke (Nextcloud) file refs selected via @wolke mentionable.
+  // Downloaded + parsed inline at searchNode time; never persisted.
+  wolkeFiles: WolkeFileRef[];
 
   // Current open document in the docs editor (primary context, not retrieval scope).
   // Set when chat is embedded in a document editor surface.

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -37,6 +37,7 @@ import {
 import { getCachedPersona } from '../../services/mem0/personaService.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
 import { getAIWorkerPool } from '../../utils/getAIWorkerPool.js';
+import { NextcloudShareManager } from '../../utils/integrations/nextcloud/shareManager.js';
 import { createLogger } from '../../utils/logger.js';
 import { ThreadId, UserId } from '../../utils/types/branded.js';
 
@@ -110,6 +111,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         defaultNotebookId: rawDefaultNotebookId,
         boardIds: rawBoardIds,
         docMentionIds: rawDocMentionIds,
+        wolkeFiles: rawWolkeFiles,
         currentDocument: rawCurrentDocument,
         customSystemPrompt: rawCustomSystemPrompt,
         roleName: rawRoleName,
@@ -145,6 +147,26 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         rawDefaultNotebookId && isKnownNotebook(rawDefaultNotebookId)
           ? rawDefaultNotebookId
           : undefined;
+
+      // Filter wolkeFiles to refs whose shareLinkId is still owned + active for this user.
+      // Stale refs (deleted/deactivated share link) are dropped silently so the chat still works.
+      let wolkeFiles: typeof rawWolkeFiles = undefined;
+      if (rawWolkeFiles?.length) {
+        try {
+          const userShareLinks = await NextcloudShareManager.getShareLinks(userId);
+          const allowedIds = new Set(userShareLinks.filter((l) => l.is_active).map((l) => l.id));
+          const filtered = rawWolkeFiles.filter((f) => allowedIds.has(f.shareLinkId));
+          wolkeFiles = filtered.length > 0 ? filtered : undefined;
+          if (filtered.length < rawWolkeFiles.length) {
+            log.warn(
+              `[ChatGraph] Dropped ${rawWolkeFiles.length - filtered.length} stale wolkeFiles ref(s) for user ${userId}`
+            );
+          }
+        } catch (err) {
+          log.warn(`[ChatGraph] wolkeFiles ownership check failed; ignoring refs`, err);
+          wolkeFiles = undefined;
+        }
+      }
 
       log.info(`[ChatGraph] Processing request for user ${userId}, agent ${agentId ?? 'default'}`);
       if (notebookIds.length > 0) {
@@ -339,6 +361,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
             ? []
             : undefined,
         boardIds: rawBoardIds?.length ? rawBoardIds : undefined,
+        wolkeFiles,
         // When the docs editor sends a currentDocument, also surface its id as a
         // doc-mention so the existing modify_doc / summary intent paths activate
         // (they key off `hasDocMentions`). Explicit @doc mentions always take

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -130,6 +130,7 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
           window.location.href = buildLoginUrl(currentPath);
         }
       },
+      wolkeConnectUrl: '/profile/wolke',
       renderSharepic: renderSharepicToImage,
       onEditSharepic: (variant: SharepicVariant) => {
         const handoffId =

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -24,6 +24,7 @@ import { detectMention } from '../../lib/mentionDetection';
 import { getFilteredForMode } from '../../lib/mentionDetection';
 import { computeMentionInsertion } from '../../lib/mentionInsertion';
 import { FileMentionPopover } from './FileMentionPopover';
+import { WolkeMentionPopover } from './WolkeMentionPopover';
 import type { CollabDocSelection } from '../../lib/documentMentionables';
 import { PlusMenu } from './PlusMenu';
 import { ModelPicker } from './ModelPicker';
@@ -195,7 +196,7 @@ function ComposerButtons({
 
 interface MentionState {
   visible: boolean;
-  mode: 'functions' | 'skills' | 'datei';
+  mode: 'functions' | 'skills' | 'datei' | 'wolke';
   query: string;
   selectedIndex: number;
   anchorRect: { x: number; y: number } | null;
@@ -255,6 +256,24 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
       // When user selects the @docs trigger, also open the unified file/doc picker
       if (mentionable.type === 'doc' && mentionable.identifier === 'docs-picker-trigger') {
         setMention((prev) => ({ ...prev, mode: 'datei' }));
+        return;
+      }
+
+      // When user selects the @wolke trigger, swap to the Wolke file picker
+      if (mentionable.type === 'wolke') {
+        // Strip the in-progress "@wolk…" trigger from the textarea — the picker
+        // inserts one @wolke:<token> per chosen file via handleWolkeSelect.
+        if (mention.mentionStart >= 0) {
+          const currentText = composerRuntime.getState().text;
+          const before = currentText.slice(0, mention.mentionStart);
+          const after = currentText.slice(textarea.selectionStart);
+          composerRuntime.setText(`${before}${after}`);
+          requestAnimationFrame(() => {
+            const pos = before.length;
+            textarea.setSelectionRange(pos, pos);
+          });
+        }
+        setMention((prev) => ({ ...prev, mode: 'wolke', visible: true, mentionStart: -1 }));
         return;
       }
 
@@ -350,10 +369,28 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
     [composerRuntime, dismissPopover, stripTriggerText]
   );
 
+  const handleWolkeSelect = useCallback(
+    (tokens: string[]) => {
+      const textarea = textareaRef.current;
+      if (!textarea || tokens.length === 0) return;
+      const currentText = composerRuntime.getState().text;
+      const caret = textarea.selectionStart;
+      const insert = `${currentText.slice(0, caret)}${tokens.join(' ')} ${currentText.slice(caret)}`;
+      composerRuntime.setText(insert);
+      dismissPopover();
+      requestAnimationFrame(() => {
+        const pos = caret + tokens.join(' ').length + 1;
+        textarea.setSelectionRange(pos, pos);
+        textarea.focus();
+      });
+    },
+    [composerRuntime, dismissPopover]
+  );
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // Don't interfere when file/doc browser is open
-      if (mention.mode === 'datei') return;
+      // Don't interfere when file/doc browser or wolke picker is open
+      if (mention.mode === 'datei' || mention.mode === 'wolke') return;
 
       const textarea = e.target;
       const text = textarea.value;
@@ -385,7 +422,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
       // In datei/docs mode, only handle Escape (cmdk handles arrow keys internally).
       // Enter is swallowed so the textarea doesn't submit the form while the picker
       // is open — the user must select via the picker or dismiss with Escape first.
-      if (mention.mode === 'datei') {
+      if (mention.mode === 'datei' || mention.mode === 'wolke') {
         if (e.key === 'Escape') {
           e.preventDefault();
           dismissPopover();
@@ -475,6 +512,12 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
               onSelect={(s) =>
                 s.kind === 'document' ? handleDocumentSelect(s.doc) : handleCollabDocSelect(s.doc)
               }
+              onDismiss={dismissPopover}
+            />
+          ) : mention.mode === 'wolke' ? (
+            <WolkeMentionPopover
+              visible={mention.visible}
+              onSelect={handleWolkeSelect}
               onDismiss={dismissPopover}
             />
           ) : mention.mode === 'skills' ? (

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -27,7 +27,7 @@ export function MentionPopover({
   anchorRect,
 }: MentionPopoverProps) {
   const listRef = useRef<HTMLDivElement>(null);
-  const { notebooks, tools, boards, docs, documents } = filterMentionables(query);
+  const { notebooks, tools, boards, docs, documents, wolke } = filterMentionables(query);
 
   const sections: MentionSection[] = useMemo(
     () =>
@@ -36,9 +36,10 @@ export function MentionPopover({
         { label: 'Boards', items: boards },
         { label: 'Dokumente', items: docs },
         { label: 'Dateien', items: documents },
+        { label: 'Wolke', items: wolke },
         { label: 'Notizbücher', items: notebooks },
       ].filter((s) => s.items.length > 0),
-    [tools, boards, docs, documents, notebooks]
+    [tools, boards, docs, documents, wolke, notebooks]
   );
 
   const totalItems = sections.reduce((sum, s) => sum + s.items.length, 0);

--- a/packages/chat/src/components/thread/WolkeMentionPopover.tsx
+++ b/packages/chat/src/components/thread/WolkeMentionPopover.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useUserShareLinksQuery,
+  useWolkeBrowseQuery,
+  type ChatWolkeFile,
+} from '../../hooks/useMentionablesQuery';
+import { useChatConfigStore } from '../../stores/chatConfigStore';
+import { encodeWolkeToken } from '../../lib/mentionables';
+
+interface WolkeMentionPopoverProps {
+  visible: boolean;
+  onSelect: (tokens: string[]) => void;
+  onDismiss: () => void;
+}
+
+interface SelectedFile {
+  shareLinkId: string;
+  path: string;
+  name: string;
+}
+
+function joinPath(parent: string, name: string): string {
+  if (!parent || parent === '/') return `/${name}`;
+  return `${parent.replace(/\/$/, '')}/${name}`;
+}
+
+function parentOf(p: string): string {
+  if (!p || p === '/') return '';
+  const trimmed = p.replace(/\/$/, '');
+  const idx = trimmed.lastIndexOf('/');
+  return idx <= 0 ? '' : trimmed.slice(0, idx);
+}
+
+export function WolkeMentionPopover({ visible, onSelect, onDismiss }: WolkeMentionPopoverProps) {
+  const wolkeConnectUrl = useChatConfigStore((s) => s.wolkeConnectUrl);
+  const { data: shareLinks, isLoading: linksLoading } = useUserShareLinksQuery(visible);
+
+  const [activeShareId, setActiveShareId] = useState<string | null>(null);
+  const [folderPath, setFolderPath] = useState<string>('');
+  const [filter, setFilter] = useState<string>('');
+  const [selection, setSelection] = useState<Map<string, SelectedFile>>(new Map());
+
+  useEffect(() => {
+    if (!visible) return;
+    if (!activeShareId && shareLinks && shareLinks.length > 0) {
+      setActiveShareId(shareLinks[0].id);
+    }
+  }, [visible, shareLinks, activeShareId]);
+
+  useEffect(() => {
+    if (!visible) {
+      setSelection(new Map());
+      setFolderPath('');
+      setFilter('');
+    }
+  }, [visible]);
+
+  const browse = useWolkeBrowseQuery(activeShareId, folderPath, visible);
+
+  const filteredFiles = useMemo(() => {
+    const files = browse.data?.files ?? [];
+    if (!filter) return files;
+    const q = filter.toLowerCase();
+    return files.filter((f) => f.name.toLowerCase().includes(q));
+  }, [browse.data, filter]);
+
+  if (!visible) return null;
+
+  const hasNoShares = !linksLoading && (!shareLinks || shareLinks.length === 0);
+  const selectionList = [...selection.values()];
+
+  const toggleFile = (file: ChatWolkeFile) => {
+    if (file.isDirectory || file.isSupported === false || !activeShareId) return;
+    const path = joinPath(folderPath, file.name);
+    const key = `${activeShareId}:${path}`;
+    setSelection((prev) => {
+      const next = new Map(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.set(key, { shareLinkId: activeShareId, path, name: file.name });
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    if (selectionList.length === 0) return;
+    const tokens = selectionList.map((f) =>
+      encodeWolkeToken({ shareLinkId: f.shareLinkId, path: f.path, name: f.name })
+    );
+    onSelect(tokens);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Wolke-Dateien auswählen"
+      className="mention-popover absolute z-50 flex max-h-[420px] w-[360px] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg"
+      style={{ bottom: '100%', left: 0, marginBottom: '0.5rem' }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          onDismiss();
+        }
+      }}
+    >
+      <div className="border-b border-border px-3 py-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted/70">
+            Wolke
+          </span>
+          {shareLinks && shareLinks.length > 1 && (
+            <select
+              value={activeShareId ?? ''}
+              onChange={(e) => {
+                setActiveShareId(e.target.value);
+                setFolderPath('');
+              }}
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+            >
+              {shareLinks.map((l) => (
+                <option key={l.id} value={l.id}>
+                  {l.label || l.id.slice(0, 8)}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+        {!hasNoShares && (
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="text"
+              autoFocus
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Dateien filtern…"
+              className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary/40"
+            />
+          </div>
+        )}
+        {!hasNoShares && folderPath && (
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              setFolderPath(parentOf(folderPath));
+              setFilter('');
+            }}
+            className="mt-2 text-xs text-foreground-muted hover:text-foreground"
+          >
+            ← {folderPath || '/'}
+          </button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {hasNoShares ? (
+          <div className="flex flex-col items-start gap-2 px-3 py-4">
+            <p className="text-sm font-medium text-foreground">Keine Wolke verbunden</p>
+            <p className="text-xs text-foreground-muted">
+              Verbinde zuerst deinen Nextcloud-Ordner, damit du Dateien per @wolke einfügen kannst.
+            </p>
+            {wolkeConnectUrl && (
+              <a
+                href={wolkeConnectUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-1 inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary/90"
+                onMouseDown={(e) => e.stopPropagation()}
+              >
+                Wolke verbinden
+              </a>
+            )}
+          </div>
+        ) : browse.isLoading ? (
+          <div className="px-3 py-4 text-sm text-foreground-muted">Lade Dateien…</div>
+        ) : browse.isError ? (
+          <div className="px-3 py-4 text-sm text-foreground-muted">
+            Fehler beim Laden der Dateien.
+          </div>
+        ) : filteredFiles.length === 0 ? (
+          <div className="px-3 py-4 text-sm text-foreground-muted">
+            {filter ? 'Keine Treffer.' : 'Ordner ist leer.'}
+          </div>
+        ) : (
+          filteredFiles.map((file) => {
+            const path = joinPath(folderPath, file.name);
+            const key = `${activeShareId}:${path}`;
+            const isSelected = selection.has(key);
+            const isDisabled = !file.isDirectory && file.isSupported === false;
+            return (
+              <button
+                key={key}
+                type="button"
+                disabled={isDisabled}
+                aria-pressed={isSelected}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  if (file.isDirectory) {
+                    setFolderPath(path);
+                    setFilter('');
+                  } else {
+                    toggleFile(file);
+                  }
+                }}
+                className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                  isSelected
+                    ? 'bg-primary/10 text-foreground'
+                    : isDisabled
+                      ? 'cursor-not-allowed text-foreground-muted/50'
+                      : 'text-foreground-muted hover:bg-primary/5'
+                }`}
+              >
+                <span aria-hidden className="text-base">
+                  {file.isDirectory ? '📁' : isSelected ? '☑️' : '📄'}
+                </span>
+                <span className="flex-1 truncate">{file.name}</span>
+                {!file.isDirectory && (
+                  <span className="text-xs text-foreground-muted/70">{file.sizeFormatted}</span>
+                )}
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border px-3 py-2">
+        <span className="text-xs text-foreground-muted">{selectionList.length} ausgewählt</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onDismiss();
+            }}
+            className="rounded-md px-2 py-1 text-xs text-foreground-muted hover:bg-primary/5"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            disabled={selectionList.length === 0 || hasNoShares}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              handleConfirm();
+            }}
+            className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+          >
+            Hinzufügen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -107,6 +107,78 @@ export function useDocsQuery() {
   });
 }
 
+export interface ChatShareLink {
+  id: string;
+  label?: string;
+  share_link?: string;
+  is_active?: boolean;
+  baseUrl?: string;
+}
+
+export interface ChatWolkeFile {
+  name: string;
+  href: string;
+  size: number | null;
+  isDirectory?: boolean;
+  fileExtension?: string;
+  isSupported?: boolean;
+  sizeFormatted?: string;
+  lastModifiedFormatted?: string;
+}
+
+export interface ChatWolkeBrowse {
+  shareLink: { id: string; label?: string; baseUrl?: string };
+  files: ChatWolkeFile[];
+}
+
+/**
+ * User's connected Nextcloud share links. Used by the @wolke picker to
+ * resolve which share to browse and to render the empty-state when the user
+ * has none. The endpoint is identical to the one apps/web's wolke feature
+ * page uses — we just route it through the chat package's ChatAdapter so
+ * mobile/desktop hosts don't need to set up the web-specific apiClient.
+ */
+export function useUserShareLinksQuery(enabled = true) {
+  const apiClient = useApiClient();
+  return useQuery<ChatShareLink[]>({
+    queryKey: ['mention-wolke-share-links'],
+    queryFn: async () => {
+      const res = await apiClient.get<{ shareLinks?: ChatShareLink[] } | ChatShareLink[]>(
+        '/nextcloud/share-links'
+      );
+      if (Array.isArray(res)) return res.filter((l) => l.is_active !== false);
+      return (res?.shareLinks ?? []).filter((l) => l.is_active !== false);
+    },
+    staleTime: STALE_TIME,
+    enabled,
+    retry: 1,
+  });
+}
+
+/**
+ * Folder listing for a single share link + path. Disabled until both
+ * `shareLinkId` and `enabled` are truthy so we don't fire empty browses.
+ */
+export function useWolkeBrowseQuery(shareLinkId: string | null, path: string, enabled = true) {
+  const apiClient = useApiClient();
+  return useQuery<ChatWolkeBrowse>({
+    queryKey: ['mention-wolke-browse', shareLinkId, path],
+    queryFn: async () => {
+      const qs = path ? `?path=${encodeURIComponent(path)}` : '';
+      const res = await apiClient.get<ChatWolkeBrowse>(
+        `/documents/wolke/browse/${shareLinkId}${qs}`
+      );
+      return {
+        shareLink: res.shareLink,
+        files: Array.isArray(res.files) ? res.files : [],
+      };
+    },
+    enabled: !!shareLinkId && enabled,
+    staleTime: 15_000,
+    retry: 1,
+  });
+}
+
 /**
  * Convenience hook that triggers all three queries — call from the chat
  * composer so dynamic mentionables are warm by the time @-popovers open.
@@ -138,4 +210,3 @@ export function useDocMentionables(): Mentionable[] {
     }));
   }, [data]);
 }
-

--- a/packages/chat/src/lib/mentionDetection.ts
+++ b/packages/chat/src/lib/mentionDetection.ts
@@ -51,8 +51,8 @@ export function detectMention(text: string, caretPosition: number): MentionDetec
 }
 
 export function getFilteredFunctions(query: string): Mentionable[] {
-  const { notebooks, tools, boards, docs, documents } = filterMentionables(query);
-  return [...tools, ...boards, ...docs, ...documents, ...notebooks];
+  const { notebooks, tools, boards, docs, documents, wolke } = filterMentionables(query);
+  return [...tools, ...boards, ...docs, ...documents, ...wolke, ...notebooks];
 }
 
 export function getFilteredSkills(query: string): Mentionable[] {

--- a/packages/chat/src/lib/mentionParser.ts
+++ b/packages/chat/src/lib/mentionParser.ts
@@ -1,6 +1,6 @@
 import { getDefaultAgent } from './agents';
 import { resolveDocumentSlug } from './documentMentionables';
-import { resolveMentionable } from './mentionables';
+import { decodeWolkeToken, resolveMentionable, type WolkeFileToken } from './mentionables';
 
 export interface MentionResult {
   agentId: string;
@@ -18,6 +18,7 @@ export interface ParsedMentions {
   hasDocumentChat: boolean;
   boardIds: string[];
   docMentionIds: string[];
+  wolkeFiles: WolkeFileToken[];
   unresolvedMentions: string[];
   cleanText: string;
 }
@@ -54,12 +55,14 @@ export function parseAllMentions(text: string): ParsedMentions {
   const textIds: string[] = [];
   const boardIds: string[] = [];
   const docMentionIds: string[] = [];
+  const wolkeFiles: WolkeFileToken[] = [];
   const seenNotebooks = new Set<string>();
   const seenTools = new Set<string>();
   const seenDocuments = new Set<string>();
   const seenTexts = new Set<string>();
   const seenBoards = new Set<string>();
   const seenDocMentions = new Set<string>();
+  const seenWolke = new Set<string>();
   const unresolvedMentions: string[] = [];
   const mentionSpans: [number, number][] = [];
 
@@ -96,6 +99,29 @@ export function parseAllMentions(text: string): ParsedMentions {
     // Handle bare @dokumentchat trigger (strip from text; signal via hasDocumentChat flag)
     if (trigger === '@' && alias === 'dokumentchat') {
       hasDocumentChat = true;
+      const triggerIndex = match.index + match[0].indexOf('@');
+      mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
+      continue;
+    }
+
+    // Handle @wolke:<base64-token> — decoded into wolkeFiles
+    if (trigger === '@' && alias.startsWith('wolke:')) {
+      const token = alias.slice(6);
+      const ref = decodeWolkeToken(token);
+      if (ref) {
+        const key = `${ref.shareLinkId}:${ref.path}`;
+        if (!seenWolke.has(key)) {
+          seenWolke.add(key);
+          wolkeFiles.push(ref);
+        }
+      }
+      const triggerIndex = match.index + match[0].indexOf('@');
+      mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
+      continue;
+    }
+
+    // Handle bare @wolke trigger (popover hint — strip, no payload)
+    if (trigger === '@' && alias === 'wolke') {
       const triggerIndex = match.index + match[0].indexOf('@');
       mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
       continue;
@@ -165,6 +191,7 @@ export function parseAllMentions(text: string): ParsedMentions {
     hasDocumentChat,
     boardIds,
     docMentionIds,
+    wolkeFiles,
     unresolvedMentions,
     cleanText,
   };
@@ -177,6 +204,7 @@ export type MentionPreviewKind =
   | 'tool'
   | 'notebook'
   | 'board'
+  | 'wolke'
   | 'unresolved';
 
 export interface MentionPreview {
@@ -210,7 +238,31 @@ export function extractMentionPreviews(text: string): MentionPreview[] {
     // types and shouldn't render chips (especially red unresolved ones).
     if (end === text.length) continue;
 
-    if (trigger === '@' && (alias === 'datei' || alias === 'dokumentchat')) {
+    if (trigger === '@' && (alias === 'datei' || alias === 'dokumentchat' || alias === 'wolke')) {
+      continue;
+    }
+
+    if (trigger === '@' && alias.startsWith('wolke:')) {
+      const token = alias.slice(6);
+      const ref = decodeWolkeToken(token);
+      if (ref) {
+        previews.push({
+          kind: 'wolke',
+          match: literal,
+          start: triggerIndex,
+          end,
+          title: ref.name,
+          avatar: '☁️',
+        });
+      } else {
+        previews.push({
+          kind: 'unresolved',
+          match: literal,
+          start: triggerIndex,
+          end,
+          title: alias,
+        });
+      }
       continue;
     }
 

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -24,11 +24,19 @@ import {
   PiFileText,
   PiPaperclip,
   PiSparkle,
+  PiCloud,
 } from 'react-icons/pi';
 import { MdDiversity1 } from 'react-icons/md';
 import { agentsList, type AgentListItem } from './agents';
 
-export type MentionableType = 'agent' | 'notebook' | 'tool' | 'document' | 'board' | 'doc';
+export type MentionableType =
+  | 'agent'
+  | 'notebook'
+  | 'tool'
+  | 'document'
+  | 'board'
+  | 'doc'
+  | 'wolke';
 export type MentionableCategory = 'skill' | 'function';
 
 export interface Mentionable {
@@ -515,6 +523,80 @@ export const documentMentionables: Mentionable[] = [
   },
 ];
 
+// @wolke opens a sub-popover that lets the user pick files from their
+// connected Nextcloud share link(s). Selected files are inserted into the
+// text as opaque `@wolke:<base64>` tokens which the parser decodes back into
+// {shareLinkId, path, name} refs sent in the request body.
+export const wolkeMentionables: Mentionable[] = [
+  {
+    type: 'wolke',
+    category: 'function',
+    trigger: '@',
+    identifier: 'wolke-trigger',
+    title: 'Wolke',
+    description: 'Eigene Wolke-Dateien einfügen',
+    avatar: '☁️',
+    icon: PiCloud,
+    backgroundColor: '#0EA5E9',
+    mention: 'wolke',
+  },
+];
+
+export interface WolkeFileToken {
+  shareLinkId: string;
+  path: string;
+  name: string;
+}
+
+// Base64-url encoding so the resulting token has no spaces, '/', or '+'
+// characters that would break the `(\S+)` mention regex.
+function toBase64Url(input: string): string {
+  if (typeof globalThis.btoa === 'function') {
+    return globalThis
+      .btoa(unescape(encodeURIComponent(input)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  }
+  return Buffer.from(input, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function fromBase64Url(input: string): string {
+  const padded = input.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
+  const full = padded + pad;
+  if (typeof globalThis.atob === 'function') {
+    return decodeURIComponent(escape(globalThis.atob(full)));
+  }
+  return Buffer.from(full, 'base64').toString('utf-8');
+}
+
+export function encodeWolkeToken(ref: WolkeFileToken): string {
+  return `@wolke:${toBase64Url(JSON.stringify(ref))}`;
+}
+
+export function decodeWolkeToken(token: string): WolkeFileToken | null {
+  try {
+    const parsed = JSON.parse(fromBase64Url(token)) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as Record<string, unknown>).shareLinkId === 'string' &&
+      typeof (parsed as Record<string, unknown>).path === 'string' &&
+      typeof (parsed as Record<string, unknown>).name === 'string'
+    ) {
+      return parsed as WolkeFileToken;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function getAllMentionables(): Mentionable[] {
   return [
     ...agentMentionables,
@@ -526,6 +608,7 @@ export function getAllMentionables(): Mentionable[] {
     ...docToolMentionables,
     ...dynamicDocMentionables,
     ...documentMentionables,
+    ...wolkeMentionables,
   ];
 }
 
@@ -543,6 +626,7 @@ function rebuildMentionableMap(): void {
     docToolMentionables,
     dynamicDocMentionables,
     documentMentionables,
+    wolkeMentionables,
   ];
   for (const source of orderedSources) {
     for (const m of source) {
@@ -569,6 +653,7 @@ export function filterMentionables(query: string): {
   boards: Mentionable[];
   docs: Mentionable[];
   documents: Mentionable[];
+  wolke: Mentionable[];
 } {
   const allBoards = [...boardToolMentionables, ...dynamicBoardMentionables];
   const allDocs = [...docToolMentionables, ...dynamicDocMentionables];
@@ -581,6 +666,7 @@ export function filterMentionables(query: string): {
       boards: allBoards,
       docs: allDocs,
       documents: documentMentionables,
+      wolke: wolkeMentionables,
     };
   }
   const q = query.toLowerCase();
@@ -597,6 +683,7 @@ export function filterMentionables(query: string): {
     boards: 'board'.startsWith(q) || q.startsWith('board') ? allBoards : allBoards.filter(matchFn),
     docs: 'dok'.startsWith(q) || q.startsWith('dok') ? allDocs : allDocs.filter(matchFn),
     documents: documentMentionables.filter(matchFn),
+    wolke: wolkeMentionables.filter(matchFn),
   };
 }
 
@@ -608,5 +695,12 @@ export function filterMentionablesByCategory(
   if (category === 'skill') {
     return [...all.agents, ...all.customAgents];
   }
-  return [...all.tools, ...all.boards, ...all.docs, ...all.documents, ...all.notebooks];
+  return [
+    ...all.tools,
+    ...all.boards,
+    ...all.docs,
+    ...all.documents,
+    ...all.wolke,
+    ...all.notebooks,
+  ];
 }

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -998,6 +998,7 @@ export function createGrueneratorModelAdapter(
       let textIds: string[] = [];
       let boardIds: string[] = [];
       let docMentionIds: string[] = [];
+      let wolkeFiles: ReturnType<typeof parseAllMentions>['wolkeFiles'] = [];
       let hasDocumentChat = false;
       if (isChatMode)
         for (let i = formattedMessages.length - 1; i >= 0; i--) {
@@ -1022,6 +1023,7 @@ export function createGrueneratorModelAdapter(
             textIds = parsed.textIds;
             boardIds = parsed.boardIds;
             docMentionIds = parsed.docMentionIds;
+            wolkeFiles = parsed.wolkeFiles;
             hasDocumentChat = parsed.hasDocumentChat;
             textPart.text = parsed.cleanText;
 
@@ -1201,6 +1203,7 @@ export function createGrueneratorModelAdapter(
           textIds: textIds.length > 0 ? textIds : undefined,
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
+          wolkeFiles: wolkeFiles.length > 0 ? wolkeFiles : undefined,
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,
@@ -1228,6 +1231,7 @@ export function createGrueneratorModelAdapter(
           textIds: textIds.length > 0 ? textIds : undefined,
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
+          wolkeFiles: wolkeFiles.length > 0 ? wolkeFiles : undefined,
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -33,6 +33,12 @@ export interface ChatConfig {
     canvasType: string,
     initialProps: Record<string, unknown>
   ) => Promise<string | null>;
+  /**
+   * URL the @wolke picker links to when the user hasn't connected any
+   * Nextcloud share link yet. Platform-specific (web: `/wolke`, native: a deep
+   * link). Omit to hide the CTA — only the warning copy renders.
+   */
+  wolkeConnectUrl?: string;
 }
 
 export interface ResolvedEndpoints {
@@ -112,6 +118,8 @@ interface ChatConfigStore extends ResolvedChatConfig {
     canvasType: string,
     initialProps: Record<string, unknown>
   ) => Promise<string | null>;
+  /** URL the @wolke empty-state CTA opens (new tab). Hidden when unset. */
+  wolkeConnectUrl?: string;
   /** threadId → context-getter, populated by host surfaces (e.g. docs editor). */
   contextProviders: Map<string, ChatRequestContextProvider>;
   /** Register a context provider for a thread. Returns the unregister function. */
@@ -177,6 +185,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
   endpoints: DEFAULT_ENDPOINTS,
   docsBaseUrl: undefined,
   onEditInDocs: undefined,
+  wolkeConnectUrl: undefined,
   contextProviders: new Map(),
   documentEditHandlers: new Map(),
 
@@ -189,6 +198,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
       onEditInDocs: config?.onEditInDocs,
       onEditSharepic: config?.onEditSharepic,
       renderSharepic: config?.renderSharepic,
+      wolkeConnectUrl: config?.wolkeConnectUrl,
     });
   },
 

--- a/packages/contracts/src/schemas/chatGraph.ts
+++ b/packages/contracts/src/schemas/chatGraph.ts
@@ -9,6 +9,20 @@
  */
 import { z } from 'zod';
 
+// ── Shared sub-schemas ──────────────────────────────────────────────────────
+
+/**
+ * Reference to a single file inside a user's connected Wolke (Nextcloud)
+ * share link. Selected via the @wolke mentionable in chat; resolved
+ * server-side at send-time by downloading the file via WebDAV.
+ */
+export const wolkeFileRefSchema = z.object({
+  shareLinkId: z.string(),
+  path: z.string(),
+  name: z.string(),
+});
+export type WolkeFileRef = z.infer<typeof wolkeFileRefSchema>;
+
 // ── Request bodies ──────────────────────────────────────────────────────────
 //
 // All optional fields use `.nullish()` (= `.optional().nullable()`) so they
@@ -35,6 +49,7 @@ export const chatStreamBodySchema = z.object({
   defaultNotebookId: z.string().nullish(),
   boardIds: z.array(z.string()).nullish(),
   docMentionIds: z.array(z.string()).nullish(),
+  wolkeFiles: z.array(wolkeFileRefSchema).nullish(),
   currentDocument: z
     .object({
       id: z.string(),


### PR DESCRIPTION
## Summary

Lets users pick files from their personal Wolke (Nextcloud) share link inside the chat composer. Selected files reach the LLM as additional source context on the same rails as `@datei`.

## Why

Today the only way to reference a file living in a user's Wolke is to upload it into the document store or copy/paste its content. `@wolke` removes that friction and slots cleanly into the existing `DocumentSource` → `perSourceResults` pipeline, so no new prompt scaffolding is needed.

The `SearchSource = 'wolke'` literal was already declared as a placeholder in `ChatGraph/types.ts` with no consumers — this PR is what wires it up.

## Design choices (confirmed with user)

- **Filename filter only** — picker searches names in the current folder; no recursive PROPFIND, no full-text indexing.
- **Inline at send-time** — backend downloads selected files via WebDAV when the message is sent, extracts text via the shared OCR pipeline, injects chunks into `perSourceResults`. No DB writes.
- **Personal share links only** — `GET /nextcloud/share-links`. Multi-link users get a dropdown inside the picker.
- **Empty state with new-tab CTA** — when the user has no connected share link, the picker shows a "Wolke verbinden" link to `/profile/wolke`. The URL is supplied via a new `ChatAdapter.wolkeConnectUrl` slot so the chat package stays platform-agnostic.

## Notes for reviewers

- The wolke retrieval helper (`apps/api/agents/.../nodes/wolkeRetrieval.ts`) reuses `NextcloudApiClient` + the shared `extractTextFromFile` from `DocumentProcessingService` — no new pdf-parse dep.
- Wolke sources always go through the multi-doc fan-out even when they're the only source, because there is no single-source path that knows how to fetch them.
- Tokens in the input are opaque base64 of `{shareLinkId, path, name}` (kept whitespace-safe so the existing `(\S+)` mention regex stays valid).
- Ownership is verified server-side in the contract router; stale `shareLinkId`s are dropped silently.

## Test plan

- [ ] `@wolke` shows up under a "Wolke" section in the mention popover
- [ ] Selecting `@wolke` opens the file picker; folder navigation + filename filter work
- [ ] Multi-selecting two files inserts two `@wolke:<token>` tokens and the LLM cites both files in its answer
- [ ] User with no share link sees "Keine Wolke verbunden" with a "Wolke verbinden" CTA that opens `/profile/wolke` in a new tab
- [ ] User with multiple share links sees the dropdown and switching reloads the file list
- [ ] Stale `shareLinkId` (deleted share link) is dropped server-side without 500-ing the request