### PR TITLE
feat(notebooks): groups-aware sharing with explicit edit policy

### DIFF
--- a/apps/api/database/postgres/migrations/notebook_sharing_replace_public_access.sql
+++ b/apps/api/database/postgres/migrations/notebook_sharing_replace_public_access.sql
@@ -1,0 +1,13 @@
+-- Drop the dormant notebook_public_access table.
+--
+-- The primary store for token-based public-notebook links was always the Qdrant
+-- collection of the same name (NotebookQdrantHelper.createPublicAccess). The
+-- Postgres table at schema.sql:371 was declared but never written to or read from
+-- — confirmed by codebase grep. Dropping it is housekeeping.
+--
+-- The new notebook sharing model (share_mode: private | groups | authenticated,
+-- edit_policy: owner_only | group_admins | all_members) is stored on the Qdrant
+-- notebook_collections payload; group shares reuse the polymorphic
+-- group_content_shares table with content_type='notebook_collections'.
+
+DROP TABLE IF EXISTS notebook_public_access CASCADE;

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -368,16 +368,6 @@ CREATE TABLE IF NOT EXISTS notebook_collection_documents (
     UNIQUE(collection_id, document_id)
 );
 
-CREATE TABLE IF NOT EXISTS notebook_public_access (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    collection_id UUID REFERENCES notebook_collections(id) ON DELETE CASCADE,
-    access_token TEXT UNIQUE NOT NULL,
-    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
-    expires_at TIMESTAMPTZ,
-    created_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
-    is_active BOOLEAN DEFAULT TRUE
-);
-
 CREATE TABLE IF NOT EXISTS notebook_usage_logs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     collection_id UUID REFERENCES notebook_collections(id) ON DELETE CASCADE,

--- a/apps/api/database/schema/notebooks.ts
+++ b/apps/api/database/schema/notebooks.ts
@@ -22,16 +22,6 @@ export const notebook_collection_documents = pgTable('notebook_collection_docume
   added_by: uuid('added_by'),
 });
 
