### PR TITLE
fix(chat): mention popovers escape viewport top via Radix Popper

### DIFF
--- a/packages/chat/src/components/thread/FileMentionPopover.tsx
+++ b/packages/chat/src/components/thread/FileMentionPopover.tsx
@@ -14,6 +14,7 @@ import {
 } from '@gruenerator/ui';
 import { useFileMentionData } from '../../hooks/useFileMentionData';
 import { useDocMentionables } from '../../hooks/useMentionablesQuery';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
 import { documentToSlug } from '../../lib/documentMentionables';
 import type {
   CollabDocSelection,
@@ -177,24 +178,19 @@ export function FileMentionPopover({ visible, onSelect, onDismiss }: FileMention
     [level, handleBack, onDismiss]
   );
 
-  if (!visible) return null;
-
   const isRootLevel = level === 'root';
 
   return (
-    <div
-      className="absolute z-50 w-72 rounded-xl border border-border bg-background shadow-lg"
-      style={{ bottom: '100%', left: 0, marginBottom: '0.5rem' }}
-      onKeyDown={handleKeyDown}
-    >
-      <Command className="rounded-xl" shouldFilter={isRootLevel}>
+    <MentionFloatingPanel open={visible} onDismiss={onDismiss} width="w-72">
+      <div onKeyDown={handleKeyDown} className="flex min-h-0 flex-1 flex-col">
+      <Command className="flex min-h-0 flex-1 flex-col rounded-xl" shouldFilter={isRootLevel}>
         <CommandInput
           placeholder={isRootLevel ? 'Suchen...' : 'In Dokumenten suchen...'}
           value={level === 'documents' ? searchQuery : undefined}
           onValueChange={level === 'documents' ? handleSearchChange : undefined}
         />
-        <CommandList>
-          <ScrollArea className="max-h-72">
+        <CommandList className="min-h-0 flex-1">
+          <ScrollArea className="h-full">
             {isRootLevel ? (
               <>
                 {/* Section 1: Notebooks */}
@@ -344,6 +340,7 @@ export function FileMentionPopover({ visible, onSelect, onDismiss }: FileMention
           </ScrollArea>
         </CommandList>
       </Command>
-    </div>
+      </div>
+    </MentionFloatingPanel>
   );
 }

--- a/packages/chat/src/components/thread/MentionFloatingPanel.tsx
+++ b/packages/chat/src/components/thread/MentionFloatingPanel.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Popover as PopoverPrimitive } from 'radix-ui';
+import { type ReactNode } from 'react';
+
+interface MentionFloatingPanelProps {
+  open: boolean;
+  onDismiss?: () => void;
+  width?: string;
+  className?: string;
+  role?: 'listbox' | 'dialog';
+  ariaLabel?: string;
+  children: ReactNode;
+}
+
+export function MentionFloatingPanel({
+  open,
+  onDismiss,
+  width = 'w-72',
+  className = '',
+  role,
+  ariaLabel,
+  children,
+}: MentionFloatingPanelProps) {
+  return (
+    <PopoverPrimitive.Root
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onDismiss?.();
+      }}
+      modal={false}
+    >
+      <PopoverPrimitive.Anchor className="block h-0 w-full" />
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          side="top"
+          align="start"
+          sideOffset={8}
+          collisionPadding={16}
+          avoidCollisions
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onFocusOutside={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => {
+            const target = e.target as Element | null;
+            if (target?.closest('.composer-root')) e.preventDefault();
+          }}
+          role={role}
+          aria-label={ariaLabel}
+          className={`mention-popover z-50 flex max-h-(--radix-popover-content-available-height) flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg ${width} ${className}`.trim()}
+        >
+          {children}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { filterMentionables, type Mentionable } from '../../lib/mentionables';
 import { getFilteredFunctions } from '../../lib/mentionDetection';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
 
 interface MentionPopoverProps {
   query: string;
@@ -68,21 +69,17 @@ export function MentionPopover({
     el?.scrollIntoView({ block: 'nearest' });
   }, [selectedIndex, visible]);
 
-  if (!visible || totalItems === 0 || !anchorRect) return null;
-
+  const isOpen = visible && totalItems > 0 && !!anchorRect;
   let itemIndex = 0;
 
   return (
-    <div
-      ref={listRef}
+    <MentionFloatingPanel
+      open={isOpen}
+      onDismiss={onDismiss}
+      width="w-64"
       role="listbox"
-      className="mention-popover absolute z-50 max-h-60 w-64 overflow-y-auto rounded-xl border border-border bg-background shadow-lg"
-      style={{
-        bottom: '100%',
-        left: 0,
-        marginBottom: '0.5rem',
-      }}
     >
+      <div ref={listRef} className="overflow-y-auto">
       {sections.map((section) => (
         <div key={section.label}>
           <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
@@ -120,7 +117,8 @@ export function MentionPopover({
               ))}
         </div>
       ))}
-    </div>
+      </div>
+    </MentionFloatingPanel>
   );
 }
 

--- a/packages/chat/src/components/thread/SkillPopover.tsx
+++ b/packages/chat/src/components/thread/SkillPopover.tsx
@@ -5,6 +5,7 @@ import { Library } from 'lucide-react';
 import { filterMentionables, type Mentionable } from '../../lib/mentionables';
 import { useSkillFavoritesStore } from '../../stores/skillFavoritesStore';
 import { SkillLibraryModal } from '../skills/SkillLibraryModal';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
 
 interface SkillPopoverProps {
   query: string;
@@ -52,23 +53,19 @@ export function SkillPopover({
     );
   }
 
-  if (!visible || !anchorRect) return null;
-
+  const isOpen = visible && !!anchorRect;
   const showEmptyHint = allItems.length === 0 && query.length > 0;
 
   let itemIndex = 0;
 
   return (
-    <div
-      ref={listRef}
+    <MentionFloatingPanel
+      open={isOpen}
+      onDismiss={onDismiss}
+      width="w-64"
       role="listbox"
-      className="mention-popover absolute z-50 max-h-60 w-64 overflow-y-auto rounded-xl border border-border bg-background shadow-lg"
-      style={{
-        bottom: '100%',
-        left: 0,
-        marginBottom: '0.5rem',
-      }}
     >
+      <div ref={listRef} className="overflow-y-auto">
       {quickAccessAgents.length > 0 && (
         <>
           <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
@@ -119,7 +116,8 @@ export function SkillPopover({
         <Library className="h-3.5 w-3.5" />
         Alle Skills durchsuchen...
       </button>
-    </div>
+      </div>
+    </MentionFloatingPanel>
   );
 }
 

--- a/packages/chat/src/components/thread/WolkeMentionPopover.tsx
+++ b/packages/chat/src/components/thread/WolkeMentionPopover.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../hooks/useMentionablesQuery';
 import { useChatConfigStore } from '../../stores/chatConfigStore';
 import { type WolkeFileToken } from '../../lib/mentionables';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
 
 interface WolkeMentionPopoverProps {
   visible: boolean;
@@ -66,8 +67,6 @@ export function WolkeMentionPopover({ visible, onSelect, onDismiss }: WolkeMenti
     return files.filter((f) => f.name.toLowerCase().includes(q));
   }, [browse.data, filter]);
 
-  if (!visible) return null;
-
   const hasNoShares = !linksLoading && (!shareLinks || shareLinks.length === 0);
   const selectionList = [...selection.values()];
 
@@ -94,18 +93,22 @@ export function WolkeMentionPopover({ visible, onSelect, onDismiss }: WolkeMenti
   };
 
   return (
-    <div
+    <MentionFloatingPanel
+      open={visible}
+      onDismiss={onDismiss}
+      width="w-[360px]"
       role="dialog"
-      aria-label="Wolke-Dateien auswählen"
-      className="mention-popover absolute z-50 flex max-h-[420px] w-[360px] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg"
-      style={{ bottom: '100%', left: 0, marginBottom: '0.5rem' }}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          onDismiss();
-        }
-      }}
+      ariaLabel="Wolke-Dateien auswählen"
     >
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onDismiss();
+          }
+        }}
+      >
       <div className="border-b border-border px-3 py-2">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted/70">
