### PR TITLE
feat(notebook): render markdown in manual search snippets

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -76,6 +76,7 @@
     "react-textarea-autosize": "^8.5.9",
     "react-use": "^17.6.0",
     "react-webcam": "^7.2.0",
+    "rehype-raw": "^7.0.0",
     "tunnel-rat": "^0.1.2",
     "tus-js-client": "^4.3.1",
     "use-image": "^1.1.4",

--- a/apps/web/src/components/common/Markdown/Markdown.tsx
+++ b/apps/web/src/components/common/Markdown/Markdown.tsx
@@ -8,7 +8,9 @@ import {
   type ReactNode,
 } from 'react';
 
-import type { Components } from 'react-markdown';
+import type { Components, Options } from 'react-markdown';
+
+type PluggableList = NonNullable<Options['rehypePlugins']>;
 
 const ReactMarkdown = lazy(() => import('react-markdown'));
 
@@ -82,6 +84,8 @@ interface MarkdownProps {
   components?: Partial<Components>;
   fallback?: ReactNode;
   inline?: boolean;
+  rehypePlugins?: PluggableList;
+  remarkPlugins?: PluggableList;
 }
 
 export const Markdown = ({
@@ -90,6 +94,8 @@ export const Markdown = ({
   components,
   fallback,
   inline,
+  rehypePlugins,
+  remarkPlugins,
 }: MarkdownProps): JSX.Element => {
   const baseComponents = inline ? INLINE_COMPONENTS : MARKDOWN_COMPONENTS;
   const Wrapper = inline ? 'span' : 'div';
@@ -101,7 +107,11 @@ export const Markdown = ({
     <MarkdownErrorBoundary fallback={rawFallback}>
       <Suspense fallback={rawFallback}>
         <Wrapper className={className}>
-          <ReactMarkdown components={{ ...baseComponents, ...components }}>
+          <ReactMarkdown
+            components={{ ...baseComponents, ...components }}
+            rehypePlugins={rehypePlugins}
+            remarkPlugins={remarkPlugins}
+          >
             {processedContent}
           </ReactMarkdown>
         </Wrapper>

--- a/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
+++ b/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
@@ -12,11 +12,13 @@ import {
   PopoverTrigger,
   StatusBanner,
 } from '@gruenerator/ui';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { HiArrowsUpDown, HiBarsArrowDown, HiCog6Tooth, HiTag } from 'react-icons/hi2';
 import { IoSearch } from 'react-icons/io5';
+import rehypeRaw from 'rehype-raw';
 
 import IndexCard from '../../../components/common/IndexCard';
+import { Markdown } from '../../../components/common/Markdown/Markdown';
 import SearchBar from '../../search/components/SearchBar';
 import ActiveFilterChips from '../manual-search/ActiveFilterChips';
 import ResearchFilterPanel from '../manual-search/ResearchFilterPanel';
@@ -26,6 +28,8 @@ import {
   type SearchMode,
   type SortOption,
 } from '../manual-search/useResearchFilters';
+
+import type { Components } from 'react-markdown';
 
 import { cn } from '@/utils/cn';
 
@@ -59,6 +63,22 @@ function formatPublishedDate(iso: string): string {
   }
 }
 
+// Inline-friendly component map for search snippets: demote h1–h6 to bold
+// spans (a header rendered as h1 inside a 200-char teaser is visually absurd),
+// collapse horizontal rules to a soft separator, keep paragraphs as spans so
+// the snippet stays inline.
+const SNIPPET_MARKDOWN_COMPONENTS: Partial<Components> = {
+  h1: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  h2: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  h3: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  h4: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  h5: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  h6: ({ children }): JSX.Element => <span className="font-semibold">{children}</span>,
+  hr: (): JSX.Element => <span className="mx-1 text-grey-400"> · </span>,
+};
+
+const SNIPPET_REHYPE_PLUGINS = [rehypeRaw];
+
 function resultToCardProps(result: ResearchResult) {
   const similarityPercent = Math.round(result.similarity_score * 100);
   const tags = result.collection_name ? [result.collection_name] : [];
@@ -68,14 +88,16 @@ function resultToCardProps(result: ResearchResult) {
   const metaParts = [`${chunkLabel} · ${similarityPercent}% Relevanz`];
   if (result.published_at) metaParts.push(formatPublishedDate(result.published_at));
 
-  const hasHighlights = result.relevant_content?.includes('<mark>');
-
   return {
     title: result.title,
-    description: hasHighlights ? (
-      <span dangerouslySetInnerHTML={{ __html: result.relevant_content }} />
-    ) : (
-      result.relevant_content
+    description: (
+      <Markdown
+        inline
+        rehypePlugins={SNIPPET_REHYPE_PLUGINS}
+        components={SNIPPET_MARKDOWN_COMPONENTS}
+      >
+        {result.relevant_content ?? ''}
+      </Markdown>
     ),
     tags,
     meta: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,9 @@ importers:
       react-webcam:
         specifier: ^7.2.0
         version: 7.2.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       tunnel-rat:
         specifier: ^0.1.2
         version: 0.1.2(@types/react@19.2.14)(immer@11.1.7)(react@19.2.6)
@@ -1885,11 +1888,6 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
-
-  '@antfu/ni@30.1.0':
-    resolution: {integrity: sha512-3VuAbPjgY52rQNn4wABaXMhBU2Oq91uy6L8nX49eJ35OLI68CyckGU+HZxcaHix4ymuGM2nFL1D6sLpgODK5xw==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
 
   '@anthropic-ai/sdk@0.78.0':
     resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
@@ -7759,8 +7757,8 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@react-grab/cli@0.1.33':
-    resolution: {integrity: sha512-UOc3PwN11Osw0NzaxRLK8trP4X+5iW1Dst3gvHRCafe3wXHyadzHYH8H1hdkcXdlIx3gsoD9ASJ+G/JH+A/jqA==}
+  '@react-grab/cli@0.1.34':
+    resolution: {integrity: sha512-L2eAxN46Vq2Ss3nDegrH7wQVMeWH03ahawp+OdzUtQWqL3cq6Bt149q9XhY3cWc9fJsxuWjLfCn+3T9uApIlBA==}
     hasBin: true
 
   '@react-hook/intersection-observer@3.1.2':
@@ -11248,6 +11246,11 @@ packages:
     peerDependencies:
       react: 19.2.6
 
+  bippy@0.5.40:
+    resolution: {integrity: sha512-3QPSDG5tgd7FCIkcKsUqmbGdlHxBxP7II5drXPNp1I0rpA9+4+/VjQOigDTbzeqTi6Xkaf1Dq7x4E8vbOuwOkA==}
+    peerDependencies:
+      react: 19.2.6
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -14214,9 +14217,6 @@ packages:
   fuzzy@0.1.3:
     resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
     engines: {node: '>= 0.6.0'}
-
-  fzf@0.5.2:
-    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -18785,8 +18785,8 @@ packages:
     peerDependencies:
       react: 19.2.6
 
-  react-grab@0.1.33:
-    resolution: {integrity: sha512-ER919JMsE4TTrb2CpEivqsIjNMSycD4HtS8v7mS3pq67U7WL1K3+C8m9AYOwW4dpuYh+EanC2eJBmfuczHJZ0A==}
+  react-grab@0.1.34:
+    resolution: {integrity: sha512-jtdOdv0kb90oqL+pMszSh9DOLgVRaX4ZE6XN4GkDEpNNUqveQfZT014+EeJraljpqQfuWKW+96NrrRqUD93D2g==}
     hasBin: true
     peerDependencies:
       react: 19.2.6
@@ -19983,6 +19983,7 @@ packages:
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   slugify@1.6.9:
     resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
@@ -20618,8 +20619,8 @@ packages:
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
@@ -22151,13 +22152,6 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.2
-
-  '@antfu/ni@30.1.0':
-    dependencies:
-      fzf: 0.5.2
-      package-manager-detector: 1.6.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
 
   '@anthropic-ai/sdk@0.78.0(zod@3.25.76)':
     dependencies:
@@ -29555,7 +29549,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.59':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@pdf-lib/fontkit@1.1.1':
     dependencies:
@@ -30867,16 +30861,17 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@react-grab/cli@0.1.33':
+  '@react-grab/cli@0.1.34':
     dependencies:
-      '@antfu/ni': 30.1.0
       commander: 14.0.3
       ignore: 7.0.5
       jsonc-parser: 3.3.1
       ora: 9.4.0
+      package-manager-detector: 1.6.0
       picocolors: 1.1.1
       prompts: 2.4.2
       smol-toml: 1.6.1
+      tinyexec: 1.1.2
 
   '@react-hook/intersection-observer@3.1.2(react@19.2.6)':
     dependencies:
@@ -34096,7 +34091,7 @@ snapshots:
       cosmiconfig: 7.1.0
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.57.1)
@@ -35303,6 +35298,10 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   bippy@0.5.39(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  bippy@0.5.40(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -37446,7 +37445,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 4.4.3
       eslint: 8.57.1
@@ -37469,7 +37468,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -38839,8 +38838,6 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   fuzzy@0.1.3: {}
-
-  fzf@0.5.2: {}
 
   gauge@4.0.4:
     dependencies:
@@ -44540,10 +44537,10 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  react-grab@0.1.33(react@19.2.6):
+  react-grab@0.1.34(react@19.2.6):
     dependencies:
-      '@react-grab/cli': 0.1.33
-      bippy: 0.5.39(react@19.2.6)
+      '@react-grab/cli': 0.1.34
+      bippy: 0.5.40(react@19.2.6)
     optionalDependencies:
       react: 19.2.6
 
@@ -44896,7 +44893,7 @@ snapshots:
       prompts: 2.4.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-grab: 0.1.33(react@19.2.6)
+      react-grab: 0.1.34(react@19.2.6)
     optionalDependencies:
       esbuild: 0.27.7
       unplugin: 2.1.0
@@ -46863,7 +46860,7 @@ snapshots:
 
   third-party-web@0.27.0: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   throat@5.0.0: {}
 


### PR DESCRIPTION
The backend's `highlightSnippet` produces strings that mix markdown (PDF chunk text uses `**bold**`, `# headers`, `---` separators) with `<mark>` HTML tags for query-term highlights. The frontend was rendering snippets via `dangerouslySetInnerHTML`, which only processes HTML — so markdown delimiters leaked through as literal `**` and `#` characters in result cards.

Switch the manual-search result card to render via the shared `<Markdown inline rehypePlugins={[rehypeRaw]}>` component. With `rehype-raw`, the `<mark>` tags survive into the rendered DOM (proper yellow highlights) AND the markdown delimiters render as styled emphasis.

## Changes
- **`Markdown.tsx`** — add `rehypePlugins` and `remarkPlugins` props, threaded into `<ReactMarkdown>`. `PluggableList` type derived from `Options['rehypePlugins']` (react-markdown v10 doesn't re-export `PluggableList`)
- **`NotebookManualSearch.tsx`** — replace `dangerouslySetInnerHTML` with `<Markdown inline rehypePlugins={[rehypeRaw]}>`. Custom components map demotes h1–h6 to inline-bold spans (a full h1 inside a 200-char teaser would be visually absurd) and collapses `---` to a soft middle-dot separator
- **`apps/web/package.json`** — `rehype-raw@^7.0.0` as an explicit dep (per the codebase's strict-import rule). The package was already in the lockfile as a transitive

## Why no sanitization library
`highlightSnippet` already escapes `&`, `<`, `>` in the source text **before** injecting `<mark>`. So the only HTML element that survives into the rendered DOM is the one we inserted ourselves — `rehype-sanitize` isn't needed for this surface.

## Test plan
- [ ] Search in a user notebook for a term that's bolded in the source PDF (e.g. `Verkehr` in a `**Verkehr**spolitik` chunk) → snippet shows the term in `<strong>` + `<mark>` (bold AND yellow-highlighted), no literal `**` characters
- [ ] Header artifacts (`# Macht Mobilität möglich`) render as inline bold instead of a giant h1
- [ ] Horizontal rules (`---`) render as a thin middle-dot separator
- [ ] System-collection search (`/research/search` path that uses the same `highlightSnippet`) — also benefits if it renders via `NotebookManualSearch`; otherwise unaffected