### PR TITLE
fix(chat): skip duplicate toolCallId on heartbeat thinking_step replay

### DIFF
--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -509,23 +509,34 @@ async function* parseSSEStream(
           const mappedToolName = DEEP_TOOL_MAP[toolName] || toolName;
 
           if (status === 'in_progress') {
-            // Preserve any pre-existing activeToolCall (e.g. the intent-derived
-            // gruenerator_examples_search tool-call set by the `intent` event)
-            // before overwriting with this thinking_step's tool. Otherwise the
-            // examples tool-call is orphaned and search_complete's result has
-            // nowhere to land — leaving the UI with classify/rerank chips and
-            // no examples card.
-            if (activeToolCall && !allToolCalls.includes(activeToolCall)) {
-              allToolCalls.push(activeToolCall);
+            // The backend heartbeat (responseStreamingService.startResponseHeartbeat)
+            // re-emits the SAME stepId every 3s. If it matches the current
+            // activeToolCall, or is already in allToolCalls, skip the
+            // archive-and-replace below — otherwise we'd render two tool-call
+            // parts with the same toolCallId and trip assistant-ui's
+            // `tapResources` with "Duplicate key toolCallId-…".
+            const isDuplicateStepId =
+              (activeToolCall !== null && activeToolCall.toolCallId === stepId) ||
+              allToolCalls.some((tc) => tc.toolCallId === stepId);
+            if (!isDuplicateStepId) {
+              // Preserve any pre-existing activeToolCall (e.g. the intent-derived
+              // gruenerator_examples_search tool-call set by the `intent` event)
+              // before overwriting with this thinking_step's tool. Otherwise the
+              // examples tool-call is orphaned and search_complete's result has
+              // nowhere to land — leaving the UI with classify/rerank chips and
+              // no examples card.
+              if (activeToolCall !== null && !allToolCalls.includes(activeToolCall)) {
+                allToolCalls.push(activeToolCall);
+              }
+              const toolArgs = { query: (args?.query as string) || title, ...args };
+              activeToolCall = {
+                type: 'tool-call',
+                toolCallId: stepId,
+                toolName: mappedToolName,
+                args: toolArgs as Record<string, string | number | boolean | null>,
+                argsText: JSON.stringify(toolArgs),
+              };
             }
-            const toolArgs = { query: (args?.query as string) || title, ...args };
-            activeToolCall = {
-              type: 'tool-call',
-              toolCallId: stepId,
-              toolName: mappedToolName,
-              args: toolArgs as Record<string, string | number | boolean | null>,
-              argsText: JSON.stringify(toolArgs),
-            };
             currentProgress = { stage: 'searching', message: title };
           } else if (status === 'completed') {
             if (activeToolCall?.toolCallId === stepId) {


### PR DESCRIPTION
## Why

GlitchTip is reporting `Error: Duplicate key toolCallId-generating_<ms> in tapResources` (issue `GRUENERATOR-AE`). The chat message render crashes when the primary model takes more than ~6s to first token.

Trace:
1. `responseStreamingService.startResponseHeartbeat` captures one `stepId = generating_<Date.now()>` and emits `thinking_step{stepId, status: in_progress}` every 3s while waiting.
2. The frontend `thinking_step` handler archives `activeToolCall` into `allToolCalls` and recreates `activeToolCall` with `toolCallId: stepId` on **every** `in_progress` event.
3. From the 2nd heartbeat tick onward, the previous heartbeat tool-call (same `stepId`) lands in `allToolCalls`, and a new `activeToolCall` exists with the same id. `buildResult` emits both → assistant-ui's `tapResources` throws.

This fix detects the duplicate-stepId case in the `in_progress` branch and skips the archive+recreate. The May 14 rerank-preservation behavior (`ea1b33e10`) is intact for genuinely new `stepId`s — only same-id replays are short-circuited.