@@ -252,6 +255,7 @@ export function WolkeMentionPopover({ visible, onSelect, onDismiss }: WolkeMenti
           </button>
         </div>
       </div>
-    </div>
+      </div>
+    </MentionFloatingPanel>
   );
 }


### PR DESCRIPTION
## Why

Mention/File/Wolke/Skill popovers all anchored themselves with a hand-rolled \`position: absolute; bottom: 100%\` shell plus a fixed \`max-h-60\` (or \`max-h-72\`) cap. When the composer sat near the viewport top — most visibly on the empty-state homepage chat — the popover content overran the top of the viewport. The search input and first group headers clipped above the visible area, and the user saw a sliced first item with no context (see screenshot in the originating thread).

## Approach

Replace the four hand-rolled shells with one shared \`MentionFloatingPanel\` built on \`radix-ui\`'s Popover primitive:

- **Portal + collision detection.** \`side="top"\` with \`avoidCollisions\` falls back to \`side="bottom"\` automatically when there isn't enough room above, so the empty-state composer flips the popover down instead of overflowing.
- **\`max-h\` bound to \`--radix-popover-content-available-height\`.** Radix computes the actually-available vertical space and exposes it as a CSS variable; using it as the max-height guarantees the panel can never overflow the viewport regardless of composer position.
- **Each popover keeps its own internal layout.** \`FileMentionPopover\` reshapes its inner Command/CommandList/ScrollArea with flexbox so the search field stays pinned at top and the ScrollArea absorbs the remaining height (was: ScrollArea capped at 288px while CommandInput escaped the cap and clipped first).

Outside-click and focus-outside auto-dismiss are explicitly neutered to preserve existing behavior (the four popovers historically dismissed only on Escape or selection, never on click-outside). A targeted \`.composer-root\` check on \`onPointerDownOutside\` allows clicks on the composer (model selector, plus menu, textarea) without closing the popover.

## Verification

1. Empty-state homepage chat → type \`@dok\` / \`@notebook\` / \`@skill\` / click "Dokumente" pill — popover now sits fully on-screen with the search field visible at the top; flips to below the composer if needed.
2. In-conversation chat (composer pinned at viewport bottom) — popover still opens upward, unchanged visual placement.
3. Escape, Enter-on-item, click-outside-composer dismiss as before.
4. Typing in the textarea while the popover is open keeps it open (focus-outside intentionally suppressed).