-export const notebook_public_access = pgTable('notebook_public_access', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  collection_id: uuid('collection_id'),
-  access_token: text('access_token').notNull().unique(),
-  created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
-  expires_at: timestamp('expires_at', { withTimezone: true }),
-  created_by: uuid('created_by'),
-  is_active: boolean('is_active').default(true),
-});
-
 export const notebook_usage_logs = pgTable('notebook_usage_logs', {
   id: uuid('id').primaryKey().defaultRandom(),
   collection_id: uuid('collection_id'),
@@ -46,5 +36,4 @@ export const notebook_usage_logs = pgTable('notebook_usage_logs', {
 
 export type NotebookCollection = InferSelectModel<typeof notebook_collections>;
 export type NotebookCollectionDocument = InferSelectModel<typeof notebook_collection_documents>;
-export type NotebookPublicAccess = InferSelectModel<typeof notebook_public_access>;
 export type NotebookUsageLog = InferSelectModel<typeof notebook_usage_logs>;

--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -24,6 +24,28 @@ const logger = createLogger('NotebookQdrantHelper');
 
 type PublicOwnership = 'owner' | 'public_data';
 
+export type NotebookShareMode = 'private' | 'groups' | 'authenticated';
+export type NotebookEditPolicy = 'owner_only' | 'group_admins' | 'all_members';
+
+const NOTEBOOK_SHARE_MODES: readonly NotebookShareMode[] = ['private', 'groups', 'authenticated'];
+const NOTEBOOK_EDIT_POLICIES: readonly NotebookEditPolicy[] = [
+  'owner_only',
+  'group_admins',
+  'all_members',
+];
+
+function normalizeShareMode(raw: unknown): NotebookShareMode {
+  return NOTEBOOK_SHARE_MODES.includes(raw as NotebookShareMode)
+    ? (raw as NotebookShareMode)
+    : 'private';
+}
+
+function normalizeEditPolicy(raw: unknown): NotebookEditPolicy {
+  return NOTEBOOK_EDIT_POLICIES.includes(raw as NotebookEditPolicy)
+    ? (raw as NotebookEditPolicy)
+    : 'owner_only';
+}
+
 interface NotebookCollectionData {
   id?: string;
   user_id: string;
@@ -42,6 +64,8 @@ interface NotebookCollectionData {
   updated_at?: string;
   is_public?: boolean;
   public_ownership?: PublicOwnership | null;
+  share_mode?: NotebookShareMode;
+  edit_policy?: NotebookEditPolicy;
 }
 
 interface NotebookCollection {
@@ -62,6 +86,8 @@ interface NotebookCollection {
   last_used_at: string | null;
   is_public: boolean;
   public_ownership: PublicOwnership | null;
+  share_mode: NotebookShareMode;
+  edit_policy: NotebookEditPolicy;
   notebook_collection_documents?: CollectionDocument[];
 }
 
@@ -201,6 +227,8 @@ class NotebookQdrantHelper {
           last_used_at: collectionData.last_used_at || null,
           is_public: collectionData.is_public === true,
           public_ownership: collectionData.public_ownership ?? null,
+          share_mode: normalizeShareMode(collectionData.share_mode),
+          edit_policy: normalizeEditPolicy(collectionData.edit_policy),
         },
       };
 
@@ -461,46 +489,12 @@ class NotebookQdrantHelper {
   }
 
   /**
-   * Create public access token
-   */
-  async createPublicAccess(
-    collectionId: string,
-    createdBy: string | null = null,
-    expiresAt: string | null = null
-  ): Promise<{ success: boolean; access_token: string }> {
-    await this.ensureInitialized();
-
-    try {
-      const accessToken = crypto.randomBytes(32).toString('hex');
-
-      const point: QdrantPoint = {
-        id: this.generateNumericId(accessToken),
-        vector: this.generateDummyVector(),
-        payload: {
-          collection_id: collectionId,
-          access_token: accessToken,
-          created_at: new Date().toISOString(),
-          expires_at: expiresAt,
-          created_by: createdBy,
-          is_active: true,
-          view_count: 0,
-          last_accessed_at: null,
-        },
-      };
-
-      await this.qdrantOps!.batchUpsert(this.qdrant.collections.notebook_public_access, [point]);
-
-      logger.info(`Created public access for collection: ${collectionId}`);
-      return { success: true, access_token: accessToken };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Error creating public access: ${message}`);
-      throw new Error(`Failed to create public access: ${message}`);
-    }
-  }
-
-  /**
    * Get public access by token
+   *
+   * Token creation/revocation was removed when the notebook share model moved
+   * to share_mode + edit_policy + group_content_shares. Existing tokens in the
+   * Qdrant `notebook_public_access` collection still resolve here so previously
+   * issued public links keep working until they expire or are cleaned up.
    */
   async getPublicAccess(accessToken: string): Promise<PublicAccessData | null> {
     await this.ensureInitialized();
@@ -535,28 +529,6 @@ class NotebookQdrantHelper {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`Error getting public access: ${message}`);
       throw new Error(`Failed to get public access: ${message}`);
-    }
-  }
-
-  /**
-   * Revoke public access
-   */
-  async revokePublicAccess(collectionId: string): Promise<{ success: boolean }> {
-    await this.ensureInitialized();
-
-    try {
-      const filter: QdrantFilter = {
-        must: [{ key: 'collection_id', match: { value: collectionId } }],
-      };
-
-      await this.qdrantOps!.batchDelete(this.qdrant.collections.notebook_public_access, filter);
-
-      logger.info(`Revoked public access for collection: ${collectionId}`);
-      return { success: true };
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error(`Error revoking public access: ${message}`);
-      throw new Error(`Failed to revoke public access: ${message}`);
     }
   }
 
@@ -633,7 +605,78 @@ class NotebookQdrantHelper {
       last_used_at: payload.last_used_at as string | null,
       is_public: payload.is_public === true,
       public_ownership: publicOwnership,
+      share_mode: normalizeShareMode(payload.share_mode),
+      edit_policy: normalizeEditPolicy(payload.edit_policy),
     };
+  }
+
+  /**
+   * Fetch notebook collections by an explicit list of IDs.
+   * Used by listAccessibleCollections to materialize group-shared notebooks.
+   */
+  async getNotebookCollectionsByIds(collectionIds: string[]): Promise<NotebookCollection[]> {
+    await this.ensureInitialized();
+    if (collectionIds.length === 0) return [];
+
+    try {
+      const filter: QdrantFilter = {
+        must: [{ key: 'collection_id', match: { any: collectionIds } }],
+      };
+
+      const results = await this.qdrantOps!.scrollDocuments(
+        this.qdrant.collections.notebook_collections,
+        filter,
+        { limit: Math.max(collectionIds.length, 100), withPayload: true }
+      );
+
+      const collections = results.map((result: ScrollPoint) =>
+        this.formatCollectionFromPayload(result.payload)
+      );
+
+      for (const collection of collections) {
+        const documents = await this.getCollectionDocuments(collection.id);
+        collection.notebook_collection_documents = documents;
+        collection.document_count = documents.length;
+      }
+
+      return collections;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error fetching notebook collections by ids: ${message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Fetch notebook collections by share_mode (e.g., 'authenticated').
+   * Lets listAccessibleCollections surface notebooks readable to any logged-in
+   * user without per-id lookups.
+   */
+  async getNotebookCollectionsByShareMode(
+    shareMode: NotebookShareMode,
+    options: GetCollectionsOptions = {}
+  ): Promise<NotebookCollection[]> {
+    await this.ensureInitialized();
+
+    try {
+      const { limit = 200, offset = 0 } = options;
+
+      const filter: QdrantFilter = {
+        must: [{ key: 'share_mode', match: { value: shareMode } }],
+      };
+
+      const results = await this.qdrantOps!.scrollDocuments(
+        this.qdrant.collections.notebook_collections,
+        filter,
+        { limit, offset, withPayload: true }
+      );
+
+      return results.map((result: ScrollPoint) => this.formatCollectionFromPayload(result.payload));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error fetching notebook collections by share_mode: ${message}`);
+      return [];
+    }
   }
 
   /**

--- a/apps/api/database/types.ts
+++ b/apps/api/database/types.ts
@@ -263,16 +263,6 @@ export interface NotebookCollectionDocumentRow {
   added_by: string | null;
 }
 
-export interface NotebookPublicAccessRow {
-  id: string;
-  collection_id: string;
-  access_token: string;
-  created_at: Date;
-  expires_at: Date | null;
-  created_by: string | null;
-  is_active: boolean;
-}
-
 export interface NotebookUsageLogRow {
   id: string;
   collection_id: string | null;
@@ -794,7 +784,6 @@ export interface Database {
   yjs_document_updates: YjsDocumentUpdateRow;
   notebook_collections: NotebookCollectionRow;
   notebook_collection_documents: NotebookCollectionDocumentRow;
-  notebook_public_access: NotebookPublicAccessRow;
   notebook_usage_logs: NotebookUsageLogRow;
   custom_generators: CustomGeneratorRow;
   custom_generator_documents: CustomGeneratorDocumentRow;

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -42,6 +42,7 @@ import { markdownController as markdownRouter } from './routes/markdown/index.js
 import { monitorRouter, monitorInternalRouter } from './routes/monitor/index.js';
 import { mountNotebookCollectionsContractRouter } from './routes/notebook/notebookCollectionsContractRouter.js';
 import { mountNotebookContractRouter } from './routes/notebook/notebookContractRouter.js';
+import { mountNotebookSharingContractRouter } from './routes/notebook/notebookSharingContractRouter.js';
 import notificationsRouter from './routes/notifications/index.js';
 import { mountNotificationsContractRouter } from './routes/notifications/notificationsContractRouter.js';
 import protokollRouter from './routes/protokoll/index.js';
@@ -305,6 +306,13 @@ export async function setupRoutes(app: Application): Promise<void> {
   // legacy router so contract-modeled routes match first. requireAuth is
   // applied at the prefix because all 10 routes require authentication.
   app.use('/api/auth/notebook-collections', requireAuth);
+  // Neutral "my groups" endpoint used by share dialogs across features. Must
+  // be `.use`'d before the contract router mounts the GET /api/auth/groups/me
+  // handler so the middleware actually runs.
+  app.use('/api/auth/groups', requireAuth);
+  // Sharing endpoints (share mode, edit policy, group shares) — mounted BEFORE
+  // the CRUD router so :id/share doesn't fall through to the legacy router.
+  mountNotebookSharingContractRouter(app);
   mountNotebookCollectionsContractRouter(app);
   app.use('/api/auth/notebook-collections', authenticatedReadLimiter, notebookCollectionsRouter);
   // Mixed-auth contract: `optionalAuth` populates req.user without rejecting,

--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -10,7 +10,6 @@
 
 import express, { type Response } from 'express';
 
-import { env } from '../../config/env.js';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import authMiddleware from '../../middleware/authMiddleware.js';
@@ -615,69 +614,6 @@ router.delete(
     } catch (error) {
       log.error('[Notebook Collections] Error in DELETE /:id:', error);
       return res.status(500).json({ error: 'Failed to delete Notebook collection' });
-    }
-  }
-);
-
-/**
- * POST /api/notebook-collections/:id/share
- * Generate public sharing link
- */
-router.post(
-  '/:id/share',
-  requireAuth,
-  async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
-    try {
-      const userId = req.user!.id;
-      const collectionId = fromParam<NotebookId>(req.params.id);
-
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
-        return res.status(404).json({ error: 'Notebook collection not found' });
-      }
-
-      const result = await notebookHelper.createPublicAccess(collectionId, userId);
-      const publicUrl = `${env.BASE_URL}/notebook/public/${result.access_token}`;
-
-      return res.json({
-        success: true,
-        public_url: publicUrl,
-        access_token: result.access_token,
-        message: 'Public link generated successfully',
-      });
-    } catch (error) {
-      log.error('[Notebook Collections] Error in POST /:id/share:', error);
-      return res.status(500).json({ error: 'Internal server error' });
-    }
-  }
-);
-
-/**
- * DELETE /api/notebook-collections/:id/share
- * Revoke public access
- */
-router.delete(
-  '/:id/share',
-  requireAuth,
-  async (req: AuthenticatedRequest<{ id: string }>, res: Response) => {
-    try {
-      const userId = req.user!.id;
-      const collectionId = fromParam<NotebookId>(req.params.id);
-
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
-        return res.status(404).json({ error: 'Notebook collection not found' });
-      }
-
-      await notebookHelper.revokePublicAccess(collectionId);
-
-      return res.json({
-        success: true,
-        message: 'Public access revoked successfully',
-      });
-    } catch (error) {
-      log.error('[Notebook Collections] Error in DELETE /:id/share:', error);
-      return res.status(500).json({ error: 'Internal server error' });
     }
   }
 );

--- a/apps/api/routes/notebook/notebookAccess.ts
+++ b/apps/api/routes/notebook/notebookAccess.ts
@@ -1,0 +1,147 @@
+/**
+ * Centralized read/edit access checks for user-owned notebook collections.
+ *
+ * Mirrors apps/api/routes/docs/documentAccess.ts but adapted to the
+ * Qdrant-backed notebook collections + the polymorphic group_content_shares
+ * table. See plan: /home/morit/.claude/plans/docs-can-be-made-majestic-pillow.md
+ */
+
+import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
+
+const helper = new NotebookQdrantHelper();
+
+export interface NotebookAccess {
+  exists: boolean;
+  isOwner: boolean;
+  canRead: boolean;
+  canEdit: boolean;
+}
+
+const DENIED: NotebookAccess = { exists: false, isOwner: false, canRead: false, canEdit: false };
+
+interface GroupShareRow {
+  group_id: string;
+  [key: string]: unknown;
+}
+
+interface MembershipRow {
+  role: string;
+  is_creator: boolean;
+  [key: string]: unknown;
+}
+
+async function getSharedGroupIds(notebookId: string): Promise<string[]> {
+  const postgres = getPostgresInstance();
+  const rows = (await postgres.query(
+    `SELECT group_id FROM group_content_shares
+       WHERE content_type = 'notebook_collections' AND content_id = $1`,
+    [notebookId]
+  )) as GroupShareRow[];
+  return rows.map((r) => r.group_id);
+}
+
+async function getMembershipsForUserInGroups(
+  userId: string,
+  groupIds: string[]
+): Promise<MembershipRow[]> {
+  if (groupIds.length === 0) return [];
+  const postgres = getPostgresInstance();
+  return (await postgres.query(
+    `SELECT gm.role, (g.created_by = gm.user_id) AS is_creator
+       FROM group_memberships gm
+       INNER JOIN groups g ON g.id = gm.group_id
+       WHERE gm.user_id = $1 AND gm.group_id = ANY($2)`,
+    [userId, groupIds]
+  )) as MembershipRow[];
+}
+
+/**
+ * Decide what `userId` can do with `notebookId`.
+ *
+ * Read:
+ *   - owner → always
+ *   - share_mode = 'authenticated' + userId present → yes
+ *   - share_mode = 'groups' + userId is a member of a shared group → yes
+ *   - otherwise → no
+ *
+ * Edit (only meaningful when canRead = true):
+ *   - owner → always
+ *   - edit_policy = 'owner_only' → no
+ *   - edit_policy = 'group_admins' → user must be admin OR creator of a shared group
+ *   - edit_policy = 'all_members' → user must be a member of a shared group
+ *
+ * Note: share_mode = 'authenticated' WITHOUT shared groups effectively falls
+ * back to owner-only edits, because edit_policy needs a shared-groups set to
+ * grant rights to anyone other than the owner. The frontend renders a hint.
+ */
+export async function checkNotebookAccess(
+  notebookId: string,
+  userId: string | null
+): Promise<NotebookAccess> {
+  const collection = await helper.getNotebookCollection(notebookId);
+  if (!collection) return DENIED;
+
+  const isOwner = userId !== null && collection.user_id === userId;
+  if (isOwner) {
+    return { exists: true, isOwner: true, canRead: true, canEdit: true };
+  }
+
+  const shareMode = collection.share_mode;
+  const editPolicy = collection.edit_policy;
+
+  if (shareMode === 'authenticated') {
+    if (!userId) return { exists: true, isOwner: false, canRead: false, canEdit: false };
+    return { exists: true, isOwner: false, canRead: true, canEdit: false };
+  }
+
+  if (shareMode === 'groups') {
+    if (!userId) return { exists: true, isOwner: false, canRead: false, canEdit: false };
+    const sharedGroupIds = await getSharedGroupIds(notebookId);
+    if (sharedGroupIds.length === 0) {
+      return { exists: true, isOwner: false, canRead: false, canEdit: false };
+    }
+    const memberships = await getMembershipsForUserInGroups(userId, sharedGroupIds);
+    if (memberships.length === 0) {
+      return { exists: true, isOwner: false, canRead: false, canEdit: false };
+    }
+
+    let canEdit = false;
+    if (editPolicy === 'all_members') {
+      canEdit = true;
+    } else if (editPolicy === 'group_admins') {
+      canEdit = memberships.some((m) => m.role === 'admin' || m.is_creator);
+    }
+    return { exists: true, isOwner: false, canRead: true, canEdit };
+  }
+
+  return { exists: true, isOwner: false, canRead: false, canEdit: false };
+}
+
+/**
+ * Convenience guard for mutation endpoints. Returns a 403/404-shaped object
+ * the caller can return directly when access is denied; otherwise null when
+ * the user is allowed to proceed.
+ */
+export async function requireNotebookEdit(
+  notebookId: string,
+  userId: string | null
+): Promise<{ status: 403 | 404; body: { error: string } } | null> {
+  const access = await checkNotebookAccess(notebookId, userId);
+  if (!access.exists) return { status: 404, body: { error: 'Notebook nicht gefunden' } };
+  if (!access.canEdit) return { status: 403, body: { error: 'Keine Berechtigung' } };
+  return null;
+}
+
+/**
+ * Convenience guard for owner-only operations (delete, change visibility).
+ */
+export async function requireNotebookOwner(
+  notebookId: string,
+  userId: string | null
+): Promise<{ status: 403 | 404; body: { error: string } } | null> {
+  const access = await checkNotebookAccess(notebookId, userId);
+  if (!access.exists) return { status: 404, body: { error: 'Notebook nicht gefunden' } };
+  if (!access.isOwner) return { status: 403, body: { error: 'Nur Eigentümer*in erlaubt' } };
+  return null;
+}

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -18,7 +18,6 @@
 import { notebookCollectionsContract, type WolkeFolderRef } from '@gruenerator/contracts';
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
-import { env } from '../../config/env.js';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import { processUploadedDocument } from '../../services/document-services/DocumentProcessingService/index.js';
@@ -35,6 +34,12 @@ import { getProfileService } from '../../services/user/ProfileService.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
 import { createLogger } from '../../utils/logger.js';
 import { fromParam, type DocumentId, type NotebookId } from '../../utils/types/branded.js';
+
+import {
+  checkNotebookAccess,
+  requireNotebookEdit,
+  requireNotebookOwner,
+} from './notebookAccess.js';
 
 import type { DocumentRecord, WolkeShareLink } from './types.js';
 import type { UserProfile } from '../../services/user/types.js';
@@ -130,14 +135,53 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         notebook_collection_documents?: Array<{ document_id: string }>;
         is_public?: boolean;
         public_ownership?: 'owner' | 'public_data' | null;
+        share_mode?: 'private' | 'groups' | 'authenticated';
+        edit_policy?: 'owner_only' | 'group_admins' | 'all_members';
       };
 
