### PR TITLE
docs: hide landesverbaende, monitor, briefings sections

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -26,7 +26,11 @@ const config: Config = {
   projectName: 'docusaurus', // Usually your repo name.
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Algolia site verification
   headTags: [

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -53,6 +53,15 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
+          // Hidden until ready — remove entries to re-enable in the sidebar.
+          // landesverbaende: dev-only LV-Korpus analysis pages.
+          // monitor: Themen-Monitor not online yet.
+          // briefings: Briefing-Archiv hidden for now.
+          exclude: [
+            'landesverbaende/**',
+            'monitor/**',
+            'briefings/**',
+          ],
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
@@ -142,7 +151,7 @@ const config: Config = {
           position: 'left',
           items: [
             { to: '/docs/category/grünerieren', label: 'Grünerieren' },
-            { to: '/docs/monitor/intro', label: 'Themen-Monitor' },
+            // { to: '/docs/monitor/intro', label: 'Themen-Monitor' }, // hidden — Themen-Monitor not online yet
             { to: '/docs/category/profil', label: 'Profil' },
             { to: '/docs/category/integrationen', label: 'Integrationen' },
           ],
@@ -219,10 +228,10 @@ const config: Config = {
               label: 'Was kann ich fragen?',
               to: '/docs/integrationen/mcp-was-kann-ich-fragen',
             },
-            {
-              label: 'Themen-Monitor',
-              to: '/docs/monitor/intro',
-            },
+            // {
+            //   label: 'Themen-Monitor',
+            //   to: '/docs/monitor/intro',
+            // }, // hidden — Themen-Monitor not online yet
           ],
         },
         {


### PR DESCRIPTION
## Why

Themen-Monitor isn't online yet, the Briefing-Archiv shouldn't be public yet, and the Landesverbände pages under `documentation/docs/landesverbaende/` are internal LV-Korpus analysis notes that only belong in dev.

Excluding them via the docs preset's `exclude` glob keeps the source files in the repo (so they can be re-enabled by deleting four lines) and skips them from both the autogenerated sidebar and the static build. Navbar/footer Themen-Monitor links are commented out in the same place to keep `onBrokenLinks: 'throw'` happy.