### PR TITLE
feat(notebooks): groups sharing + notion-style slug URLs

### DIFF
--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -5,6 +5,7 @@
 
 import * as crypto from 'crypto';
 
+import { generateSlugSuffix } from '@gruenerator/shared/utils';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getSystemCollectionConfig } from '../../config/systemCollectionsConfig.js';
@@ -66,6 +67,16 @@ interface NotebookCollectionData {
   public_ownership?: PublicOwnership | null;
   share_mode?: NotebookShareMode;
   edit_policy?: NotebookEditPolicy;
+  /**
+   * 6-char URL-safe tail used in Notion-style slugs (`my-notes-Ab3xK9`).
+   * Assigned at creation, immutable afterwards — rename rewrites the name
+   * prefix but never the suffix, so shared URLs survive renames. `null` only
+   * appears for legacy rows in the transient window before the boot-time
+   * backfill (apps/api/services/migrations/backfillNotebookSlugSuffixes.ts)
+   * has run; if such a row is edited before backfill, storeNotebookCollection
+   * mints a fresh suffix.
+   */
+  slug_suffix?: string | null;
 }
 
 interface NotebookCollection {
@@ -88,6 +99,7 @@ interface NotebookCollection {
   public_ownership: PublicOwnership | null;
   share_mode: NotebookShareMode;
   edit_policy: NotebookEditPolicy;
+  slug_suffix: string | null;
   notebook_collection_documents?: CollectionDocument[];
 }
 
@@ -206,6 +218,12 @@ class NotebookQdrantHelper {
         collectionData.custom_prompt || ''
       );
 
+      // Slug suffix: keep an existing one if provided (preserves stability on
+      // rename), otherwise mint a fresh collision-free 6-char tail. The chance
+      // of a real collision at 56^6 ≈ 30 billion is negligible, but probing
+      // once is cheap and matches the share_token uniqueness pattern.
+      const slugSuffix = collectionData.slug_suffix ?? (await this.allocateFreshSlugSuffix());
+
       const point: QdrantPoint = {
         id: this.generateNumericId(collectionId),
         vector: embedding,
@@ -229,6 +247,7 @@ class NotebookQdrantHelper {
           public_ownership: collectionData.public_ownership ?? null,
           share_mode: normalizeShareMode(collectionData.share_mode),
           edit_policy: normalizeEditPolicy(collectionData.edit_policy),
+          slug_suffix: slugSuffix,
         },
       };
 
@@ -240,6 +259,97 @@ class NotebookQdrantHelper {
       const message = error instanceof Error ? error.message : String(error);
       logger.error(`Error storing Notebook collection: ${message}`);
       throw new Error(`Failed to store Notebook collection: ${message}`);
+    }
+  }
+
+  /**
+   * Mint a slug suffix that isn't already claimed by another notebook.
+   * Retries up to 5 times — at 56^6 the loop almost never iterates twice.
+   */
+  private async allocateFreshSlugSuffix(): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = generateSlugSuffix();
+      const existing = await this.getNotebookCollectionBySlugSuffix(candidate);
+      if (!existing) return candidate;
+    }
+    // Statistically unreachable, but better than a silent dup.
+    throw new Error('Failed to allocate unique slug suffix after 5 attempts');
+  }
+
+  /**
+   * One-shot backfill: scan every notebook point and assign a fresh
+   * `slug_suffix` to anything missing one. Idempotent — re-running after a
+   * successful backfill is a no-op because matching points have a suffix.
+   *
+   * Reads payloads directly (instead of going through the public update path)
+   * to avoid re-embedding 5k notebooks. Suffixes are uniqueness-checked via
+   * the same allocateFreshSlugSuffix helper used at create time.
+   */
+  async backfillSlugSuffixes(): Promise<{ scanned: number; updated: number }> {
+    await this.ensureInitialized();
+
+    let scanned = 0;
+    let updated = 0;
+
+    // Single scroll with a large limit — notebook counts are O(thousands) per
+    // tenant, so a windowed scroll isn't needed yet. If the dataset grows
+    // beyond ~100k rows, switch to a paged scroll via the raw Qdrant client.
+    const allResults = await this.qdrantOps!.scrollDocuments(
+      this.qdrant.collections.notebook_collections,
+      {},
+      { limit: 100_000, withPayload: true }
+    );
+
+    for (const point of allResults) {
+      scanned++;
+      const existingSuffix = point.payload.slug_suffix;
+      if (typeof existingSuffix === 'string' && existingSuffix.length > 0) continue;
+
+      const fresh = await this.allocateFreshSlugSuffix();
+      // Patch only the slug_suffix field via Qdrant's set_payload — leaves
+      // the existing semantic embedding intact. A batchUpsert here would
+      // require re-supplying the vector and silently overwrite each
+      // notebook's embedding with zeros.
+      await this.qdrantOps!.client.setPayload(this.qdrant.collections.notebook_collections, {
+        payload: { slug_suffix: fresh },
+        points: [point.id],
+      });
+      updated++;
+
+      if (updated > 0 && updated % 50 === 0) {
+        logger.info(`[backfillSlugSuffixes] Progress: ${updated} slugs assigned`);
+      }
+    }
+
+    logger.info(`[backfillSlugSuffixes] Done. scanned=${scanned} updated=${updated}`);
+    return { scanned, updated };
+  }
+
+  /**
+   * Resolve a notebook by its Notion-style slug tail (the 6-char suffix
+   * after the last `-` in URLs like `/notebooks/my-research-Ab3xK9`).
+   * Returns null when no notebook has that suffix.
+   */
+  async getNotebookCollectionBySlugSuffix(slugSuffix: string): Promise<NotebookCollection | null> {
+    await this.ensureInitialized();
+
+    try {
+      const filter: QdrantFilter = {
+        must: [{ key: 'slug_suffix', match: { value: slugSuffix } }],
+      };
+
+      const results = await this.qdrantOps!.scrollDocuments(
+        this.qdrant.collections.notebook_collections,
+        filter,
+        { limit: 1, withPayload: true }
+      );
+
+      if (results.length === 0) return null;
+      return this.formatCollectionFromPayload(results[0].payload);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error getting Notebook collection by slug suffix: ${message}`);
+      return null;
     }
   }
 
@@ -607,6 +717,10 @@ class NotebookQdrantHelper {
       public_ownership: publicOwnership,
       share_mode: normalizeShareMode(payload.share_mode),
       edit_policy: normalizeEditPolicy(payload.edit_policy),
+      slug_suffix:
+        typeof payload.slug_suffix === 'string' && payload.slug_suffix.length > 0
+          ? payload.slug_suffix
+          : null,
     };
   }
 

--- a/apps/api/database/services/PostgresService/PostgresService.ts
+++ b/apps/api/database/services/PostgresService/PostgresService.ts
@@ -93,6 +93,22 @@ export class PostgresService {
         );
       }
 
+      // Run idempotent data backfills that touch Qdrant payloads (not SQL).
+      // Dynamic import so the migrations module isn't required for tests that
+      // construct PostgresService without notebook infra. Failures inside the
+      // backfill itself are swallowed by the runner — only an import error
+      // would propagate here.
+      try {
+        const { backfillNotebookSlugSuffixes } =
+          await import('../../../services/migrations/backfillNotebookSlugSuffixes.js');
+        await backfillNotebookSlugSuffixes();
+      } catch (error) {
+        console.warn(
+          '[PostgresService] ⚠️ Notebook slug backfill skipped:',
+          (error as Error).message
+        );
+      }
+
       // Auto-sync schema columns (non-critical — log internally)
       let schemaOk = true;
       try {

--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -158,6 +158,7 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
           remove_missing_on_sync: !!collection.remove_missing_on_sync,
           labels,
           wolke_folders,
+          slug_suffix: collection.slug_suffix ?? null,
         };
       })
     );
@@ -263,6 +264,11 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
 
     const result = await notebookHelper.storeNotebookCollection(collectionData);
     const collectionId = result.collection_id;
+    // storeNotebookCollection minted (or preserved) the slug suffix; refetch to
+    // surface it back to the client so the UI can navigate straight to the
+    // pretty URL instead of falling back to the UUID path.
+    const persisted = await notebookHelper.getNotebookCollection(collectionId);
+    const slugSuffix = persisted?.slug_suffix ?? null;
 
     try {
       await notebookHelper.addDocumentsToCollection(collectionId, allDocumentIds, userId);
@@ -305,6 +311,7 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
         documents_from_wolke: selection_mode === 'wolke' ? wolkeDocuments.length : 0,
         wolke_share_links: selection_mode === 'wolke' ? wolke_share_link_ids : [],
         created_at: new Date().toISOString(),
+        slug_suffix: slugSuffix,
       },
       message: `Notebook collection created successfully with ${allDocumentIds.length} document(s)`,
     });

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -16,6 +16,7 @@
  */
 
 import { notebookCollectionsContract, type WolkeFolderRef } from '@gruenerator/contracts';
+import { extractSlugSuffix } from '@gruenerator/shared/utils';
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
@@ -113,7 +114,61 @@ async function validateWolkeShareLinks(
 
 const s = initServer();
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export const notebookCollectionsContractRouter = s.router(notebookCollectionsContract, {
+  resolveCollection: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const input = args.params.slugOrId;
+
+      // UUID branch: legacy URL or direct ID — look up by canonical id.
+      // Slug branch: pretty URL, dig the 6-char tail out and resolve via the
+      // payload index. If neither matches, the user typed a system-notebook
+      // slug or pure noise; let the frontend resolver handle the not-found UI.
+      let collectionId: string | null = null;
+      if (UUID_RE.test(input)) {
+        collectionId = input;
+      } else {
+        const suffix = extractSlugSuffix(input);
+        if (suffix) {
+          const bySlug = await notebookHelper.getNotebookCollectionBySlugSuffix(suffix);
+          collectionId = bySlug?.id ?? null;
+        }
+      }
+
+      if (!collectionId) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+
+      const access = await checkNotebookAccess(collectionId, userId);
+      if (!access.exists) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (!access.canRead) {
+        return { status: 403 as const, body: { error: 'Keine Berechtigung' } };
+      }
+
+      const collection = await notebookHelper.getNotebookCollection(collectionId);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+
+      return {
+        status: 200 as const,
+        body: {
+          id: collection.id,
+          slug_suffix: collection.slug_suffix ?? '',
+          name: collection.name,
+          share_mode: collection.share_mode ?? null,
+        },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.resolveCollection] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
   listCollections: async (args) => {
     try {
       const userId = getUserId(args.req);

--- a/apps/api/routes/notebook/types.ts
+++ b/apps/api/routes/notebook/types.ts
@@ -108,6 +108,7 @@ export interface TransformedCollection {
   notebook_collection_documents?: Array<{ document_id: string }>;
   labels?: string[];
   wolke_folders?: WolkeFolderRef[];
+  slug_suffix?: string | null;
 }
 
 /**
@@ -134,6 +135,7 @@ export interface CollectionCreateResponse {
     documents_from_wolke: number;
     wolke_share_links: string[];
     created_at: string;
+    slug_suffix?: string | null;
   };
   message: string;
 }
@@ -233,6 +235,7 @@ export interface NotebookCollectionFromQdrant {
   updated_at: string;
   settings?: Record<string, unknown> | undefined;
   notebook_collection_documents?: Array<{ document_id: string }>;
+  slug_suffix?: string | null;
 }
 
 /**

--- a/apps/api/services/migrations/backfillNotebookSlugSuffixes.ts
+++ b/apps/api/services/migrations/backfillNotebookSlugSuffixes.ts
@@ -1,0 +1,62 @@
+/**
+ * Boot-time backfill: assign Notion-style slug suffixes to every notebook
+ * that predates the slug feature. Idempotent via a marker row in the
+ * existing `schema_migrations` table — once the marker is present, future
+ * boots short-circuit immediately.
+ *
+ * Runs after PostgresService init finishes its SQL migrations.
+ */
+
+import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('backfillNotebookSlugSuffixes');
+
+const MARKER = '__node_notebook_slug_backfill_v1';
+
+/**
+ * Run the backfill if it hasn't been recorded yet. Failures are swallowed
+ * with a warning — the slug column is non-critical (UUID URLs still work)
+ * and we don't want to block API startup on a Qdrant hiccup.
+ */
+export async function backfillNotebookSlugSuffixes(): Promise<void> {
+  const postgres = getPostgresInstance();
+
+  try {
+    const alreadyRun = await postgres.query<{ filename: string }>(
+      'SELECT filename FROM schema_migrations WHERE filename = $1 LIMIT 1',
+      [MARKER]
+    );
+    if (alreadyRun.length > 0) {
+      log.debug('[backfillNotebookSlugSuffixes] Marker present, skipping');
+      return;
+    }
+  } catch (error) {
+    log.warn(
+      '[backfillNotebookSlugSuffixes] Could not read schema_migrations — skipping:',
+      (error as Error).message
+    );
+    return;
+  }
+
+  log.info('[backfillNotebookSlugSuffixes] Marker absent, running backfill');
+  try {
+    const helper = new NotebookQdrantHelper();
+    const result = await helper.backfillSlugSuffixes();
+    log.info(
+      `[backfillNotebookSlugSuffixes] Completed: scanned=${result.scanned} updated=${result.updated}`
+    );
+
+    await postgres.query(
+      'INSERT INTO schema_migrations (filename) VALUES ($1) ON CONFLICT (filename) DO NOTHING',
+      [MARKER]
+    );
+    log.info('[backfillNotebookSlugSuffixes] Marker recorded');
+  } catch (error) {
+    log.warn(
+      '[backfillNotebookSlugSuffixes] Backfill failed (non-critical, will retry on next boot):',
+      (error as Error).message
+    );
+  }
+}

--- a/apps/web/src/features/notebook/components/NotebookResolver.tsx
+++ b/apps/web/src/features/notebook/components/NotebookResolver.tsx
@@ -1,7 +1,9 @@
+import { extractSlugSuffix } from '@gruenerator/shared/utils';
 import { useParams } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
 import { getNotebookConfigBySlug } from '../config/notebookPagesConfig';
+import { useNotebookResolver } from '../hooks/useNotebookResolver';
 
 import { DynamicNotebookPage, NotebookPageContent } from './NotebookPage';
 
@@ -9,6 +11,20 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 function NotebookResolverPage() {
   const { idOrSlug } = useParams<{ idOrSlug: string }>();
+
+  // System-notebook lookup runs synchronously off a hardcoded config — covers
+  // `/notebooks/bayern`, `/notebooks/grundsatz`, etc. with zero latency.
+  const slugConfig = idOrSlug ? getNotebookConfigBySlug(idOrSlug) : null;
+  const isUuid = !!idOrSlug && UUID_RE.test(idOrSlug);
+  const hasSlugSuffix = !!idOrSlug && extractSlugSuffix(idOrSlug) !== null;
+
+  // Only hit the backend resolver for inputs that look like a user-notebook
+  // slug AND aren't already a known system slug or a raw UUID. Anything else
+  // is either handled locally or genuinely unknown.
+  const resolverQuery = useNotebookResolver(
+    idOrSlug ?? '',
+    !!idOrSlug && !slugConfig && !isUuid && hasSlugSuffix
+  );
 
   if (!idOrSlug) {
     return (
@@ -18,13 +34,25 @@ function NotebookResolverPage() {
     );
   }
 
-  const slugConfig = getNotebookConfigBySlug(idOrSlug);
   if (slugConfig) {
     return <NotebookPageContent config={slugConfig} />;
   }
 
-  if (UUID_RE.test(idOrSlug)) {
+  if (isUuid) {
     return <DynamicNotebookPage id={idOrSlug} />;
+  }
+
+  if (hasSlugSuffix) {
+    if (resolverQuery.isPending) {
+      return (
+        <div className="flex flex-1 items-center justify-center p-md text-foreground-muted">
+          <p>Notebook wird geladen…</p>
+        </div>
+      );
+    }
+    if (resolverQuery.data) {
+      return <DynamicNotebookPage id={resolverQuery.data.id} />;
+    }
   }
 
   return (

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -1,3 +1,4 @@
+import { buildNotebookSlug } from '@gruenerator/shared/utils';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -378,18 +379,33 @@ function NotebooksIndexFooter() {
     void navigate('/notebooks/neu');
   }, [navigate]);
 
+  // Resolve a collectionId to the Notion-style URL fragment when the row has
+  // a slug_suffix, falling back to the raw UUID for legacy pre-backfill rows.
+  // The bearbeiten/view routes both accept either form via NotebookResolver,
+  // so a fallback simply gives a less-pretty URL — never a 404.
+  const buildSlugFragment = useCallback(
+    (collectionId: string): string => {
+      const c = qaCollections.find((x) => x.id === collectionId);
+      if (c?.slug_suffix) return buildNotebookSlug(c.name, c.slug_suffix);
+      return collectionId;
+    },
+    [qaCollections]
+  );
+
   const handleEdit = useCallback(
     (collectionId: string) => {
-      void navigate(`/notebooks/${collectionId}/bearbeiten`);
+      void navigate(`/notebooks/${buildSlugFragment(collectionId)}/bearbeiten`);
     },
-    [navigate]
+    [navigate, buildSlugFragment]
   );
 
   const handleView = useCallback(
     (collectionId: string) => {
-      void navigate(`/notebook/${collectionId}`, { state: { freshConversation: true } });
+      void navigate(`/notebooks/${buildSlugFragment(collectionId)}`, {
+        state: { freshConversation: true },
+      });
     },
-    [navigate]
+    [navigate, buildSlugFragment]
   );
 
   const handleDelete = useCallback(
@@ -401,12 +417,18 @@ function NotebooksIndexFooter() {
 
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
-  const handleShare = useCallback((collectionId: string) => {
-    const url = `${window.location.origin}/notebook/${collectionId}`;
-    void navigator.clipboard.writeText(url);
-    setCopiedId(collectionId);
-    setTimeout(() => setCopiedId(null), 2000);
-  }, []);
+  const handleShare = useCallback(
+    (collectionId: string) => {
+      // Canonical URL: plural `/notebooks/...` with the Notion-style slug. The
+      // legacy singular `/notebook/:id` route still redirects, but copying the
+      // canonical form means the redirect never fires for share recipients.
+      const url = `${window.location.origin}/notebooks/${buildSlugFragment(collectionId)}`;
+      void navigator.clipboard.writeText(url);
+      setCopiedId(collectionId);
+      setTimeout(() => setCopiedId(null), 2000);
+    },
+    [buildSlugFragment]
+  );
 
   return (
     <section className="mt-xl">

--- a/apps/web/src/features/notebook/hooks/useNotebookResolver.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookResolver.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve a Notion-style notebook slug (or raw UUID) to its canonical ID.
+ *
+ * Used by NotebookResolver to translate pretty URLs like
+ * `/notebooks/my-research-Ab3xK9` into the UUID downstream components
+ * (DynamicNotebookPage, useNotebookSharing) already consume. The lookup
+ * only fires for inputs that are neither a system-notebook slug nor a
+ * direct UUID — those skip the network round-trip entirely.
+ */
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useQuery } from '@tanstack/react-query';
+
+interface ResolvedNotebook {
+  id: string;
+  slug_suffix: string;
+  name: string;
+  share_mode: 'private' | 'groups' | 'authenticated' | null;
+}
+
+export function useNotebookResolver(slugOrId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ['notebook', 'resolve', slugOrId],
+    enabled,
+    retry: false,
+    queryFn: async (): Promise<ResolvedNotebook | null> => {
+      const client = getContractsClient();
+      const result = await client.notebookCollections.resolveCollection({
+        params: { slugOrId },
+      });
+      if (result.status === 200) return result.body;
+      if (result.status === 404) return null;
+      throw new Error(`Failed to resolve notebook (HTTP ${result.status})`);
+    },
+  });
+}

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -55,6 +55,12 @@ export interface NotebookCollection {
   share_mode?: NotebookShareMode | null;
   edit_policy?: NotebookEditPolicy | null;
   access_source?: NotebookAccessSource | null;
+  /**
+   * Stable 6-char tail used to build pretty URLs (`/notebooks/<name>-Ab3xK9`).
+   * Null only for legacy rows before the boot-time backfill has run; once
+   * present, never changes — renames rewrite the name prefix only.
+   */
+  slug_suffix?: string | null;
 }
 
 /**

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -23,12 +23,39 @@ import {
   likeCollectionResponseSchema,
   unlikeCollectionResponseSchema,
   listMyLikedCollectionsResponseSchema,
+  resolveCollectionResponseSchema,
 } from '../schemas/notebookCollections.js';
 
 const c = initContract();
 
 export const notebookCollectionsContract = c.router(
   {
+    /**
+     * GET /api/auth/notebook-collections/resolve/:slugOrId
+     * Resolve a notebook URL fragment (Notion-style slug or UUID) to its
+     * canonical ID. Used by NotebookResolver on the frontend to translate
+     * pretty URLs into the UUID downstream components already consume.
+     *
+     * IMPORTANT: this entry must appear BEFORE listCollections in the router
+     * object — ts-rest preserves declaration order when building the Express
+     * matcher, and the parameterised `/resolve/:slugOrId` path otherwise gets
+     * shadowed by other `/:id` routes at the same depth (e.g. /likes,
+     * /public). Adding it first means `/resolve/...` always matches first.
+     */
+    resolveCollection: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/resolve/:slugOrId',
+      pathParams: z.object({ slugOrId: z.string() }),
+      responses: {
+        200: resolveCollectionResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Resolve a notebook slug or UUID to its canonical ID',
+    },
+
     /**
      * GET /api/auth/notebook-collections
      * List the authenticated user's notebook collections.

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -125,6 +125,10 @@ export const wolkeShareLinkSchema = z.object({
 /**
  * TransformedCollection — the shape returned by GET /. Uses z.unknown() for
  * `settings` because it is a Record<string, unknown> with no index signature.
+ *
+ * `slug_suffix` is the stable 6-char tail used in pretty URLs (see
+ * packages/shared/src/utils/slug.ts). Nullish on the schema for legacy points
+ * predating the backfill — the API guarantees a value on post-backfill rows.
  */
 export const transformedCollectionSchema = z.object({
   id: z.string(),
@@ -154,6 +158,7 @@ export const transformedCollectionSchema = z.object({
   share_mode: notebookShareModeSchema.nullish(),
   edit_policy: notebookEditPolicySchema.nullish(),
   access_source: notebookAccessSourceSchema.nullish(),
+  slug_suffix: z.string().nullish(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────
@@ -186,6 +191,7 @@ export const createCollectionResponseSchema = z.object({
     auto_sync: z.boolean().nullish(),
     remove_missing_on_sync: z.boolean().nullish(),
     settings: z.unknown().nullish(),
+    slug_suffix: z.string().nullish(),
   }),
   message: z.string(),
 });
@@ -242,4 +248,19 @@ export const unlikeCollectionResponseSchema = z.object({
 export const listMyLikedCollectionsResponseSchema = z.object({
   success: z.literal(true),
   liked_ids: z.array(z.string()),
+});
+
+/**
+ * Resolve a notebook URL fragment (slug or UUID) to its canonical ID.
+ * Used by the frontend NotebookResolver to translate Notion-style slug URLs
+ * like `/notebooks/my-research-Ab3xK9` into the UUID the rest of the app
+ * already consumes. The route honours the same access rules as direct
+ * id-based lookups; share_mode is returned so the resolver can short-circuit
+ * UI states (e.g. "shared notebook" banner) without a second round-trip.
+ */
+export const resolveCollectionResponseSchema = z.object({
+  id: z.string(),
+  slug_suffix: z.string(),
+  name: z.string(),
+  share_mode: notebookShareModeSchema.nullable(),
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -156,6 +156,7 @@
     "@ts-rest/core": "^3.52.1",
     "axios": "^1.16.0",
     "clsx": "^2.1.1",
+    "nanoid": "^5.1.11",
     "tailwind-merge": "^3.5.0",
     "yjs": "^13.6.30",
     "zustand": "^5.0.13"

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -29,3 +29,6 @@ export { escapeHtml } from './escapeHtml.js';
 // German relative time formatting
 export { formatRelativeTime } from './formatRelativeTime.js';
 export type { FormatRelativeTimeOptions } from './formatRelativeTime.js';
+
+// Notebook URL slug helpers (Notion-style: name-prefix + stable 6-char suffix)
+export { slugifyName, generateSlugSuffix, buildNotebookSlug, extractSlugSuffix } from './slug.js';

--- a/packages/shared/src/utils/slug.ts
+++ b/packages/shared/src/utils/slug.ts
@@ -1,0 +1,64 @@
+/**
+ * Notebook slug helpers — Notion-style URLs.
+ *
+ *   "Wahlkampf 2026" + "Ab3xK9"  →  "wahlkampf-2026-Ab3xK9"
+ *                                    └── name part ──┘└─id─┘
+ *
+ * The 6-char suffix is the stable identifier the backend resolves against;
+ * the name prefix is cosmetic and updates whenever the notebook is renamed.
+ */
+import { customAlphabet } from 'nanoid';
+
+const SUFFIX_LENGTH = 6;
+
+// URL-safe alphabet without visually ambiguous chars (no 0/O, 1/l/I).
+const SUFFIX_ALPHABET = 'abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+const nanoidSuffix = customAlphabet(SUFFIX_ALPHABET, SUFFIX_LENGTH);
+const COMBINING_DIACRITICS = /[̀-ͯ]/g;
+const SUFFIX_RE = new RegExp(`-([${SUFFIX_ALPHABET}]{${SUFFIX_LENGTH}})$`);
+
+/**
+ * Turn an arbitrary user-supplied name into a URL-safe slug fragment.
+ * Diacritics are stripped, the result is lowercased, non-alphanumerics
+ * become `-`, repeats collapsed, length capped at 40 chars.
+ * Empty results (e.g. all-emoji titles) fall back to "notebook".
+ */
+export function slugifyName(name: string): string {
+  const normalized = name
+    .normalize('NFD')
+    .replace(COMBINING_DIACRITICS, '')
+    .toLowerCase()
+    .replace(/ß/g, 'ss')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+    .replace(/-+$/g, '');
+  return normalized || 'notebook';
+}
+
+/**
+ * Generate a fresh 6-character slug suffix. nanoid's customAlphabet uses
+ * rejection sampling on top of Web Crypto, so the output is uniformly
+ * distributed across the alphabet (no modulo bias).
+ */
+export function generateSlugSuffix(): string {
+  return nanoidSuffix();
+}
+
+/**
+ * Compose the final slug shown in the URL: `<slugified-name>-<suffix>`.
+ */
+export function buildNotebookSlug(name: string, suffix: string): string {
+  return `${slugifyName(name)}-${suffix}`;
+}
+
+/**
+ * Pull the stable 6-char suffix back out of a slug. Returns null if the
+ * input does not end in `-<6 alphabet chars>`. Callers should fall back
+ * to UUID-style lookup when this returns null.
+ */
+export function extractSlugSuffix(slug: string): string | null {
+  const match = SUFFIX_RE.exec(slug);
+  return match ? match[1] : null;
+}

--- a/packages/shared/src/utils/slug.ts
+++ b/packages/shared/src/utils/slug.ts
@@ -60,5 +60,5 @@ export function buildNotebookSlug(name: string, suffix: string): string {
  */
 export function extractSlugSuffix(slug: string): string | null {
   const match = SUFFIX_RE.exec(slug);
-  return match ? match[1] : null;
+  return match?.[1] ?? null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1381,6 +1381,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      nanoid:
+        specifier: '>=5.0.9'
+        version: 5.1.11
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -34091,7 +34094,7 @@ snapshots:
       cosmiconfig: 7.1.0
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.6.0)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.57.1)
@@ -37445,7 +37448,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       debug: 4.4.3
       eslint: 8.57.1
@@ -37468,7 +37471,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.2(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Why

Two layered changes to user notebooks:

1. **Groups-aware sharing with explicit edit policy** (cc053df64). Replaces the old token-based public-access model with a `share_mode` (private / groups / authenticated) × `edit_policy` (owner_only / group_admins / all_members) matrix backed by the polymorphic `group_content_shares` table. The dormant `notebook_public_access` Postgres table is dropped; the canonical store moves fully onto the Qdrant payload.

2. **Notion-style slug URLs for user notebooks** (e299d58c2). Replaces `/notebooks/<uuid>` with `/notebooks/<name>-<6-char-suffix>`. The 6-char suffix is the stable identifier the backend resolves against; the name prefix is cosmetic and rewrites on rename, so already-shared links survive title changes. The suffix lives on the same Qdrant payload that change 1 made canonical — a boot-time idempotent backfill mints suffixes for pre-existing rows. Legacy UUID URLs keep resolving forever as a safety net.

The slug work directly piggybacks on the sharing work — its resolver endpoint reuses `checkNotebookAccess` for permission gating, and both store their state on the same payload.