### PR TITLE
feat(notebooks): like/heart for "Von der Basis" cards with system notifications

### DIFF
--- a/apps/api/database/postgres/migrations/create_entity_likes.sql
+++ b/apps/api/database/postgres/migrations/create_entity_likes.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS entity_likes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  entity_type text NOT NULL,
+  entity_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT entity_likes_user_entity_unique UNIQUE (user_id, entity_type, entity_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_likes_entity ON entity_likes (entity_type, entity_id);
+CREATE INDEX IF NOT EXISTS idx_entity_likes_user_type ON entity_likes (user_id, entity_type);
+CREATE INDEX IF NOT EXISTS idx_entity_likes_popularity ON entity_likes (entity_type, entity_id, created_at);
+
+DROP TABLE IF EXISTS template_likes;

--- a/apps/api/database/schema/entityLikes.ts
+++ b/apps/api/database/schema/entityLikes.ts
@@ -1,0 +1,23 @@
+import { type InferSelectModel } from 'drizzle-orm';
+import { index, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+
+export const entityLikes = pgTable(
+  'entity_likes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    user_id: uuid('user_id').notNull(),
+    entity_type: text('entity_type').notNull(),
+    entity_id: text('entity_id').notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    unique('entity_likes_user_entity_unique').on(t.user_id, t.entity_type, t.entity_id),
+    index('idx_entity_likes_entity').on(t.entity_type, t.entity_id),
+    index('idx_entity_likes_user_type').on(t.user_id, t.entity_type),
+    index('idx_entity_likes_popularity').on(t.entity_type, t.entity_id, t.created_at),
+  ]
+);
+
+export type EntityLike = InferSelectModel<typeof entityLikes>;
+
+export type EntityLikeType = 'notebook' | 'template';

--- a/apps/api/database/schema/index.ts
+++ b/apps/api/database/schema/index.ts
@@ -9,6 +9,7 @@ export * from './knowledge.js';
 export * from './system.js';
 export * from './features.js';
 export * from './templates.js';
+export * from './entityLikes.js';
 export * from './media.js';
 export * from './notebooks.js';
 export * from './collaborative.js';

--- a/apps/api/database/schema/templates.ts
+++ b/apps/api/database/schema/templates.ts
@@ -1,5 +1,5 @@
 import { type InferSelectModel } from 'drizzle-orm';
-import { boolean, index, jsonb, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+import { boolean, index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const userTemplates = pgTable(
   'user_templates',
@@ -36,22 +36,3 @@ export const userTemplates = pgTable(
 );
 
 export type UserTemplate = InferSelectModel<typeof userTemplates>;
-
-export const templateLikes = pgTable(
-  'template_likes',
-  {
-    id: uuid('id').primaryKey().defaultRandom(),
-    user_id: uuid('user_id').notNull(),
-    template_id: text('template_id').notNull(),
-    template_type: text('template_type').notNull().default('system'),
-    created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  },
-  (t) => [
-    unique('template_likes_user_template_unique').on(t.user_id, t.template_id),
-    index('idx_template_likes_user_id').on(t.user_id),
-    index('idx_template_likes_template_id').on(t.template_id),
-    index('idx_template_likes_popularity').on(t.template_id, t.created_at),
-  ]
-);
-
-export type TemplateLike = InferSelectModel<typeof templateLikes>;

--- a/apps/api/routes/auth/templates/templateGallery.ts
+++ b/apps/api/routes/auth/templates/templateGallery.ts
@@ -13,6 +13,11 @@ import { z } from 'zod';
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import authMiddlewareModule from '../../../middleware/authMiddleware.js';
 import { validateBody, type TypedRequest } from '../../../middleware/validateBody.js';
+import {
+  getLikedEntityIdsForUser,
+  likeEntity,
+  unlikeEntity,
+} from '../../../services/entityLikes/EntityLikesService.js';
 import { createLogger } from '../../../utils/logger.js';
 
 import type { AuthRequest } from '../types.js';
@@ -171,7 +176,10 @@ router.post(
   '/examples/similar',
   ensureAuthenticated,
   validateBody(similarBodySchema),
-  async (req: TypedRequest<{ query: string; type?: string; limit?: number }>, res: Response): Promise<void> => {
+  async (
+    req: TypedRequest<{ query: string; type?: string; limit?: number }>,
+    res: Response
+  ): Promise<void> => {
     try {
       const userId = req.user!.id;
       const { query, type, limit = 5 } = req.body;
@@ -665,21 +673,9 @@ router.get(
   async (req: AuthRequest, res: Response): Promise<void> => {
     try {
       const userId = req.user!.id;
-
-      const postgres = getPostgresInstance();
-      await postgres.ensureInitialized();
-
-      const likes = await postgres.query(
-        'SELECT template_id, template_type, created_at FROM template_likes WHERE user_id = $1 ORDER BY created_at DESC',
-        [userId],
-        { table: 'template_likes' }
-      );
-
-      res.json({
-        success: true,
-        likes: likes || [],
-        count: (likes || []).length,
-      });
+      const ids = await getLikedEntityIdsForUser({ userId, entityType: 'template' });
+      const likes = ids.map((id) => ({ template_id: id }));
+      res.json({ success: true, likes, count: likes.length });
     } catch (error) {
       const err = error as Error;
       log.error('[Template Likes] GET error:', err);
@@ -693,28 +689,20 @@ router.post(
   '/vorlagen/:templateId/like',
   ensureAuthenticated,
   validateBody(likeBodySchema),
-  async (req: TypedRequest<{ templateType?: string }, { templateId: string }>, res: Response): Promise<void> => {
+  async (
+    req: TypedRequest<{ templateType?: string }, { templateId: string }>,
+    res: Response
+  ): Promise<void> => {
     try {
       const userId = req.user!.id;
       const { templateId } = req.params;
-      const { templateType = 'system' } = req.body;
 
       if (!templateId) {
         res.status(400).json({ success: false, message: 'Template ID erforderlich' });
         return;
       }
 
-      const postgres = getPostgresInstance();
-      await postgres.ensureInitialized();
-
-      await postgres.query(
-        `INSERT INTO template_likes (user_id, template_id, template_type)
-       VALUES ($1, $2, $3)
-       ON CONFLICT (user_id, template_id) DO NOTHING`,
-        [userId, templateId, templateType],
-        { table: 'template_likes' }
-      );
-
+      await likeEntity({ userId, entityType: 'template', entityId: templateId });
       log.info(`[Template Likes] User ${userId} liked template ${templateId}`);
       res.json({ success: true, liked: true });
     } catch (error) {
@@ -739,15 +727,7 @@ router.delete(
         return;
       }
 
-      const postgres = getPostgresInstance();
-      await postgres.ensureInitialized();
-
-      await postgres.query(
-        'DELETE FROM template_likes WHERE user_id = $1 AND template_id = $2',
-        [userId, templateId],
-        { table: 'template_likes' }
-      );
-
+      await unlikeEntity({ userId, entityType: 'template', entityId: templateId });
       log.info(`[Template Likes] User ${userId} unliked template ${templateId}`);
       res.json({ success: true, liked: false });
     } catch (error) {

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -24,6 +24,14 @@ import { getPostgresInstance } from '../../database/services/PostgresService.js'
 import { processUploadedDocument } from '../../services/document-services/DocumentProcessingService/index.js';
 import { getQdrantDocumentService } from '../../services/document-services/DocumentSearchService/index.js';
 import { getPostgresDocumentService } from '../../services/document-services/PostgresDocumentService/index.js';
+import {
+  getLikeCountsForEntities,
+  getLikedEntityIdsForUser,
+  likeEntity,
+  unlikeEntity,
+} from '../../services/entityLikes/EntityLikesService.js';
+import { createNotification } from '../../services/notifications/NotificationService.js';
+import { getProfileService } from '../../services/user/ProfileService.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
 import { createLogger } from '../../utils/logger.js';
 import { fromParam, type DocumentId, type NotebookId } from '../../utils/types/branded.js';
@@ -214,6 +222,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       const collections =
         (await notebookHelper.getPublicNotebookCollections()) as NotebookCollectionFromQdrantRaw[];
 
+      const likeCounts = await getLikeCountsForEntities(
+        'notebook',
+        collections.map((c) => c.id)
+      );
+
       const transformedData = await Promise.all(
         collections.map(async (collection) => {
           const documentIds = (collection.notebook_collection_documents || []).map(
@@ -248,6 +261,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             wolke_folders,
             is_public: collection.is_public === true,
             public_ownership: collection.public_ownership ?? null,
+            likes_count: likeCounts.get(collection.id) ?? 0,
           };
         })
       );
@@ -835,6 +849,85 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       };
     } catch (error) {
       log.error('[notebookCollectionsContract.removeDocument] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  listMyLikedCollections: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const liked_ids = await getLikedEntityIdsForUser({ userId, entityType: 'notebook' });
+      return {
+        status: 200 as const,
+        body: { success: true, liked_ids },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.listMyLikedCollections] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  likeCollection: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collectionId = fromParam<NotebookId>(args.params.id);
+
+      const collection = await notebookHelper.getNotebookCollection(collectionId);
+      if (!collection || collection.is_public !== true) {
+        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
+      }
+
+      const result = await likeEntity({ userId, entityType: 'notebook', entityId: collectionId });
+
+      if (result.createdNew && collection.user_id && collection.user_id !== userId) {
+        const profile = await getProfileService().getProfileById(userId);
+        const likerName = profile?.display_name?.trim() || 'Jemand';
+        createNotification({
+          userId: collection.user_id,
+          type: 'notebook_liked',
+          title: `${likerName} mag dein Notizbuch`,
+          body: collection.name ?? null,
+          metadata: {
+            notebookId: collectionId,
+            notebookTitle: collection.name,
+            likerId: userId,
+            likerName,
+          },
+          actionUrl: `/notebook/${collectionId}`,
+          groupKey: `notebook:${collectionId}:liked`,
+        }).catch((err) => {
+          log.warn('[notebookCollectionsContract.likeCollection] notification failed', err);
+        });
+      }
+
+      return {
+        status: 200 as const,
+        body: { success: true, liked: true, count: result.count },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.likeCollection] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  unlikeCollection: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collectionId = fromParam<NotebookId>(args.params.id);
+
+      const collection = await notebookHelper.getNotebookCollection(collectionId);
+      if (!collection || collection.is_public !== true) {
+        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
+      }
+
+      const result = await unlikeEntity({ userId, entityType: 'notebook', entityId: collectionId });
+
+      return {
+        status: 200 as const,
+        body: { success: true, liked: false, count: result.count },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.unlikeCollection] Error:', error);
       return { status: 500 as const, body: { error: 'Internal server error' } };
     }
   },

--- a/apps/api/services/entityLikes/EntityLikesService.ts
+++ b/apps/api/services/entityLikes/EntityLikesService.ts
@@ -1,0 +1,113 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { entityLikes, type EntityLikeType } from '../../database/schema/index.js';
+import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('EntityLikesService');
+
+export interface LikeParams {
+  userId: string;
+  entityType: EntityLikeType;
+  entityId: string;
+}
+
+export async function likeEntity(
+  params: LikeParams
+): Promise<{ liked: true; count: number; createdNew: boolean }> {
+  const db = getDrizzleInstance();
+  const inserted = await db
+    .insert(entityLikes)
+    .values({
+      user_id: params.userId,
+      entity_type: params.entityType,
+      entity_id: params.entityId,
+    })
+    .onConflictDoNothing({
+      target: [entityLikes.user_id, entityLikes.entity_type, entityLikes.entity_id],
+    })
+    .returning({ id: entityLikes.id });
+
+  const count = await getLikeCount(params.entityType, params.entityId);
+  return { liked: true, count, createdNew: inserted.length > 0 };
+}
+
+export async function unlikeEntity(params: LikeParams): Promise<{ liked: false; count: number }> {
+  const db = getDrizzleInstance();
+  await db
+    .delete(entityLikes)
+    .where(
+      and(
+        eq(entityLikes.user_id, params.userId),
+        eq(entityLikes.entity_type, params.entityType),
+        eq(entityLikes.entity_id, params.entityId)
+      )
+    );
+
+  const count = await getLikeCount(params.entityType, params.entityId);
+  return { liked: false, count };
+}
+
+export async function getLikeCount(entityType: EntityLikeType, entityId: string): Promise<number> {
+  const db = getDrizzleInstance();
+  const rows = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(entityLikes)
+    .where(and(eq(entityLikes.entity_type, entityType), eq(entityLikes.entity_id, entityId)));
+  return rows[0]?.count ?? 0;
+}
+
+export async function getLikeCountsForEntities(
+  entityType: EntityLikeType,
+  entityIds: string[]
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  if (entityIds.length === 0) return result;
+
+  const db = getDrizzleInstance();
+  const rows = await db
+    .select({
+      entity_id: entityLikes.entity_id,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(entityLikes)
+    .where(and(eq(entityLikes.entity_type, entityType), inArray(entityLikes.entity_id, entityIds)))
+    .groupBy(entityLikes.entity_id);
+
+  for (const row of rows) {
+    result.set(row.entity_id, row.count);
+  }
+  return result;
+}
+
+export async function getLikedEntityIdsForUser(params: {
+  userId: string;
+  entityType: EntityLikeType;
+}): Promise<string[]> {
+  const db = getDrizzleInstance();
+  const rows = await db
+    .select({ entity_id: entityLikes.entity_id })
+    .from(entityLikes)
+    .where(
+      and(eq(entityLikes.user_id, params.userId), eq(entityLikes.entity_type, params.entityType))
+    );
+  return rows.map((r) => r.entity_id);
+}
+
+export async function isLikedByUser(params: LikeParams): Promise<boolean> {
+  const db = getDrizzleInstance();
+  const rows = await db
+    .select({ id: entityLikes.id })
+    .from(entityLikes)
+    .where(
+      and(
+        eq(entityLikes.user_id, params.userId),
+        eq(entityLikes.entity_type, params.entityType),
+        eq(entityLikes.entity_id, params.entityId)
+      )
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export { log as entityLikesLog };

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -36,6 +36,7 @@ const DEFAULT_CHANNEL_PREFERENCES: Record<NotificationType, ChannelPreferences> 
   group_content_shared: { email: true, push: true, in_app: true },
   group_deleted: { email: false, push: true, in_app: true },
   transfer_downloaded: { email: false, push: true, in_app: true },
+  notebook_liked: { email: false, push: false, in_app: true },
 };
 
 /**

--- a/apps/web/src/components/common/LikeButton.tsx
+++ b/apps/web/src/components/common/LikeButton.tsx
@@ -1,0 +1,64 @@
+import { memo } from 'react';
+import { IoHeart, IoHeartOutline } from 'react-icons/io5';
+
+import { cn } from '@/utils/cn';
+
+export interface LikeButtonProps {
+  liked: boolean;
+  count: number;
+  onToggle: () => void;
+  loading?: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
+  className?: string;
+}
+
+export const LikeButton = memo(function LikeButton({
+  liked,
+  count,
+  onToggle,
+  loading = false,
+  disabled = false,
+  disabledReason,
+  className,
+}: LikeButtonProps) {
+  const interactive = !disabled && !loading;
+  const ariaLabel = liked ? 'Like entfernen' : 'Liken';
+
+  return (
+    <button
+      type="button"
+      aria-pressed={liked}
+      aria-label={disabled && disabledReason ? disabledReason : ariaLabel}
+      title={disabled && disabledReason ? disabledReason : ariaLabel}
+      disabled={!interactive}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (interactive) onToggle();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.stopPropagation();
+        }
+      }}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-1 text-xs transition-colors',
+        interactive
+          ? 'cursor-pointer text-grey-500 hover:bg-grey-100 hover:text-red-500 dark:text-grey-400 dark:hover:bg-grey-800'
+          : 'cursor-not-allowed text-grey-400 dark:text-grey-600',
+        liked && interactive && 'text-red-500 dark:text-red-400',
+        loading && 'opacity-60',
+        className
+      )}
+    >
+      {liked ? (
+        <IoHeart className="text-base" aria-hidden />
+      ) : (
+        <IoHeartOutline className="text-base" aria-hidden />
+      )}
+      {count > 0 ? <span className="tabular-nums">{count}</span> : null}
+    </button>
+  );
+});
+
+export default LikeButton;

--- a/apps/web/src/features/likes/hooks/useEntityLikes.ts
+++ b/apps/web/src/features/likes/hooks/useEntityLikes.ts
@@ -1,0 +1,147 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo, useState } from 'react';
+
+import { useAuthStore } from '../../../stores/authStore';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+export type EntityLikeType = 'notebook' | 'template';
+
+const likedIdsQueryKey = (entityType: EntityLikeType) => ['entityLikes', entityType] as const;
+
+const PUBLIC_NOTEBOOKS_KEY = ['notebookCollections', 'public'] as const;
+
+async function fetchLikedIds(entityType: EntityLikeType): Promise<string[]> {
+  if (entityType !== 'notebook') {
+    return [];
+  }
+  const client = getContractsClient();
+  const result = await client.notebookCollections.listMyLikedCollections();
+  if (result.status !== 200) {
+    throw new Error('Konnte Likes nicht laden');
+  }
+  return result.body.liked_ids;
+}
+
+async function callLike(
+  entityType: EntityLikeType,
+  entityId: string
+): Promise<{ liked: boolean; count: number }> {
+  if (entityType !== 'notebook') {
+    throw new Error(`Like backend for entityType '${entityType}' not wired yet`);
+  }
+  const client = getContractsClient();
+  const result = await client.notebookCollections.likeCollection({ params: { id: entityId } });
+  if (result.status !== 200) throw new Error('Like fehlgeschlagen');
+  return { liked: true, count: result.body.count };
+}
+
+async function callUnlike(
+  entityType: EntityLikeType,
+  entityId: string
+): Promise<{ liked: boolean; count: number }> {
+  if (entityType !== 'notebook') {
+    throw new Error(`Unlike backend for entityType '${entityType}' not wired yet`);
+  }
+  const client = getContractsClient();
+  const result = await client.notebookCollections.unlikeCollection({ params: { id: entityId } });
+  if (result.status !== 200) throw new Error('Unlike fehlgeschlagen');
+  return { liked: false, count: result.body.count };
+}
+
+function patchPublicNotebooksCache(
+  qc: ReturnType<typeof useQueryClient>,
+  entityId: string,
+  delta: number
+) {
+  qc.setQueryData<NotebookCollection[] | undefined>(PUBLIC_NOTEBOOKS_KEY, (prev) => {
+    if (!prev) return prev;
+    return prev.map((c) =>
+      c.id === entityId ? { ...c, likes_count: Math.max(0, (c.likes_count ?? 0) + delta) } : c
+    );
+  });
+}
+
+export interface UseEntityLikesResult {
+  likedIds: Set<string>;
+  isLoaded: boolean;
+  toggleLike: (entityId: string) => void;
+  isToggling: (entityId: string) => boolean;
+  canLike: boolean;
+}
+
+export function useEntityLikes(entityType: EntityLikeType): UseEntityLikesResult {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const qc = useQueryClient();
+  const [pending, setPending] = useState<Set<string>>(() => new Set());
+
+  const query = useQuery({
+    queryKey: likedIdsQueryKey(entityType),
+    queryFn: () => fetchLikedIds(entityType),
+    enabled: isAuthenticated && entityType === 'notebook',
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const likedIds = useMemo(() => new Set(query.data ?? []), [query.data]);
+
+  const mutation = useMutation({
+    mutationFn: async (entityId: string) => {
+      const isCurrentlyLiked = likedIds.has(entityId);
+      return isCurrentlyLiked ? callUnlike(entityType, entityId) : callLike(entityType, entityId);
+    },
+    onMutate: async (entityId) => {
+      setPending((prev) => {
+        const next = new Set(prev);
+        next.add(entityId);
+        return next;
+      });
+      const previousIds = query.data ?? [];
+      const isCurrentlyLiked = likedIds.has(entityId);
+      const nextIds = isCurrentlyLiked
+        ? previousIds.filter((id) => id !== entityId)
+        : [...previousIds, entityId];
+      qc.setQueryData(likedIdsQueryKey(entityType), nextIds);
+
+      if (entityType === 'notebook') {
+        patchPublicNotebooksCache(qc, entityId, isCurrentlyLiked ? -1 : 1);
+      }
+      return { previousIds, wasLiked: isCurrentlyLiked };
+    },
+    onError: (_err, entityId, context) => {
+      if (context) {
+        qc.setQueryData(likedIdsQueryKey(entityType), context.previousIds);
+        if (entityType === 'notebook') {
+          patchPublicNotebooksCache(qc, entityId, context.wasLiked ? 1 : -1);
+        }
+      }
+    },
+    onSettled: (_data, _err, entityId) => {
+      setPending((prev) => {
+        const next = new Set(prev);
+        next.delete(entityId);
+        return next;
+      });
+    },
+  });
+
+  const toggleLike = useCallback(
+    (entityId: string) => {
+      if (!isAuthenticated) return;
+      mutation.mutate(entityId);
+    },
+    [isAuthenticated, mutation]
+  );
+
+  const isToggling = useCallback((entityId: string) => pending.has(entityId), [pending]);
+
+  return {
+    likedIds,
+    isLoaded: query.isSuccess || !isAuthenticated,
+    toggleLike,
+    isToggling,
+    canLike: isAuthenticated,
+  };
+}

--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -3,15 +3,27 @@ import { memo, useMemo, useState } from 'react';
 import { HiBookOpen } from 'react-icons/hi';
 import { useNavigate } from 'react-router-dom';
 
+import { LikeButton } from '../../../components/common/LikeButton';
+import { useEntityLikes } from '../../likes/hooks/useEntityLikes';
 import { usePublicNotebookCollections } from '../hooks/usePublicNotebookCollections';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
+interface VonDerBasisCardProps {
+  collection: NotebookCollection;
+  liked: boolean;
+  toggling: boolean;
+  canLike: boolean;
+  onToggleLike: (id: string) => void;
+}
+
 const VonDerBasisCard = memo(function VonDerBasisCard({
   collection,
-}: {
-  collection: NotebookCollection;
-}) {
+  liked,
+  toggling,
+  canLike,
+  onToggleLike,
+}: VonDerBasisCardProps) {
   const navigate = useNavigate();
   return (
     <div
@@ -37,12 +49,21 @@ const VonDerBasisCard = memo(function VonDerBasisCard({
           </div>
         ) : null}
       </div>
+      <LikeButton
+        liked={liked}
+        count={collection.likes_count ?? 0}
+        loading={toggling}
+        disabled={!canLike}
+        disabledReason={canLike ? undefined : 'Melde dich an, um zu liken'}
+        onToggle={() => onToggleLike(collection.id)}
+      />
     </div>
   );
 });
 
 export function VonDerBasisSection() {
   const { data, isLoading } = usePublicNotebookCollections({ enabled: true });
+  const { likedIds, toggleLike, isToggling, canLike } = useEntityLikes('notebook');
   const [query, setQuery] = useState('');
 
   const collections = data ?? [];
@@ -87,7 +108,14 @@ export function VonDerBasisSection() {
       ) : (
         <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
           {filtered.map((c) => (
-            <VonDerBasisCard key={c.id} collection={c} />
+            <VonDerBasisCard
+              key={c.id}
+              collection={c}
+              liked={likedIds.has(c.id)}
+              toggling={isToggling(c.id)}
+              canLike={canLike}
+              onToggleLike={toggleLike}
+            />
           ))}
         </div>
       )}

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -1,4 +1,4 @@
-import { FileText, LayoutDashboard, MessageSquare, Share2, Users } from 'lucide-react';
+import { FileText, Heart, LayoutDashboard, MessageSquare, Share2, Users } from 'lucide-react';
 
 import { openLinkAction, type NotificationTypeConfig } from '../notificationConfig';
 
@@ -71,6 +71,14 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
     description: 'Wenn eine Gruppe aufgelöst wird',
     icon: Users,
     group: 'groups',
+  },
+
+  notebook_liked: {
+    label: 'Notizbuch-Likes',
+    description: 'Wenn andere dein öffentliches Notizbuch mögen',
+    icon: Heart,
+    group: 'system',
+    actions: (ctx) => [openLinkAction('Notizbuch öffnen')(ctx)],
   },
 
   // transfer_downloaded: {

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -47,6 +47,7 @@ export interface NotebookCollection {
   selection_mode?: 'documents' | 'wolke' | 'mixed';
   labels?: string[];
   wolke_folders?: WolkeFolderRef[];
+  likes_count?: number;
 }
 
 /**

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -21,6 +21,9 @@ import {
   simpleSuccessMessageSchema,
   shareCollectionResponseSchema,
   bulkDeleteResponseSchema,
+  likeCollectionResponseSchema,
+  unlikeCollectionResponseSchema,
+  listMyLikedCollectionsResponseSchema,
 } from '../schemas/notebookCollections.js';
 
 const c = initContract();
@@ -223,6 +226,60 @@ export const notebookCollectionsContract = c.router(
         500: notebookErrorResponseSchema,
       },
       summary: 'Bulk delete notebook collections',
+    },
+
+    /**
+     * GET /api/auth/notebook-collections/likes
+     * Return the IDs of public notebooks the authenticated user has liked.
+     * Kept separate from listPublicCollections so the public listing stays
+     * user-agnostic and cacheable.
+     */
+    listMyLikedCollections: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/likes',
+      responses: {
+        200: listMyLikedCollectionsResponseSchema,
+        401: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: "List the authenticated user's liked notebook IDs",
+    },
+
+    /**
+     * POST /api/auth/notebook-collections/:id/like
+     * Like a public notebook collection. Idempotent; only fresh likes
+     * trigger a notification to the notebook owner (and never if owner === self).
+     */
+    likeCollection: {
+      method: 'POST',
+      path: '/api/auth/notebook-collections/:id/like',
+      pathParams: z.object({ id: z.string() }),
+      body: c.noBody(),
+      responses: {
+        200: likeCollectionResponseSchema,
+        401: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Like a public notebook collection',
+    },
+
+    /**
+     * DELETE /api/auth/notebook-collections/:id/like
+     * Remove the authenticated user's like from a notebook collection.
+     */
+    unlikeCollection: {
+      method: 'DELETE',
+      path: '/api/auth/notebook-collections/:id/like',
+      pathParams: z.object({ id: z.string() }),
+      body: c.noBody(),
+      responses: {
+        200: unlikeCollectionResponseSchema,
+        401: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Unlike a notebook collection',
     },
   },
   { pathPrefix: '' }

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -137,6 +137,7 @@ export const transformedCollectionSchema = z.object({
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullable().optional(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
+  likes_count: z.number().nullish(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────
@@ -215,4 +216,21 @@ export const bulkDeleteResponseSchema = z.object({
   failed_ids: z.array(z.string()),
   total_requested: z.number(),
   deleted_ids: z.array(z.string()),
+});
+
+export const likeCollectionResponseSchema = z.object({
+  success: z.literal(true),
+  liked: z.literal(true),
+  count: z.number(),
+});
+
+export const unlikeCollectionResponseSchema = z.object({
+  success: z.literal(true),
+  liked: z.literal(false),
+  count: z.number(),
+});
+
+export const listMyLikedCollectionsResponseSchema = z.object({
+  success: z.literal(true),
+  liked_ids: z.array(z.string()),
 });

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -32,6 +32,7 @@ export const notificationTypeSchema = z.enum([
   'group_content_shared',
   'group_deleted',
   'transfer_downloaded',
+  'notebook_liked',
 ]);
 export type NotificationType = z.infer<typeof notificationTypeSchema>;
 

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -23,6 +23,7 @@ import {
   searchContract,
   boardsContract,
   notebookContract,
+  notebookCollectionsContract,
   wordpressContract,
   transferContract,
   notificationsContract,
@@ -131,6 +132,7 @@ const _recentValuesClient = () => initClient(recentValuesContract, CLIENT_OPTS);
 const _searchClient = () => initClient(searchContract, CLIENT_OPTS);
 const _boardsClient = () => initClient(boardsContract, CLIENT_OPTS);
 const _notebookClient = () => initClient(notebookContract, CLIENT_OPTS);
+const _notebookCollectionsClient = () => initClient(notebookCollectionsContract, CLIENT_OPTS);
 const _wordpressClient = () => initClient(wordpressContract, CLIENT_OPTS);
 const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
 const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS);
@@ -147,6 +149,7 @@ export interface ContractsClient {
   search: ReturnType<typeof _searchClient>;
   boards: ReturnType<typeof _boardsClient>;
   notebook: ReturnType<typeof _notebookClient>;
+  notebookCollections: ReturnType<typeof _notebookCollectionsClient>;
   wordpress: ReturnType<typeof _wordpressClient>;
   transfer: ReturnType<typeof _transferClient>;
   notifications: ReturnType<typeof _notificationsClient>;
@@ -180,6 +183,7 @@ export function getContractsClient(): ContractsClient {
     search: _searchClient(),
     boards: _boardsClient(),
     notebook: _notebookClient(),
+    notebookCollections: _notebookCollectionsClient(),
     wordpress: _wordpressClient(),
     transfer: _transferClient(),
     notifications: _notificationsClient(),


### PR DESCRIPTION
## Summary

Hearts for the public notebooks in **Von der Basis** on `/notebooks`. The card now shows an inline heart + count on the right; clicking it toggles the like without firing the card's navigate handler. When someone else hearts a notebook, the owner gets an in-app notification (no email, no push); same-user re-presses are no-ops and self-likes never notify.

## Why these architectural choices

- **Polymorphic `entity_likes` table** (`user_id`, `entity_type`, `entity_id`) instead of a per-feature `notebook_likes` table, because the next ask is the same UI on Vorlagen. The existing `template_likes` table had no live data yet, so it's dropped in the same migration and the three `/vorlagen/likes` endpoints are rewired onto the shared service — a templates-launch PR can later wire `IndexCard.isLiked` / `onLikeToggle` (already exposed) with no further backend work.
- **`likes_count` enriched on the public listing**, but `liked_by_me` deliberately split into a separate `GET /likes` endpoint so the public response stays user-agnostic and cacheable.
- **Fresh-like detection** via Drizzle `onConflictDoNothing().returning()`: the row is only returned when an insert actually happened, which is the sole gate for firing `createNotification`. Toggling a like off and back on creates no duplicate notification.
- **Notification grouping** via `group_key=notebook:{id}:liked` so the existing dropdown collapses "Anna and 4 others liked your notebook" into one row.

## Test plan

- [ ] Backend boots — `entity_likes` is created with the three indices; `template_likes` is gone.
- [ ] User A on `/notebooks` hearts a public notebook owned by user B → heart fills, count increments optimistically, request returns 200 with the canonical count.
- [ ] User B sees a `notebook_liked` row in the notification dropdown via SSE, with `group_key=notebook:{id}:liked`.
- [ ] User A unhearts → count decrements; no new notification is fired.
- [ ] User A hearts their own public notebook → DB row created, count increments, no notification for user A.
- [ ] Logged-out user on `/notebooks` → counts visible, heart button disabled with the "Melde dich an, um zu liken" tooltip.
- [ ] `/auth/vorlagen/likes` GET/POST/DELETE still respond with the documented shape after the rewire (smoke test; templates aren't live yet).