-      const collections = (await notebookHelper.getUserNotebookCollections(
+      const owned = (await notebookHelper.getUserNotebookCollections(
         userId
       )) as NotebookCollectionFromQdrantRaw[];
+      const ownedIds = new Set(owned.map((c) => c.id));
+
+      // Notebooks shared with any group the user belongs to.
+      const groupSharedIdRows = (await postgres.query(
+        `SELECT DISTINCT gcs.content_id
+           FROM group_content_shares gcs
+           INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id
+           WHERE gcs.content_type = 'notebook_collections' AND gm.user_id = $1`,
+        [userId]
+      )) as Array<{ content_id: string }>;
+      const groupSharedIds = groupSharedIdRows
+        .map((r) => r.content_id)
+        .filter((id) => !ownedIds.has(id));
+      const groupShared = (
+        groupSharedIds.length > 0
+          ? ((await notebookHelper.getNotebookCollectionsByIds(
+              groupSharedIds
+            )) as NotebookCollectionFromQdrantRaw[])
+          : []
+      ).filter((c) => c.share_mode === 'groups');
+      const groupSharedIdsSet = new Set(groupShared.map((c) => c.id));
+
+      // Notebooks visible to any authenticated user — excluding ones we already have.
+      const authShared = (
+        (await notebookHelper.getNotebookCollectionsByShareMode(
+          'authenticated'
+        )) as NotebookCollectionFromQdrantRaw[]
+      ).filter((c) => !ownedIds.has(c.id) && !groupSharedIdsSet.has(c.id));
+
+      const tagged: Array<{
+        collection: NotebookCollectionFromQdrantRaw;
+        access_source: 'owned' | 'shared' | 'authenticated';
+      }> = [
+        ...owned.map((c) => ({ collection: c, access_source: 'owned' as const })),
+        ...groupShared.map((c) => ({ collection: c, access_source: 'shared' as const })),
+        ...authShared.map((c) => ({ collection: c, access_source: 'authenticated' as const })),
+      ];
 
       const transformedData = await Promise.all(
-        collections.map(async (collection) => {
+        tagged.map(async ({ collection, access_source }) => {
           const documentIds = (collection.notebook_collection_documents || []).map(
             (qcd) => qcd.document_id
           );
@@ -179,13 +223,16 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             wolke_folders,
             is_public: collection.is_public === true,
             public_ownership: collection.public_ownership ?? null,
+            access_source,
           };
         })
       );
 
       const totalWolkeFolders = transformedData.reduce((acc, c) => acc + c.wolke_folders.length, 0);
       log.debug(
-        `[listCollections] returning ${transformedData.length} collection(s), ${totalWolkeFolders} wolke_folders total`
+        `[listCollections] returning ${transformedData.length} collection(s) ` +
+          `(owned=${owned.length} shared=${groupShared.length} authenticated=${authShared.length}), ` +
+          `${totalWolkeFolders} wolke_folders total`
       );
 
       return {
@@ -498,10 +545,15 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         };
       }
 
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
+
       const existingCollection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!existingCollection || existingCollection.user_id !== userId) {
+      if (!existingCollection) {
         return { status: 404 as const, body: { error: 'Notebook collection not found' } };
       }
+
+      const isOwner = existingCollection.user_id === userId;
 
       let allDocumentIds: string[] = [];
       let wolkeDocuments: DocumentRecord[] = [];
@@ -596,7 +648,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         updateData.remove_missing_on_sync = false;
       }
 
-      if (typeof is_public === 'boolean') {
+      if (isOwner && typeof is_public === 'boolean') {
         updateData.is_public = is_public;
         updateData.public_ownership = is_public ? (public_ownership ?? null) : null;
       }
@@ -632,8 +684,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       const userId = getUserId(args.req);
       const collectionId = fromParam<NotebookId>(args.params.id);
 
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
+
       const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
+      if (!collection) {
         return { status: 404 as const, body: { error: 'Notebook collection not found' } };
       }
 
@@ -717,8 +772,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         };
       }
 
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
+      const access = await checkNotebookAccess(collectionId, userId);
+      if (!access.exists) {
+        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
+      }
+      if (!access.canRead) {
         return { status: 404 as const, body: { error: 'Notebook collection not found' } };
       }
 
