### PR TITLE
fix(chat): @wolke picker hits correct /api-prefixed endpoints

### DIFF
--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -169,12 +169,16 @@ export function useUserShareLinksQuery(enabled = true) {
     queryKey: ['mention-wolke-share-links'],
     queryFn: async () => {
       const res = await apiClient.get<{ shareLinks?: ChatShareLink[] } | ChatShareLink[]>(
-        '/nextcloud/share-links'
+        '/api/nextcloud/share-links'
       );
       if (Array.isArray(res)) return res.filter((l) => l.is_active !== false);
       return (res?.shareLinks ?? []).filter((l) => l.is_active !== false);
     },
-    staleTime: STALE_TIME,
+    // Re-fetch on every picker open: users add/remove share links via
+    // /profile/wolke between sessions, and stale caching would keep showing
+    // the "Keine Wolke verbunden" empty state after the user just connected.
+    staleTime: 0,
+    refetchOnMount: 'always',
     enabled,
     retry: 1,
   });
@@ -191,7 +195,7 @@ export function useWolkeBrowseQuery(shareLinkId: string | null, path: string, en
     queryFn: async () => {
       const qs = path ? `?path=${encodeURIComponent(path)}` : '';
       const res = await apiClient.get<ChatWolkeBrowse>(
-        `/documents/wolke/browse/${shareLinkId}${qs}`
+        `/api/documents/wolke/browse/${shareLinkId}${qs}`
       );
       return {
         shareLink: res.shareLink,


### PR DESCRIPTION
## Summary

After #880 landed, users who connected a Wolke via `/profile/wolke` and then opened `@wolke` in chat still saw the "Keine Wolke verbunden" empty state. Two bugs combined:

- The chat package's `createChatApiClient` doesn't auto-prefix `/api`, so `/nextcloud/share-links` and `/documents/wolke/browse/:id` were 404ing and the hook fell through to `[]`.
- The share-link query had `staleTime: 60s`, so even after fixing the URL, the picker would have kept showing the cached empty result for a minute after the user connected.

Fix: add `/api/` to both URLs and set `staleTime: 0` + `refetchOnMount: 'always'` on the share-link query.

## Test plan
- [ ] Connect a Wolke at `/profile/wolke`
- [ ] Open `@wolke` in a chat — share link + file list render
- [ ] Disconnect it, reopen `@wolke` — empty-state appears without page reload