### PR TITLE
chore(notebook): harden wolke_folders persistence — debug logs + schema lock

### DIFF
--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -175,6 +175,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         })
       );
 
+      const totalWolkeFolders = transformedData.reduce((acc, c) => acc + c.wolke_folders.length, 0);
+      log.debug(
+        `[listCollections] returning ${transformedData.length} collection(s), ${totalWolkeFolders} wolke_folders total`
+      );
+
       return {
         status: 200 as const,
         body: { success: true, collections: transformedData },
@@ -281,6 +286,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       const document_ids = documentIdsRaw ?? [];
       const wolke_share_link_ids = wolkeLinkIdsRaw ?? [];
       const wolke_folders = Array.isArray(wolkeFoldersRaw) ? wolkeFoldersRaw : [];
+      log.debug(
+        `[createCollection] incoming wolke_folders raw=${typeof wolkeFoldersRaw} array=${Array.isArray(wolkeFoldersRaw)} count=${wolke_folders.length}`
+      );
 
       if (!name || !name.trim()) {
         return { status: 400 as const, body: { error: 'Name is required' } };
@@ -545,6 +553,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       };
 
       const existingSettings = (existingCollection.settings as Record<string, unknown>) || {};
+      const existingWolkeFoldersCount = Array.isArray(existingSettings.wolke_folders)
+        ? (existingSettings.wolke_folders as unknown[]).length
+        : 0;
       const settingsPatch: Record<string, unknown> = { ...existingSettings };
       let settingsChanged = false;
       if (Array.isArray(labels)) {
@@ -558,6 +569,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       if (settingsChanged) {
         updateData.settings = settingsPatch;
       }
+      log.debug(
+        `[updateCollection ${collectionId}] incoming wolke_folders raw=${typeof wolkeFoldersRaw} array=${Array.isArray(wolkeFoldersRaw)} count=${Array.isArray(wolkeFoldersRaw) ? wolkeFoldersRaw.length : 0} existing=${existingWolkeFoldersCount} settingsChanged=${settingsChanged}`
+      );
 
       if (selection_mode === 'wolke') {
         if (typeof auto_sync === 'boolean') updateData.auto_sync = auto_sync;

--- a/apps/api/routes/notebook/wolkeFolders.vitest.ts
+++ b/apps/api/routes/notebook/wolkeFolders.vitest.ts
@@ -1,0 +1,146 @@
+/**
+ * Schema-level tests that lock the wolke_folders contract.
+ *
+ * A user reported that wolke_folders disappear on page reload. The save → read
+ * roundtrip in `notebookCollectionsContractRouter.ts` looks correct, but Zod
+ * schemas are the most plausible silent-stripper: `.object()` defaults to
+ * `strip` mode and any field missing from the schema would be removed during
+ * parse without an error.
+ *
+ * These tests assert wolke_folders survives:
+ *   1. `createCollectionBodySchema` parse (frontend → server body)
+ *   2. `updateCollectionBodySchema` parse (frontend → server body)
+ *   3. `transformedCollectionSchema` parse (server response → frontend)
+ *   4. The full editor payload schema (frontend internal save type)
+ *
+ * If any of these strips the field, this test catches it. If they all
+ * preserve, the bug is elsewhere (storage layer, deploy lag, or browser cache).
+ *
+ * Run: `pnpm --filter @gruenerator/api test`
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  createCollectionBodySchema,
+  notebookEditorSavePayloadSchema,
+  transformedCollectionSchema,
+  updateCollectionBodySchema,
+  type WolkeFolderRef,
+} from '@gruenerator/contracts';
+
+const sampleFolder: WolkeFolderRef = {
+  shareLinkId: 'share-abc-123',
+  shareLabel: 'My Wolke',
+  folderPath: '',
+  folderName: 'My Wolke',
+  lastSyncedAt: '2026-05-16T01:00:00.000Z',
+};
+
+const sampleFolderMinimal: WolkeFolderRef = {
+  shareLinkId: 'share-xyz-456',
+  folderPath: 'subdir/',
+  folderName: 'Sub',
+  lastSyncedAt: null,
+};
+
+describe('wolke_folders schema contract', () => {
+  it('createCollectionBodySchema preserves wolke_folders through parse', () => {
+    const input = {
+      name: 'Test Notebook',
+      description: 'desc',
+      selection_mode: 'documents' as const,
+      document_ids: ['doc-1'],
+      wolke_folders: [sampleFolder, sampleFolderMinimal],
+    };
+    const parsed = createCollectionBodySchema.parse(input);
+    expect(parsed.wolke_folders).toHaveLength(2);
+    expect(parsed.wolke_folders?.[0]).toEqual(sampleFolder);
+    expect(parsed.wolke_folders?.[1]).toEqual(sampleFolderMinimal);
+  });
+
+  it('updateCollectionBodySchema preserves wolke_folders through parse', () => {
+    const input = {
+      name: 'Updated Notebook',
+      wolke_folders: [sampleFolder],
+    };
+    const parsed = updateCollectionBodySchema.parse(input);
+    expect(parsed.wolke_folders).toEqual([sampleFolder]);
+  });
+
+  it('updateCollectionBodySchema preserves empty wolke_folders array', () => {
+    // Empty array is a meaningful signal: "user removed all folders". Must
+    // not be silently dropped to undefined, or the server cannot distinguish
+    // "no change requested" from "clear all folders".
+    const parsed = updateCollectionBodySchema.parse({
+      name: 'Updated',
+      wolke_folders: [],
+    });
+    expect(Array.isArray(parsed.wolke_folders)).toBe(true);
+    expect(parsed.wolke_folders).toHaveLength(0);
+  });
+
+  it('transformedCollectionSchema surfaces wolke_folders on read', () => {
+    const serverResponse = {
+      id: 'notebook-1',
+      user_id: 'user-1',
+      name: 'Test',
+      description: null,
+      custom_prompt: null,
+      selection_mode: 'documents',
+      auto_sync: false,
+      remove_missing_on_sync: false,
+      created_at: '2026-05-16T00:00:00.000Z',
+      updated_at: '2026-05-16T01:00:00.000Z',
+      documents: [],
+      document_count: 0,
+      wolke_share_links: [],
+      has_wolke_sources: false,
+      documents_from_wolke: 0,
+      wolke_folders: [sampleFolder],
+    };
+    const parsed = transformedCollectionSchema.parse(serverResponse);
+    expect(parsed.wolke_folders).toEqual([sampleFolder]);
+  });
+
+  it('notebookEditorSavePayloadSchema preserves wolkeFolders (camelCase)', () => {
+    const payload = {
+      name: 'Test',
+      description: '',
+      selectionMode: 'documents' as const,
+      documents: ['doc-1'],
+      documentMeta: [{ id: 'doc-1', title: 'Document 1' }],
+      labels: [],
+      isPublic: false,
+      publicOwnership: null,
+      wolkeFolders: [sampleFolder, sampleFolderMinimal],
+    };
+    const parsed = notebookEditorSavePayloadSchema.parse(payload);
+    expect(parsed.wolkeFolders).toHaveLength(2);
+    expect(parsed.wolkeFolders[0]).toEqual(sampleFolder);
+  });
+
+  it('notebookEditorSavePayloadSchema defaults wolkeFolders to [] when missing', () => {
+    const payload = {
+      name: 'Test',
+      description: '',
+      selectionMode: 'documents' as const,
+      documents: ['doc-1'],
+      documentMeta: [{ id: 'doc-1', title: 'Document 1' }],
+      labels: [],
+      isPublic: false,
+      publicOwnership: null,
+    };
+    const parsed = notebookEditorSavePayloadSchema.parse(payload);
+    expect(parsed.wolkeFolders).toEqual([]);
+  });
+
+  it('rejects malformed wolke_folder entries (missing required shareLinkId)', () => {
+    expect(() =>
+      createCollectionBodySchema.parse({
+        name: 'X',
+        wolke_folders: [{ folderPath: '', folderName: 'no-id', lastSyncedAt: null }],
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Why

User reports wolke folder pointers disappear on page reload after saving a notebook. The save → read path on master looks correct top-to-bottom (I traced all 9 layers from frontend payload through contract router into Qdrant settings, back through list response, hydrate, and editor state), so the bug is plausibly one of:

1. A subtle drop somewhere I missed
2. Production deployment lag — PR #881 added the persistence path today; gruenerator.eu may still be serving an older image
3. Browser-cached old JS bundle

Rather than guess, this PR adds the **visibility** to distinguish those next time it reproduces, plus locks the schema layer (the most plausible silent-stripper candidate) so a future refactor can't regress it.

## What changed

### 1. Debug logs in `notebookCollectionsContractRouter.ts`

Three new lines tell us exactly which layer dropped the value when the bug reproduces:

- `[createCollection] incoming wolke_folders raw=… array=… count=…`
- `[updateCollection :id] incoming wolke_folders raw=… array=… count=… existing=N settingsChanged=…`
- `[listCollections] returning N collection(s), M wolke_folders total`

When a user reports the bug, grep prod logs:
- Save logs show `count=2` but list shows `0`? → storage/read bug
- Save logs show `count=0` but UI shows folders? → request body dropping the field client-side
- Neither log fires? → wrong code path or deploy lag

### 2. `wolkeFolders.vitest.ts` — schema contract lock

7 tests assert wolke_folders survives Zod parse for:
- `createCollectionBodySchema` (frontend → server body)
- `updateCollectionBodySchema` (incl. empty array as "clear all signal")
- `transformedCollectionSchema` (server response → frontend)
- `notebookEditorSavePayloadSchema` (frontend internal save type)
- default-to-`[]` when missing
- malformed-entry rejection

Zod's `.object()` defaults to `strip` mode — any field missing from the schema gets silently removed during parse. If a future refactor ever drops the field declaration, these tests fail immediately instead of waiting for a user to lose their data.

## Out of scope

- **Root-cause fix**: I haven't found one. The code path looks correct. If this PR's logs catch the bug, follow-up will be surgical.
- **Frontend telemetry**: considered logging a `console.warn` when hydrate receives empty `wolke_folders` for an existing notebook, but the false-positive rate (legitimately empty) is too high to be useful.
- **React Query invalidation**: already present in `useNotebookCollections` (`onSuccess` invalidates the list query). Not the issue.

## Test plan

- [x] `pnpm --filter @gruenerator/api test routes/notebook/wolkeFolders.vitest.ts` → 7 tests pass.
- [x] `pnpm --filter @gruenerator/api typecheck` clean.
- [ ] After merge: monitor prod logs for the new `[createCollection]` / `[updateCollection]` / `[listCollections]` lines when wolke folder activity occurs.