@@ -756,10 +814,8 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       const userId = getUserId(args.req);
       const collectionId = fromParam<NotebookId>(args.params.id);
 
-      const existingCollection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!existingCollection || existingCollection.user_id !== userId) {
-        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
-      }
+      const guard = await requireNotebookOwner(collectionId, userId);
+      if (guard) return guard;
 
       await notebookHelper.deleteNotebookCollection(collectionId);
 
@@ -776,66 +832,14 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
     }
   },
 
-  shareCollection: async (args) => {
-    try {
-      const userId = getUserId(args.req);
-      const collectionId = fromParam<NotebookId>(args.params.id);
-
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
-        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
-      }
-
-      const result = await notebookHelper.createPublicAccess(collectionId, userId);
-      const publicUrl = `${env.BASE_URL}/notebook/public/${result.access_token}`;
-
-      return {
-        status: 200 as const,
-        body: {
-          success: true,
-          public_url: publicUrl,
-          access_token: result.access_token,
-          message: 'Public link generated successfully',
-        },
-      };
-    } catch (error) {
-      log.error('[notebookCollectionsContract.shareCollection] Error:', error);
-      return { status: 500 as const, body: { error: 'Internal server error' } };
-    }
-  },
-
-  revokeShare: async (args) => {
-    try {
-      const userId = getUserId(args.req);
-      const collectionId = fromParam<NotebookId>(args.params.id);
-
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
-        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
-      }
-
-      await notebookHelper.revokePublicAccess(collectionId);
-
-      return {
-        status: 200 as const,
-        body: { success: true, message: 'Public access revoked successfully' },
-      };
-    } catch (error) {
-      log.error('[notebookCollectionsContract.revokeShare] Error:', error);
-      return { status: 500 as const, body: { error: 'Internal server error' } };
-    }
-  },
-
   removeDocument: async (args) => {
     try {
       const userId = getUserId(args.req);
       const collectionId = fromParam<NotebookId>(args.params.id);
       const documentId = fromParam<DocumentId>(args.params.documentId);
 
-      const collection = await notebookHelper.getNotebookCollection(collectionId);
-      if (!collection || collection.user_id !== userId) {
-        return { status: 404 as const, body: { error: 'Notebook collection not found' } };
-      }
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
 
       await notebookHelper.removeDocumentsFromCollection(collectionId, [documentId]);
 

--- a/apps/api/routes/notebook/notebookSharingContractRouter.ts
+++ b/apps/api/routes/notebook/notebookSharingContractRouter.ts
@@ -1,0 +1,284 @@
+/**
+ * ts-rest contract router for notebook sharing endpoints.
+ *
+ * Mounted alongside notebookCollectionsContractRouter. Uses the polymorphic
+ * group_content_shares table (content_type='notebook_collections') for group
+ * shares and the Qdrant notebook payload (share_mode, edit_policy) for the
+ * read/edit decision matrix.
+ *
+ * All routes require auth — `requireAuth` is applied at the path prefix in
+ * routes.ts. `getUserId` throws when req.user is missing as a safety guard.
+ */
+
+import { notebookSharingContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { createLogger } from '../../utils/logger.js';
+
+import { checkNotebookAccess } from './notebookAccess.js';
+
+import type { UserProfile } from '../../services/user/types.js';
+import type { Application, Request } from 'express';
+
+const log = createLogger('notebookSharingContractRouter');
+const notebookHelper = new NotebookQdrantHelper();
+
+function getUserId(req: Request): string {
+  const user = req.user as UserProfile | undefined;
+  if (!user?.id) {
+    throw new Error('Authentication required');
+  }
+  return user.id;
+}
+
+interface UserGroupRow {
+  id: string;
+  name: string;
+  role: string;
+  [key: string]: unknown;
+}
+
+interface GroupShareJoinRow {
+  group_id: string;
+  group_name: string;
+  shared_at: string | Date;
+  [key: string]: unknown;
+}
+
+interface MembershipRow {
+  user_id: string;
+  [key: string]: unknown;
+}
+
+interface ExistingShareRow {
+  id: string;
+  [key: string]: unknown;
+}
+
+const s = initServer();
+
+export const notebookSharingContractRouter = s.router(notebookSharingContract, {
+  listMyGroups: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const postgres = getPostgresInstance();
+      const groups = (await postgres.query(
+        `SELECT g.id, g.name, gm.role
+           FROM groups g
+           INNER JOIN group_memberships gm ON gm.group_id = g.id
+           WHERE gm.user_id = $1
+           ORDER BY g.name ASC`,
+        [userId]
+      )) as UserGroupRow[];
+      return {
+        status: 200 as const,
+        body: groups.map((g) => ({ id: g.id, name: g.name, role: g.role })),
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.listMyGroups] Error:', error);
+      return { status: 500 as const, body: { error: 'Failed to fetch user groups' } };
+    }
+  },
+
+  getShareSettings: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const access = await checkNotebookAccess(args.params.id, userId);
+      if (!access.exists) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (!access.canRead) {
+        return { status: 403 as const, body: { error: 'Keine Berechtigung' } };
+      }
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      return {
+        status: 200 as const,
+        body: { share_mode: collection.share_mode, edit_policy: collection.edit_policy },
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.getShareSettings] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  setShareMode: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return { status: 403 as const, body: { error: 'Nur Eigentümer*in erlaubt' } };
+      }
+      await notebookHelper.updateNotebookCollection(args.params.id, {
+        share_mode: args.body.mode,
+      });
+      return {
+        status: 200 as const,
+        body: { success: true, message: 'Sichtbarkeit aktualisiert' },
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.setShareMode] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  setEditPolicy: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return { status: 403 as const, body: { error: 'Nur Eigentümer*in erlaubt' } };
+      }
+      await notebookHelper.updateNotebookCollection(args.params.id, {
+        edit_policy: args.body.policy,
+      });
+      return {
+        status: 200 as const,
+        body: { success: true, message: 'Bearbeitungsrechte aktualisiert' },
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.setEditPolicy] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  listGroupShares: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return { status: 403 as const, body: { error: 'Nur Eigentümer*in kann Freigaben sehen' } };
+      }
+      const postgres = getPostgresInstance();
+      const shares = (await postgres.query(
+        `SELECT gcs.group_id, g.name AS group_name, gcs.shared_at
+           FROM group_content_shares gcs
+           INNER JOIN groups g ON g.id = gcs.group_id
+           WHERE gcs.content_type = 'notebook_collections' AND gcs.content_id = $1
+           ORDER BY gcs.shared_at DESC`,
+        [args.params.id]
+      )) as GroupShareJoinRow[];
+      return {
+        status: 200 as const,
+        body: shares.map((s_) => ({
+          group_id: s_.group_id,
+          group_name: s_.group_name,
+          shared_at:
+            s_.shared_at instanceof Date ? s_.shared_at.toISOString() : String(s_.shared_at),
+        })),
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.listGroupShares] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  addGroupShare: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const { group_id } = args.body;
+      const notebookId = args.params.id;
+
+      const collection = await notebookHelper.getNotebookCollection(notebookId);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return {
+          status: 403 as const,
+          body: { error: 'Nur Eigentümer*in kann Gruppen hinzufügen' },
+        };
+      }
+
+      const postgres = getPostgresInstance();
+      const membership = (await postgres.query(
+        'SELECT user_id FROM group_memberships WHERE group_id = $1 AND user_id = $2',
+        [group_id, userId]
+      )) as MembershipRow[];
+      if (membership.length === 0) {
+        return {
+          status: 403 as const,
+          body: { error: 'Du musst Mitglied der Gruppe sein, um zu teilen' },
+        };
+      }
+
+      const existing = (await postgres.query(
+        `SELECT id FROM group_content_shares
+           WHERE content_type = 'notebook_collections' AND content_id = $1 AND group_id = $2`,
+        [notebookId, group_id]
+      )) as ExistingShareRow[];
+      if (existing.length > 0) {
+        return {
+          status: 409 as const,
+          body: { error: 'Notebook ist bereits mit dieser Gruppe geteilt' },
+        };
+      }
+
+      const permissions = { read: true, write: false };
+      await postgres.query(
+        `INSERT INTO group_content_shares
+            (content_type, content_id, group_id, shared_by_user_id, permissions)
+          VALUES ('notebook_collections', $1, $2, $3, $4)`,
+        [notebookId, group_id, userId, JSON.stringify(permissions)]
+      );
+
+      return {
+        status: 201 as const,
+        body: { success: true, message: 'Notebook mit Gruppe geteilt' },
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.addGroupShare] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  deleteGroupShare: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return {
+          status: 403 as const,
+          body: { error: 'Nur Eigentümer*in kann Freigaben entfernen' },
+        };
+      }
+      const postgres = getPostgresInstance();
+      const result = (await postgres.query(
+        `DELETE FROM group_content_shares
+           WHERE content_type = 'notebook_collections' AND content_id = $1 AND group_id = $2
+           RETURNING id`,
+        [args.params.id, args.params.groupId]
+      )) as ExistingShareRow[];
+      if (result.length === 0) {
+        return { status: 404 as const, body: { error: 'Freigabe nicht gefunden' } };
+      }
+      return { status: 200 as const, body: { success: true, message: 'Freigabe entfernt' } };
+    } catch (error) {
+      log.error('[notebookSharingContract.deleteGroupShare] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+});
+
+export function mountNotebookSharingContractRouter(app: Application): void {
+  createExpressEndpoints(notebookSharingContract, notebookSharingContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'notebookSharingContract'),
+  });
+}

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -10,17 +10,19 @@ import {
 } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
