### PR TITLE
fix(chat): respondNode reads researchMeta directly to stop artifact↔reply drift

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
@@ -17,7 +17,13 @@ import { INTERMEDIATE_MODEL } from '../llmConfig.js';
 
 import { type AnchorDescriptor, getActiveAnchors } from './anchorContext.js';
 
-import type { ChatGraphState, DocumentSource, SearchResult, ThreadAttachment } from '../types.js';
+import type {
+  ChatGraphState,
+  DocumentSource,
+  ResearchToolResult,
+  SearchResult,
+  ThreadAttachment,
+} from '../types.js';
 
 const log = createLogger('ChatGraph:Respond');
 
@@ -191,7 +197,58 @@ async function cleanFindings(state: ChatGraphState): Promise<string | null> {
  * For complex research queries with a researchBrief, uses LLM cleaning
  * to produce a coherent summary instead of raw truncated snippets.
  */
-async function formatSearchContext(state: ChatGraphState): Promise<string> {
+export function formatResearchWrapperContext(meta: ResearchToolResult): string {
+  // Wrapper-mode prompt: the synthesized answer is rendered separately as the
+  // Recherche-Karte (researchMeta tool result). The agent must NOT re-synthesize
+  // from chunks — that produces drift (small models drop confidence and emit
+  // "keine Informationen" while the card shows a confident answer). Treat this
+  // as a thin conversational wrapper around the artifact.
+  const synthesisPreview = meta.answer.length > 800 ? `${meta.answer.slice(0, 800)}…` : meta.answer;
+  const followUpHint =
+    meta.followUpQuestions.length > 0
+      ? 'nimm ggf. eine der Folge-Fragen aus der Karte auf, oder '
+      : '';
+  return `
+
+## RECHERCHE ABGESCHLOSSEN — DU BIST WRAPPER, NICHT ANTWORTGEBER
+
+Die vollständige Recherche-Antwort und alle ${meta.citations.length} Quellen werden dem*der Nutzer*in als separate Recherche-Karte oberhalb deiner Antwort angezeigt.
+
+WICHTIG:
+1. Wiederhole NICHT die Recherche-Antwort — sie ist bereits sichtbar.
+2. Verweise konversationell auf die Karte (maximal 2 Sätze).
+3. Sage NIE "keine Informationen", "keine Treffer", "konnte nichts finden" o.ä. — die Recherche WAR erfolgreich (Konfidenz: ${meta.confidence}, ${meta.citations.length} Quellen).
+4. Wenn passend: ${followUpHint}biete eine weiterführende Frage an.
+
+Synthese (NUR zur Orientierung — wiederhole sie nicht):
+${synthesisPreview}`;
+}
+
+export async function formatSearchContext(state: ChatGraphState): Promise<string> {
+  // Research mode with usable synthesis: emit a wrapper-mode block so the
+  // model writes a thin conversational reference, not a re-synthesis from
+  // raw chunks. The tool artifact (researchMeta) is the single source of
+  // truth for the answer; the chat reply just frames it.
+  if (
+    state.intent === 'research' &&
+    state.researchMeta?.answer &&
+    state.researchMeta.confidence !== 'low'
+  ) {
+    log.info(
+      `[Respond] Wrapper-mode (intent=research, confidence=${state.researchMeta.confidence}, citations=${state.researchMeta.citations.length}, answer_len=${state.researchMeta.answer.length})`
+    );
+    return formatResearchWrapperContext(state.researchMeta);
+  }
+
+  // Log why wrapper-mode did NOT apply so regressions are easy to spot in
+  // production logs (e.g. confidence dropping to 'low', meta missing,
+  // intent mis-classified).
+  if (state.intent === 'research') {
+    log.info(
+      `[Respond] Wrapper-mode skipped for research intent: hasMeta=${!!state.researchMeta}, hasAnswer=${!!state.researchMeta?.answer}, confidence=${state.researchMeta?.confidence ?? 'none'} — falling through to chunk-based context`
+    );
+  }
+
   if (state.searchResults.length === 0) {
     return '';
   }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.vitest.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { formatResearchWrapperContext, formatSearchContext } from './respondNode.js';
+
+import type { ChatGraphState, ResearchToolResult, SearchResult } from '../types.js';
+
+vi.mock('../../../../utils/logger.js', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+function makeResults(n: number): SearchResult[] {
+  return Array.from({ length: n }, (_, i) => ({
+    source: `gruenerator:test-${i}`,
+    title: `Result ${i}`,
+    content: `Content for result ${i}`.repeat(5),
+    relevance: 0.8,
+  }));
+}
+
+function makeMeta(overrides: Partial<ResearchToolResult> = {}): ResearchToolResult {
+  return {
+    answer:
+      'Moritz Wächter ist eine in Deutschland tätige Fachkraft im Bereich Digitalisierung und Technologie, die bei Strategy& aktiv ist.',
+    citations: [
+      { id: '1', title: 'Strategy& Profile', url: 'https://example.com/a', snippet: 'snippet a' },
+      { id: '2', title: 'PwC Press', url: 'https://example.com/b', snippet: 'snippet b' },
+    ] as ResearchToolResult['citations'],
+    confidence: 'high',
+    searchSteps: [{ tool: 'linkup', query: 'wer ist moritz wächter', resultsCount: 8 }],
+    followUpQuestions: ['Welche Projekte hat er bei Strategy& geleitet?'],
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<ChatGraphState> = {}): ChatGraphState {
+  return {
+    intent: 'research',
+    searchResults: makeResults(4),
+    searchQuery: 'wer ist moritz wächter',
+    researchBrief: null,
+    researchMeta: null,
+    documentSources: [],
+    perSourceResults: {},
+    documentChatIds: [],
+    notebookCollectionIds: [],
+    notebookDocumentIds: [],
+    searchSources: ['web'],
+    complexity: 'simple',
+    aiWorkerPool: null,
+    ...overrides,
+  } as unknown as ChatGraphState;
+}
+
+describe('formatResearchWrapperContext', () => {
+  it('emits the wrapper directive block and never instructs the model to claim "no results"', () => {
+    const out = formatResearchWrapperContext(makeMeta());
+    expect(out).toContain('RECHERCHE ABGESCHLOSSEN');
+    expect(out).toContain('DU BIST WRAPPER');
+    expect(out).toContain('Wiederhole NICHT');
+    // The whole point of this PR: agent must be told NOT to say "keine ..." when
+    // the artifact has a confident answer. If this assertion breaks, someone
+    // softened the prompt and re-opened the artifact↔reply drift bug.
+    expect(out).toMatch(/Sage NIE.+keine Informationen/);
+  });
+
+  it('includes confidence and citation count for the model to ground its wrapper on', () => {
+    const out = formatResearchWrapperContext(makeMeta({ confidence: 'medium' }));
+    expect(out).toContain('Konfidenz: medium');
+    expect(out).toContain('2 Quellen');
+  });
+
+  it('truncates the synthesis preview at 800 chars with an ellipsis', () => {
+    const long = 'x'.repeat(1500);
+    const out = formatResearchWrapperContext(makeMeta({ answer: long }));
+    expect(out).toContain('…');
+    // Ensures we don't dump the entire synthesis (which the model would then echo)
+    expect(out.length).toBeLessThan(2000);
+  });
+});
+
+describe('formatSearchContext routing', () => {
+  it('routes to wrapper-mode when research intent + high-confidence synthesis is present', async () => {
+    const state = makeState({ researchMeta: makeMeta({ confidence: 'high' }) });
+    const out = await formatSearchContext(state);
+    expect(out).toContain('RECHERCHE ABGESCHLOSSEN');
+    expect(out).not.toContain('## SUCHERGEBNISSE');
+  });
+
+  it('routes to wrapper-mode when confidence is medium', async () => {
+    const state = makeState({ researchMeta: makeMeta({ confidence: 'medium' }) });
+    const out = await formatSearchContext(state);
+    expect(out).toContain('RECHERCHE ABGESCHLOSSEN');
+  });
+
+  it('falls through to chunk-based formatting when researchMeta is null', async () => {
+    const state = makeState({ researchMeta: null });
+    const out = await formatSearchContext(state);
+    expect(out).toContain('## SUCHERGEBNISSE');
+    expect(out).not.toContain('RECHERCHE ABGESCHLOSSEN');
+  });
+
+  it('falls through to chunk-based formatting when confidence is low', async () => {
+    const state = makeState({ researchMeta: makeMeta({ confidence: 'low' }) });
+    const out = await formatSearchContext(state);
+    expect(out).toContain('## SUCHERGEBNISSE');
+    expect(out).not.toContain('RECHERCHE ABGESCHLOSSEN');
+  });
+
+  it('falls through to chunk-based formatting when intent is not research (e.g. search)', async () => {
+    const state = makeState({
+      intent: 'search',
+      researchMeta: makeMeta({ confidence: 'high' }),
+    });
+    const out = await formatSearchContext(state);
+    expect(out).toContain('## SUCHERGEBNISSE');
+    expect(out).not.toContain('RECHERCHE ABGESCHLOSSEN');
+  });
+
+  it('returns empty string when neither wrapper-mode applies nor any search results exist', async () => {
+    const state = makeState({ researchMeta: null, searchResults: [] });
+    const out = await formatSearchContext(state);
+    expect(out).toBe('');
+  });
+});

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -692,17 +692,12 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         // Build enriched citations from results
         citations = buildCitations(results);
 
-        // Include the synthesized answer as context
-        if (researchResult.answer) {
-          results.unshift({
-            source: 'research_synthesis',
-            title: 'Recherche-Zusammenfassung',
-            content: researchResult.answer,
-            relevance: 1.0,
-          });
-        }
-
         // Capture full metadata for the persisted tool-call payload.
+        // The synthesized `answer` is consumed directly by respondNode via
+        // `state.researchMeta` (wrapper-mode prompt), so we no longer
+        // need to unshift it into `results` as a fake `research_synthesis`
+        // chunk — that workaround caused drift when small response models
+        // treated it as one source among many and contradicted the artifact.
         researchMeta = {
           answer: researchResult.answer,
           citations,
@@ -710,6 +705,9 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
           searchSteps: researchResult.searchSteps,
           followUpQuestions: researchResult.followUpQuestions,
         };
+        log.info(
+          `[Search] researchMeta captured (answer_len=${researchResult.answer?.length ?? 0}, confidence=${researchResult.confidence}, citations=${citations.length}, follow_ups=${researchResult.followUpQuestions.length})`
+        );
         break;
       }
 


### PR DESCRIPTION
## Why

Concrete bug: `@recherche wer ist moritz wächter`. The Recherche-Karte shows "Moritz Wächter ist eine in Deutschland tätige Fachkraft … Strategy& (PwC) … hohe Konfidenz, 8 Quellen". The chat reply *immediately below* says "In den vorliegenden Suchergebnissen finden sich keine Informationen zu einer Person namens Moritz Wächter." Two surfaces, one turn, contradicting each other.

## Root cause

`respondNode` never had access to the structured tool output. The synthesized `researchResult.answer` was unshifted into `state.searchResults` in searchNode as a fake `research_synthesis` chunk — by the time it reached the response model it was structurally indistinguishable from any other source snippet. Small models (e.g. Gemma) weight all chunks democratically and may re-derive a contradicting answer from the rest.

## Fix

- `respondNode` reads `state.researchMeta` directly. When intent is `research` AND a non-low-confidence synthesis exists, `formatSearchContext` emits a wrapper-mode prompt block: the model is told the synthesis is already shown to the user as the Recherche-Karte, must write at most 2 conversational sentences, and is explicitly forbidden from claiming "keine Informationen".
- `searchNode` no longer unshifts the synthesis as a fake chunk. That workaround existed only to thread the synthesis through respondNode before this direct contract.
- Two `info` logs (`[Search] researchMeta captured`, `[Respond] Wrapper-mode`) record the routing decision once per turn — non-spammy, useful for future debugging.
- `respondNode.vitest.ts` locks in the contract: wrapper-mode triggers for high/medium confidence; low confidence and non-research intents fall through to chunk-based formatting; the "Sage NIE keine Informationen" guard is asserted so the contradiction cannot quietly return.

Aligned with the artifact-vs-wrapper pattern documented in `project_artifact_vs_summary_pattern.md` — the tool produces the artifact, the agent produces the wrapper.