### PR TITLE
fix(groups): cap group member avatars at 2 on mobile

### DIFF
--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -295,8 +295,11 @@ const GroupInfoSection = memo(
                     <span className="text-xs text-foreground">…</span>
                   ) : (
                     <>
-                      {members?.slice(0, 5).map((member) => (
-                        <span key={member.user_id} className="relative">
+                      {members?.slice(0, 5).map((member, idx) => (
+                        <span
+                          key={member.user_id}
+                          className={`relative ${idx >= 2 ? 'hidden sm:inline-block' : 'inline-block'}`}
+                        >
                           <img
                             src={getRobotAvatarPath(validateRobotId(member.avatar_robot_id))}
                             alt=""
@@ -307,8 +310,13 @@ const GroupInfoSection = memo(
                           )}
                         </span>
                       ))}
+                      {memberCount > 2 && (
+                        <span className="sm:hidden flex items-center justify-center size-7 rounded-full ring-2 ring-background bg-grey-200 dark:bg-grey-700 text-[0.6rem] font-semibold text-grey-600 dark:text-grey-300">
+                          +{memberCount - 2}
+                        </span>
+                      )}
                       {memberCount > 5 && (
-                        <span className="flex items-center justify-center size-7 rounded-full ring-2 ring-background bg-grey-200 dark:bg-grey-700 text-[0.6rem] font-semibold text-grey-600 dark:text-grey-300">
+                        <span className="hidden sm:flex items-center justify-center size-7 rounded-full ring-2 ring-background bg-grey-200 dark:bg-grey-700 text-[0.6rem] font-semibold text-grey-600 dark:text-grey-300">
                           +{memberCount - 5}
                         </span>
                       )}


### PR DESCRIPTION
On mobile the absolute-positioned member-avatar cluster in the group header overlapped the group title, because rendering up to 5 avatars + the `+N` badge produced a chip row wider than the available space next to the title.

Mobile now caps at 2 avatars + `+(memberCount - 2)`; desktop is unchanged at 5 + `+(memberCount - 5)`. CSS-only via Tailwind responsive `hidden sm:inline-block` / `sm:hidden` — no media-query hook, SSR-safe.