### PR TITLE
fix(docs): persist permission grant on public share-link open

### DIFF
--- a/apps/api/routes/docs/documentAccess.ts
+++ b/apps/api/routes/docs/documentAccess.ts
@@ -62,8 +62,10 @@ export async function checkDocumentAccess(
 }
 
 export function autoGrantSharePermission(document: CollaborativeDocument, userId: string): void {
+  const isLinkShared =
+    document.share_mode === 'authenticated' || document.share_mode === 'public';
   if (
-    document.share_mode !== 'authenticated' ||
+    !isLinkShared ||
     document.created_by === userId ||
     (document.permissions && document.permissions[userId])
   ) {


### PR DESCRIPTION
## Summary

A doc shared via a public link (`share_mode = 'public'`) never appeared in the recipient's **Meine Dokumente** or **Zuletzt** lists after they opened it. `autoGrantSharePermission` (`apps/api/routes/docs/documentAccess.ts`) only fired for `share_mode === 'authenticated'`, so for public links no row was written to the doc's `permissions` JSONB. Both list queries (`recentActivityController.ts:fetchRecentDocs` and `docsContractRouter.ts:listDocuments`) scope to `created_by` / `permissions ? userId` / group-share — with no grant, the doc was invisible to the viewer.

Extend the guard so the grant also fires for `share_mode === 'public'` when the visitor is authenticated. The level inherits the link's configured `share_permission`, matching the existing authenticated path. Anonymous viewers remain stateless (no `userId` to write).

## Test plan

- [ ] Owner: create a doc → ShareModal → *Freigabemodus = Öffentlich* → copy link
- [ ] Second user (logged in, different account): open link → doc renders
- [ ] Second user: visit `/docs` → doc appears with `accessType = 'direct'`
- [ ] Second user: workplace home → doc appears in **Zuletzt**
- [ ] DB sanity: `SELECT permissions FROM collaborative_documents WHERE id = '<doc-id>';` shows the second user keyed in with `granted_by: 'auto:share_link'`
- [ ] Regression: `share_mode = 'authenticated'` still auto-grants as before
- [ ] Regression: owner opening their own doc does not create a spurious self-grant
- [ ] Regression: anonymous viewer of a public link still loads the doc, no DB write