### PR TITLE
feat(workplace): consolidate create actions in sidebar Neu menu

### DIFF
--- a/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
+++ b/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
@@ -5,9 +5,21 @@ import {
   DropdownMenuTrigger,
   useIsMobile,
 } from '@gruenerator/ui';
-import { type MutableRefObject, memo, useState, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { type MutableRefObject, memo, useCallback, useState } from 'react';
 import { HiOutlineDocumentText } from 'react-icons/hi';
-import { PiPlus, PiChatCircle, PiVideoCamera } from 'react-icons/pi';
+import {
+  PiChatCircle,
+  PiImageSquare,
+  PiKanban,
+  PiPencilLine,
+  PiPlus,
+  PiVideoCamera,
+} from 'react-icons/pi';
+import { useNavigate } from 'react-router-dom';
+
+import { useBoardsTyped } from '../../../hooks/useBoardsTyped';
+import apiClient from '../../utils/apiClient';
 
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
@@ -27,7 +39,17 @@ const NewItemDropdown = memo(function NewItemDropdown({
   onClose,
 }: NewItemDropdownProps) {
   const isMobile = useIsMobile();
+  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
+
+  const { createBoard } = useBoardsTyped({ enabled: false });
+
+  const createEmptyDoc = useMutation({
+    mutationFn: async () => {
+      const res = await apiClient.post('/docs', { title: 'Neues Dokument' });
+      return res.data as { id: string };
+    },
+  });
 
   const handleOpenChange = useCallback(
     (isOpen: boolean) => {
@@ -36,6 +58,39 @@ const NewItemDropdown = memo(function NewItemDropdown({
     },
     [openRef]
   );
+
+  const handleCreateDoc = useCallback(() => {
+    createEmptyDoc.mutate(undefined, {
+      onSuccess: (data) => {
+        void navigate(`/docs/${data.id}`);
+        onClose();
+      },
+    });
+  }, [createEmptyDoc, navigate, onClose]);
+
+  const handleCreateBoard = useCallback(() => {
+    createBoard.mutate(
+      { title: 'Neues Board' },
+      {
+        onSuccess: (board) => {
+          void navigate(`/boards/${board.id}`);
+          onClose();
+        },
+      }
+    );
+  }, [createBoard, navigate, onClose]);
+
+  const handleCreateWhiteboard = useCallback(() => {
+    createBoard.mutate(
+      { title: 'Neues Whiteboard', boardType: 'whiteboard' },
+      {
+        onSuccess: (board) => {
+          void navigate(`/boards/${board.id}`);
+          onClose();
+        },
+      }
+    );
+  }, [createBoard, navigate, onClose]);
 
   return (
     <div className="flex flex-col gap-0.5 p-0 mt-xs">
@@ -61,9 +116,21 @@ const NewItemDropdown = memo(function NewItemDropdown({
             <PiChatCircle />
             <span>Neuer Chat</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => onLinkClick('/docs', 'Dokumente')}>
+          <DropdownMenuItem onClick={handleCreateDoc}>
             <HiOutlineDocumentText />
             <span>Neues Dokument</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleCreateBoard}>
+            <PiKanban />
+            <span>Neues Board</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleCreateWhiteboard}>
+            <PiPencilLine />
+            <span>Neues Whiteboard</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onLinkClick('/imagine', 'Bild erstellen')}>
+            <PiImageSquare />
+            <span>Bild erstellen</span>
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => onLinkClick('/reel', 'Reel')}>
             <PiVideoCamera />

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -1,6 +1,7 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import { Dialog, DialogContent, DialogTitle, SectionHeader } from '@gruenerator/ui';
 import React, { memo, useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import ToolGrid from '../../../components/common/ToolGrid';
 import { useAuthStore } from '../../../stores/authStore';
@@ -24,6 +25,7 @@ type CreationPhase =
   | { kind: 'processing'; name: string; documents: Array<{ id: string; title: string }> };
 
 const NotebooksSection: React.FC = memo(() => {
+  const navigate = useNavigate();
   const [phase, setPhase] = useState<CreationPhase>({ kind: 'closed' });
   const [showAll, setShowAll] = useState(false);
   const locale = useAuthStore((state) => state.locale);
@@ -106,6 +108,7 @@ const NotebooksSection: React.FC = memo(() => {
     <section className="mb-xl">
       <SectionHeader
         title="Notebooks"
+        onTitleClick={() => navigate('/notebooks')}
         onCreate={handleCreate}
         createLabel="Eigenes Notebook erstellen"
       />

--- a/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
+++ b/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
@@ -2,16 +2,12 @@ import {
   CardActionsMenu,
   CardGrid,
   cn,
-  DropdownMenu,
-  DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
   SectionHeader,
   Skeleton,
   VideoCard,
 } from '@gruenerator/ui';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Download, Share2, Trash2 } from 'lucide-react';
 import React, { memo, useCallback, useState } from 'react';
 import { FaImage, FaVideo } from 'react-icons/fa';
@@ -27,14 +23,7 @@ import {
   FiRadio,
 } from 'react-icons/fi';
 import { HiOutlineDocumentText } from 'react-icons/hi';
-import {
-  PiImageSquare,
-  PiKanban,
-  PiPencilLine,
-  PiStar,
-  PiStarFill,
-  PiVideoCamera,
-} from 'react-icons/pi';
+import { PiKanban, PiPencilLine, PiStar, PiStarFill } from 'react-icons/pi';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ShareMediaModal } from '../../../components/common/ShareMediaModal';
@@ -514,17 +503,7 @@ const RecentlyCreatedSection: React.FC = memo(() => {
     })
     .slice(0, 10);
 
-  const { createBoard, deleteBoard } = useBoardsTyped({ enabled: true });
-
-  const createEmptyDoc = useMutation({
-    mutationFn: async () => {
-      const res = await apiClient.post('/docs', { title: 'Neues Dokument' });
-      return res.data as { id: string };
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['recent-activity'] });
-    },
-  });
+  const { deleteBoard } = useBoardsTyped({ enabled: true });
 
   const handleConvertText = useCallback(
     async (textId: string) => {
@@ -601,61 +580,9 @@ const RecentlyCreatedSection: React.FC = memo(() => {
     void navigator.clipboard.writeText(`${window.location.origin}${item.href}`);
   }, []);
 
-  const handleCreateDoc = useCallback(() => {
-    createEmptyDoc.mutate(undefined, {
-      onSuccess: (data) => navigate(`/docs/${data.id}`),
-    });
-  }, [createEmptyDoc, navigate]);
-
-  const handleCreateBoard = useCallback(() => {
-    createBoard.mutate(
-      { title: 'Neues Board' },
-      { onSuccess: (board) => navigate(`/boards/${board.id}`) }
-    );
-  }, [createBoard, navigate]);
-
-  const handleCreateWhiteboard = useCallback(() => {
-    createBoard.mutate(
-      { title: 'Neues Whiteboard', boardType: 'whiteboard' },
-      { onSuccess: (board) => navigate(`/boards/${board.id}`) }
-    );
-  }, [createBoard, navigate]);
-
-  const createMenu = useCallback(
-    (trigger: React.ReactNode) => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuItem onClick={handleCreateDoc}>
-            <HiOutlineDocumentText />
-            Dokument
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleCreateBoard}>
-            <PiKanban />
-            Board
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={handleCreateWhiteboard}>
-            <PiPencilLine />
-            Whiteboard
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => navigate('/imagine')}>
-            <PiImageSquare />
-            Bild erstellen
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => navigate('/studio/video')}>
-            <PiVideoCamera />
-            Reel / Video erstellen
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    ),
-    [handleCreateDoc, handleCreateBoard, handleCreateWhiteboard, navigate]
-  );
-
   return (
     <section className="mb-xl">
-      <SectionHeader title="Zuletzt erstellt" createLabel="Neu erstellen" createMenu={createMenu} />
+      <SectionHeader title="Zuletzt" />
 
       {isLoading ? (
         <CardGrid columns="5">

--- a/packages/ui/src/components/section-header.tsx
+++ b/packages/ui/src/components/section-header.tsx
@@ -27,6 +27,7 @@ function SectionHeader({
   size = 'default',
   title,
   titleHref,
+  onTitleClick,
   onCreate,
   createLabel,
   createMenu,
@@ -40,6 +41,8 @@ function SectionHeader({
   VariantProps<typeof sectionHeaderVariants> & {
     title: string;
     titleHref?: string;
+    /** In-app click handler for the title. Takes precedence over `titleHref`. */
+    onTitleClick?: () => void;
     onCreate?: () => void;
     createLabel?: string;
     /** Wraps the plus button as a dropdown trigger. Receives the button as children. */
@@ -135,7 +138,17 @@ function SectionHeader({
       {...props}
     >
       <div className="flex items-center gap-xs">
-        {titleHref ? (
+        {onTitleClick ? (
+          <button
+            type="button"
+            onClick={onTitleClick}
+            className="bg-transparent border-none p-0 cursor-pointer text-left"
+          >
+            <Heading className={cn(headingClass, 'hover:text-primary-600 transition-colors')}>
+              {title}
+            </Heading>
+          </button>
+        ) : titleHref ? (
           <a href={titleHref} target="_blank" rel="noopener noreferrer" className="no-underline">
             <Heading className={cn(headingClass, 'hover:text-primary-600 transition-colors')}>
               {title}


### PR DESCRIPTION
The Workplace "Zuletzt" section had a "+" dropdown that duplicated and extended the sidebar's "Neu" button — two competing create surfaces for the same actions. Since the section is just a list of recently-created items and the sidebar stays reachable across the whole app, the create surface belongs in the sidebar; the workplace section gets a quieter header and a small UX upgrade where the Notebooks title becomes an in-app link to `/notebooks`.

Behaviorally the sidebar's "Neues Dokument" now creates and opens a doc (it used to navigate to the docs list); other entries gained from the old "+" menu are Board, Whiteboard, and Bild erstellen.