### PR TITLE
fix(chat): allow application/x-gruenerator-wolke in attachment adapter

### DIFF
--- a/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
@@ -21,6 +21,7 @@ const SYNTHETIC_MENTION_TYPES = [
   'application/x-gruenerator-datei-notebook',
   'application/x-gruenerator-datei-document',
   'application/x-gruenerator-datei-text',
+  'application/x-gruenerator-wolke',
 ];
 
 export class GrueneratorAttachmentAdapter implements AttachmentAdapter {


### PR DESCRIPTION
Hotfix: #890 introduced `application/x-gruenerator-wolke` chips but didn't add the MIME type to `GrueneratorAttachmentAdapter.SYNTHETIC_MENTION_TYPES`, so AUI's `addAttachment` validation rejected every selection. One-line allowlist addition next to the existing collab-doc / datei-* entries.