### PR TITLE
chore(wolke): tighten share-link types and remove unsafe casts

### DIFF
--- a/apps/api/routes/documents/wolkeController.ts
+++ b/apps/api/routes/documents/wolkeController.ts
@@ -183,21 +183,10 @@ router.get(
         folderPath,
       });
 
-      // Get the share link
-      const shareLink = (await wolkeSyncService.getShareLink(userId, shareLinkId)) as {
-        id?: string;
-        label?: string;
-        base_url?: string;
-        share_link?: string;
-      } | null;
-
-      if (!shareLink) {
-        res.status(404).json({ success: false, message: 'Share link not found' });
-        return;
-      }
+      const shareLink = await wolkeSyncService.getShareLink(userId, shareLinkId);
 
       // List all files and folders (unfiltered, unlike listFolderContents which is for sync)
-      const client = await NextcloudApiClient.create(shareLink.share_link ?? '');
+      const client = await NextcloudApiClient.create(shareLink.share_link);
       const files = await client.listFolder(folderPath || undefined);
 
       // Filter and enrich files with additional metadata for UI
@@ -233,10 +222,9 @@ router.get(
       });
     } catch (error) {
       log.error('[GET /browse/:shareLinkId] Error:', error);
-      res.status(500).json({
-        success: false,
-        message: (error as Error).message || 'Failed to browse Wolke files',
-      });
+      const message = (error as Error).message || 'Failed to browse Wolke files';
+      const status = message === 'Share link not found' ? 404 : 500;
+      res.status(status).json({ success: false, message });
     }
   }
 );
