### PR TITLE
feat(notebook): add Docs as third source option (experimental)

### DIFF
--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -29,7 +29,7 @@ import type {
   NotebookCollectionFromQdrant,
 } from './types.js';
 import type { AuthenticatedRequest } from '../../middleware/types.js';
-import type { WolkeFolderRef } from '@gruenerator/contracts';
+import type { LinkedDocRef, WolkeFolderRef } from '@gruenerator/contracts';
 
 const log = createLogger('notebookCollections');
 const { requireAuth } = authMiddleware;
@@ -145,6 +145,9 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
         const wolke_folders: WolkeFolderRef[] = Array.isArray(settings.wolke_folders)
           ? (settings.wolke_folders as WolkeFolderRef[])
           : [];
+        const linked_docs: LinkedDocRef[] = Array.isArray(settings.linked_docs)
+          ? (settings.linked_docs as LinkedDocRef[])
+          : [];
 
         return {
           ...collection,
@@ -158,6 +161,7 @@ router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =>
           remove_missing_on_sync: !!collection.remove_missing_on_sync,
           labels,
           wolke_folders,
+          linked_docs,
           slug_suffix: collection.slug_suffix ?? null,
         };
       })
@@ -193,8 +197,10 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       remove_missing_on_sync = false,
       labels,
       wolke_folders: wolkeFoldersRaw,
+      linked_docs: linkedDocsRaw,
     } = req.body as CreateCollectionBody;
     const wolke_folders = Array.isArray(wolkeFoldersRaw) ? wolkeFoldersRaw : [];
+    const linked_docs = Array.isArray(linkedDocsRaw) ? linkedDocsRaw : [];
 
     if (!name || !name.trim()) {
       return res.status(400).json({ error: 'Name is required' });
@@ -259,6 +265,7 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       settings: {
         ...(Array.isArray(labels) ? { labels: labels.map((l) => l.trim()).filter(Boolean) } : {}),
         wolke_folders,
+        linked_docs,
       },
     };
 
