### PR TITLE
fix(docs-chat): hide inert tool toggles, restore model picker

### DIFF
--- a/apps/web/src/features/docs/DocsAssistantChat.tsx
+++ b/apps/web/src/features/docs/DocsAssistantChat.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { GrueneratorThread } from '@gruenerator/chat';
-import type { ReactNode } from 'react';
 
 import { DocAiEditToggle } from './DocAiEditToggle';
 import { useDocsChat } from './DocsChatProvider';
 import { SelectionChip } from './SelectionChip';
+
+import type { ReactNode } from 'react';
 
 function DocsChatStatus({ children }: { children: ReactNode }) {
   return (
@@ -27,16 +28,14 @@ export function DocsAssistantChat() {
   }
 
   if (state.status === 'error') {
-    return (
-      <DocsChatStatus>Chat konnte nicht geladen werden: {state.error.message}</DocsChatStatus>
-    );
+    return <DocsChatStatus>Chat konnte nicht geladen werden: {state.error.message}</DocsChatStatus>;
   }
 
   return (
     <GrueneratorThread
       firstName={state.userName ?? null}
       density="compact"
-      composerLayout="compact-overflow"
+      showToolToggles={false}
       composerSlots={{
         aboveInput: <SelectionChip documentId={state.documentId} />,
         sendAdornment: (

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -48,12 +48,6 @@ interface GrueneratorComposerProps {
   showPlusMenu?: boolean;
   showToolToggles?: boolean;
   showModelPicker?: boolean;
-  /**
-   * Toolbar layout. `compact-overflow` is tuned for narrow side panels
-   * (e.g. the docs editor 320px aside): hides ModelPicker to save horizontal
-   * room. All other toggles stay visible because they still fit.
-   */
-  layout?: 'default' | 'compact-overflow';
   insideAgent?: boolean;
   /** Render-prop slots for surface-specific UI. */
   slots?: {
@@ -224,7 +218,6 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
   showPlusMenu = true,
   showToolToggles = true,
   showModelPicker = true,
-  layout = 'default',
   insideAgent = false,
   slots,
   requireProfileHydration = false,
@@ -581,7 +574,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
             {toolbarExtra}
           </div>
           <div className="flex items-center gap-0.5">
-            {showModelPicker && layout !== 'compact-overflow' && <ModelPicker />}
+            {showModelPicker && <ModelPicker />}
             {/* TODO: re-enable when realtime voice agent is ready for users
             <ComposerVoiceToggle />
             */}

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -29,7 +29,6 @@ interface GrueneratorThreadProps {
   showPlusMenu?: boolean;
   showToolToggles?: boolean;
   showModelPicker?: boolean;
-  composerLayout?: 'default' | 'compact-overflow';
   composerSlots?: {
     aboveInput?: ReactNode;
     belowInput?: ReactNode;
@@ -82,7 +81,6 @@ export function GrueneratorThread({
   showPlusMenu,
   showToolToggles,
   showModelPicker,
-  composerLayout,
   composerSlots,
   requireProfileHydration,
   userLocale,
@@ -155,7 +153,6 @@ export function GrueneratorThread({
           {...(showPlusMenu !== undefined && { showPlusMenu })}
           {...(showToolToggles !== undefined && { showToolToggles })}
           {...(showModelPicker !== undefined && { showModelPicker })}
-          {...(composerLayout !== undefined && { layout: composerLayout })}
           {...(composerSlots ? { slots: composerSlots } : {})}
           {...(requireProfileHydration !== undefined && { requireProfileHydration })}
         />


### PR DESCRIPTION
## Summary
The composer toggles (search / web / examples / research) in the docs editor's AI sidebar were dead UI: `DocsChatProvider` hardcodes the `enabledTools` payload in its adapter config, so toggling them in the toolbar never reached the backend. Hide them via the existing `showToolToggles` prop seam.

Restore `ModelPicker` in the same sidebar. It had been suppressed by a one-off `composerLayout="compact-overflow"` variant whose entire job was hiding `ModelPicker` to save horizontal room — with the picker now wanted in this surface, the variant is dead weight and is removed alongside (orphaned cleanup; `DocsAssistantChat` was its only consumer).

## Test plan
- [ ] Open a doc, open the AI sidebar → `ModelPicker` visible, tool-toggle row gone
- [ ] @-mention popover, `PlusMenu`, `SelectionChip`, AI-edit toggle (existing `composerSlots`) all still work
- [ ] Main `/chat` page composer unaffected (no remaining `compact-overflow` consumers)