@@ -258,13 +246,7 @@ router.post(
 
       log.debug(`[POST /import] Importing ${files.length} files from share link ${shareLinkId}`);
 
-      // Get the share link
-      const shareLink = (await wolkeSyncService.getShareLink(userId, shareLinkId)) as {
-        id: string;
-        url: string;
-        token?: string;
-        share_link?: string;
-      };
+      const shareLink = await wolkeSyncService.getShareLink(userId, shareLinkId);
 
       const results: WolkeImportResult[] = [];
       let successCount = 0;

--- a/apps/api/services/sync/WolkeSyncService.ts
+++ b/apps/api/services/sync/WolkeSyncService.ts
@@ -24,6 +24,7 @@ import { mistralEmbeddingService } from '../mistral/index.js';
 import { ocrService } from '../OcrService/index.js';
 
 import type { NextcloudFile, FileProcessResult, SyncResult } from './types.js';
+import type { NextcloudShareLink } from '../../utils/integrations/nextcloud/types.js';
 
 type WolkeSyncRow = typeof wolkeSyncStatus.$inferSelect;
 
@@ -156,12 +157,12 @@ export class WolkeSyncService {
   }
 
   /**
-   * Get share link by ID
+   * Get share link by ID. Throws if not found or not active.
    */
-  async getShareLink(userId: string, shareLinkId: string): Promise<unknown> {
+  async getShareLink(userId: string, shareLinkId: string): Promise<NextcloudShareLink> {
     try {
       const shareLinks = await NextcloudShareManager.getShareLinks(userId);
-      const shareLink = shareLinks.find((link: { id: string }) => link.id === shareLinkId);
+      const shareLink = shareLinks.find((link) => link.id === shareLinkId);
 
       if (!shareLink) {
         throw new Error('Share link not found');
@@ -182,11 +183,11 @@ export class WolkeSyncService {
    * List files in a Nextcloud folder
    */
   async listFolderContents(
-    shareLink: { id: string; url: string; token?: string; share_link?: string },
+    shareLink: NextcloudShareLink,
     _folderPath: string = ''
   ): Promise<NextcloudFile[]> {
     try {
-      const client = await NextcloudApiClient.create(shareLink.share_link || shareLink.url);
+      const client = await NextcloudApiClient.create(shareLink.share_link);
       const shareInfo = await client.getShareInfo();
 
       if (!shareInfo.success) {
@@ -309,7 +310,7 @@ export class WolkeSyncService {
     userId: string,
     shareLinkId: string,
     file: NextcloudFile,
-    shareLink: { id: string; url: string; token?: string; share_link?: string }
+    shareLink: NextcloudShareLink
   ): Promise<FileProcessResult> {
     try {
       console.log(`[WolkeSyncService] Processing file: ${file.name}`);
@@ -355,7 +356,7 @@ export class WolkeSyncService {
       }
 
       // Download file from Nextcloud
-      const client = await NextcloudApiClient.create(shareLink.share_link || shareLink.url);
+      const client = await NextcloudApiClient.create(shareLink.share_link);
       console.log(`[WolkeSyncService] Downloading file: ${file.name}`);
       const fileData = await client.downloadFile(file.href);
 
@@ -539,15 +540,7 @@ export class WolkeSyncService {
       });
 
       try {
-        // Get share link
-        const shareLink = (await this.getShareLink(userId, shareLinkId)) as {
-          id: string;
-          url: string;
-          token?: string;
-          share_link?: string;
-        };
-
-        // List folder contents
+        const shareLink = await this.getShareLink(userId, shareLinkId);
         const files = await this.listFolderContents(shareLink, folderPath);
 
         let processedCount = 0;

--- a/apps/web/src/features/wolke/lib/wolkeApi.ts
+++ b/apps/web/src/features/wolke/lib/wolkeApi.ts
@@ -1,4 +1,25 @@
+import {
+  type ConnectionTestResult,
+  type ParsedShareLink,
+  type ShareLink,
+  type ShareLinkValidationResult,
+  type SyncStatus,
+  type WolkeFileItem,
+  type WolkeScope,
+} from '@gruenerator/wolke';
+
 import apiClient from '@/components/utils/apiClient';
+
+// Re-export the shared domain types so existing consumers of this module keep
+// working without each call site having to switch to @gruenerator/wolke.
+export type {
+  ConnectionTestResult,
+  ShareLink,
+  ShareLinkValidationResult,
+  SyncStatus,
+  WolkeFileItem,
+  WolkeScope,
+};
 
 // ── API response shapes ────────────────────────────────────────────────
 
@@ -22,65 +43,6 @@ interface FilesResponse {
 interface SyncStatusesResponse {
   success: boolean;
   syncStatuses?: SyncStatus[];
-}
-
-export type WolkeScope = 'personal' | 'group';
-
-export interface ShareLink {
-  id: string;
-  share_link?: string;
-  label?: string;
-  folder_name?: string;
-  base_url?: string;
-  share_token?: string;
-  is_active?: boolean;
-  created_at?: string;
-  updated_at?: string;
-  display_name?: string;
-  user_id?: string;
-}
-
-export interface SyncStatus {
-  share_link_id: string;
-  folder_path: string;
-  auto_sync_enabled: boolean;
-  sync_status: 'idle' | 'syncing' | 'completed' | 'failed';
-  last_sync_at: string | null;
-  files_processed: number;
-  files_failed: number;
-  created_at?: string;
-  updated_at?: string;
-}
-
-export interface WolkeFileItem {
-  path: string;
-  name: string;
-  size?: number;
-  mimeType?: string;
-  lastModified?: string;
-  isDirectory?: boolean;
-  fileExtension: string;
-  isSupported: boolean;
-  sizeFormatted: string;
-  lastModifiedFormatted?: string;
-}
-
-export interface ConnectionTestResult {
-  success: boolean;
-  message?: string;
-}
-
-export interface ShareLinkValidationResult {
-  isValid: boolean;
-  shareToken?: string;
-  baseUrl?: string;
-  error: string | null;
-}
-
-interface ParsedShareLink {
-  baseUrl: string;
-  shareToken: string;
-  fullPath: string;
 }
 
 function getBasePath(scope?: WolkeScope, scopeId?: string | null): string {


### PR DESCRIPTION
## Why

A wolke type-safety audit (from the PR #881 follow-up) found that `WolkeSyncService.getShareLink` was returning `Promise<unknown>`, forcing every caller to write its own `as { ... }` cast. The two casts in `wolkeController.ts` disagreed about whether the share link has a `url` field (it does not — the canonical `NextcloudShareLink` shape only has `share_link`), and the `shareLink.share_link || shareLink.url` fallback in `processFile`/`listFolderContents` was dead code reading an always-undefined property.

This PR removes the `unknown` return + three call-site casts and points the API surface at the existing `NextcloudShareLink` interface. TypeScript immediately flagged a third latent reference to the phantom `url` field inside `processFile` (line 359) that was previously hidden by the loose typing — also fixed.

Separately, `apps/web/src/features/wolke/lib/wolkeApi.ts` had hand-written copies of `ShareLink` / `SyncStatus` / `WolkeFileItem` / `WolkeScope` / `ConnectionTestResult` / `ShareLinkValidationResult` / `ParsedShareLink` that exactly duplicated `@gruenerator/wolke`'s exports. Re-exporting from the shared package keeps the public surface identical while collapsing two sources of truth into one. The API client functions in that file remain duplicated for now (separate, larger cleanup).

The `/browse` 404 path for "share link not found" is preserved by translating the throw message in the outer catch instead of via an unreachable null-check — no behavioural change visible to clients.

## Out of scope (deferred for a follow-up)

The same audit also flagged:

- **Hand-written response interfaces in `packages/wolke/src/api/wolkeApiClient.ts`** that duplicate backend Zod schemas — should `z.infer` from contracts instead.
- **Missing ts-rest contracts on `/documents/wolke/*` and `/api/nextcloud/*` endpoints** — they have Zod request schemas but no response schemas, so the frontend can't verify response shape at compile time.
- **`packages/wolke/src/types.ts` uses `?:` instead of `\| null`** for fields the backend can return as `null` — would touch every consumer, deserves its own audit.
- **JSONB columns (`nextcloud_share_links`, `wolke_share_links` on `profiles`) typed as `Record<string, unknown>[]`** with no runtime validation on read — invasive fix needing Zod parse-on-read.
- **Full dedup of `apps/web/.../features/wolke/lib/wolkeApi.ts`** function bodies vs `@gruenerator/wolke` (this PR only collapses the type duplication).

## Test plan

- [ ] `pnpm --filter @gruenerator/api typecheck` clean
- [ ] `pnpm --filter @gruenerator/web typecheck` clean
- [ ] Open `/profile/wolke`, add a share link, browse + import — confirm no runtime regressions on the share-link plumbing.
- [ ] Open the notebook editor's Wolke section, click "Synchronisieren" on a folder, verify documents still flow into the grid (this PR removed casts but kept behaviour).