### PR TITLE
feat(chat): render @wolke selections as attachment chips

### DIFF
--- a/packages/chat/src/components/assistant-ui/attachment.tsx
+++ b/packages/chat/src/components/assistant-ui/attachment.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PropsWithChildren, useEffect, useState, type FC } from 'react';
-import { XIcon, PlusIcon, FileText, FileSearch } from 'lucide-react';
+import { XIcon, PlusIcon, FileText, FileSearch, Cloud } from 'lucide-react';
 import {
   AttachmentPrimitive,
   ComposerPrimitive,
@@ -132,10 +132,13 @@ const GruenAttachmentChip: FC = () => {
   );
 
   const isCollab = contentType === 'application/x-gruenerator-collab-doc';
-  const Icon = isCollab ? FileText : FileSearch;
-  const variant = isCollab
-    ? 'bg-cyan-500/10 text-cyan-900 border-cyan-500/30 dark:text-cyan-100'
-    : 'bg-primary/5 text-foreground border-primary/20';
+  const isWolke = contentType === 'application/x-gruenerator-wolke';
+  const Icon = isWolke ? Cloud : isCollab ? FileText : FileSearch;
+  const variant = isWolke
+    ? 'bg-sky-500/10 text-sky-900 border-sky-500/30 dark:text-sky-100'
+    : isCollab
+      ? 'bg-cyan-500/10 text-cyan-900 border-cyan-500/30 dark:text-cyan-100'
+      : 'bg-primary/5 text-foreground border-primary/20';
 
   return (
     <AttachmentPrimitive.Root

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -26,6 +26,7 @@ import { computeMentionInsertion } from '../../lib/mentionInsertion';
 import { FileMentionPopover } from './FileMentionPopover';
 import { WolkeMentionPopover } from './WolkeMentionPopover';
 import type { CollabDocSelection } from '../../lib/documentMentionables';
+import type { WolkeFileToken } from '../../lib/mentionables';
 import { PlusMenu } from './PlusMenu';
 import { ModelPicker } from './ModelPicker';
 import { getCaretCoords } from '../../lib/caretPosition';
@@ -363,19 +364,30 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
   );
 
   const handleWolkeSelect = useCallback(
-    (tokens: string[]) => {
-      const textarea = textareaRef.current;
-      if (!textarea || tokens.length === 0) return;
-      const currentText = composerRuntime.getState().text;
-      const caret = textarea.selectionStart;
-      const insert = `${currentText.slice(0, caret)}${tokens.join(' ')} ${currentText.slice(caret)}`;
-      composerRuntime.setText(insert);
+    (files: WolkeFileToken[]) => {
+      if (files.length === 0) return;
+      for (const f of files) {
+        void composerRuntime.addAttachment({
+          id: `gruenerator-wolke-${f.shareLinkId}:${f.path}`,
+          type: 'document',
+          name: f.name,
+          contentType: 'application/x-gruenerator-wolke',
+          content: [
+            {
+              type: 'data',
+              name: 'gruenerator-mention',
+              data: {
+                kind: 'wolke',
+                shareLinkId: f.shareLinkId,
+                path: f.path,
+                name: f.name,
+              },
+            },
+          ],
+        });
+      }
       dismissPopover();
-      requestAnimationFrame(() => {
-        const pos = caret + tokens.join(' ').length + 1;
-        textarea.setSelectionRange(pos, pos);
-        textarea.focus();
-      });
+      requestAnimationFrame(() => textareaRef.current?.focus());
     },
     [composerRuntime, dismissPopover]
   );

--- a/packages/chat/src/components/thread/WolkeMentionPopover.tsx
+++ b/packages/chat/src/components/thread/WolkeMentionPopover.tsx
@@ -7,11 +7,11 @@ import {
   type ChatWolkeFile,
 } from '../../hooks/useMentionablesQuery';
 import { useChatConfigStore } from '../../stores/chatConfigStore';
-import { encodeWolkeToken } from '../../lib/mentionables';
+import { type WolkeFileToken } from '../../lib/mentionables';
 
 interface WolkeMentionPopoverProps {
   visible: boolean;
-  onSelect: (tokens: string[]) => void;
+  onSelect: (files: WolkeFileToken[]) => void;
   onDismiss: () => void;
 }
 
@@ -88,10 +88,9 @@ export function WolkeMentionPopover({ visible, onSelect, onDismiss }: WolkeMenti
 
   const handleConfirm = () => {
     if (selectionList.length === 0) return;
-    const tokens = selectionList.map((f) =>
-      encodeWolkeToken({ shareLinkId: f.shareLinkId, path: f.path, name: f.name })
+    onSelect(
+      selectionList.map((f) => ({ shareLinkId: f.shareLinkId, path: f.path, name: f.name }))
     );
-    onSelect(tokens);
   };
 
   return (

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -1051,13 +1051,15 @@ export function createGrueneratorModelAdapter(
         const seenDocs = new Set(documentIds);
         const seenTexts = new Set(textIds);
         const seenCollab = new Set(docMentionIds);
+        const seenWolke = new Set(wolkeFiles.map((f) => `${f.shareLinkId}:${f.path}`));
         type GruenMentionData =
           | { kind: 'collab'; id: string; slug: string; title: string }
           | {
               kind: 'document';
               documentId: string;
               sourceType: 'notebook' | 'document' | 'text';
-            };
+            }
+          | { kind: 'wolke'; shareLinkId: string; path: string; name: string };
         const attachments = (lastUserMsg as { attachments: readonly CompleteAttachment[] })
           .attachments;
         for (const att of attachments) {
@@ -1083,6 +1085,16 @@ export function createGrueneratorModelAdapter(
                   seenDocs.add(data.documentId);
                   documentIds.push(data.documentId);
                 }
+              }
+            } else if (data.kind === 'wolke') {
+              const key = `${data.shareLinkId}:${data.path}`;
+              if (!seenWolke.has(key)) {
+                seenWolke.add(key);
+                wolkeFiles.push({
+                  shareLinkId: data.shareLinkId,
+                  path: data.path,
+                  name: data.name,
+                });
               }
             }
           }


### PR DESCRIPTION
## Summary

Replaces the raw `@wolke:eyJ…` base64 tokens in the composer text with proper assistant-ui attachment chips — same UI as `@datei` and `@doc`, with a Cloud icon and sky-blue palette to match Wolke's brand.

## Before / after

Before: `@wolke:eyJzaGFyZUxpbmtJZCI6IjE3Nzg4OTE2…`

After: a tidy chip like the document/doc-mention ones, with a cloud icon and the filename.

## How it works

- `GruenAttachmentChip` gains a wolke variant (cloud icon, `bg-sky-500/10` palette) keyed on `application/x-gruenerator-wolke`.
- `WolkeMentionPopover.onSelect` now passes typed `WolkeFileToken[]` (not encoded strings).
- `GrueneratorComposer.handleWolkeSelect` adds one `composerRuntime.addAttachment(...)` per picked file with a `kind: 'wolke'` data part — same pattern as the document/collab chips.
- `GrueneratorModelAdapter`'s existing attachment-extraction loop gets a `kind: 'wolke'` branch that appends to `wolkeFiles`, deduping by `shareLinkId:path`.

The base64 token decoder in `mentionParser` stays in place so any messages saved during the previous, less-polished UX still get parsed correctly.

## Test plan
- [ ] Open `@wolke`, pick two files — both render as cloud chips above the input, no ugly base64 text
- [ ] Click the X on a chip — removes that file, request body reflects it
- [ ] Send the message — backend logs show `wolkeFiles.length` matches the chip count
- [ ] An old saved message with the legacy `@wolke:<base64>` token still resolves (backward-compat)