-import { HiArrowLeft } from 'react-icons/hi';
+import { HiArrowLeft, HiShare } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import PageContainer from '../../../components/common/PageContainer';
 import ErrorBoundary from '../../../components/ErrorBoundary';
+import { useAuthStore } from '../../../stores/authStore';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
+import { NotebookShareModal } from './NotebookShareModal';
 
 import type { NotebookCollection } from '../../../types/notebook';
 
@@ -33,9 +35,11 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
   const queryClient = useQueryClient();
   const params = useParams<{ id: string }>();
   const pollDocumentStatus = useDocumentsStore((s) => s.pollDocumentStatus);
+  const currentUserId = useAuthStore((s) => s.user?.id ?? null);
   const { query, createQACollection, updateQACollection, isCreating, isUpdating } =
     useNotebookCollections({ isActive: true });
   const [editingField, setEditingField] = useState<'name' | 'desc' | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
 
   const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
   const editingCollection = useMemo<NotebookCollection | null>(() => {
@@ -132,7 +136,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
   return (
     <ErrorBoundary>
       <PageContainer maxWidth="lg" noPadTop>
-        <div className="mb-md">
+        <div className="mb-md flex items-center justify-between gap-md">
           <Button
             variant="ghost"
             size="sm"
@@ -142,7 +146,28 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
             <HiArrowLeft size={14} />
             Meine Notebooks
           </Button>
+          {mode === 'edit' &&
+          editingCollection &&
+          currentUserId &&
+          editingCollection.user_id === currentUserId ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShareOpen(true)}
+              className="gap-xs"
+            >
+              <HiShare size={14} />
+              Teilen
+            </Button>
+          ) : null}
         </div>
+        {mode === 'edit' && editingCollection ? (
+          <NotebookShareModal
+            notebookId={editingCollection.id}
+            open={shareOpen}
+            onOpenChange={setShareOpen}
+          />
+        ) : null}
 
         {mode === 'edit' && editingCollection ? (
           <div className="mb-xl text-center">

--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -1,0 +1,221 @@
+/**
+ * Modal for managing notebook sharing: visibility (private/groups/authenticated),
+ * edit policy (owner_only/group_admins/all_members), and the set of groups the
+ * notebook is shared with.
+ *
+ * Owner-only: callers must gate by ownership before opening — the server still
+ * rejects non-owners with 403, but rendering the modal for them is bad UX.
+ */
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+} from '@gruenerator/ui';
+import { useMemo } from 'react';
+import { HiTrash } from 'react-icons/hi';
+
+import {
+  useAddNotebookGroupShare,
+  useMyGroupsForSharing,
+  useNotebookGroupShares,
+  useNotebookShareSettings,
+  useRemoveNotebookGroupShare,
+  useSetNotebookEditPolicy,
+  useSetNotebookShareMode,
+} from '../hooks/useNotebookSharing';
+
+import type { NotebookEditPolicy, NotebookShareMode } from '@gruenerator/contracts';
+
+interface NotebookShareModalProps {
+  notebookId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SHARE_MODE_LABELS: Record<NotebookShareMode, string> = {
+  private: 'Privat — nur ich',
+  groups: 'Mit Gruppen geteilt',
+  authenticated: 'Mit Anmeldung — alle eingeloggten Nutzer*innen',
+};
+
+const EDIT_POLICY_LABELS: Record<NotebookEditPolicy, string> = {
+  owner_only: 'Nur ich',
+  group_admins: 'Gruppen-Admins der geteilten Gruppen',
+  all_members: 'Alle Mitglieder der geteilten Gruppen',
+};
+
+export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookShareModalProps) {
+  const settingsQuery = useNotebookShareSettings(notebookId, open);
+  const groupSharesQuery = useNotebookGroupShares(notebookId, open);
+  const myGroupsQuery = useMyGroupsForSharing(open);
+
+  const setShareMode = useSetNotebookShareMode(notebookId);
+  const setEditPolicy = useSetNotebookEditPolicy(notebookId);
+  const addGroupShare = useAddNotebookGroupShare(notebookId);
+  const removeGroupShare = useRemoveNotebookGroupShare(notebookId);
+
+  const shareMode = settingsQuery.data?.share_mode ?? 'private';
+  const editPolicy = settingsQuery.data?.edit_policy ?? 'owner_only';
+
+  const sharedGroupIds = useMemo(
+    () => new Set((groupSharesQuery.data ?? []).map((g) => g.group_id)),
+    [groupSharesQuery.data]
+  );
+  const availableGroups = useMemo(
+    () => (myGroupsQuery.data ?? []).filter((g) => !sharedGroupIds.has(g.id)),
+    [myGroupsQuery.data, sharedGroupIds]
+  );
+
+  const editPolicyMeaningful = shareMode === 'groups';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Notebook teilen</DialogTitle>
+          <DialogDescription>
+            Lege fest, wer dieses Notebook sehen und bearbeiten darf.
+          </DialogDescription>
+        </DialogHeader>
+
+        {settingsQuery.isError ? (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            Keine Berechtigung, die Freigabe-Einstellungen zu verwalten.
+          </p>
+        ) : null}
+
+        {settingsQuery.isLoading ? (
+          <p className="text-sm text-grey-500">Wird geladen…</p>
+        ) : settingsQuery.data ? (
+          <div className="flex flex-col gap-md">
+            <div>
+              <p className="mb-xs text-sm font-semibold">Sichtbarkeit</p>
+              <Select
+                value={shareMode}
+                onValueChange={(v) => setShareMode.mutate(v as NotebookShareMode)}
+                disabled={setShareMode.isPending}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(SHARE_MODE_LABELS) as NotebookShareMode[]).map((m) => (
+                    <SelectItem key={m} value={m}>
+                      {SHARE_MODE_LABELS[m]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {shareMode === 'groups' ? (
+              <div>
+                <p className="mb-xs text-sm font-semibold">Gruppen</p>
+                {groupSharesQuery.data && groupSharesQuery.data.length > 0 ? (
+                  <ul className="mb-xs flex flex-col gap-xs">
+                    {groupSharesQuery.data.map((share) => (
+                      <li
+                        key={share.group_id}
+                        className="flex items-center justify-between rounded-md border border-grey-200 bg-background p-xs dark:border-grey-700"
+                      >
+                        <span className="truncate text-sm">{share.group_name}</span>
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => removeGroupShare.mutate(share.group_id)}
+                          disabled={removeGroupShare.isPending}
+                          aria-label={`${share.group_name} entfernen`}
+                        >
+                          <HiTrash size={14} />
+                        </Button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mb-xs text-xs text-grey-500">Noch keine Gruppen hinzugefügt.</p>
+                )}
+                {availableGroups.length > 0 ? (
+                  <Select
+                    value=""
+                    onValueChange={(v) => {
+                      if (v) addGroupShare.mutate(v);
+                    }}
+                    disabled={addGroupShare.isPending}
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Gruppe hinzufügen…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {availableGroups.map((g) => (
+                        <SelectItem key={g.id} value={g.id}>
+                          {g.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : myGroupsQuery.data && myGroupsQuery.data.length === 0 ? (
+                  <p className="text-xs text-grey-500">
+                    Du bist noch in keiner Gruppe. Tritt einer Gruppe bei, um Notebooks zu teilen.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <Separator />
+
+            <div>
+              <p className="mb-xs text-sm font-semibold">Wer darf bearbeiten?</p>
+              <Select
+                value={editPolicy}
+                onValueChange={(v) => setEditPolicy.mutate(v as NotebookEditPolicy)}
+                disabled={setEditPolicy.isPending || shareMode === 'private'}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(EDIT_POLICY_LABELS) as NotebookEditPolicy[]).map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {EDIT_POLICY_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {shareMode === 'private' ? (
+                <p className="mt-xs text-xs text-grey-500">
+                  Bei privaten Notebooks kann nur die Eigentümer*in bearbeiten.
+                </p>
+              ) : null}
+              {shareMode === 'authenticated' && editPolicy !== 'owner_only' ? (
+                <p className="mt-xs text-xs text-grey-500">
+                  Diese Option wirkt nur, wenn das Notebook zusätzlich mit Gruppen geteilt wird.
+                </p>
+              ) : null}
+              {editPolicyMeaningful && (groupSharesQuery.data?.length ?? 0) === 0 ? (
+                <p className="mt-xs text-xs text-grey-500">
+                  Füge oben Gruppen hinzu, damit Mitglieder bearbeiten können.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Schließen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
@@ -1,0 +1,152 @@
+/**
+ * React Query hooks for the notebook sharing endpoints.
+ *
+ * Wraps the typed ts-rest client (`notebookSharing` namespace) — the body
+ * shapes are inferred from the contract, so request payloads are checked
+ * at compile time and responses are status-narrowed.
+ */
+import {
+  type NotebookEditPolicy,
+  type NotebookShareMode,
+  type NotebookUserGroup,
+  type NotebookGroupShare,
+  type NotebookShareSettings,
+} from '@gruenerator/contracts';
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+const SHARE_SETTINGS_KEY = (id: string) => ['notebook', 'share', 'settings', id];
+const GROUP_SHARES_KEY = (id: string) => ['notebook', 'share', 'groups', id];
+const MY_GROUPS_KEY = ['notebook', 'share', 'my-groups'];
+
+export function useNotebookShareSettings(notebookId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: notebookId ? SHARE_SETTINGS_KEY(notebookId) : ['notebook', 'share', 'settings', '_'],
+    enabled: enabled && !!notebookId,
+    retry: false,
+    queryFn: async (): Promise<NotebookShareSettings> => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.getShareSettings({
+        params: { id: notebookId as string },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to fetch share settings (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+  });
+}
+
+export function useNotebookGroupShares(notebookId: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: notebookId ? GROUP_SHARES_KEY(notebookId) : ['notebook', 'share', 'groups', '_'],
+    enabled: enabled && !!notebookId,
+    retry: false,
+    queryFn: async (): Promise<NotebookGroupShare[]> => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.listGroupShares({
+        params: { id: notebookId as string },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to fetch group shares (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+  });
+}
+
+export function useMyGroupsForSharing(enabled: boolean) {
+  return useQuery({
+    queryKey: MY_GROUPS_KEY,
+    enabled,
+    retry: false,
+    queryFn: async (): Promise<NotebookUserGroup[]> => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.listMyGroups({});
+      if (result.status !== 200) {
+        throw new Error(`Failed to fetch user groups (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+  });
+}
+
+export function useSetNotebookShareMode(notebookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (mode: NotebookShareMode) => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.setShareMode({
+        params: { id: notebookId },
+        body: { mode },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to set share mode (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
+      void qc.invalidateQueries({ queryKey: ['notebookCollections'] });
+    },
+  });
+}
+
+export function useSetNotebookEditPolicy(notebookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (policy: NotebookEditPolicy) => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.setEditPolicy({
+        params: { id: notebookId },
+        body: { policy },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to set edit policy (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
+    },
+  });
+}
+
+export function useAddNotebookGroupShare(notebookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.addGroupShare({
+        params: { id: notebookId },
+        body: { group_id: groupId },
+      });
+      if (result.status !== 201) {
+        throw new Error(`Failed to add group share (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: GROUP_SHARES_KEY(notebookId) });
+    },
+  });
+}
+
+export function useRemoveNotebookGroupShare(notebookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.deleteGroupShare({
+        params: { id: notebookId, groupId },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to remove group share (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: GROUP_SHARES_KEY(notebookId) });
+    },
+  });
+}

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -23,6 +23,10 @@ export interface WolkeShareLink {
  */
 export type NotebookPublicOwnership = 'owner' | 'public_data';
 
+export type NotebookShareMode = 'private' | 'groups' | 'authenticated';
+export type NotebookEditPolicy = 'owner_only' | 'group_admins' | 'all_members';
+export type NotebookAccessSource = 'owned' | 'shared' | 'authenticated';
+
 /**
  * Base notebook collection type representing a Q&A collection
  */
@@ -48,6 +52,9 @@ export interface NotebookCollection {
   labels?: string[];
   wolke_folders?: WolkeFolderRef[];
   likes_count?: number;
+  share_mode?: NotebookShareMode | null;
+  edit_policy?: NotebookEditPolicy | null;
+  access_source?: NotebookAccessSource | null;
 }
 
 /**

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -12,6 +12,7 @@ export { sharesContract } from './sharesContract.js';
 export { userProfileContract } from './userProfileContract.js';
 export { notebookContract } from './notebookContract.js';
 export { notebookCollectionsContract } from './notebookCollectionsContract.js';
+export { notebookSharingContract } from './notebookSharingContract.js';
 export { docsContract } from './docsContract.js';
 export { documentsContract } from './documentsContract.js';
 export { subtitlerContract } from './subtitlerContract.js';

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -19,7 +19,6 @@ import {
   syncCollectionResponseSchema,
   searchResultItemSchema,
   simpleSuccessMessageSchema,
-  shareCollectionResponseSchema,
   bulkDeleteResponseSchema,
   likeCollectionResponseSchema,
   unlikeCollectionResponseSchema,
@@ -155,42 +154,6 @@ export const notebookCollectionsContract = c.router(
         500: notebookErrorResponseSchema,
       },
       summary: 'Delete a notebook collection',
-    },
-
-    /**
-     * POST /api/auth/notebook-collections/:id/share
-     * Generate a public sharing link for a notebook collection.
-     */
-    shareCollection: {
-      method: 'POST',
-      path: '/api/auth/notebook-collections/:id/share',
-      pathParams: z.object({ id: z.string() }),
-      body: c.noBody(),
-      responses: {
-        200: shareCollectionResponseSchema,
-        401: notebookErrorResponseSchema,
-        404: notebookErrorResponseSchema,
-        500: notebookErrorResponseSchema,
-      },
-      summary: 'Generate a public sharing link for a notebook collection',
-    },
-
-    /**
-     * DELETE /api/auth/notebook-collections/:id/share
-     * Revoke public access to a notebook collection.
-     */
-    revokeShare: {
-      method: 'DELETE',
-      path: '/api/auth/notebook-collections/:id/share',
-      pathParams: z.object({ id: z.string() }),
-      body: c.noBody(),
-      responses: {
-        200: simpleSuccessMessageSchema,
-        401: notebookErrorResponseSchema,
-        404: notebookErrorResponseSchema,
-        500: notebookErrorResponseSchema,
-      },
-      summary: 'Revoke public access to a notebook collection',
     },
 
     /**

--- a/packages/contracts/src/contracts/notebookSharingContract.ts
+++ b/packages/contracts/src/contracts/notebookSharingContract.ts
@@ -1,0 +1,165 @@
+/**
+ * ts-rest contract for notebook sharing endpoints.
+ *
+ * Why a separate contract from notebookCollectionsContract:
+ *   - keeps the CRUD contract stable and tight,
+ *   - lets the docs share UI's reusable GroupShareSection point at this contract
+ *     with a different urlPrefix without dragging notebook CRUD types along.
+ *
+ * Path shape matches the CRUD contract: `/api/auth/notebook-collections/:id/...`.
+ *
+ * `GET /api/auth/groups/me` is the neutral "my groups" endpoint that both the
+ * docs and notebook share UIs can call (replacing `/api/docs/groups/me` over
+ * time).
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { notebookErrorResponseSchema } from '../schemas/notebook.js';
+import {
+  notebookAddGroupShareBodySchema,
+  notebookEditPolicyBodySchema,
+  notebookGroupSharesResponseSchema,
+  notebookShareErrorResponseSchema,
+  notebookShareModeBodySchema,
+  notebookShareSettingsSchema,
+  notebookSimpleSuccessSchema,
+  notebookUserGroupsResponseSchema,
+} from '../schemas/notebookSharing.js';
+
+const c = initContract();
+
+export const notebookSharingContract = c.router(
+  {
+    /**
+     * GET /api/auth/groups/me
+     * List the groups the authenticated user belongs to. Used by share dialogs
+     * (docs + notebooks) to populate the "add a group" dropdown.
+     */
+    listMyGroups: {
+      method: 'GET',
+      path: '/api/auth/groups/me',
+      responses: {
+        200: notebookUserGroupsResponseSchema,
+        401: notebookShareErrorResponseSchema,
+        500: notebookShareErrorResponseSchema,
+      },
+      summary: 'List groups the authenticated user belongs to',
+    },
+
+    /**
+     * GET /api/auth/notebook-collections/:id/share
+     * Read current share settings (share_mode + edit_policy).
+     */
+    getShareSettings: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/:id/share',
+      pathParams: z.object({ id: z.string() }),
+      responses: {
+        200: notebookShareSettingsSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Get share settings for a notebook collection',
+    },
+
+    /**
+     * PUT /api/auth/notebook-collections/:id/share/mode
+     * Update share_mode (private | groups | authenticated). Owner only.
+     */
+    setShareMode: {
+      method: 'PUT',
+      path: '/api/auth/notebook-collections/:id/share/mode',
+      pathParams: z.object({ id: z.string() }),
+      body: notebookShareModeBodySchema,
+      responses: {
+        200: notebookSimpleSuccessSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Set notebook share mode',
+    },
+
+    /**
+     * PUT /api/auth/notebook-collections/:id/share/edit-policy
+     * Update edit_policy (owner_only | group_admins | all_members). Owner only.
+     */
+    setEditPolicy: {
+      method: 'PUT',
+      path: '/api/auth/notebook-collections/:id/share/edit-policy',
+      pathParams: z.object({ id: z.string() }),
+      body: notebookEditPolicyBodySchema,
+      responses: {
+        200: notebookSimpleSuccessSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Set notebook edit policy',
+    },
+
+    /**
+     * GET /api/auth/notebook-collections/:id/groups
+     * List the groups this notebook is shared with. Owner only.
+     */
+    listGroupShares: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/:id/groups',
+      pathParams: z.object({ id: z.string() }),
+      responses: {
+        200: notebookGroupSharesResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'List groups a notebook is shared with',
+    },
+
+    /**
+     * POST /api/auth/notebook-collections/:id/groups
+     * Share a notebook with a group. Owner only; caller must be member of
+     * the group.
+     */
+    addGroupShare: {
+      method: 'POST',
+      path: '/api/auth/notebook-collections/:id/groups',
+      pathParams: z.object({ id: z.string() }),
+      body: notebookAddGroupShareBodySchema,
+      responses: {
+        201: notebookSimpleSuccessSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        409: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Share a notebook with a group',
+    },
+
+    /**
+     * DELETE /api/auth/notebook-collections/:id/groups/:groupId
+     * Stop sharing a notebook with a group. Owner only.
+     */
+    deleteGroupShare: {
+      method: 'DELETE',
+      path: '/api/auth/notebook-collections/:id/groups/:groupId',
+      pathParams: z.object({ id: z.string(), groupId: z.string() }),
+      body: c.noBody(),
+      responses: {
+        200: notebookSimpleSuccessSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Unshare a notebook from a group',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,6 +28,7 @@ export {
   userProfileContract,
   notebookContract,
   notebookCollectionsContract,
+  notebookSharingContract,
   docsContract,
   documentsContract,
   subtitlerContract,
@@ -57,6 +58,7 @@ export * from './schemas/shares.js';
 export * from './schemas/userProfile.js';
 export * from './schemas/notebook.js';
 export * from './schemas/notebookCollections.js';
+export * from './schemas/notebookSharing.js';
 export * from './schemas/docs.js';
 export * from './schemas/documents.js';
 export * from './schemas/subtitler.js';

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -13,6 +13,19 @@ import { z } from 'zod';
 export const publicOwnershipSchema = z.enum(['owner', 'public_data']);
 export type PublicOwnership = z.infer<typeof publicOwnershipSchema>;
 
+export const notebookShareModeSchema = z.enum(['private', 'groups', 'authenticated']);
+export type NotebookShareMode = z.infer<typeof notebookShareModeSchema>;
+
+export const notebookEditPolicySchema = z.enum(['owner_only', 'group_admins', 'all_members']);
+export type NotebookEditPolicy = z.infer<typeof notebookEditPolicySchema>;
+
+/**
+ * Tag every notebook in a list response with how the calling user can reach it.
+ * Lets the UI render a "Mit dir geteilt" section without re-querying access.
+ */
+export const notebookAccessSourceSchema = z.enum(['owned', 'shared', 'authenticated']);
+export type NotebookAccessSource = z.infer<typeof notebookAccessSourceSchema>;
+
 /**
  * Experimental: Wolke folder attached to a notebook.
  *
@@ -138,6 +151,9 @@ export const transformedCollectionSchema = z.object({
   public_ownership: publicOwnershipSchema.nullable().optional(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
   likes_count: z.number().nullish(),
+  share_mode: notebookShareModeSchema.nullish(),
+  edit_policy: notebookEditPolicySchema.nullish(),
+  access_source: notebookAccessSourceSchema.nullish(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────
@@ -199,13 +215,6 @@ export const searchResultItemSchema = z.object({
 
 export const simpleSuccessMessageSchema = z.object({
   success: z.boolean(),
-  message: z.string(),
-});
-
-export const shareCollectionResponseSchema = z.object({
-  success: z.boolean(),
-  public_url: z.string(),
-  access_token: z.string(),
   message: z.string(),
 });
 

--- a/packages/contracts/src/schemas/notebookSharing.ts
+++ b/packages/contracts/src/schemas/notebookSharing.ts
@@ -1,0 +1,64 @@
+/**
+ * Zod schemas for notebook-collection sharing endpoints.
+ *
+ * The notebook share model has two independent axes:
+ *   - share_mode    : who can READ the notebook (private | groups | authenticated)
+ *   - edit_policy   : who can WRITE non-visibility content (owner_only | group_admins | all_members)
+ * Group shares live in the polymorphic `group_content_shares` table with
+ * `content_type='notebook_collections'`. There is no per-user grant for notebooks.
+ */
+import { z } from 'zod';
+
+import { notebookEditPolicySchema, notebookShareModeSchema } from './notebookCollections.js';
+
+// ── Settings shape ──────────────────────────────────────────────────────────
+
+export const notebookShareSettingsSchema = z.object({
+  share_mode: notebookShareModeSchema,
+  edit_policy: notebookEditPolicySchema,
+});
+export type NotebookShareSettings = z.infer<typeof notebookShareSettingsSchema>;
+
+// ── Request bodies ──────────────────────────────────────────────────────────
+
+export const notebookShareModeBodySchema = z.object({
+  mode: notebookShareModeSchema,
+});
+
+export const notebookEditPolicyBodySchema = z.object({
+  policy: notebookEditPolicySchema,
+});
+
+export const notebookAddGroupShareBodySchema = z.object({
+  group_id: z.string(),
+});
+
+// ── Response shapes ─────────────────────────────────────────────────────────
+
+export const notebookGroupShareSchema = z.object({
+  group_id: z.string(),
+  group_name: z.string(),
+  shared_at: z.string(),
+});
+export type NotebookGroupShare = z.infer<typeof notebookGroupShareSchema>;
+
+export const notebookGroupSharesResponseSchema = z.array(notebookGroupShareSchema);
+
+export const notebookUserGroupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  role: z.string(),
+});
+export type NotebookUserGroup = z.infer<typeof notebookUserGroupSchema>;
+
+export const notebookUserGroupsResponseSchema = z.array(notebookUserGroupSchema);
+
+export const notebookSimpleSuccessSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+});
+
+export const notebookShareErrorResponseSchema = z.object({
+  error: z.string(),
+  details: z.string().optional(),
+});

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -24,6 +24,7 @@ import {
   boardsContract,
   notebookContract,
   notebookCollectionsContract,
+  notebookSharingContract,
   wordpressContract,
   transferContract,
   notificationsContract,
@@ -133,6 +134,7 @@ const _searchClient = () => initClient(searchContract, CLIENT_OPTS);
 const _boardsClient = () => initClient(boardsContract, CLIENT_OPTS);
 const _notebookClient = () => initClient(notebookContract, CLIENT_OPTS);
 const _notebookCollectionsClient = () => initClient(notebookCollectionsContract, CLIENT_OPTS);
+const _notebookSharingClient = () => initClient(notebookSharingContract, CLIENT_OPTS);
 const _wordpressClient = () => initClient(wordpressContract, CLIENT_OPTS);
 const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
 const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS);
@@ -150,6 +152,7 @@ export interface ContractsClient {
   boards: ReturnType<typeof _boardsClient>;
   notebook: ReturnType<typeof _notebookClient>;
   notebookCollections: ReturnType<typeof _notebookCollectionsClient>;
+  notebookSharing: ReturnType<typeof _notebookSharingClient>;
   wordpress: ReturnType<typeof _wordpressClient>;
   transfer: ReturnType<typeof _transferClient>;
   notifications: ReturnType<typeof _notificationsClient>;
@@ -184,6 +187,7 @@ export function getContractsClient(): ContractsClient {
     boards: _boardsClient(),
     notebook: _notebookClient(),
     notebookCollections: _notebookCollectionsClient(),
+    notebookSharing: _notebookSharingClient(),
     wordpress: _wordpressClient(),
     transfer: _transferClient(),
     notifications: _notificationsClient(),


### PR DESCRIPTION
## Summary

Replaces the binary owner-vs-anonymous-token notebook sharing with three mutually-exclusive visibility modes and an independent edit-policy axis, both wired through the existing groups system.

- **Visibility** (`share_mode`): `private` | `groups` | `authenticated` — no public option per scope decision.
- **Edit policy** (`edit_policy`): `owner_only` | `group_admins` | `all_members` — gates everything a non-owner could do, including adding/removing documents.
- **Group plumbing reuses** the polymorphic `group_content_shares` table with `content_type='notebook_collections'` (already accepted from the group side by `AddContentToGroupModal`). No new join table.
- **Token public access dropped**: the dormant Postgres `notebook_public_access` table is dropped; `shareCollection`/`revokeShare` contract endpoints + helper methods are removed. Anonymous `/notebook/public/:token` viewing of pre-existing Qdrant tokens still resolves so in-flight links keep working until a follow-up cleanup.

The notebook detail page now shows a Teilen button for the owner, opening a modal to manage visibility, edit policy, and the set of shared groups. The list endpoint tags each notebook with `access_source` (`owned` | `shared` | `authenticated`) so the UI can surface the "shared with me" distinction.

Why an architectural pivot from the original plan: the Drizzle `notebook_collections` Postgres table is dead code — `grep` returned zero queries against it. Live data lives in the Qdrant notebook_collections payload, so `share_mode`/`edit_policy` are added there (with safe-default normalizers for older payloads). This avoids dead-code-adjacent columns and keeps the migration to one DROP.

Closes the plan in [docs-can-be-made-majestic-pillow.md](https://github.com/netzbegruenung/Gruenerator/blob/master/.) (local plan file).

## Test plan
- [ ] User A creates a notebook, opens Teilen → switches to `groups`, adds Group X. User B (member of X) sees the notebook in the list with `access_source='shared'`.
- [ ] With `edit_policy=owner_only`, User B cannot add documents. Switching to `all_members` enables it; switching to `group_admins` enables it only for admins.
- [ ] User C (logged-in, no shared group) sees the notebook only when `share_mode='authenticated'`.
- [ ] Pre-existing public token links `/notebook/public/:token` still resolve via the read path.
- [ ] Owner-only operations (delete, change share settings) reject non-owners with 403.
- [ ] Migration runs cleanly on a fresh `pnpm dev:backend` (Postgres `notebook_public_access` table drops).