### PR TITLE
fix(notebook): manual search returns results instead of always-zero

### DIFF
--- a/apps/api/routes/notebook/notebookContractRouter.ts
+++ b/apps/api/routes/notebook/notebookContractRouter.ts
@@ -290,6 +290,27 @@ export const notebookContractRouter = s.router(notebookContract, {
         return { status: 403 as const, body: { error: 'Forbidden' } };
       }
 
+      // Resolve notebook → document IDs via the n:m join collection. Chunks
+      // in the `documents` Qdrant collection are NOT tagged with collection_id
+      // (membership lives in `notebook_collection_documents`), so filtering on
+      // a `collection_id` payload field on chunks returns zero results.
+      const collectionDocs = await notebookHelper.getCollectionDocuments(collectionId);
+      const documentIds = collectionDocs.map((d) => d.document_id);
+
+      if (documentIds.length === 0) {
+        return {
+          status: 200 as const,
+          body: {
+            results: [],
+            metadata: {
+              totalResults: 0,
+              collections: [collectionId as string],
+              timeMs: Date.now() - startTime,
+            },
+          },
+        };
+      }
+
       const effectiveLimit = Math.min(Math.max(limit ?? 30, 1), 100);
       const effectiveMode = mode ?? 'hybrid';
       const effectiveSort = sortBy ?? 'relevance';
@@ -306,10 +327,8 @@ export const notebookContractRouter = s.router(notebookContract, {
           textWeight,
           threshold: 0.2,
           searchCollection: 'documents',
-          additionalFilter: {
-            must: [{ key: 'collection_id', match: { value: collectionId } }],
-          },
         },
+        filters: { documentIds },
       });
 
       const tagged = (resp.results ?? []).map((doc) => ({


### PR DESCRIPTION
`researchSearch` (the manual-search endpoint for user notebooks at `/api/auth/notebook/:id/search`) was filtering the `documents` Qdrant collection by a `collection_id` payload field. That field doesn't exist on document chunks — notebook↔document membership lives on the separate `notebook_collection_documents` Qdrant collection as an n:m join. The broken filter returned zero results for every user-notebook manual search, no matter the query or threshold.

Live log from user reproducing the bug:
```
"additionalFilter": { "must": [{ "key": "collection_id", "match": { "value": "d5cd1215-…" } }] }
[QdrantOperations:vectorSearch] DEBUG - No results even without threshold - possible embedding mismatch or empty collection
Vector search: 0 results, top score: none
```

Switch to the pattern `searchCollection` already uses (at `notebookCollectionsContractRouter.ts:697-710`): fetch document IDs via `notebookHelper.getCollectionDocuments(collectionId)`, pass them as `filters.documentIds`. Empty notebooks short-circuit with the same response shape so downstream consumers don't see undefined `metadata` fields.

## Blast radius
- Only the `researchSearch` handler — `/api/auth/notebook/:id/researchSearch` for user notebooks
- System collections bounced earlier (400 at line 278), unaffected
- Auth (403/404 checks), sort modes, dedup, threshold logic, response shape — all unchanged
- `userId` Qdrant filter still applied (defense-in-depth)

## Test plan
- [ ] Open a user notebook → switch to manual search → type a query that should match content in uploaded docs → results appear (was always 0 before)
- [ ] Manual search on a notebook with 0 documents → empty results + populated metadata (no 500)
- [ ] Manual search on a system collection path → still bounced with 400 ("Use /research/search for system collections")