### PR TITLE
fix(api): add linked_docs to local CreateCollectionBody / UpdateCollectionBody

### DIFF
--- a/apps/api/routes/notebook/types.ts
+++ b/apps/api/routes/notebook/types.ts
@@ -5,7 +5,7 @@
 import { type AuthenticatedRequest } from '../../middleware/types.js';
 
 import type AIWorkerPool from '../../workers/aiWorkerPool.js';
-import type { WolkeFolderRef } from '@gruenerator/contracts';
+import type { LinkedDocRef, WolkeFolderRef } from '@gruenerator/contracts';
 import type { ParamsDictionary } from 'express-serve-static-core';
 
 // =============================================================================
@@ -26,6 +26,7 @@ export interface CreateCollectionBody {
   remove_missing_on_sync?: boolean | undefined;
   labels?: string[] | undefined;
   wolke_folders?: WolkeFolderRef[] | undefined;
+  linked_docs?: LinkedDocRef[] | undefined;
 }
 
 /**
@@ -42,6 +43,7 @@ export interface UpdateCollectionBody {
   remove_missing_on_sync?: boolean | undefined;
   labels?: string[] | undefined;
   wolke_folders?: WolkeFolderRef[] | undefined;
+  linked_docs?: LinkedDocRef[] | undefined;
 }
 
 /**
@@ -108,6 +110,7 @@ export interface TransformedCollection {
   notebook_collection_documents?: Array<{ document_id: string }>;
   labels?: string[];
   wolke_folders?: WolkeFolderRef[];
+  linked_docs?: LinkedDocRef[];
   slug_suffix?: string | null;
 }
 


### PR DESCRIPTION
Master's api Docker image build started failing after #913 merged: TS2339 on `routes/notebook/collectionsController.ts(200,7)` and `(353,9)` because the controller destructures `linked_docs` but the hand-written `CreateCollectionBody` / `UpdateCollectionBody` interfaces in `apps/api/routes/notebook/types.ts` didn't have the field.

Dev `pnpm typecheck` missed this gap because the workspace's `development` exports condition resolves `@gruenerator/contracts` to the raw `.ts` files. The Docker build does a real compile of the contracts package first and then consumes the emitted `.d.ts`, so the hand-written body interface (which is the actual type at the request-body cast site) becomes the source of truth. The schema-vs-interface drift is exactly the **4-layer type-safety audit** miss flagged in the project memory.

This adds `linked_docs?: LinkedDocRef[]` to both body interfaces and to `TransformedCollection`. Verified locally with the exact Dockerfile command:

```
cd apps/api && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --project tsconfig.build.json
```

Follow-up worth tracking separately: those hand-written body interfaces should probably be replaced with `z.infer<typeof createCollectionBodySchema>` so this drift can't happen again. Not doing it in this hotfix to keep the diff surgical.