### PR TITLE
fix(chat): show user-created notebooks under @notebook

### DIFF
--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -708,11 +708,21 @@ export function filterMentionables(query: string): {
     m.title.toLowerCase().includes(q) ||
     m.identifier.toLowerCase().includes(q);
 
+  const isNotebookCategoryQuery =
+    'notebook'.startsWith(q) ||
+    q.startsWith('notebook') ||
+    'notizbuch'.startsWith(q) ||
+    q.startsWith('notizbuch') ||
+    'notiz'.startsWith(q) ||
+    q.startsWith('notiz');
+
   return {
     agents: agentMentionables.filter(matchFn),
     customAgents: customAgentMentionables.filter(matchFn),
-    notebooks: notebookMentionables.filter(matchFn),
-    userNotebooks: dynamicUserNotebookMentionables.filter(matchFn),
+    notebooks: isNotebookCategoryQuery ? notebookMentionables : notebookMentionables.filter(matchFn),
+    userNotebooks: isNotebookCategoryQuery
+      ? dynamicUserNotebookMentionables
+      : dynamicUserNotebookMentionables.filter(matchFn),
     tools: toolMentionables.filter(matchFn),
     boards: 'board'.startsWith(q) || q.startsWith('board') ? allBoards : allBoards.filter(matchFn),
     docs: 'dok'.startsWith(q) || q.startsWith('dok') ? allDocs : allDocs.filter(matchFn),


### PR DESCRIPTION
## Why

Typing `@notebook` in chat only showed the hardcoded system notebooks — user-created ones (from `notebook_collections`) were missing, even though the popover was structurally ready to render them under a `meine` sub-label and the backend already resolves user-notebook UUIDs end-to-end (ownership-checked via `resolveUserNotebookDocumentIds`, scoped at `searchNode` by document IDs).

`filterMentionables` only inspected `mention` / `title` / `identifier`. System notebooks happened to match `@notebook` because every entry has an identifier like `gruenerator-notebook`, `hamburg-notebook`, etc. User notebooks use `identifier: <uuid>` plus the user's chosen title, so they never matched a generic category query like `@notebook` or `@notiz`.

This change adds the category-keyword pass-through that already exists for `@board` and `@dok` (lines 717-718 in the same function) — when the query is a prefix of the category word, return the whole bucket instead of per-item filtering. Specific-name lookups continue to fall through to `matchFn` unchanged.

Confirmed end-to-end manually: with this fix in place, both `meine` and `system` sub-sections render; @bundestag, @board, @dok regress-tested fine; selecting a user notebook from the popover passes its UUID through to `chatGraphContractRouter` → `resolveUserNotebookDocumentIds` → `searchNode`'s document-scoped Qdrant query exactly as before.