### PR TITLE
feat(notebook): align Wolke sections with Dokumente styling and split synced docs

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor.tsx
@@ -1,9 +1,9 @@
 import { type NotebookEditorSavePayload, type WolkeFolderRef } from '@gruenerator/contracts';
-import { Badge, Button, Input, Label, Separator, Switch } from '@gruenerator/ui';
+import { Badge, Button, Input, Label, SectionHeader, Separator, Switch } from '@gruenerator/ui';
 import { AnimatePresence, motion } from 'motion/react';
-import { useState, useEffect, useCallback, useRef, type DragEvent } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { HiArrowLeft, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
+import { HiArrowLeft, HiCloud, HiUpload, HiX, HiPlus, HiPencil } from 'react-icons/hi';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
@@ -18,7 +18,7 @@ interface NotebookCollection {
   id?: string;
   name: string;
   description?: string;
-  documents?: { id: string; title?: string }[];
+  documents?: { id: string; title?: string; source_type?: string | null }[];
   labels?: string[];
   is_public?: boolean;
   public_ownership?: PublicOwnership | null;
@@ -34,6 +34,8 @@ interface UploadedDocument {
   id: string;
   title: string;
   filename?: string;
+  /** 'wolke' when the document was synced from a Wolke folder. Undefined for manual uploads. */
+  source?: 'wolke';
   [key: string]: unknown;
 }
 
@@ -142,6 +144,7 @@ const NotebookEditor = ({
           editingCollection.documents.map((doc) => ({
             id: doc.id,
             title: doc.title || 'Dokument',
+            ...(doc.source_type === 'wolke' ? { source: 'wolke' as const } : {}),
           }))
         );
         setStep(2);
@@ -282,7 +285,7 @@ const NotebookEditor = ({
         const seen = new Set(prev.map((d) => d.id));
         const additions: UploadedDocument[] = docs
           .filter((d) => !seen.has(d.id))
-          .map((d) => ({ id: d.id, title: d.title }));
+          .map((d) => ({ id: d.id, title: d.title, source: 'wolke' as const }));
         return [...prev, ...additions];
       });
       setIndexingDocIds((prev) => {
@@ -318,6 +321,15 @@ const NotebookEditor = ({
   const handleRemoveLabel = useCallback((labelToRemove: string) => {
     setLabels((prev) => prev.filter((l) => l !== labelToRemove));
   }, []);
+
+  const wolkeDocuments = useMemo(
+    () => uploadedDocuments.filter((d) => d.source === 'wolke'),
+    [uploadedDocuments]
+  );
+  const manualDocuments = useMemo(
+    () => uploadedDocuments.filter((d) => d.source !== 'wolke'),
+    [uploadedDocuments]
+  );
 
   const onSubmit = async (data: NotebookEditorFormData): Promise<void> => {
     if (uploadedDocuments.length === 0) return;
@@ -601,41 +613,98 @@ const NotebookEditor = ({
                   disabled={loading || isUploading}
                 />
 
+                {wolkeDocuments.length > 0 && (
+                  <section>
+                    <SectionHeader
+                      title="Wolke Dokumente"
+                      actions={
+                        <span className="text-sm text-grey-500">{wolkeDocuments.length}</span>
+                      }
+                    />
+                    <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+                      {wolkeDocuments.map((doc) => {
+                        const isIndexing = indexingDocIds.has(doc.id);
+                        const displayName = doc.filename || doc.title;
+                        return (
+                          <div
+                            key={doc.id}
+                            className={cn(
+                              'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
+                              isIndexing ? 'opacity-90' : 'hover:shadow-sm'
+                            )}
+                            aria-label={`Wolke: ${displayName}`}
+                          >
+                            <div
+                              className="pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md bg-secondary-400 dark:bg-secondary-700"
+                              aria-hidden
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className={cn(
+                                'absolute right-1 top-1 transition-opacity',
+                                isIndexing
+                                  ? 'opacity-60'
+                                  : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+                              )}
+                              onClick={() => handleRemoveDocument(doc.id)}
+                              disabled={loading}
+                              aria-label={`${doc.title} entfernen`}
+                            >
+                              <HiX size={12} />
+                            </Button>
+                            <div className="flex items-start gap-xs pr-6">
+                              <HiCloud
+                                size={14}
+                                className="mt-[2px] shrink-0 text-secondary-600 dark:text-secondary-400"
+                                aria-hidden
+                              />
+                              <div
+                                className="line-clamp-3 break-words text-sm font-medium leading-snug text-foreground"
+                                title={displayName}
+                              >
+                                {displayName}
+                              </div>
+                            </div>
+                            {isIndexing ? (
+                              <div className="mt-auto flex items-center gap-xs text-xs text-grey-500">
+                                <div className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                                <span>Wird verarbeitet…</span>
+                              </div>
+                            ) : null}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </section>
+                )}
+
                 <section
-                  className="relative space-y-md"
+                  className="relative"
                   onDragEnter={handleDragEnter}
                   onDragOver={handleDragOver}
                   onDragLeave={handleDragLeave}
                   onDrop={handleDrop}
                 >
-                  <div className="flex items-center justify-between gap-md">
-                    <h2 className="text-xl font-semibold text-foreground-heading">Dokumente</h2>
-                    <div className="flex items-center gap-sm">
+                  <SectionHeader
+                    title="Dokumente"
+                    onCreate={() => fileInputRef.current?.click()}
+                    createLabel="Dokumente hinzufügen"
+                    actions={
                       <span className="text-sm text-grey-500">
-                        {uploadedDocuments.length}/{MAX_DOCUMENTS}
+                        {manualDocuments.length}/{MAX_DOCUMENTS}
                       </span>
-                      <Button
-                        type="button"
-                        size="icon-sm"
-                        variant="outline"
-                        onClick={() => fileInputRef.current?.click()}
-                        disabled={
-                          loading || isUploading || uploadedDocuments.length >= MAX_DOCUMENTS
-                        }
-                        aria-label="Dokumente hinzufügen"
-                      >
-                        <HiPlus size={16} />
-                      </Button>
-                    </div>
-                  </div>
+                    }
+                  />
 
-                  {uploadedDocuments.length === 0 ? (
+                  {manualDocuments.length === 0 ? (
                     <p className="py-lg text-center text-sm text-grey-500">
                       Noch keine Dokumente. Ziehe Dateien hierher oder klicke auf +.
                     </p>
                   ) : (
                     <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-                      {uploadedDocuments.map((doc) => {
+                      {manualDocuments.map((doc) => {
                         const isIndexing = indexingDocIds.has(doc.id);
                         const fileType = getFileTypeStyle(doc.filename || doc.title);
                         return (

--- a/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
@@ -1,8 +1,8 @@
 import { type WolkeFolderRef } from '@gruenerator/contracts';
-import { Badge, Button } from '@gruenerator/ui';
+import { Badge, Button, SectionHeader } from '@gruenerator/ui';
 import { useShareLinks, type ShareLink } from '@gruenerator/wolke';
 import { useState, useCallback, useMemo } from 'react';
-import { HiCloud, HiPlus, HiRefresh, HiX, HiExclamation } from 'react-icons/hi';
+import { HiCloud, HiExclamation, HiRefresh, HiX } from 'react-icons/hi';
 import { Link } from 'react-router-dom';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
@@ -38,6 +38,15 @@ function pickShareLabel(link: ShareLink): string {
     link.label?.trim() || link.display_name?.trim() || link.folder_name?.trim() || 'Wolke-Ordner'
   );
 }
+
+const ExperimentalBadge = (
+  <Badge
+    variant="outline"
+    className="border-amber-300 bg-amber-50 text-[10px] uppercase text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+  >
+    Experimentell
+  </Badge>
+);
 
 const NotebookEditorWolkeSection = ({
   folders,
@@ -97,7 +106,7 @@ const NotebookEditorWolkeSection = ({
         const sliced = supported.slice(0, Math.max(0, remainingSlots));
         const skipped = supported.length - sliced.length;
         if (sliced.length === 0) {
-          setError('Notebook ist voll (max. 20 Dokumente).');
+          setError('Notebook ist voll.');
           return;
         }
 
@@ -128,7 +137,7 @@ const NotebookEditorWolkeSection = ({
 
         if (skipped > 0) {
           setError(
-            `${skipped} Datei${skipped === 1 ? '' : 'en'} übersprungen — max. 20 pro Notebook.`
+            `${skipped} Datei${skipped === 1 ? '' : 'en'} übersprungen — Notebook fast voll.`
           );
         }
       } catch (e) {
@@ -143,38 +152,26 @@ const NotebookEditorWolkeSection = ({
   const isLoading = shareLinksQuery.isLoading;
   const hasShareLinks = (shareLinksQuery.data ?? []).length > 0;
 
+  const headerActions = (
+    <div className="flex items-center gap-xs">
+      {ExperimentalBadge}
+      {hasShareLinks && <span className="text-sm text-grey-500">{folders.length}</span>}
+    </div>
+  );
+
   return (
-    <section className="rounded-xl bg-background-alt/50 px-sm py-sm">
-      <header className="flex flex-wrap items-center justify-between gap-xs pb-xs">
-        <div className="flex items-center gap-xs">
-          <HiCloud className="text-grey-400" size={16} aria-hidden />
-          <span className="text-sm font-semibold text-foreground">Wolke-Ordner</span>
-          <Badge
-            variant="outline"
-            className="border-amber-300 bg-amber-50 text-[10px] uppercase text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-          >
-            Experimentell
-          </Badge>
-        </div>
-        {hasShareLinks && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            disabled={disabled || availableLinks.length === 0}
-            onClick={() => setPickerOpen((v) => !v)}
-            aria-label="Wolke-Ordner hinzufügen"
-          >
-            <HiPlus size={14} />
-            Ordner hinzufügen
-          </Button>
-        )}
-      </header>
+    <section>
+      <SectionHeader
+        title="Wolke-Ordner"
+        onCreate={hasShareLinks ? () => setPickerOpen((v) => !v) : undefined}
+        createLabel="Wolke-Ordner hinzufügen"
+        actions={headerActions}
+      />
 
       {isLoading ? (
-        <div className="h-16 animate-pulse rounded-md bg-grey-100 dark:bg-grey-900" />
+        <div className="h-24 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900" />
       ) : !hasShareLinks ? (
-        <div className="flex flex-col items-start gap-xs rounded-lg border border-dashed border-grey-300 bg-background p-md dark:border-grey-700">
+        <div className="flex flex-col items-start gap-xs rounded-xl border border-dashed border-grey-300 bg-background p-md dark:border-grey-700">
           <p className="m-0 text-sm text-foreground">Du hast noch keine Wolke verbunden.</p>
           <p className="m-0 text-xs text-grey-500">
             Verbinde sie einmal und du kannst hier ganze Ordner als Quelle hinzufügen.
@@ -186,7 +183,7 @@ const NotebookEditorWolkeSection = ({
       ) : (
         <>
           {pickerOpen && availableLinks.length > 0 && (
-            <div className="mb-xs flex flex-col gap-1 rounded-lg border border-grey-200 bg-background p-xs dark:border-grey-700">
+            <div className="mb-md flex flex-col gap-1 rounded-xl border border-grey-200 bg-background p-xs dark:border-grey-700">
               <p className="m-0 px-1 pb-1 text-xs uppercase tracking-wide text-grey-500">
                 Verbundene Wolken
               </p>
@@ -204,68 +201,87 @@ const NotebookEditorWolkeSection = ({
             </div>
           )}
 
-          {folders.length === 0 && !pickerOpen && (
-            <p className="m-0 text-xs text-grey-500">
-              Noch kein Ordner verknüpft — füge einen hinzu und synchronisiere ihn manuell.
+          {folders.length === 0 && !pickerOpen ? (
+            <p className="py-lg text-center text-sm text-grey-500">
+              Noch kein Wolke-Ordner verknüpft. Klicke auf + um einen hinzuzufügen.
             </p>
-          )}
-
-          {folders.length > 0 && (
-            <ul className="flex flex-col gap-xs">
-              {folders.map((folder) => {
-                const isSyncing = syncingId === folder.shareLinkId;
-                return (
-                  <li
-                    key={folder.shareLinkId}
-                    className={cn(
-                      'group flex items-center gap-sm rounded-lg border border-grey-200 bg-background p-sm dark:border-grey-800',
-                      isSyncing && 'opacity-90'
-                    )}
-                  >
-                    <HiCloud size={16} className="shrink-0 text-grey-400" aria-hidden />
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground">
-                        {folder.folderName}
+          ) : (
+            folders.length > 0 && (
+              <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+                {folders.map((folder) => {
+                  const isSyncing = syncingId === folder.shareLinkId;
+                  return (
+                    <div
+                      key={folder.shareLinkId}
+                      className={cn(
+                        'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
+                        isSyncing ? 'opacity-90' : 'hover:shadow-sm'
+                      )}
+                      aria-label={`Wolke-Ordner: ${folder.folderName}`}
+                    >
+                      <div
+                        className="pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md bg-secondary-400 dark:bg-secondary-700"
+                        aria-hidden
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        className={cn(
+                          'absolute right-1 top-1 transition-opacity',
+                          isSyncing
+                            ? 'opacity-60'
+                            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+                        )}
+                        disabled={disabled || isSyncing}
+                        onClick={() => handleRemove(folder.shareLinkId)}
+                        title="Bereits importierte Dokumente bleiben im Notebook."
+                        aria-label={`${folder.folderName} entfernen`}
+                      >
+                        <HiX size={12} />
+                      </Button>
+                      <div className="flex items-start gap-xs pr-6">
+                        <HiCloud
+                          size={14}
+                          className="mt-[2px] shrink-0 text-secondary-600 dark:text-secondary-400"
+                          aria-hidden
+                        />
+                        <div
+                          className="line-clamp-2 break-words text-sm font-medium leading-snug text-foreground"
+                          title={folder.folderName}
+                        >
+                          {folder.folderName}
+                        </div>
                       </div>
-                      <div className="mt-[2px] text-xs text-grey-500">
-                        {isSyncing ? 'Wird synchronisiert…' : formatRelative(folder.lastSyncedAt)}
+                      <div className="mt-auto flex items-center justify-between gap-xs">
+                        <span className="text-xs text-grey-500">
+                          {isSyncing ? 'Wird synchronisiert…' : formatRelative(folder.lastSyncedAt)}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={disabled || isSyncing || remainingSlots <= 0}
+                          onClick={() => void handleSync(folder)}
+                          aria-label={`${folder.folderName} synchronisieren`}
+                        >
+                          {isSyncing ? (
+                            <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                          ) : (
+                            <HiRefresh size={12} />
+                          )}
+                          Sync
+                        </Button>
                       </div>
                     </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      disabled={disabled || isSyncing || remainingSlots <= 0}
-                      onClick={() => void handleSync(folder)}
-                      aria-label={`${folder.folderName} synchronisieren`}
-                    >
-                      {isSyncing ? (
-                        <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                      ) : (
-                        <HiRefresh size={14} />
-                      )}
-                      Synchronisieren
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-                      disabled={disabled || isSyncing}
-                      onClick={() => handleRemove(folder.shareLinkId)}
-                      title="Nur die Verbindung wird entfernt — bereits importierte Dokumente bleiben im Notebook."
-                      aria-label={`${folder.folderName} entfernen`}
-                    >
-                      <HiX size={12} />
-                    </Button>
-                  </li>
-                );
-              })}
-            </ul>
+                  );
+                })}
+              </div>
+            )
           )}
 
           {error && (
-            <div className="mt-xs flex items-start gap-xs rounded-md bg-amber-50 px-sm py-xs text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+            <div className="mt-md flex items-start gap-xs rounded-md bg-amber-50 px-sm py-xs text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
               <HiExclamation size={14} className="mt-[1px] shrink-0" aria-hidden />
               <span>{error}</span>
             </div>


### PR DESCRIPTION
## Why

The Wolke-Ordner section used a bespoke compact header that looked nothing like the rest of the editor, and Wolke-imported documents were lumped into the same "Dokumente" grid as manually uploaded files. The user wanted (a) the Wolke section to look "like Dokumente" and (b) synced documents in their own labelled section so the distinction between "I uploaded this" and "this came from a folder I synced" is visible.

While addressing it I also noticed the existing Dokumente section was the odd one out in the codebase — it hand-rolled its header with `<h2>` + count + outline plus-button, while the rest of the app uses the shared `<SectionHeader>` from `@gruenerator/ui` (NotebooksSection, VonDerBasis, etc.). This PR migrates Dokumente onto SectionHeader at the same time so all three sections share one canonical pattern.

## What changed

- **Wolke-Ordner**: shared `<SectionHeader>` header, folder entries render as cards in the same grid layout as Dokumente instead of horizontal list rows.
- **Wolke Dokumente** (new): appears once ≥1 doc has been synced from a Wolke folder. Cards mirror the Dokumente card shape but use a cloud icon and secondary-tinted corner accent so synced docs are visually distinct from manual uploads.
- **Dokumente**: migrated to `<SectionHeader>` for consistency with the rest of the app.
- **Doc-source split**: uses the existing `source_type` field on each document row (already populated by the backend for Wolke imports). On editing-load hydrate, docs with `source_type === 'wolke'` get tagged `source: 'wolke'` on the `UploadedDocument`; the two grids derive via `filter`. No parallel state, no sync hazard.

## Out of scope

- Sub-folder navigation inside a Wolke share (still root-only).
- Auto-sync (still a manual button — the persisted folder pointer is the foundation).
- Surfacing how the global doc limit (100) is shared between manual + Wolke sections — currently each section shows its own count.

## Test plan

- [ ] Open the editor with a notebook that has no Wolke folders → Dokumente section uses SectionHeader; no Wolke Dokumente section rendered.
- [ ] Open the editor as a user with no Wolke share links → Wolke-Ordner shows empty-state CTA linking to `/profile/wolke`.
- [ ] As a user with ≥1 share link: click the + on Wolke-Ordner → inline picker opens → select a folder → folder card appears in the Wolke-Ordner grid (matches Dokumente card dimensions).
- [ ] Click Sync on a folder → "Wolke Dokumente" section appears with the imported docs; nothing lands in the regular Dokumente grid.
- [ ] Edit an existing notebook that already has Wolke-imported docs → on load, those docs show under "Wolke Dokumente"; manually uploaded docs show under "Dokumente".
- [ ] Remove a Wolke folder → folder card disappears, Wolke Dokumente section keeps showing the previously-imported docs.
- [ ] Remove a Wolke doc individually → it leaves the Wolke Dokumente grid; the folder pointer stays so future syncs can re-import via server dedup.