### PR TITLE
feat(notebook): experimental Wolke-Ordner section in notebook editor

### DIFF
--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -30,6 +30,7 @@ import type {
   NotebookCollectionFromQdrant,
 } from './types.js';
 import type { AuthenticatedRequest } from '../../middleware/types.js';
+import type { WolkeFolderRef } from '@gruenerator/contracts';
 
 const log = createLogger('notebookCollections');
 const { requireAuth } = authMiddleware;
@@ -142,6 +143,9 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
 
         const settings = (collection.settings as Record<string, unknown>) || {};
         const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+        const wolke_folders: WolkeFolderRef[] = Array.isArray(settings.wolke_folders)
+          ? (settings.wolke_folders as WolkeFolderRef[])
+          : [];
 
         return {
           ...collection,
@@ -154,6 +158,7 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
           auto_sync: !!collection.auto_sync,
           remove_missing_on_sync: !!collection.remove_missing_on_sync,
           labels,
+          wolke_folders,
         };
       })
     );
@@ -187,7 +192,9 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       auto_sync = false,
       remove_missing_on_sync = false,
       labels,
+      wolke_folders: wolkeFoldersRaw,
     } = req.body as CreateCollectionBody;
+    const wolke_folders = Array.isArray(wolkeFoldersRaw) ? wolkeFoldersRaw : [];
 
     if (!name || !name.trim()) {
       return res.status(400).json({ error: 'Name is required' });
@@ -251,6 +258,7 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       remove_missing_on_sync: selection_mode === 'wolke' ? !!remove_missing_on_sync : false,
       settings: {
         ...(Array.isArray(labels) ? { labels: labels.map((l) => l.trim()).filter(Boolean) } : {}),
+        wolke_folders,
       },
     };
 
@@ -328,6 +336,7 @@ router.put(
         auto_sync,
         remove_missing_on_sync,
         labels,
+        wolke_folders: wolkeFoldersRaw,
       } = req.body as UpdateCollectionBody;
 
       if (!name || !name.trim()) {
@@ -395,12 +404,19 @@ router.put(
         wolke_share_link_ids: selection_mode === 'wolke' ? wolke_share_link_ids : null,
       };
 
+      const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
+      const settingsPatch: Record<string, unknown> = { ...existingSettings };
+      let settingsChanged = false;
       if (Array.isArray(labels)) {
-        const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
-        updateData.settings = {
-          ...existingSettings,
-          labels: labels.map((l) => l.trim()).filter(Boolean),
-        };
+        settingsPatch.labels = labels.map((l) => l.trim()).filter(Boolean);
+        settingsChanged = true;
+      }
+      if (Array.isArray(wolkeFoldersRaw)) {
+        settingsPatch.wolke_folders = wolkeFoldersRaw;
+        settingsChanged = true;
+      }
+      if (settingsChanged) {
+        updateData.settings = settingsPatch;
       }
 
       if (selection_mode === 'wolke') {

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -15,7 +15,7 @@
  * guard only — should never fire in production).
  */
 
-import { notebookCollectionsContract } from '@gruenerator/contracts';
+import { notebookCollectionsContract, type WolkeFolderRef } from '@gruenerator/contracts';
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { env } from '../../config/env.js';
@@ -153,6 +153,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
 
           const settings = (collection.settings as Record<string, unknown>) || {};
           const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+          const wolke_folders = Array.isArray(settings.wolke_folders)
+            ? (settings.wolke_folders as WolkeFolderRef[])
+            : [];
 
           return {
             ...collection,
@@ -165,6 +168,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             auto_sync: !!collection.auto_sync,
             remove_missing_on_sync: !!collection.remove_missing_on_sync,
             labels,
+            wolke_folders,
             is_public: collection.is_public === true,
             public_ownership: collection.public_ownership ?? null,
           };
@@ -221,6 +225,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
 
           const settings = (collection.settings as Record<string, unknown>) || {};
           const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+          const wolke_folders = Array.isArray(settings.wolke_folders)
+            ? (settings.wolke_folders as WolkeFolderRef[])
+            : [];
 
           return {
             ...collection,
@@ -233,6 +240,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             auto_sync: !!collection.auto_sync,
             remove_missing_on_sync: !!collection.remove_missing_on_sync,
             labels,
+            wolke_folders,
             is_public: collection.is_public === true,
             public_ownership: collection.public_ownership ?? null,
           };
@@ -266,11 +274,13 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         labels,
         is_public,
         public_ownership,
+        wolke_folders: wolkeFoldersRaw,
       } = args.body;
 
       const selection_mode = selectionModeRaw ?? 'documents';
       const document_ids = documentIdsRaw ?? [];
       const wolke_share_link_ids = wolkeLinkIdsRaw ?? [];
