### PR TITLE
fix(docs): keep chat composer above mobile keyboard

### DIFF
--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -739,7 +739,7 @@ function EditorContent() {
           <aside
             className={
               effectivePanel === 'chat'
-                ? 'w-80 min-w-80 max-w-80 flex flex-col border-l border-grey-200 dark:border-grey-700 bg-background dark:bg-grey-900 overflow-hidden max-md:fixed max-md:inset-0 max-md:w-full max-md:min-w-full max-md:max-w-full max-md:border-l-0 max-md:z-[200]'
+                ? 'w-80 min-w-80 max-w-80 flex flex-col border-l border-grey-200 dark:border-grey-700 bg-background dark:bg-grey-900 overflow-hidden max-md:fixed max-md:inset-0 max-md:w-full max-md:min-w-full max-md:max-w-full max-md:border-l-0 max-md:z-[200] max-md:pb-[var(--mobile-keyboard-offset,0px)]'
                 : 'hidden'
             }
           >


### PR DESCRIPTION
The docs chat aside is positioned `max-md:fixed max-md:inset-0` on mobile, which spans the full layout viewport. Because the app's viewport meta uses `interactive-widget=resizes-visual`, the layout viewport does not shrink when the on-screen keyboard opens — so the composer at the bottom of the flex column ended up hidden behind the keyboard.

The boards comments (CardDetailPanel) and the docs editor `<main>` already handle this by consuming `--mobile-keyboard-offset` as `paddingBottom`. The CSS variable is published by `BlockNoteEditor`'s `useMobileKeyboardOffset` hook, which is always mounted alongside the chat aside in the docs editor — so we just need the chat aside to consume it too.

Single className addition: `max-md:pb-[var(--mobile-keyboard-offset,0px)]` on the chat `<aside>`.

## Test plan
- [ ] Open a docs document on a mobile device (or DevTools mobile emulator with on-screen keyboard).
- [ ] Open the AI chat panel — verify it covers the screen as before.
- [ ] Tap the composer to open the keyboard — verify the composer (and Send button) sit just above the keyboard, not behind it.
- [ ] Dismiss the keyboard — verify the chat returns to full-height layout, no leftover bottom padding.
- [ ] Verify desktop view (`md:` and up) is unchanged: aside is the 320 px right rail, no padding artifact.