### PR TITLE
polish(chat): sticky group headings in mention popovers

### DIFF
--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -85,7 +85,7 @@ export function MentionPopover({
     >
       {sections.map((section) => (
         <div key={section.label}>
-          <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
+          <div className="sticky top-0 z-[1] bg-background px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
             {section.label}
           </div>
           {section.kind === 'flat'

--- a/packages/chat/src/components/thread/SkillPopover.tsx
+++ b/packages/chat/src/components/thread/SkillPopover.tsx
@@ -71,7 +71,7 @@ export function SkillPopover({
     >
       {quickAccessAgents.length > 0 && (
         <>
-          <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
+          <div className="sticky top-0 z-[1] bg-background px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
             Skills
           </div>
           {quickAccessAgents.map((agent) => {
@@ -89,7 +89,7 @@ export function SkillPopover({
       )}
       {customAgents.length > 0 && (
         <>
-          <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
+          <div className="sticky top-0 z-[1] bg-background px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-foreground-muted/60">
             Meine Skills
           </div>
           {customAgents.map((agent) => {

--- a/packages/chat/src/styles/chat.css
+++ b/packages/chat/src/styles/chat.css
@@ -447,6 +447,13 @@
   animation: mention-popover-in 0.15s ease-out;
 }
 
+.mention-popover [cmdk-group-heading] {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--color-background);
+}
+
 /* Three-dot menu */
 .menu-dropdown {
   position: relative;


### PR DESCRIPTION
## Why

Follow-up polish to #903. When a mention popover's content is long enough to scroll, the user could lose track of which bucket a partially-scrolled item belongs to — the group label scrolled out of view above the visible window. Now the top-level heading sticks to the panel's scroll-top edge, so context stays visible.

## Scope

- **MentionPopover / SkillPopover** — inline Tailwind classes (\`sticky top-0 z-[1] bg-background\`) on the section heading div.
- **FileMentionPopover** — the heading is rendered by \`cmdk\`'s \`<CommandGroup heading>\` (via \`[cmdk-group-heading]\` attribute), not a className we control directly. A single CSS rule scoped to \`.mention-popover [cmdk-group-heading]\` in \`chat.css\` covers it, keeping the rule out of any other surface.
- **Subgroup sublabels** (\`meine\` / \`system\` under Notizbücher) deliberately stay non-sticky — nested sticky elements with the same \`top: 0\` overlap and produce muddled visuals; the parent bucket label is enough context.

## Verification

1. Open a popover with enough content to scroll (e.g. \`@\` on a user with many notebooks/docs/saved texts), scroll down — the current section label remains visible at the top of the scroll area and is replaced by the next one when you cross into a new section.
2. Confirm the heading text is fully opaque (\`bg-background\`) over scrolling content, not see-through.
3. Confirm the entrance animation (\`mention-popover-in\`) still plays — the sticky rule doesn't interact with \`transform\` on the popover root.

## Stacks on top of

#903 (Radix Popper migration) — works either way, but visually most useful once panels can grow to the full available viewport height.