+      const wolke_folders = Array.isArray(wolkeFoldersRaw) ? wolkeFoldersRaw : [];
 
       if (!name || !name.trim()) {
         return { status: 400 as const, body: { error: 'Name is required' } };
@@ -359,6 +369,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
           selection_mode === 'wolke' ? !!(remove_missing_on_sync ?? false) : false,
         settings: {
           ...(Array.isArray(labels) ? { labels: labels.map((l) => l.trim()).filter(Boolean) } : {}),
+          wolke_folders,
         },
         is_public: is_public === true,
         public_ownership: is_public === true ? (public_ownership ?? null) : null,
@@ -438,6 +449,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         labels,
         is_public,
         public_ownership,
+        wolke_folders: wolkeFoldersRaw,
       } = args.body;
 
       const selection_mode = selectionModeRaw ?? 'documents';
@@ -532,12 +544,19 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         wolke_share_link_ids: selection_mode === 'wolke' ? wolke_share_link_ids : null,
       };
 
+      const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
+      const settingsPatch: Record<string, unknown> = { ...existingSettings };
+      let settingsChanged = false;
       if (Array.isArray(labels)) {
-        const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
-        updateData.settings = {
-          ...existingSettings,
-          labels: labels.map((l) => l.trim()).filter(Boolean),
-        };
+        settingsPatch.labels = labels.map((l) => l.trim()).filter(Boolean);
+        settingsChanged = true;
+      }
+      if (Array.isArray(wolkeFoldersRaw)) {
+        settingsPatch.wolke_folders = wolkeFoldersRaw;
+        settingsChanged = true;
+      }
+      if (settingsChanged) {
+        updateData.settings = settingsPatch;
       }
 
       if (selection_mode === 'wolke') {

--- a/apps/api/routes/notebook/types.ts
+++ b/apps/api/routes/notebook/types.ts
@@ -5,6 +5,7 @@
 import { type AuthenticatedRequest } from '../../middleware/types.js';
 
 import type AIWorkerPool from '../../workers/aiWorkerPool.js';
+import type { WolkeFolderRef } from '@gruenerator/contracts';
 import type { ParamsDictionary } from 'express-serve-static-core';
 
 // =============================================================================
@@ -24,6 +25,7 @@ export interface CreateCollectionBody {
   auto_sync?: boolean | undefined;
   remove_missing_on_sync?: boolean | undefined;
   labels?: string[] | undefined;
+  wolke_folders?: WolkeFolderRef[] | undefined;
 }
 
 /**
@@ -39,6 +41,7 @@ export interface UpdateCollectionBody {
   auto_sync?: boolean | undefined;
   remove_missing_on_sync?: boolean | undefined;
   labels?: string[] | undefined;
+  wolke_folders?: WolkeFolderRef[] | undefined;
 }
 
 /**
@@ -103,6 +106,8 @@ export interface TransformedCollection {
   has_wolke_sources: boolean;
   documents_from_wolke: number;
   notebook_collection_documents?: Array<{ document_id: string }>;
+  labels?: string[];
+  wolke_folders?: WolkeFolderRef[];
 }
 
 /**

--- a/apps/web/src/features/auth/services/profileApiService.ts
+++ b/apps/web/src/features/auth/services/profileApiService.ts
@@ -486,6 +486,9 @@ export const profileApiService = {
       ...(collectionData.public_ownership
         ? { public_ownership: collectionData.public_ownership }
         : {}),
+      ...(Array.isArray(collectionData.wolkeFolders)
+        ? { wolke_folders: collectionData.wolkeFolders }
+        : {}),
     };
 
     const response = await apiClient.post<NotebookCollectionMutationResponse>(
@@ -526,6 +529,9 @@ export const profileApiService = {
         : {}),
       ...(collectionData.public_ownership
         ? { public_ownership: collectionData.public_ownership }
+        : {}),
+      ...(Array.isArray(collectionData.wolkeFolders)
+        ? { wolke_folders: collectionData.wolkeFolders }
         : {}),
     };
 

--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,4 +1,4 @@
-import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
+import { type NotebookEditorSavePayload, type WolkeFolderRef } from '@gruenerator/contracts';
 import { Badge, Button, Input, Label, Separator, Switch } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
@@ -7,6 +7,10 @@ import { HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
+
+import NotebookEditorWolkeSection, {
+  type ImportedWolkeDocument,
+} from './NotebookEditorWolkeSection';
 
 type PublicOwnership = 'owner' | 'public_data';
 
@@ -18,6 +22,7 @@ interface NotebookCollection {
   labels?: string[];
   is_public?: boolean;
   public_ownership?: PublicOwnership | null;
+  wolke_folders?: WolkeFolderRef[];
 }
 
 interface NotebookEditorFormData {
@@ -88,6 +93,7 @@ const NotebookEditor = ({
   const [editing, setEditing] = useState<null | 'name' | 'desc' | 'labels'>(null);
   const [isPublic, setIsPublic] = useState(false);
   const [publicOwnership, setPublicOwnership] = useState<PublicOwnership | null>(null);
+  const [wolkeFolders, setWolkeFolders] = useState<WolkeFolderRef[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { uploadFileOnly, pollDocumentStatus } = useDocumentsStore();
@@ -130,6 +136,7 @@ const NotebookEditor = ({
       setLabels(editingCollection.labels || []);
       setIsPublic(editingCollection.is_public === true);
       setPublicOwnership(editingCollection.public_ownership ?? null);
+      setWolkeFolders(editingCollection.wolke_folders ?? []);
       if (editingCollection.documents?.length) {
         setUploadedDocuments(
           editingCollection.documents.map((doc) => ({
@@ -144,6 +151,7 @@ const NotebookEditor = ({
       setLabels([]);
       setIsPublic(false);
       setPublicOwnership(null);
+      setWolkeFolders([]);
       setUploadedDocuments([]);
       setStep(1);
     }
@@ -263,7 +271,39 @@ const NotebookEditor = ({
     setStep(1);
     reset({ name: '', description: '' });
     setLabels([]);
+    setWolkeFolders([]);
   }, [reset]);
+
+  const handleWolkeDocsImported = useCallback(
+    (docs: ImportedWolkeDocument[]) => {
+      if (docs.length === 0) return;
+      const wasEmpty = uploadedDocuments.length === 0;
+      setUploadedDocuments((prev) => {
+        const seen = new Set(prev.map((d) => d.id));
+        const additions: UploadedDocument[] = docs
+          .filter((d) => !seen.has(d.id))
+          .map((d) => ({ id: d.id, title: d.title }));
+        return [...prev, ...additions];
+      });
+      setIndexingDocIds((prev) => {
+        const next = new Set(prev);
+        docs.forEach((d) => next.add(d.id));
+        return next;
+      });
+      docs.forEach((d) => {
+        void pollDocumentStatus(d.id).finally(() => {
+          setIndexingDocIds((prev) => {
+            if (!prev.has(d.id)) return prev;
+            const next = new Set(prev);
+            next.delete(d.id);
+            return next;
+          });
+        });
+      });
+      if (wasEmpty) setStep(2);
+    },
+    [uploadedDocuments.length, pollDocumentStatus]
+  );
 
   const handleAddLabel = useCallback(() => {
     const trimmed = newLabel.trim();
@@ -293,6 +333,7 @@ const NotebookEditor = ({
       labels,
       isPublic,
       publicOwnership: isPublic ? publicOwnership : null,
+      wolkeFolders,
     };
 
     await onSave(payload);
@@ -305,6 +346,7 @@ const NotebookEditor = ({
     setNewLabel('');
     setIsPublic(false);
     setPublicOwnership(null);
+    setWolkeFolders([]);
     setStep(1);
     if (onCancel) onCancel();
   };
@@ -550,6 +592,14 @@ const NotebookEditor = ({
                     )
                   )}
                 </section>
+
+                <NotebookEditorWolkeSection
+                  folders={wolkeFolders}
+                  onFoldersChange={setWolkeFolders}
+                  remainingSlots={MAX_DOCUMENTS - uploadedDocuments.length}
+                  onDocsImported={handleWolkeDocsImported}
+                  disabled={loading || isUploading}
+                />
 
                 <section
                   className="relative space-y-md"

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -61,6 +61,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         custom_prompt: collection.custom_prompt,
         is_public: data.isPublic,
         public_ownership: data.publicOwnership,
+        wolkeFolders: data.wolkeFolders,
       });
 
       toast.success(`Notebook „${data.name}" gespeichert`);
@@ -84,6 +85,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         labels: data.labels,
         is_public: data.isPublic,
         public_ownership: data.publicOwnership,
+        wolkeFolders: data.wolkeFolders,
       });
       toast.success(`Notebook „${data.name}" erstellt`);
       goBack();

--- a/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
@@ -1,0 +1,279 @@
+import { type WolkeFolderRef } from '@gruenerator/contracts';
+import { Badge, Button } from '@gruenerator/ui';
+import { useShareLinks, type ShareLink } from '@gruenerator/wolke';
+import { useState, useCallback, useMemo } from 'react';
+import { HiCloud, HiPlus, HiRefresh, HiX, HiExclamation } from 'react-icons/hi';
+import { Link } from 'react-router-dom';
+
+import { useDocumentsStore } from '../../../stores/documentsStore';
+import { cn } from '../../../utils/cn';
+
+export interface ImportedWolkeDocument {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  folders: WolkeFolderRef[];
+  onFoldersChange: (next: WolkeFolderRef[]) => void;
+  remainingSlots: number;
+  /** Called with newly synced documents — parent appends to its list and starts indexing polling. */
+  onDocsImported: (docs: ImportedWolkeDocument[]) => void;
+  disabled: boolean;
+}
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'Noch nicht synchronisiert';
+  const then = new Date(iso).getTime();
+  const diff = Date.now() - then;
+  if (Number.isNaN(then)) return 'Noch nicht synchronisiert';
+  if (diff < 60_000) return 'Synchronisiert vor wenigen Sekunden';
+  if (diff < 3_600_000) return `Synchronisiert vor ${Math.round(diff / 60_000)} Min.`;
+  if (diff < 86_400_000) return `Synchronisiert vor ${Math.round(diff / 3_600_000)} Std.`;
+  return `Synchronisiert am ${new Date(iso).toLocaleDateString('de-DE')}`;
+}
+
+function pickShareLabel(link: ShareLink): string {
+  return (
+    link.label?.trim() || link.display_name?.trim() || link.folder_name?.trim() || 'Wolke-Ordner'
+  );
+}
+
+const NotebookEditorWolkeSection = ({
+  folders,
+  onFoldersChange,
+  remainingSlots,
+  onDocsImported,
+  disabled,
+}: Props) => {
+  const shareLinksQuery = useShareLinks();
+  const { browseWolkeFiles, importWolkeFiles } = useDocumentsStore();
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const attachedIds = useMemo(() => new Set(folders.map((f) => f.shareLinkId)), [folders]);
+  const availableLinks = useMemo(
+    () => (shareLinksQuery.data ?? []).filter((l) => !attachedIds.has(l.id)),
+    [shareLinksQuery.data, attachedIds]
+  );
+
+  const handleAttach = useCallback(
+    (link: ShareLink) => {
+      const next: WolkeFolderRef = {
+        shareLinkId: link.id,
+        shareLabel: pickShareLabel(link),
+        folderPath: '',
+        folderName: pickShareLabel(link),
+        lastSyncedAt: null,
+      };
+      onFoldersChange([...folders, next]);
+      setPickerOpen(false);
+      setError(null);
+    },
+    [folders, onFoldersChange]
+  );
+
+  const handleRemove = useCallback(
+    (shareLinkId: string) => {
+      onFoldersChange(folders.filter((f) => f.shareLinkId !== shareLinkId));
+    },
+    [folders, onFoldersChange]
+  );
+
+  const handleSync = useCallback(
+    async (folder: WolkeFolderRef) => {
+      setSyncingId(folder.shareLinkId);
+      setError(null);
+      try {
+        const browseResult = await browseWolkeFiles(folder.shareLinkId);
+        const supported = browseResult.files.filter((f) => f.isSupported);
+        if (supported.length === 0) {
+          setError(`Keine unterstützten Dateien in "${folder.folderName}" gefunden.`);
+          return;
+        }
+
+        const sliced = supported.slice(0, Math.max(0, remainingSlots));
+        const skipped = supported.length - sliced.length;
+        if (sliced.length === 0) {
+          setError('Notebook ist voll (max. 20 Dokumente).');
+          return;
+        }
+
+        const result = await importWolkeFiles(folder.shareLinkId, sliced);
+        const imported = (result.results ?? [])
+          .filter((r) => r.success && r.documentId)
+          .map((r) => ({ id: r.documentId as string, title: r.filename }));
+
+        const alreadyImported = (result.results ?? []).filter(
+          (r) => r.skipped && r.documentId && r.reason === 'already_imported'
+        );
+        if (alreadyImported.length > 0) {
+          onDocsImported(
+            alreadyImported.map((r) => ({ id: r.documentId as string, title: r.filename }))
+          );
+        }
+
+        if (imported.length > 0) {
+          onDocsImported(imported);
+        }
+
+        const syncedAt = new Date().toISOString();
+        onFoldersChange(
+          folders.map((f) =>
+            f.shareLinkId === folder.shareLinkId ? { ...f, lastSyncedAt: syncedAt } : f
+          )
+        );
+
+        if (skipped > 0) {
+          setError(
+            `${skipped} Datei${skipped === 1 ? '' : 'en'} übersprungen — max. 20 pro Notebook.`
+          );
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Synchronisation fehlgeschlagen.');
+      } finally {
+        setSyncingId(null);
+      }
+    },
+    [browseWolkeFiles, importWolkeFiles, remainingSlots, folders, onFoldersChange, onDocsImported]
+  );
+
+  const isLoading = shareLinksQuery.isLoading;
+  const hasShareLinks = (shareLinksQuery.data ?? []).length > 0;
+
+  return (
+    <section className="rounded-xl bg-background-alt/50 px-sm py-sm">
+      <header className="flex flex-wrap items-center justify-between gap-xs pb-xs">
+        <div className="flex items-center gap-xs">
+          <HiCloud className="text-grey-400" size={16} aria-hidden />
+          <span className="text-sm font-semibold text-foreground">Wolke-Ordner</span>
+          <Badge
+            variant="outline"
+            className="border-amber-300 bg-amber-50 text-[10px] uppercase text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+          >
+            Experimentell
+          </Badge>
+        </div>
+        {hasShareLinks && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={disabled || availableLinks.length === 0}
+            onClick={() => setPickerOpen((v) => !v)}
+            aria-label="Wolke-Ordner hinzufügen"
+          >
+            <HiPlus size={14} />
+            Ordner hinzufügen
+          </Button>
+        )}
+      </header>
+
+      {isLoading ? (
+        <div className="h-16 animate-pulse rounded-md bg-grey-100 dark:bg-grey-900" />
+      ) : !hasShareLinks ? (
+        <div className="flex flex-col items-start gap-xs rounded-lg border border-dashed border-grey-300 bg-background p-md dark:border-grey-700">
+          <p className="m-0 text-sm text-foreground">Du hast noch keine Wolke verbunden.</p>
+          <p className="m-0 text-xs text-grey-500">
+            Verbinde sie einmal und du kannst hier ganze Ordner als Quelle hinzufügen.
+          </p>
+          <Button asChild type="button" size="sm" className="mt-xs">
+            <Link to="/profile/wolke">Wolke verbinden →</Link>
+          </Button>
+        </div>
+      ) : (
+        <>
+          {pickerOpen && availableLinks.length > 0 && (
+            <div className="mb-xs flex flex-col gap-1 rounded-lg border border-grey-200 bg-background p-xs dark:border-grey-700">
+              <p className="m-0 px-1 pb-1 text-xs uppercase tracking-wide text-grey-500">
+                Verbundene Wolken
+              </p>
+              {availableLinks.map((link) => (
+                <button
+                  key={link.id}
+                  type="button"
+                  className="flex items-center gap-sm rounded-md px-sm py-xs text-left transition-colors hover:bg-background-alt"
+                  onClick={() => handleAttach(link)}
+                >
+                  <HiCloud size={14} className="shrink-0 text-grey-400" aria-hidden />
+                  <span className="truncate text-sm text-foreground">{pickShareLabel(link)}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {folders.length === 0 && !pickerOpen && (
+            <p className="m-0 text-xs text-grey-500">
+              Noch kein Ordner verknüpft — füge einen hinzu und synchronisiere ihn manuell.
+            </p>
+          )}
+
+          {folders.length > 0 && (
+            <ul className="flex flex-col gap-xs">
+              {folders.map((folder) => {
+                const isSyncing = syncingId === folder.shareLinkId;
+                return (
+                  <li
+                    key={folder.shareLinkId}
+                    className={cn(
+                      'group flex items-center gap-sm rounded-lg border border-grey-200 bg-background p-sm dark:border-grey-800',
+                      isSyncing && 'opacity-90'
+                    )}
+                  >
+                    <HiCloud size={16} className="shrink-0 text-grey-400" aria-hidden />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-foreground">
+                        {folder.folderName}
+                      </div>
+                      <div className="mt-[2px] text-xs text-grey-500">
+                        {isSyncing ? 'Wird synchronisiert…' : formatRelative(folder.lastSyncedAt)}
+                      </div>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      disabled={disabled || isSyncing || remainingSlots <= 0}
+                      onClick={() => void handleSync(folder)}
+                      aria-label={`${folder.folderName} synchronisieren`}
+                    >
+                      {isSyncing ? (
+                        <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                      ) : (
+                        <HiRefresh size={14} />
+                      )}
+                      Synchronisieren
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                      disabled={disabled || isSyncing}
+                      onClick={() => handleRemove(folder.shareLinkId)}
+                      title="Nur die Verbindung wird entfernt — bereits importierte Dokumente bleiben im Notebook."
+                      aria-label={`${folder.folderName} entfernen`}
+                    >
+                      <HiX size={12} />
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {error && (
+            <div className="mt-xs flex items-start gap-xs rounded-md bg-amber-50 px-sm py-xs text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+              <HiExclamation size={14} className="mt-[1px] shrink-0" aria-hidden />
+              <span>{error}</span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default NotebookEditorWolkeSection;

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -484,6 +484,7 @@ function NotebooksIndexFooter() {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
       } else {
         const result = await createQACollection({
@@ -492,6 +493,7 @@ function NotebooksIndexFooter() {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
 
         if (result?.id && data.documents.length) {

--- a/apps/web/src/features/recherche/RecherchePage.tsx
+++ b/apps/web/src/features/recherche/RecherchePage.tsx
@@ -558,6 +558,7 @@ const RecherchePage = () => {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
       } else {
         const result = await createQACollection({
@@ -566,6 +567,7 @@ const RecherchePage = () => {
           selectionMode: data.selectionMode,
           documents: data.documents,
           labels: data.labels,
+          wolkeFolders: data.wolkeFolders,
         });
 
         if (result?.id && data.documents.length) {

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -90,6 +90,7 @@ const NotebooksSection: React.FC = memo(() => {
         name: data.name,
         description: data.description,
         documents: data.documents,
+        wolkeFolders: data.wolkeFolders,
       });
       // Hand off to the progress view, which polls per-document status until terminal.
       // documentMeta carries the upload titles for the progress rows; the IDs from

--- a/apps/web/src/stores/documentsStore.ts
+++ b/apps/web/src/stores/documentsStore.ts
@@ -62,10 +62,25 @@ interface WolkeBrowseApiResponse {
   files: WolkeFile[];
 }
 
+/**
+ * Mirrors apps/api/routes/documents/types.ts WolkeImportResult.
+ * TODO: move to @gruenerator/contracts and z.infer instead of duplicating.
+ */
+interface WolkeImportResult {
+  filename: string;
+  success: boolean;
+  skipped?: boolean;
+  reason?: string;
+  documentId?: string;
+  vectorsCreated?: number;
+  error?: string;
+}
+
 interface WolkeImportApiResponse {
   success: boolean;
   message?: string;
-  summary?: Record<string, unknown>;
+  results?: WolkeImportResult[];
+  summary?: { total: number; successful: number; failed: number; skipped: number };
 }
 
 interface Document {
@@ -141,7 +156,8 @@ interface WolkeFileResponse {
 
 interface WolkeImportResponse {
   success: boolean;
-  summary?: Record<string, unknown>;
+  results?: WolkeImportResult[];
+  summary?: { total: number; successful: number; failed: number; skipped: number };
   message?: string;
 }
 
@@ -770,4 +786,5 @@ export type {
   WolkeFile,
   WolkeFileResponse,
   WolkeImportResponse,
+  WolkeImportResult,
 };

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -2,6 +2,8 @@
  * Notebook/Q&A Collection Types
  */
 
+import { type WolkeFolderRef } from '@gruenerator/contracts';
+
 import type { Document } from './documents';
 
 /**
@@ -44,6 +46,7 @@ export interface NotebookCollection {
   wolke_share_links?: WolkeShareLink[];
   selection_mode?: 'documents' | 'wolke' | 'mixed';
   labels?: string[];
+  wolke_folders?: WolkeFolderRef[];
 }
 
 /**
@@ -76,6 +79,7 @@ export interface NotebookCollectionInput {
   remove_missing_on_sync?: boolean;
   is_public?: boolean;
   public_ownership?: NotebookPublicOwnership | null;
+  wolkeFolders?: WolkeFolderRef[];
 }
 
 /**

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -13,6 +13,26 @@ import { z } from 'zod';
 export const publicOwnershipSchema = z.enum(['owner', 'public_data']);
 export type PublicOwnership = z.infer<typeof publicOwnershipSchema>;
 
+/**
+ * Experimental: Wolke folder attached to a notebook.
+ *
+ * Persisted inside `settings.wolke_folders` (JSONB on `notebook_collections`).
+ * On HTTP body the field name is snake_case (`wolke_folders`) to match the rest
+ * of the collection contract; the inner object keeps camelCase because the
+ * payload is opaque to Postgres.
+ *
+ * Sync is manual today (button on the editor card). The persisted pointer is
+ * the foundation a future auto-sync follow-up needs.
+ */
+export const wolkeFolderRefSchema = z.object({
+  shareLinkId: z.string(),
+  shareLabel: z.string().nullish(),
+  folderPath: z.string(),
+  folderName: z.string(),
+  lastSyncedAt: z.string().nullable().optional(),
+});
+export type WolkeFolderRef = z.infer<typeof wolkeFolderRefSchema>;
+
 export const createCollectionBodySchema = z.object({
   name: z.string(),
   description: z.string().nullish(),
@@ -25,6 +45,7 @@ export const createCollectionBodySchema = z.object({
   labels: z.array(z.string()).nullish(),
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullish(),
+  wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
 });
 
 export const updateCollectionBodySchema = z.object({
@@ -39,6 +60,7 @@ export const updateCollectionBodySchema = z.object({
   labels: z.array(z.string()).nullish(),
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullish(),
+  wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
 });
 
 export const bulkDeleteBodySchema = z.object({
@@ -66,6 +88,7 @@ export const notebookEditorSavePayloadSchema = z.object({
   labels: z.array(z.string()),
   isPublic: z.boolean(),
   publicOwnership: publicOwnershipSchema.nullable(),
+  wolkeFolders: z.array(wolkeFolderRefSchema).default([]),
 });
 
 export type NotebookEditorSavePayload = z.infer<typeof notebookEditorSavePayloadSchema>;
@@ -113,6 +136,7 @@ export const transformedCollectionSchema = z.object({
   labels: z.array(z.string()).nullish(),
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullable().optional(),
+  wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Notebook authors who keep material in Nextcloud ("Wolke") today have to download and re-upload files one at a time. All the Wolke infrastructure already exists (`/profile/wolke` share-link store, browse + import endpoints, `@gruenerator/wolke` hooks), so this PR lifts those pieces into the notebook editor: pick a connected share, click sync, the files become notebook documents through the existing upload pipeline.

The folder pointer persists on the notebook so the section is meaningful on reopen. This also lays the foundation for auto-sync (the explicit follow-up).

## Behaviour confirmed with the author

- Multiple folders per notebook.
- Removing a folder pointer keeps the documents that were synced from it — they're notebook-owned now, not folder-owned.
- Manual sync only for this PR; automatic sync is a deliberate follow-up.

## Storage

`settings.wolke_folders` JSONB on `notebook_collections` — same column `labels` already lives in. **No migration, no Drizzle change.** Existing notebooks deserialize as `[]`.

## 4-layer type-safety audit

- **Contract**: `wolkeFolderRefSchema` in `packages/contracts/src/schemas/notebookCollections.ts`, derived everywhere via `z.infer`.
- **Zod**: extends `notebookEditorSavePayloadSchema`, `createCollectionBodySchema`, `updateCollectionBodySchema`, and `transformedCollectionSchema`.
- **Drizzle**: reuses existing `settings` JSONB column — no schema change.
- **ts-rest server**: `notebookCollectionsContractRouter` accepts + persists + surfaces on list/create/update; legacy `collectionsController` kept in sync for fallback parity.

## Follow-ups (not in this PR)

- **Auto-sync** — swap manual button for background polling via `/documents/wolke/sync` + `wolke_sync_status` table. The persisted folder array is what that needs.
- **Recursive folder ingestion** — currently one level deep (root of the share). The `WolkeFolderBrowser` component in `@gruenerator/wolke` is ready for sub-folder navigation when this becomes needed.
- **Etag-based change detection on re-sync** — `wolke_etag` is tracked server-side but not yet surfaced.
- **Wolke type-safety audit found ~6 pre-existing holes** (hand-written response interfaces in `wolkeApiClient.ts`, `getShareLink()` returning `Promise<unknown>`, optional-vs-nullable in `packages/wolke/src/types.ts`, missing ts-rest contracts on `/documents/wolke/*` endpoints). Not introduced by this PR; tackling separately keeps this diff scoped.

## Test plan

- [ ] As a user with no Wolke share links: open notebook editor → step 2 → confirm empty-state card + "Wolke verbinden →" links to `/profile/wolke`.
- [ ] As a user with ≥1 share link: add folder → card appears → click Synchronisieren → documents flow into the grid → save → reload → folders + docs persist.
- [ ] Multiple folders: attach two, sync both, verify they survive reload.
- [ ] Remove a folder → confirm previously-synced docs stay in the notebook.
- [ ] Re-sync the same folder twice → server-side dedup means no duplicate docs.
- [ ] Notebook full path: attach a folder with >20 supported files → confirm 20 import, error message reports the skip count.