### PR TITLE
polish(notebook): refine document card accent as integrated top-edge shimmer

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor/DocumentCard.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/DocumentCard.tsx
@@ -26,8 +26,10 @@ export default function DocumentCard({ doc, indexing, loading, onRemove }: Docum
     >
       <div
         className={cn(
-          'pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md',
-          isWolke ? 'bg-secondary-400 dark:bg-secondary-700' : fileType?.cornerClass
+          'pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-transparent to-transparent',
+          isWolke
+            ? 'via-secondary-400/50 dark:via-secondary-500/40'
+            : fileType?.accentVia
         )}
         aria-hidden
       />

--- a/apps/web/src/features/notebook/components/NotebookEditor/shared.ts
+++ b/apps/web/src/features/notebook/components/NotebookEditor/shared.ts
@@ -31,27 +31,27 @@ export const ACCEPTED_EXTENSIONS = ['.pdf', '.docx', '.doc', '.txt', '.md', '.od
 export const MAX_DOCUMENTS = 100;
 export const TOTAL_STEPS = 4;
 
-export function getFileTypeStyle(filename: string): { label: string; cornerClass: string } {
+export function getFileTypeStyle(filename: string): { label: string; accentVia: string } {
   const ext = filename.toLowerCase().split('.').pop() ?? '';
   switch (ext) {
     case 'pdf':
-      return { label: 'PDF', cornerClass: 'bg-red-400 dark:bg-red-700' };
+      return { label: 'PDF', accentVia: 'via-red-400/50 dark:via-red-500/40' };
     case 'docx':
-      return { label: 'DOCX', cornerClass: 'bg-blue-400 dark:bg-blue-700' };
+      return { label: 'DOCX', accentVia: 'via-blue-400/50 dark:via-blue-500/40' };
     case 'doc':
-      return { label: 'DOC', cornerClass: 'bg-blue-400 dark:bg-blue-700' };
+      return { label: 'DOC', accentVia: 'via-blue-400/50 dark:via-blue-500/40' };
     case 'odt':
-      return { label: 'ODT', cornerClass: 'bg-emerald-400 dark:bg-emerald-700' };
+      return { label: 'ODT', accentVia: 'via-emerald-400/50 dark:via-emerald-500/40' };
     case 'rtf':
-      return { label: 'RTF', cornerClass: 'bg-orange-400 dark:bg-orange-700' };
+      return { label: 'RTF', accentVia: 'via-orange-400/50 dark:via-orange-500/40' };
     case 'md':
-      return { label: 'MD', cornerClass: 'bg-slate-400 dark:bg-slate-600' };
+      return { label: 'MD', accentVia: 'via-slate-400/50 dark:via-slate-500/40' };
     case 'txt':
-      return { label: 'TXT', cornerClass: 'bg-slate-400 dark:bg-slate-600' };
+      return { label: 'TXT', accentVia: 'via-slate-400/50 dark:via-slate-500/40' };
     default:
       return {
         label: ext.slice(0, 4).toUpperCase() || 'FILE',
-        cornerClass: 'bg-grey-400 dark:bg-grey-600',
+        accentVia: 'via-grey-400/50 dark:via-grey-500/40',
       };
   }
 }


### PR DESCRIPTION
Refines the document card's color accent. The previous chunky 12px-wide solid corner bar on each document card read as a separate decoration glued onto the card. Replace it with a 2px-tall full-width gradient at the top edge (`transparent → color/50 → transparent`) that visually merges with the card's rounded border — file-type color is still readable at a glance for recognition, but the treatment is restrained, modern, and "feels like the border has a tint" rather than "has a label stuck to it." Because the card has `overflow-hidden rounded-xl`, the shimmer is clipped by the rounded corner, so its ends are softly rounded rather than hard-capped.

Two-file change: `shared.ts` renames `cornerClass` → `accentVia` and swaps the solid `bg-*-400` palette for the `via-*-400/50` middle stop of a 3-stop gradient; `DocumentCard.tsx` swaps the corner div for a full-width top-edge gradient div. Wolke variant gets the same treatment.

## Test plan
- [ ] Visit `/notebooks/new`, upload a PDF + DOCX + ODT → all three cards show a faint tinted shimmer along the top edge (red/blue/green respectively), fading at the corners
- [ ] Connect a Wolke folder → Wolke documents show a teal shimmer in the same position
- [ ] Open an existing notebook in edit mode → document grid uses the same refined accent
- [ ] Dark mode toggle → shimmer remains subtle but visible (uses 500/40 in dark vs 400/50 in light)