### PR TITLE
feat(groups): add mobile members-list entry point

### DIFF
--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -27,6 +27,7 @@ import {
   HiOutlineLink,
   HiOutlinePhotograph,
   HiOutlineTrash,
+  HiOutlineUserGroup,
   HiPencil,
   HiCheck,
   HiX,
@@ -165,6 +166,7 @@ const GroupInfoSection = memo(
     const navigate = useNavigate();
     const { members, isLoadingMembers } = useGroupMembers(groupId, { isActive: true });
     const [membersPopoverOpen, setMembersPopoverOpen] = useState(false);
+    const [membersDialogOpen, setMembersDialogOpen] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const cloneTemplate = useCloneCanvasTemplate();
 
@@ -487,6 +489,18 @@ const GroupInfoSection = memo(
                       ? 'Verwalte Mitglieder und geteilte Inhalte.'
                       : 'Du bist Mitglied dieser Gruppe.')}
                 </p>
+                {!isLoadingMembers && (
+                  <button
+                    type="button"
+                    onClick={() => setMembersDialogOpen(true)}
+                    className="sm:hidden mt-sm self-start inline-flex items-center gap-1.5 rounded-full bg-grey-100 dark:bg-grey-800 px-sm py-xs text-xs font-medium text-foreground hover:bg-grey-200 dark:hover:bg-grey-700 transition-colors"
+                  >
+                    <HiOutlineUserGroup className="size-3.5" aria-hidden="true" />
+                    <span>
+                      {memberCount} {memberCount === 1 ? 'Mitglied' : 'Mitglieder'}
+                    </span>
+                  </button>
+                )}
               </div>
             )}
           </div>
@@ -638,7 +652,9 @@ const GroupInfoSection = memo(
                                   )}
                                   {section.cloneOnOpen && (
                                     <p className="text-[10px] text-primary-600 mt-xxs m-0">
-                                      {isCloning ? 'Vorlage wird geöffnet...' : 'Klicken um Kopie zu erstellen'}
+                                      {isCloning
+                                        ? 'Vorlage wird geöffnet...'
+                                        : 'Klicken um Kopie zu erstellen'}
                                     </p>
                                   )}
                                 </div>
@@ -659,7 +675,10 @@ const GroupInfoSection = memo(
                                     {cardInner}
                                   </button>
                                 ) : href ? (
-                                  <a href={href} className="flex flex-col no-underline text-foreground">
+                                  <a
+                                    href={href}
+                                    className="flex flex-col no-underline text-foreground"
+                                  >
                                     {cardInner}
                                   </a>
                                 ) : (
@@ -776,6 +795,24 @@ const GroupInfoSection = memo(
                 Endgültig löschen
               </Button>
             </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={membersDialogOpen} onOpenChange={setMembersDialogOpen}>
+          <DialogContent className="max-w-md p-md">
+            <DialogHeader>
+              <DialogTitle>Mitglieder{!isLoadingMembers ? ` (${memberCount})` : ''}</DialogTitle>
+            </DialogHeader>
+            <div className="max-h-[60vh] overflow-y-auto">
+              <GroupMembersList
+                groupId={groupId}
+                isActive={membersDialogOpen}
+                hideHeader
+                isCurrentUserAdmin={data?.isAdmin}
+                currentUserId={currentUserId}
+                createdBy={data?.groupInfo?.created_by}
+              />
+            </div>
           </DialogContent>
         </Dialog>
       </>


### PR DESCRIPTION
Follow-up to #905. Hiding the avatar cluster on mobile in #905 removed the only entry point to the member list for non-admins; admins also lost easy access (the three-dot dropdown has no \"Mitglieder anzeigen\" action). Without this PR, the member list is unreachable on mobile after #905 ships.

I considered eight options (in-body section, three-dot menu reuse, tappable group avatar, inline-in-description, metadata replacement, bottom drawer, dedicated route, and the chosen pill+Dialog). The pill wins on signal-to-change ratio: discoverable text + count, surgical (34 net additions), reuses the existing `GroupMembersList` verbatim, and lives in flow under the description so it never competes with the title for absolute-positioned space.

Desktop is untouched — the avatar popover stays the desktop affordance. The Dialog `<DialogTitle>Mitglieder (N)</DialogTitle>` provides the a11y label; `hideHeader` on the list prevents a duplicate header. Singular/plural handled (`1 Mitglied` vs `N Mitglieder`); loading state gated to prevent a brief `0 Mitglieder` flash.