@@ -343,6 +350,7 @@ router.put(
         remove_missing_on_sync,
         labels,
         wolke_folders: wolkeFoldersRaw,
+        linked_docs: linkedDocsRaw,
       } = req.body as UpdateCollectionBody;
 
       if (!name || !name.trim()) {
@@ -419,6 +427,10 @@ router.put(
       }
       if (Array.isArray(wolkeFoldersRaw)) {
         settingsPatch.wolke_folders = wolkeFoldersRaw;
+        settingsChanged = true;
+      }
+      if (Array.isArray(linkedDocsRaw)) {
+        settingsPatch.linked_docs = linkedDocsRaw;
         settingsChanged = true;
       }
       if (settingsChanged) {

--- a/apps/web/src/features/auth/services/profileApiService.ts
+++ b/apps/web/src/features/auth/services/profileApiService.ts
@@ -489,6 +489,9 @@ export const profileApiService = {
       ...(Array.isArray(collectionData.wolkeFolders)
         ? { wolke_folders: collectionData.wolkeFolders }
         : {}),
+      ...(Array.isArray(collectionData.linkedDocs)
+        ? { linked_docs: collectionData.linkedDocs }
+        : {}),
     };
 
     const response = await apiClient.post<NotebookCollectionMutationResponse>(
@@ -532,6 +535,9 @@ export const profileApiService = {
         : {}),
       ...(Array.isArray(collectionData.wolkeFolders)
         ? { wolke_folders: collectionData.wolkeFolders }
+        : {}),
+      ...(Array.isArray(collectionData.linkedDocs)
+        ? { linked_docs: collectionData.linkedDocs }
         : {}),
     };
 

--- a/apps/web/src/features/notebook/components/NotebookEditor/NotebookEditForm.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/NotebookEditForm.tsx
@@ -12,6 +12,7 @@ import {
 import { motion } from 'motion/react';
 import { HiUpload } from 'react-icons/hi';
 
+import NotebookEditorDocsSection from '../NotebookEditorDocsSection';
 import NotebookEditorWolkeSection from '../NotebookEditorWolkeSection';
 
 import DocumentCard from './DocumentCard';
@@ -48,8 +49,11 @@ export default function NotebookEditForm({ state }: NotebookEditFormProps) {
     handleDragLeave,
     handleRemoveDocument,
     handleWolkeDocsImported,
+    handleDocsImported,
     handleSubmit,
     onSubmit,
+    linkedDocs,
+    setLinkedDocs,
   } = state;
 
   return (
@@ -62,6 +66,15 @@ export default function NotebookEditForm({ state }: NotebookEditFormProps) {
           onFoldersChange={setWolkeFolders}
           remainingSlots={MAX_DOCUMENTS - uploadedDocuments.length}
           onDocsImported={handleWolkeDocsImported}
+          disabled={loading || isUploading}
+        />
+
+        <NotebookEditorDocsSection
+          linkedDocs={linkedDocs}
+          onLinkedDocsChange={setLinkedDocs}
+          remainingSlots={MAX_DOCUMENTS - uploadedDocuments.length}
+          onDocsImported={handleDocsImported}
+          onUploadedDocumentRemoved={handleRemoveDocument}
           disabled={loading || isUploading}
         />
 

--- a/apps/web/src/features/notebook/components/NotebookEditor/ReviewStep.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/ReviewStep.tsx
@@ -20,6 +20,7 @@ export default function ReviewStep({ state }: ReviewStepProps) {
     watchedDesc,
     manualDocuments,
     wolkeDocuments,
+    linkedDocs,
     labels,
     isPublic,
     publicOwnership,
@@ -42,6 +43,7 @@ export default function ReviewStep({ state }: ReviewStepProps) {
             <span className="font-medium text-foreground">
               {manualDocuments.length} eigene
               {wolkeDocuments.length > 0 && `, ${wolkeDocuments.length} aus der Wolke`}
+              {linkedDocs.length > 0 && `, ${linkedDocs.length} aus Docs`}
             </span>
           </div>
           {labels.length > 0 && (

--- a/apps/web/src/features/notebook/components/NotebookEditor/SourcesStep.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditor/SourcesStep.tsx
@@ -1,8 +1,9 @@
 import { Button, SectionHeader } from '@gruenerator/ui';
-import { HiCloud, HiUpload } from 'react-icons/hi';
+import { HiCloud, HiDocumentText, HiUpload } from 'react-icons/hi';
 
 import { cn } from '../../../../utils/cn';
 
+import NotebookEditorDocsSection from '../NotebookEditorDocsSection';
 import NotebookEditorWolkeSection from '../NotebookEditorWolkeSection';
 
 import DocumentCard from './DocumentCard';
@@ -35,9 +36,14 @@ export default function SourcesStep({ state }: SourcesStepProps) {
     handleDragLeave,
     handleRemoveDocument,
     handleWolkeDocsImported,
+    handleDocsImported,
     handleCancel,
     handleNext,
     canAdvanceFromSources,
+    linkedDocs,
+    setLinkedDocs,
+    docsPanelOpen,
+    setDocsPanelOpen,
   } = state;
 
   return (
@@ -48,7 +54,7 @@ export default function SourcesStep({ state }: SourcesStepProps) {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <div className="grid grid-cols-1 gap-md sm:grid-cols-2">
+      <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3">
         <button
           type="button"
           onClick={() => !isUploading && fileInputRef.current?.click()}
@@ -101,6 +107,25 @@ export default function SourcesStep({ state }: SourcesStepProps) {
             </p>
           </div>
         </button>
+
+        <button
+          type="button"
+          onClick={() => setDocsPanelOpen(!docsPanelOpen)}
+          className={cn(
+            'group flex min-h-[180px] flex-col items-center justify-center gap-sm rounded-xl border-2 p-lg text-center transition-all',
+            docsPanelOpen
+              ? 'border-amber-500 bg-amber-50 dark:border-amber-600 dark:bg-amber-950/30'
+              : 'border-grey-200 hover:border-amber-400 hover:bg-background-alt dark:border-grey-700'
+          )}
+        >
+          <div className="flex items-center justify-center rounded-xl bg-amber-50 p-md text-amber-600 transition-colors group-hover:bg-amber-100 dark:bg-amber-950/40 dark:text-amber-400">
+            <HiDocumentText size={28} />
+          </div>
+          <div>
+            <p className="m-0 text-base font-semibold text-foreground">Aus Docs importieren</p>
+            <p className="mt-xs m-0 text-xs text-grey-500">Eigene Docs als Quelle einbinden</p>
+          </div>
+        </button>
       </div>
 
       <input
@@ -121,6 +146,19 @@ export default function SourcesStep({ state }: SourcesStepProps) {
             onFoldersChange={setWolkeFolders}
             remainingSlots={MAX_DOCUMENTS - uploadedDocuments.length}
             onDocsImported={handleWolkeDocsImported}
+            disabled={loading || isUploading}
+          />
+        </div>
+      )}
+
+      {docsPanelOpen && (
+        <div className="rounded-xl border border-grey-200 bg-background p-md dark:border-grey-800">
+          <NotebookEditorDocsSection
+            linkedDocs={linkedDocs}
+            onLinkedDocsChange={setLinkedDocs}
+            remainingSlots={MAX_DOCUMENTS - uploadedDocuments.length}
+            onDocsImported={handleDocsImported}
+            onUploadedDocumentRemoved={handleRemoveDocument}
             disabled={loading || isUploading}
           />
         </div>

--- a/apps/web/src/features/notebook/components/NotebookEditor/shared.ts
+++ b/apps/web/src/features/notebook/components/NotebookEditor/shared.ts
@@ -1,4 +1,4 @@
-import { type WolkeFolderRef } from '@gruenerator/contracts';
+import { type LinkedDocRef, type WolkeFolderRef } from '@gruenerator/contracts';
 import { type DragEvent } from 'react';
 
 export type PublicOwnership = 'owner' | 'public_data';
@@ -12,6 +12,7 @@ export interface NotebookCollection {
   is_public?: boolean;
   public_ownership?: PublicOwnership | null;
   wolke_folders?: WolkeFolderRef[];
+  linked_docs?: LinkedDocRef[];
 }
 
 export interface NotebookEditorFormData {

--- a/apps/web/src/features/notebook/components/NotebookEditor/useNotebookEditorState.ts
+++ b/apps/web/src/features/notebook/components/NotebookEditor/useNotebookEditorState.ts
@@ -1,9 +1,14 @@
-import { type NotebookEditorSavePayload, type WolkeFolderRef } from '@gruenerator/contracts';
+import {
+  type LinkedDocRef,
+  type NotebookEditorSavePayload,
+  type WolkeFolderRef,
+} from '@gruenerator/contracts';
 import { useState, useEffect, useCallback, useMemo, useRef, type DragEvent } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
 import { useDocumentsStore } from '../../../../stores/documentsStore';
 
+import { type ImportedLinkedDoc } from '../NotebookEditorDocsSection';
 import { type ImportedWolkeDocument } from '../NotebookEditorWolkeSection';
 
 import {
@@ -42,6 +47,8 @@ export function useNotebookEditorState({
   const [publicOwnership, setPublicOwnership] = useState<PublicOwnership | null>(null);
   const [wolkeFolders, setWolkeFolders] = useState<WolkeFolderRef[]>([]);
   const [wolkePanelOpen, setWolkePanelOpen] = useState(false);
+  const [linkedDocs, setLinkedDocs] = useState<LinkedDocRef[]>([]);
+  const [docsPanelOpen, setDocsPanelOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { uploadFileOnly, pollDocumentStatus } = useDocumentsStore();
@@ -63,6 +70,7 @@ export function useNotebookEditorState({
       setIsPublic(editingCollection.is_public === true);
       setPublicOwnership(editingCollection.public_ownership ?? null);
       setWolkeFolders(editingCollection.wolke_folders ?? []);
+      setLinkedDocs(editingCollection.linked_docs ?? []);
       if (editingCollection.documents?.length) {
         setUploadedDocuments(
           editingCollection.documents.map((doc) => ({
@@ -79,11 +87,17 @@ export function useNotebookEditorState({
       setIsPublic(false);
       setPublicOwnership(null);
       setWolkeFolders([]);
+      setLinkedDocs([]);
       setUploadedDocuments([]);
       setStep(0);
       setWolkePanelOpen(false);
+      setDocsPanelOpen(false);
     }
   }, [editingCollection, reset]);
+
+  useEffect(() => {
+    if (linkedDocs.length > 0) setDocsPanelOpen(true);
+  }, [linkedDocs.length]);
 
   useEffect(() => {
     if (wolkeFolders.length > 0) setWolkePanelOpen(true);
@@ -193,6 +207,35 @@ export function useNotebookEditorState({
     setUploadedDocuments((prev) => prev.filter((doc) => doc.id !== id));
   }, []);
 
+  const handleDocsImported = useCallback(
+    (docs: ImportedLinkedDoc[]) => {
+      if (docs.length === 0) return;
+      setUploadedDocuments((prev) => {
+        const seen = new Set(prev.map((d) => d.id));
+        const additions: UploadedDocument[] = docs
+          .filter((d) => !seen.has(d.id))
+          .map((d) => ({ id: d.id, title: d.title }));
+        return [...prev, ...additions];
+      });
+      setIndexingDocIds((prev) => {
+        const next = new Set(prev);
+        docs.forEach((d) => next.add(d.id));
+        return next;
+      });
+      docs.forEach((d) => {
+        void pollDocumentStatus(d.id).finally(() => {
+          setIndexingDocIds((prev) => {
+            if (!prev.has(d.id)) return prev;
+            const next = new Set(prev);
+            next.delete(d.id);
+            return next;
+          });
+        });
+      });
+    },
+    [pollDocumentStatus]
+  );
+
   const handleWolkeDocsImported = useCallback(
     (docs: ImportedWolkeDocument[]) => {
       if (docs.length === 0) return;
@@ -240,9 +283,13 @@ export function useNotebookEditorState({
     () => uploadedDocuments.filter((d) => d.source === 'wolke'),
     [uploadedDocuments]
   );
+  const linkedDocDocumentIds = useMemo(
+    () => new Set(linkedDocs.flatMap((d) => (d.documentId ? [d.documentId] : []))),
+    [linkedDocs]
+  );
   const manualDocuments = useMemo(
-    () => uploadedDocuments.filter((d) => d.source !== 'wolke'),
-    [uploadedDocuments]
+    () => uploadedDocuments.filter((d) => d.source !== 'wolke' && !linkedDocDocumentIds.has(d.id)),
+    [uploadedDocuments, linkedDocDocumentIds]
   );
 
   const handleBack = useCallback(() => setStep((s) => Math.max(0, s - 1)), []);
@@ -267,10 +314,20 @@ export function useNotebookEditorState({
         isPublic,
         publicOwnership: isPublic ? publicOwnership : null,
         wolkeFolders,
+        linkedDocs,
       };
       await onSave(payload);
     },
-    [onSave, editingCollection, uploadedDocuments, labels, isPublic, publicOwnership, wolkeFolders]
+    [
+      onSave,
+      editingCollection,
+      uploadedDocuments,
+      labels,
+      isPublic,
+      publicOwnership,
+      wolkeFolders,
+      linkedDocs,
+    ]
   );
 
   const handleCancel = useCallback(() => {
@@ -281,14 +338,12 @@ export function useNotebookEditorState({
     setIsPublic(false);
     setPublicOwnership(null);
     setWolkeFolders([]);
+    setLinkedDocs([]);
     setStep(0);
     if (onCancel) onCancel();
   }, [reset, onCancel]);
 
-  const submitForm = useCallback(
-    () => void handleSubmit(onSubmit)(),
-    [handleSubmit, onSubmit]
-  );
+  const submitForm = useCallback(() => void handleSubmit(onSubmit)(), [handleSubmit, onSubmit]);
 
   return {
     step,
@@ -304,6 +359,8 @@ export function useNotebookEditorState({
     publicOwnership,
     wolkeFolders,
     wolkePanelOpen,
+    linkedDocs,
+    docsPanelOpen,
     fileInputRef,
     watchedName,
     watchedDesc,
@@ -319,6 +376,8 @@ export function useNotebookEditorState({
     setPublicOwnership,
     setWolkeFolders,
     setWolkePanelOpen,
+    setLinkedDocs,
+    setDocsPanelOpen,
     setValue,
     handleSubmit,
     onSubmit,
@@ -330,6 +389,7 @@ export function useNotebookEditorState({
     handleDragLeave,
     handleRemoveDocument,
     handleWolkeDocsImported,
+    handleDocsImported,
     handleAddLabel,
     handleRemoveLabel,
     handleBack,

--- a/apps/web/src/features/notebook/components/NotebookEditorDocsSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorDocsSection.tsx
@@ -1,0 +1,304 @@
+import { type LinkedDocRef } from '@gruenerator/contracts';
+import { useDocuments, type Document } from '@gruenerator/docs';
+import { Badge, Button, SectionHeader } from '@gruenerator/ui';
+import { useState, useCallback, useMemo } from 'react';
+import { HiDocumentText, HiExclamation, HiRefresh, HiX } from 'react-icons/hi';
+import { Link } from 'react-router-dom';
+
+import { useDocumentsStore } from '../../../stores/documentsStore';
+import { cn } from '../../../utils/cn';
+
+export interface ImportedLinkedDoc {
+  id: string;
+  title: string;
+}
+
+interface Props {
+  linkedDocs: LinkedDocRef[];
+  onLinkedDocsChange: (next: LinkedDocRef[]) => void;
+  remainingSlots: number;
+  /** Called with newly imported documents — parent appends to uploadedDocuments and starts indexing polling. */
+  onDocsImported: (docs: ImportedLinkedDoc[]) => void;
+  /** Called when a previously imported Document should leave the parent's uploadedDocuments (re-sync or unlink). */
+  onUploadedDocumentRemoved: (documentId: string) => void;
+  disabled: boolean;
+}
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'Noch nicht importiert';
+  const then = new Date(iso).getTime();
+  const diff = Date.now() - then;
+  if (Number.isNaN(then)) return 'Noch nicht importiert';
+  if (diff < 60_000) return 'Importiert vor wenigen Sekunden';
+  if (diff < 3_600_000) return `Importiert vor ${Math.round(diff / 60_000)} Min.`;
+  if (diff < 86_400_000) return `Importiert vor ${Math.round(diff / 3_600_000)} Std.`;
+  return `Importiert am ${new Date(iso).toLocaleDateString('de-DE')}`;
+}
+
+const ExperimentalBadge = (
+  <Badge
+    variant="outline"
+    className="border-amber-300 bg-amber-50 text-[10px] uppercase text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+  >
+    Experimentell
+  </Badge>
+);
+
+async function fetchDocMarkdown(docId: string): Promise<string> {
+  const res = await fetch(`/api/docs/${docId}/export/markdown`, { credentials: 'include' });
+  if (!res.ok) {
+    throw new Error(`Markdown-Export fehlgeschlagen (${res.status})`);
+  }
+  return res.text();
+}
+
+const NotebookEditorDocsSection = ({
+  linkedDocs,
+  onLinkedDocsChange,
+  remainingSlots,
+  onDocsImported,
+  onUploadedDocumentRemoved,
+  disabled,
+}: Props) => {
+  const docsQuery = useDocuments();
+  const { uploadFileOnly } = useDocumentsStore();
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [syncingId, setSyncingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const attachedIds = useMemo(() => new Set(linkedDocs.map((d) => d.docId)), [linkedDocs]);
+  const availableDocs = useMemo(
+    () => (docsQuery.data ?? []).filter((d) => !attachedIds.has(d.id)),
+    [docsQuery.data, attachedIds]
+  );
+
+  const importDoc = useCallback(
+    async (docId: string, docTitle: string): Promise<ImportedLinkedDoc> => {
+      const markdown = await fetchDocMarkdown(docId);
+      const safeName = docTitle.replace(/[^\p{L}\p{N}\s.-]+/gu, '_').slice(0, 80) || 'Dokument';
+      const file = new File([markdown], `${safeName}.md`, { type: 'text/markdown' });
+      const uploaded = await uploadFileOnly(file, file.name);
+      return { id: uploaded.id, title: uploaded.title || docTitle };
+    },
+    [uploadFileOnly]
+  );
+
+  const handleAttach = useCallback(
+    async (doc: Document) => {
+      if (remainingSlots <= 0) {
+        setError('Notebook ist voll.');
+        return;
+      }
+      setSyncingId(doc.id);
+      setError(null);
+      try {
+        const imported = await importDoc(doc.id, doc.title);
+        onDocsImported([imported]);
+        const newRef: LinkedDocRef = {
+          docId: doc.id,
+          docTitle: doc.title,
+          documentId: imported.id,
+          lastSyncedAt: new Date().toISOString(),
+        };
+        onLinkedDocsChange([...linkedDocs, newRef]);
+        setPickerOpen(false);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Import fehlgeschlagen.');
+      } finally {
+        setSyncingId(null);
+      }
+    },
+    [importDoc, onDocsImported, onLinkedDocsChange, linkedDocs, remainingSlots]
+  );
+
+  const handleSync = useCallback(
+    async (ref: LinkedDocRef) => {
+      if (remainingSlots <= 0 && !ref.documentId) {
+        setError('Notebook ist voll.');
+        return;
+      }
+      setSyncingId(ref.docId);
+      setError(null);
+      try {
+        if (ref.documentId) {
+          onUploadedDocumentRemoved(ref.documentId);
+        }
+        const imported = await importDoc(ref.docId, ref.docTitle);
+        onDocsImported([imported]);
+        const updated: LinkedDocRef = {
+          ...ref,
+          documentId: imported.id,
+          lastSyncedAt: new Date().toISOString(),
+        };
+        onLinkedDocsChange(linkedDocs.map((d) => (d.docId === ref.docId ? updated : d)));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Sync fehlgeschlagen.');
+      } finally {
+        setSyncingId(null);
+      }
+    },
+    [
+      importDoc,
+      onDocsImported,
+      onLinkedDocsChange,
+      onUploadedDocumentRemoved,
+      linkedDocs,
+      remainingSlots,
+    ]
+  );
+
+  const handleRemove = useCallback(
+    (docId: string) => {
+      const ref = linkedDocs.find((d) => d.docId === docId);
+      if (ref?.documentId) {
+        onUploadedDocumentRemoved(ref.documentId);
+      }
+      onLinkedDocsChange(linkedDocs.filter((d) => d.docId !== docId));
+    },
+    [linkedDocs, onLinkedDocsChange, onUploadedDocumentRemoved]
+  );
+
+  const isLoading = docsQuery.isLoading;
+  const hasAnyDocs = (docsQuery.data ?? []).length > 0;
+
+  const headerActions = (
+    <div className="flex items-center gap-xs">
+      {ExperimentalBadge}
+      {hasAnyDocs && <span className="text-sm text-grey-500">{linkedDocs.length}</span>}
+    </div>
+  );
+
+  return (
+    <section>
+      <SectionHeader
+        title="Docs"
+        onCreate={hasAnyDocs && linkedDocs.length > 0 ? () => setPickerOpen((v) => !v) : undefined}
+        createLabel="Doc hinzufügen"
+        actions={headerActions}
+      />
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900" />
+      ) : !hasAnyDocs ? (
+        <div className="flex flex-col items-start gap-xs rounded-xl border border-dashed border-grey-300 bg-background p-md dark:border-grey-700">
+          <p className="m-0 text-sm text-foreground">Du hast noch keine Docs.</p>
+          <p className="m-0 text-xs text-grey-500">
+            Erstelle ein Doc und du kannst es hier als Quelle hinzufügen.
+          </p>
+          <Button asChild type="button" size="sm" className="mt-xs">
+            <Link to="/docs">Zu meinen Docs →</Link>
+          </Button>
+        </div>
+      ) : (
+        <>
+          {(pickerOpen || linkedDocs.length === 0) && availableDocs.length > 0 && (
+            <div className="mb-md flex flex-col gap-1 rounded-xl border border-grey-200 bg-background p-xs dark:border-grey-700">
+              <p className="m-0 px-1 pb-1 text-xs uppercase tracking-wide text-grey-500">
+                Deine Docs
+              </p>
+              {availableDocs.map((doc) => (
+                <button
+                  key={doc.id}
+                  type="button"
+                  disabled={disabled || syncingId === doc.id}
+                  className="flex items-center gap-sm rounded-md px-sm py-xs text-left transition-colors hover:bg-background-alt disabled:opacity-60"
+                  onClick={() => void handleAttach(doc)}
+                >
+                  {syncingId === doc.id ? (
+                    <span className="size-3.5 shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                  ) : (
+                    <HiDocumentText size={14} className="shrink-0 text-grey-400" aria-hidden />
+                  )}
+                  <span className="truncate text-sm text-foreground">{doc.title}</span>
+                </button>
+              ))}
+            </div>
+          )}
+
+          {linkedDocs.length > 0 && (
+            <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              {linkedDocs.map((ref) => {
+                const isSyncing = syncingId === ref.docId;
+                return (
+                  <div
+                    key={ref.docId}
+                    className={cn(
+                      'group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md transition-all duration-200 dark:border-grey-800',
+                      isSyncing ? 'opacity-90' : 'hover:shadow-sm'
+                    )}
+                    aria-label={`Doc: ${ref.docTitle}`}
+                  >
+                    <div
+                      className="pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-transparent via-amber-400/50 to-transparent dark:via-amber-500/40"
+                      aria-hidden
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      className={cn(
+                        'absolute right-1 top-1 transition-opacity',
+                        isSyncing
+                          ? 'opacity-60'
+                          : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+                      )}
+                      disabled={disabled || isSyncing}
+                      onClick={() => handleRemove(ref.docId)}
+                      title="Importierter Inhalt wird ebenfalls entfernt."
+                      aria-label={`${ref.docTitle} entfernen`}
+                    >
+                      <HiX size={12} />
+                    </Button>
+                    <div className="flex items-start gap-xs pr-6">
+                      <HiDocumentText
+                        size={14}
+                        className="mt-[2px] shrink-0 text-amber-600 dark:text-amber-400"
+                        aria-hidden
+                      />
+                      <div
+                        className="line-clamp-2 break-words text-sm font-medium leading-snug text-foreground"
+                        title={ref.docTitle}
+                      >
+                        {ref.docTitle}
+                      </div>
+                    </div>
+                    <div className="mt-auto flex items-center justify-between gap-xs">
+                      <span className="text-xs text-grey-500">
+                        {isSyncing ? 'Wird importiert…' : formatRelative(ref.lastSyncedAt)}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={disabled || isSyncing || (remainingSlots <= 0 && !ref.documentId)}
+                        onClick={() => void handleSync(ref)}
+                        aria-label={`${ref.docTitle} synchronisieren`}
+                      >
+                        {isSyncing ? (
+                          <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                        ) : (
+                          <HiRefresh size={12} />
+                        )}
+                        Sync
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-md flex items-start gap-xs rounded-md bg-amber-50 px-sm py-xs text-xs text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+              <HiExclamation size={14} className="mt-[1px] shrink-0" aria-hidden />
+              <span>{error}</span>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+};
+
+export default NotebookEditorDocsSection;

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -1,4 +1,5 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
+import { DocsProvider } from '@gruenerator/docs';
 import {
   Button,
   Empty,
@@ -20,6 +21,7 @@ import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useAuthStore } from '../../../stores/authStore';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
+import { webAppDocsAdapter } from '../../docs/docsAdapter';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
@@ -73,6 +75,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         is_public: data.isPublic,
         public_ownership: data.publicOwnership,
         wolkeFolders: data.wolkeFolders,
+        linkedDocs: data.linkedDocs,
       });
 
       toast.success(`Notebook „${data.name}" gespeichert`);
@@ -97,6 +100,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
         is_public: data.isPublic,
         public_ownership: data.publicOwnership,
         wolkeFolders: data.wolkeFolders,
+        linkedDocs: data.linkedDocs,
       });
       toast.success(`Notebook „${data.name}" erstellt`);
       const slug = created.slug_suffix
@@ -145,149 +149,154 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
 
   return (
     <ErrorBoundary>
-      <PageContainer maxWidth="lg" noPadTop>
-        <div className="mb-md flex items-center justify-between gap-md">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={goBack}
-            className="-ml-2 gap-xs text-grey-500 hover:text-foreground"
-          >
-            <HiArrowLeft size={14} />
-            Meine Notebooks
-          </Button>
-          {mode === 'edit' &&
-          editingCollection &&
-          currentUserId &&
-          editingCollection.user_id === currentUserId ? (
+      <DocsProvider adapter={webAppDocsAdapter}>
+        <PageContainer maxWidth="lg" noPadTop>
+          <div className="mb-md flex items-center justify-between gap-md">
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
-              onClick={() => setShareOpen(true)}
-              className="gap-xs"
+              onClick={goBack}
+              className="-ml-2 gap-xs text-grey-500 hover:text-foreground"
             >
-              <HiShare size={14} />
-              Teilen
+              <HiArrowLeft size={14} />
+              Meine Notebooks
             </Button>
+            {mode === 'edit' &&
+            editingCollection &&
+            currentUserId &&
+            editingCollection.user_id === currentUserId ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShareOpen(true)}
+                className="gap-xs"
+              >
+                <HiShare size={14} />
+                Teilen
+              </Button>
+            ) : null}
+          </div>
+          {mode === 'edit' && editingCollection ? (
+            <NotebookShareModal
+              notebookId={editingCollection.id}
+              open={shareOpen}
+              onOpenChange={setShareOpen}
+            />
           ) : null}
-        </div>
-        {mode === 'edit' && editingCollection ? (
-          <NotebookShareModal
-            notebookId={editingCollection.id}
-            open={shareOpen}
-            onOpenChange={setShareOpen}
-          />
-        ) : null}
 
-        {mode === 'edit' && editingCollection ? (
-          <div className="mb-xl text-center">
-            {editingField === 'name' ? (
-              <input
-                autoFocus
-                defaultValue={editingCollection.name}
-                maxLength={100}
-                onBlur={(e) => void commitHeroName(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    void commitHeroName(e.currentTarget.value);
-                  } else if (e.key === 'Escape') {
-                    e.preventDefault();
-                    setEditingField(null);
-                  }
-                }}
-                className="mb-xs w-full bg-transparent text-center text-4xl font-semibold text-foreground-heading outline-none max-md:text-2xl"
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => setEditingField('name')}
-                disabled={isUpdating}
-                className="mb-xs block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
-                aria-label="Name bearbeiten"
-              >
-                <h1 className="text-4xl font-semibold text-foreground-heading max-md:text-2xl">
-                  {editingCollection.name}
-                </h1>
-              </button>
-            )}
-
-            {editingField === 'desc' ? (
-              <textarea
-                autoFocus
-                rows={2}
-                defaultValue={editingCollection.description ?? ''}
-                maxLength={500}
-                placeholder="Beschreibung hinzufügen…"
-                onBlur={(e) => void commitHeroDesc(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                    e.preventDefault();
-                    void commitHeroDesc(e.currentTarget.value);
-                  } else if (e.key === 'Escape') {
-                    e.preventDefault();
-                    setEditingField(null);
-                  }
-                }}
-                className="w-full resize-none bg-transparent text-center text-lg text-grey-500 outline-none placeholder:text-grey-400 dark:text-grey-400"
-              />
-            ) : (
-              <button
-                type="button"
-                onClick={() => setEditingField('desc')}
-                disabled={isUpdating}
-                className="block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
-                aria-label="Beschreibung bearbeiten"
-              >
-                <p
-                  className={cn(
-                    'text-lg',
-                    editingCollection.description
-                      ? 'text-grey-500 dark:text-grey-400'
-                      : 'italic text-grey-400'
-                  )}
+          {mode === 'edit' && editingCollection ? (
+            <div className="mb-xl text-center">
+              {editingField === 'name' ? (
+                <input
+                  autoFocus
+                  defaultValue={editingCollection.name}
+                  maxLength={100}
+                  onBlur={(e) => void commitHeroName(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void commitHeroName(e.currentTarget.value);
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setEditingField(null);
+                    }
+                  }}
+                  className="mb-xs w-full bg-transparent text-center text-4xl font-semibold text-foreground-heading outline-none max-md:text-2xl"
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingField('name')}
+                  disabled={isUpdating}
+                  className="mb-xs block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
+                  aria-label="Name bearbeiten"
                 >
-                  {editingCollection.description || 'Beschreibung hinzufügen…'}
-                </p>
-              </button>
-            )}
-          </div>
-        ) : null}
+                  <h1 className="text-4xl font-semibold text-foreground-heading max-md:text-2xl">
+                    {editingCollection.name}
+                  </h1>
+                </button>
+              )}
 
-        {mode === 'edit' && query.isLoading ? (
-          <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="h-28 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900" />
-            ))}
-          </div>
-        ) : isEditMissing ? (
-          <Empty>
-            <EmptyHeader>
-              <EmptyTitle>Notebook nicht gefunden</EmptyTitle>
-              <EmptyDescription>
-                Dieses Notebook existiert nicht oder wurde gelöscht.
-              </EmptyDescription>
-            </EmptyHeader>
-            <EmptyContent>
-              <Button onClick={goBack}>Zurück zu Meine Notebooks</Button>
-            </EmptyContent>
-          </Empty>
-        ) : mode === 'edit' && editingCollection ? (
-          <NotebookEditor
-            editingCollection={editingCollection}
-            loading={isUpdating}
-            onCancel={goBack}
-            onSave={(data) => handleEditSave(editingCollection, data)}
-          />
-        ) : (
-          <NotebookEditor
-            editingCollection={null}
-            loading={isCreating}
-            onCancel={goBack}
-            onSave={handleCreateSave}
-          />
-        )}
-      </PageContainer>
+              {editingField === 'desc' ? (
+                <textarea
+                  autoFocus
+                  rows={2}
+                  defaultValue={editingCollection.description ?? ''}
+                  maxLength={500}
+                  placeholder="Beschreibung hinzufügen…"
+                  onBlur={(e) => void commitHeroDesc(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      void commitHeroDesc(e.currentTarget.value);
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setEditingField(null);
+                    }
+                  }}
+                  className="w-full resize-none bg-transparent text-center text-lg text-grey-500 outline-none placeholder:text-grey-400 dark:text-grey-400"
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingField('desc')}
+                  disabled={isUpdating}
+                  className="block w-full rounded-md px-2 py-1 text-center transition-colors hover:bg-background-alt/50"
+                  aria-label="Beschreibung bearbeiten"
+                >
+                  <p
+                    className={cn(
+                      'text-lg',
+                      editingCollection.description
+                        ? 'text-grey-500 dark:text-grey-400'
+                        : 'italic text-grey-400'
+                    )}
+                  >
+                    {editingCollection.description || 'Beschreibung hinzufügen…'}
+                  </p>
+                </button>
+              )}
+            </div>
+          ) : null}
+
+          {mode === 'edit' && query.isLoading ? (
+            <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-28 animate-pulse rounded-xl bg-grey-100 dark:bg-grey-900"
+                />
+              ))}
+            </div>
+          ) : isEditMissing ? (
+            <Empty>
+              <EmptyHeader>
+                <EmptyTitle>Notebook nicht gefunden</EmptyTitle>
+                <EmptyDescription>
+                  Dieses Notebook existiert nicht oder wurde gelöscht.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button onClick={goBack}>Zurück zu Meine Notebooks</Button>
+              </EmptyContent>
+            </Empty>
+          ) : mode === 'edit' && editingCollection ? (
+            <NotebookEditor
+              editingCollection={editingCollection}
+              loading={isUpdating}
+              onCancel={goBack}
+              onSave={(data) => handleEditSave(editingCollection, data)}
+            />
+          ) : (
+            <NotebookEditor
+              editingCollection={null}
+              loading={isCreating}
+              onCancel={goBack}
+              onSave={handleCreateSave}
+            />
+          )}
+        </PageContainer>
+      </DocsProvider>
     </ErrorBoundary>
   );
 }

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -2,7 +2,7 @@
  * Notebook/Q&A Collection Types
  */
 
-import { type WolkeFolderRef } from '@gruenerator/contracts';
+import { type LinkedDocRef, type WolkeFolderRef } from '@gruenerator/contracts';
 
 import type { Document } from './documents';
 
@@ -51,6 +51,7 @@ export interface NotebookCollection {
   selection_mode?: 'documents' | 'wolke' | 'mixed';
   labels?: string[];
   wolke_folders?: WolkeFolderRef[];
+  linked_docs?: LinkedDocRef[];
   likes_count?: number;
   share_mode?: NotebookShareMode | null;
   edit_policy?: NotebookEditPolicy | null;
@@ -94,6 +95,7 @@ export interface NotebookCollectionInput {
   is_public?: boolean;
   public_ownership?: NotebookPublicOwnership | null;
   wolkeFolders?: WolkeFolderRef[];
+  linkedDocs?: LinkedDocRef[];
 }
 
 /**

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -46,6 +46,25 @@ export const wolkeFolderRefSchema = z.object({
 });
 export type WolkeFolderRef = z.infer<typeof wolkeFolderRefSchema>;
 
+/**
+ * Experimental: User-owned Doc linked to a notebook as a source.
+ *
+ * Persisted inside `settings.linked_docs` (JSONB on `notebook_collections`).
+ * Each entry remembers which Doc was imported and the resulting Document id
+ * so a re-sync can replace the previous snapshot in place.
+ *
+ * The actual content import goes through the regular file-upload path
+ * (markdown export → File → uploadFileOnly), so security and indexing
+ * reuse the same plumbing as manual uploads.
+ */
+export const linkedDocRefSchema = z.object({
+  docId: z.string(),
+  docTitle: z.string(),
+  documentId: z.string().nullable().optional(),
+  lastSyncedAt: z.string().nullable().optional(),
+});
+export type LinkedDocRef = z.infer<typeof linkedDocRefSchema>;
+
 export const createCollectionBodySchema = z.object({
   name: z.string(),
   description: z.string().nullish(),
@@ -59,6 +78,7 @@ export const createCollectionBodySchema = z.object({
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullish(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
+  linked_docs: z.array(linkedDocRefSchema).nullish(),
 });
 
 export const updateCollectionBodySchema = z.object({
@@ -74,6 +94,7 @@ export const updateCollectionBodySchema = z.object({
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullish(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
+  linked_docs: z.array(linkedDocRefSchema).nullish(),
 });
 
 export const bulkDeleteBodySchema = z.object({
@@ -102,6 +123,7 @@ export const notebookEditorSavePayloadSchema = z.object({
   isPublic: z.boolean(),
   publicOwnership: publicOwnershipSchema.nullable(),
   wolkeFolders: z.array(wolkeFolderRefSchema).default([]),
+  linkedDocs: z.array(linkedDocRefSchema).default([]),
 });
 
 export type NotebookEditorSavePayload = z.infer<typeof notebookEditorSavePayloadSchema>;
@@ -154,6 +176,7 @@ export const transformedCollectionSchema = z.object({
   is_public: z.boolean().nullish(),
   public_ownership: publicOwnershipSchema.nullable().optional(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
+  linked_docs: z.array(linkedDocRefSchema).nullish(),
   likes_count: z.number().nullish(),
   share_mode: notebookShareModeSchema.nullish(),
   edit_policy: notebookEditPolicySchema.nullish(),


### PR DESCRIPTION
Adds user-owned Docs as a third source option in the notebook creation wizard (next to file uploads and Wolke folders), marked **Experimentell** to match the Wolke pattern. UI mirrors `NotebookEditorWolkeSection` so the mental model stays consistent across source types: choice card on step 1 → expandable picker listing your Docs → per-link Sync button that refreshes the imported snapshot.

**Stacked on top of #912** — the diff shown to GitHub includes those four wizard-polish commits until #912 merges, at which point this PR's diff resolves to the three Docs commits only.

## Implementation — no new backend endpoint needed

The pleasant part of the design is that doc-to-markdown import reuses the existing file-upload pipeline:

1. User picks a Doc from the picker → frontend `GET /api/docs/:id/export/markdown` (already exists)
2. Wraps the response in `new File([markdown], "<title>.md", { type: "text/markdown" })`
3. Calls the same `uploadFileOnly()` that manual file uploads use → returns a Document id
4. Re-sync flow removes the previous Document id from `uploadedDocuments` before importing the new snapshot, so a refreshed Doc *replaces* its old copy instead of leaving a stale one behind

The backend change is only persistence: a parallel `settings.linked_docs` JSONB field next to `settings.wolke_folders`. No new contract route, no new ingestion service.

## What's in the diff

- `LinkedDocRef` Zod schema (`contracts/schemas/notebookCollections.ts`) wired through create/update body, editor save payload, and `transformedCollectionSchema`
- `collectionsController` reads/writes `linked_docs` from settings JSONB
- New `NotebookEditorDocsSection.tsx` (component, mirrors `NotebookEditorWolkeSection`)
- Wizard `SourcesStep` adds the third card + expandable Docs panel; review step counts "X aus Docs"
- Edit form renders the section below Wolke
- `NotebookEditorPage` is wrapped in `<DocsProvider adapter={webAppDocsAdapter}>` so `useDocuments()` works
- `linkedDocDocumentIds` excludes imported markdown from the manual documents grid (Docs section card is the canonical UI for them — avoids duplicate display)

## Known follow-up (separate plan-mode session)

A single "Refresh all" action that diff-syncs *both* Wolke folders and Linked Docs in one click — adding new items, removing gone items, refreshing changed ones. Tracked but deliberately out of scope here.

## Test plan
- [ ] Open `/notebooks/neu`, click the third "Aus Docs importieren" card → expands a panel listing your Docs (or "Du hast noch keine Docs." with a link to `/docs` if empty)
- [ ] Click a doc → snapshot imports as markdown, appears as a card with `Importiert vor wenigen Sekunden`, doesn't double-show in the manual grid
- [ ] Click Sync on a doc card → old document removed, new snapshot imported with refreshed timestamp
- [ ] Save the notebook → review step counts include "X aus Docs"; reload edit page, Docs cards persist with their `lastSyncedAt`
- [ ] Edit existing notebook → docs section renders below Wolke section, Sync works there too
- [ ] Remove a doc card → the imported markdown also disappears from the notebook