### PR TITLE
fix(notebook): wizard polish — empty state, width, Wolke UX, edit redirect

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditor/NotebookCreateWizard.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/NotebookCreateWizard.tsx
@@ -14,7 +14,7 @@ interface NotebookCreateWizardProps {
 export default function NotebookCreateWizard({ state }: NotebookCreateWizardProps) {
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.3 }}>
-      <div className="mx-auto w-full max-w-3xl">
+      <div className="mx-auto w-full max-w-4xl">
         <AnimatePresence mode="wait">
           <motion.div
             key={state.step}

--- a/apps/web/src/features/notebook/components/NotebookEditor/SourcesStep.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/SourcesStep.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyTitle,
-  SectionHeader,
-} from '@gruenerator/ui';
+import { Button, SectionHeader } from '@gruenerator/ui';
 import { HiCloud, HiUpload } from 'react-icons/hi';
 
 import { cn } from '../../../../utils/cn';
@@ -133,7 +126,7 @@ export default function SourcesStep({ state }: SourcesStepProps) {
         </div>
       )}
 
-      {uploadedDocuments.length > 0 ? (
+      {uploadedDocuments.length > 0 && (
         <section className="space-y-md">
           <SectionHeader
             title="Hinzugefügte Dokumente"
@@ -164,13 +157,6 @@ export default function SourcesStep({ state }: SourcesStepProps) {
             ))}
           </div>
         </section>
-      ) : (
-        <Empty>
-          <EmptyHeader>
-            <EmptyTitle>Noch keine Dokumente</EmptyTitle>
-            <EmptyDescription>Wähle oben eine Quelle, um loszulegen.</EmptyDescription>
-          </EmptyHeader>
-        </Empty>
       )}
 
       {isDragOver && (

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -8,6 +8,7 @@ import {
   EmptyTitle,
   toast,
 } from '@gruenerator/ui';
+import { buildNotebookSlug, extractSlugSuffix } from '@gruenerator/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { HiArrowLeft, HiShare } from 'react-icons/hi';
@@ -44,7 +45,13 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
   const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
   const editingCollection = useMemo<NotebookCollection | null>(() => {
     if (mode !== 'edit' || !params.id) return null;
-    return collections.find((c) => c.id === params.id) ?? null;
+    const byId = collections.find((c) => c.id === params.id);
+    if (byId) return byId;
+    const suffix = extractSlugSuffix(params.id);
+    if (suffix) {
+      return collections.find((c) => c.slug_suffix === suffix) ?? null;
+    }
+    return null;
   }, [collections, mode, params.id]);
 
   const goBack = useCallback(() => {
@@ -82,7 +89,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
 
   const handleCreateSave = useCallback(
     async (data: NotebookEditorSavePayload) => {
-      await createQACollection({
+      const created = await createQACollection({
         name: data.name,
         description: data.description,
         documents: data.documents,
@@ -92,9 +99,12 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         wolkeFolders: data.wolkeFolders,
       });
       toast.success(`Notebook „${data.name}" erstellt`);
-      goBack();
+      const slug = created.slug_suffix
+        ? buildNotebookSlug(created.name, created.slug_suffix)
+        : created.id;
+      void navigate(`/notebooks/${slug}/bearbeiten`);
     },
-    [createQACollection, goBack]
+    [createQACollection, navigate]
   );
 
   const commitHeroName = useCallback(

--- a/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorWolkeSection.tsx
@@ -163,7 +163,7 @@ const NotebookEditorWolkeSection = ({
     <section>
       <SectionHeader
         title="Wolke-Ordner"
-        onCreate={hasShareLinks ? () => setPickerOpen((v) => !v) : undefined}
+        onCreate={hasShareLinks && folders.length > 0 ? () => setPickerOpen((v) => !v) : undefined}
         createLabel="Wolke-Ordner hinzufügen"
         actions={headerActions}
       />
@@ -182,7 +182,7 @@ const NotebookEditorWolkeSection = ({
         </div>
       ) : (
         <>
-          {pickerOpen && availableLinks.length > 0 && (
+          {(pickerOpen || folders.length === 0) && availableLinks.length > 0 && (
             <div className="mb-md flex flex-col gap-1 rounded-xl border border-grey-200 bg-background p-xs dark:border-grey-700">
               <p className="m-0 px-1 pb-1 text-xs uppercase tracking-wide text-grey-500">
                 Verbundene Wolken
@@ -201,83 +201,77 @@ const NotebookEditorWolkeSection = ({
             </div>
           )}
 
-          {folders.length === 0 && !pickerOpen ? (
-            <p className="py-lg text-center text-sm text-grey-500">
-              Noch kein Wolke-Ordner verknüpft. Klicke auf + um einen hinzuzufügen.
-            </p>
-          ) : (
-            folders.length > 0 && (
-              <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-                {folders.map((folder) => {
-                  const isSyncing = syncingId === folder.shareLinkId;
-                  return (
+          {folders.length > 0 && (
+            <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              {folders.map((folder) => {
+                const isSyncing = syncingId === folder.shareLinkId;
+                return (
+                  <div
+                    key={folder.shareLinkId}
+                    className={cn(
+                      'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
+                      isSyncing ? 'opacity-90' : 'hover:shadow-sm'
+                    )}
+                    aria-label={`Wolke-Ordner: ${folder.folderName}`}
+                  >
                     <div
-                      key={folder.shareLinkId}
+                      className="pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md bg-secondary-400 dark:bg-secondary-700"
+                      aria-hidden
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
                       className={cn(
-                        'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
-                        isSyncing ? 'opacity-90' : 'hover:shadow-sm'
+                        'absolute right-1 top-1 transition-opacity',
+                        isSyncing
+                          ? 'opacity-60'
+                          : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
                       )}
-                      aria-label={`Wolke-Ordner: ${folder.folderName}`}
+                      disabled={disabled || isSyncing}
+                      onClick={() => handleRemove(folder.shareLinkId)}
+                      title="Bereits importierte Dokumente bleiben im Notebook."
+                      aria-label={`${folder.folderName} entfernen`}
                     >
-                      <div
-                        className="pointer-events-none absolute right-0 top-0 h-[3px] w-12 rounded-bl-md bg-secondary-400 dark:bg-secondary-700"
+                      <HiX size={12} />
+                    </Button>
+                    <div className="flex items-start gap-xs pr-6">
+                      <HiCloud
+                        size={14}
+                        className="mt-[2px] shrink-0 text-secondary-600 dark:text-secondary-400"
                         aria-hidden
                       />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon-xs"
-                        className={cn(
-                          'absolute right-1 top-1 transition-opacity',
-                          isSyncing
-                            ? 'opacity-60'
-                            : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
-                        )}
-                        disabled={disabled || isSyncing}
-                        onClick={() => handleRemove(folder.shareLinkId)}
-                        title="Bereits importierte Dokumente bleiben im Notebook."
-                        aria-label={`${folder.folderName} entfernen`}
+                      <div
+                        className="line-clamp-2 break-words text-sm font-medium leading-snug text-foreground"
+                        title={folder.folderName}
                       >
-                        <HiX size={12} />
-                      </Button>
-                      <div className="flex items-start gap-xs pr-6">
-                        <HiCloud
-                          size={14}
-                          className="mt-[2px] shrink-0 text-secondary-600 dark:text-secondary-400"
-                          aria-hidden
-                        />
-                        <div
-                          className="line-clamp-2 break-words text-sm font-medium leading-snug text-foreground"
-                          title={folder.folderName}
-                        >
-                          {folder.folderName}
-                        </div>
-                      </div>
-                      <div className="mt-auto flex items-center justify-between gap-xs">
-                        <span className="text-xs text-grey-500">
-                          {isSyncing ? 'Wird synchronisiert…' : formatRelative(folder.lastSyncedAt)}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={disabled || isSyncing || remainingSlots <= 0}
-                          onClick={() => void handleSync(folder)}
-                          aria-label={`${folder.folderName} synchronisieren`}
-                        >
-                          {isSyncing ? (
-                            <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                          ) : (
-                            <HiRefresh size={12} />
-                          )}
-                          Sync
-                        </Button>
+                        {folder.folderName}
                       </div>
                     </div>
-                  );
-                })}
-              </div>
-            )
+                    <div className="mt-auto flex items-center justify-between gap-xs">
+                      <span className="text-xs text-grey-500">
+                        {isSyncing ? 'Wird synchronisiert…' : formatRelative(folder.lastSyncedAt)}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={disabled || isSyncing || remainingSlots <= 0}
+                        onClick={() => void handleSync(folder)}
+                        aria-label={`${folder.folderName} synchronisieren`}
+                      >
+                        {isSyncing ? (
+                          <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                        ) : (
+                          <HiRefresh size={12} />
+                        )}
+                        Sync
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
           )}
 
           {error && (


### PR DESCRIPTION
Four fixes for the freshly-shipped notebook creation wizard, surfaced by hands-on use.

**1. Drop redundant empty state on step 1.** The wizard rendered an `<Empty>` ("Noch keine Dokumente — Wähle oben eine Quelle, um loszulegen") on first open. The two big choice cards above are themselves the call-to-action; the Empty was duplicate narration of what's plainly visible — and inside the narrower container it wrapped to 1–2 words per line, looking visually broken.

**2. Widen wizard container.** The wizard sat inside `PageContainer maxWidth="lg"` (1200px) but capped its own content at `max-w-3xl` (768px), leaving a wide empty strip on the right. Widening to `max-w-4xl` (896px) keeps card proportions sensible while letting the page-level container be the outer width authority.

**3. Show available Wolke connections immediately.** Previously the Wolke section showed "Noch kein Wolke-Ordner verknüpft. Klicke auf + um einen hinzuzufügen." as an empty fallback — an extra click before users saw which shares they could attach. Now when `folders.length === 0` the available-links list renders inline by default; the + button is reserved for adding another after at least one folder is attached.

**4. Edit page resolves by slug suffix + post-create redirects to it.** `NotebookEditorPage` looked up the collection via `c.id === params.id`, but URLs are Notion-style slugs (e.g. `test-notebook-mWEjXA`). The /bearbeiten route bypasses `NotebookResolver`, so every pretty edit URL — including the ones `NotebooksIndexPage`'s edit button generates — was already silently 404'ing as "Notebook nicht gefunden". This was a latent bug independent of the new wizard. Fix: fall back to matching by `extractSlugSuffix(params.id)` against `c.slug_suffix` when the raw-id lookup misses (collections are already in cache, no extra network round-trip). Then `handleCreateSave` captures the created collection from the awaited mutation, builds its pretty slug, and navigates to `/notebooks/<slug>/bearbeiten` so users land on the edit hero of the notebook they just created instead of being bounced to the list.

## Test plan
- [ ] Open `/notebooks/neu` → step 1 shows two cards + nothing below them on a fresh page (no broken-looking Empty)
- [ ] Resize/look on a 1440px+ screen → wizard fills more of the page, less empty whitespace on right
- [ ] Open Wolke card with no folders attached → list of available Wolke connections appears immediately (no extra click on +)
- [ ] Create a notebook → toast appears, URL changes to `/notebooks/<slug>/bearbeiten`, edit hero shows the notebook name (no 404)
- [ ] From `/notebooks` list, click edit on an existing notebook → still resolves correctly (regression check for legacy raw-UUID URLs)