### PR TITLE
docs(notebooks): add new section with create-your-own-notebook guide

### DIFF
--- a/documentation/docs/notebooks/_category_.json
+++ b/documentation/docs/notebooks/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Notebooks",
+  "position": 6,
+  "link": {
+    "type": "generated-index",
+    "description": "Anleitungen rund um eigene Notebooks: erstellen, verwalten und teilen."
+  }
+}

--- a/documentation/docs/notebooks/eigenes-notebook-erstellen.md
+++ b/documentation/docs/notebooks/eigenes-notebook-erstellen.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 1
+title: Eigenes Notebook erstellen
+---
+
+# Eigenes Notebook erstellen
+
+Ein Notebook bündelt Dokumente zu einem Thema und macht ihren Inhalt im Grünerator durchsuchbar — etwa für Anträge, Beschlüsse, Programme oder Pressemitteilungen. Diese Anleitung führt dich Schritt für Schritt durch die Erstellung deines ersten eigenen Notebooks.
+
+## Was du benötigst
+
+Ein angemeldetes Grünerator-Konto und ein paar Dokumente, die du zusammenfassen, durchsuchen oder als Wissensbasis nutzen möchtest. Unterstützt werden **PDF, DOCX, DOC, TXT, MD, ODT und RTF** — bis zu **100 Dokumente** pro Notebook und **maximal 50 MB** pro Datei.
+
+## Schritt-für-Schritt
+
+### Schritt 1: Zur Notebook-Übersicht
+
+Öffne in der Navigation **Notebooks → Meine Notebooks** (`/notebooks/meine`). Dort siehst du eine Liste deiner eigenen Notebooks — beim ersten Mal ist sie leer, mit einem Hinweis und einem grünen Button **„Eigenes Notebook erstellen"**. Klicke auf den Button, oder oben rechts auf **„Neues Notebook"**.
+
+### Schritt 2: Dateien hochladen
+
+Im ersten Schritt des Editors siehst du eine große, gestrichelte Ablage-Fläche. Du hast zwei Möglichkeiten:
+
+- **Klicken** und Dateien aus dem Dateibrowser auswählen (Mehrfachauswahl möglich).
+- **Drag &amp; Drop** — eine oder mehrere Dateien einfach auf die Fläche ziehen.
+
+Dateien in nicht unterstützten Formaten werden übersprungen, und überschüssige Uploads (über 100 hinaus) werden mit einem Hinweis abgelehnt. Sobald die erste Datei hochgeladen ist, springt der Editor automatisch zu Schritt 2 und schlägt einen Notebook-Namen vor — abgeleitet vom Dateinamen der ersten Datei (gekürzt auf 60 Zeichen).
+
+:::tip Hochladen vs. Indexieren
+Das **Hochladen** dauert nur Sekunden, das anschließende **Indexieren** (damit der Inhalt durchsuchbar wird) läuft im Hintergrund weiter. Du erkennst noch laufende Indexierung an einem kleinen Lade-Indikator („Wird verarbeitet…") auf der Dokumenten-Karte. Du kannst das Notebook trotzdem schon speichern.
+:::
+
+### Schritt 3: Name, Beschreibung und Labels
+
+Im zweiten Schritt klickst du auf den vorgeschlagenen Namen, um ihn anzupassen (max. 100 Zeichen). Darunter kannst du eine optionale **Beschreibung** hinzufügen (max. 500 Zeichen) — sie hilft dir und anderen, später schnell zu erkennen, worum es im Notebook geht.
+
+Über den gestrichelten Button **„Label hinzufügen"** vergibst du bis zu **10 Labels** (max. 30 Zeichen pro Label). Labels sind freie Schlagworte und helfen beim Sortieren und Filtern in der Notebook-Übersicht.
+
+### Schritt 4 (optional): Wolke-Ordner anbinden
+
+Wenn du bereits einen Freigabe-Link aus der Grünen Wolke eingerichtet hast, kannst du einen ganzen Cloud-Ordner an dein Notebook hängen. Dokumente aus dem Ordner werden dann automatisch importiert und mit der Wolke synchronisiert. Diese Funktion ist mit einem **„Experimentell"**-Badge gekennzeichnet — der Komfort wächst, aber die Sync-Logik kann sich noch ändern.
+
+Mehr zur Einrichtung des Wolke-Links: → [Wolke einbinden](/docs/Profil/gruene-wolke-tutorial).
+
+### Schritt 5 (optional): Notebook öffentlich machen
+
+Mit dem Schalter **„Notebook öffentlich machen"** taucht dein Notebook unter **„Von der Basis"** auf der allgemeinen Notebooks-Seite auf — sichtbar für alle Grünerator-Nutzer*innen. Sobald du den Schalter aktivierst, musst du eine der beiden Aussagen bestätigen:
+
+- **„Ich besitze die Daten oder habe die Rechte zur Veröffentlichung"** — z.&nbsp;B. eigene Texte, Beschlüsse deines Verbands, Material, das du selbst veröffentlichen darfst.
+- **„Die Daten sind öffentlich verfügbar"** — z.&nbsp;B. offizielle Dokumente, Pressemitteilungen, frei zugängliche Veröffentlichungen.
+
+Ohne diese Bestätigung lässt sich das Notebook nicht als öffentlich speichern. Hintergrund: Damit stellen wir sicher, dass nur Inhalte mit klarer Rechtelage veröffentlicht werden.
+
+:::caution Privat ist die sichere Voreinstellung
+Wenn du dir bei den Rechten unsicher bist, lass das Notebook privat — du kannst es jederzeit später öffentlich schalten.
+:::
+
+### Schritt 6: Speichern
+
+Klicke unten rechts auf **„Erstellen"**. Der Button bleibt deaktiviert, solange noch kein Name eingetragen, kein Dokument hochgeladen oder die öffentlich-Bestätigung offen ist. Nach dem Speichern landest du wieder auf **Meine Notebooks** und siehst eine Erfolgsmeldung.
+
+## Dein Notebook nach der Erstellung
+
+Auf **Meine Notebooks** findest du jede deiner Sammlungen als Karte. Dort hast du folgende Möglichkeiten:
+
+- **Öffnen** — bringt dich zur Notebook-Detailseite, von der aus du chatten und durchsuchen kannst.
+- **Umbenennen** — schnelle Namens- und Beschreibungsänderung im Dialog.
+- **Bearbeiten** — öffnet wieder den Editor mit allen Optionen (Dokumente, Labels, Wolke, öffentlich).
+- **Link kopieren** — kopiert die URL des Notebooks in die Zwischenablage.
+- **Löschen** — entfernt das Notebook unwiderruflich. **Wichtig:** Die enthaltenen Dokumente bleiben in deiner persönlichen Bibliothek erhalten und können in andere Notebooks aufgenommen werden.
+
+### Dateien per Drag &amp; Drop hinzufügen
+
+Du kannst Dateien direkt aus deinem Dateibrowser auf eine Notebook-Karte ziehen, ohne den Editor zu öffnen. Während des Ziehens hebt sich die Karte hervor, und ein Hinweis bestätigt, in welches Notebook die Datei fließt. Ist das Notebook voll (100 Dokumente erreicht), erscheint stattdessen ein roter Hinweis und der Drop wird abgelehnt.
+
+## Häufige Fragen
+
+**Was passiert mit Dokumenten, wenn ich ein Notebook lösche?**
+Die Dokumente bleiben in deiner persönlichen Dokumenten-Bibliothek erhalten — nur die Sammlung wird gelöscht.
+
+**Kann ich dasselbe Dokument in mehrere Notebooks aufnehmen?**
+Ja. Beim Bearbeiten eines Notebooks kannst du beliebige Dokumente aus deiner Bibliothek auswählen.
+
+**Wie lange dauert die Indexierung?**
+Bei Text-PDFs und reinen Textdateien meist nur Sekunden. Eingescannte PDFs (mit OCR) und sehr große Dateien können einige Minuten brauchen. Das Notebook ist trotzdem sofort nutzbar — neue Dokumente erscheinen in den Antworten, sobald die Indexierung abgeschlossen ist.
+
+**Mein Dokument wird nicht akzeptiert.**
+Prüfe die Dateiendung (PDF, DOCX, DOC, TXT, MD, ODT, RTF) und die Dateigröße (max. 50 MB). Andere Formate musst du vorher konvertieren.
+
+## Verwandte Themen
+
+- [Wolke einbinden](/docs/Profil/gruene-wolke-tutorial) — Voraussetzung, um Wolke-Ordner an Notebooks zu hängen.
+- [Deine Daten im Grünerator](/docs/ueber-den-gruenerator/notebook) — Hintergrund zu Notebooks für Landesverbände und Abgeordnetenbüros.

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -156,6 +156,7 @@ const config: Config = {
           items: [
             { to: '/docs/category/grünerieren', label: 'Grünerieren' },
             // { to: '/docs/monitor/intro', label: 'Themen-Monitor' }, // hidden — Themen-Monitor not online yet
+            { to: '/docs/category/notebooks', label: 'Notebooks' },
             { to: '/docs/category/profil', label: 'Profil' },
             { to: '/docs/category/integrationen', label: 'Integrationen' },
           ],


### PR DESCRIPTION
## Why

Users had no docs for creating their own notebook — the feature is in the UI at \`/notebooks/meine/neu\` but undocumented. New top-level **Notebooks** section (auto-generated index) with a single guide that walks through the 2-step editor wizard, the optional Wolke and public-share paths, and what the post-creation tile actions do.

The guide pulls all limits, formats, and constraint behavior from the editor source (\`apps/web/src/features/notebook/components/NotebookEditor.tsx\`), so file-format / size / count numbers stay accurate to what the form actually enforces.

Also adds **Notebooks** to the Anleitung navbar dropdown so the section is discoverable.