### PR TITLE
feat(notebooks): per-locale audience for share_mode='authenticated'

### DIFF
--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -27,6 +27,7 @@ type PublicOwnership = 'owner' | 'public_data';
 
 export type NotebookShareMode = 'private' | 'groups' | 'authenticated';
 export type NotebookEditPolicy = 'owner_only' | 'group_admins' | 'all_members';
+export type NotebookAudience = 'de-DE' | 'de-AT' | 'all';
 
 const NOTEBOOK_SHARE_MODES: readonly NotebookShareMode[] = ['private', 'groups', 'authenticated'];
 const NOTEBOOK_EDIT_POLICIES: readonly NotebookEditPolicy[] = [
@@ -34,6 +35,7 @@ const NOTEBOOK_EDIT_POLICIES: readonly NotebookEditPolicy[] = [
   'group_admins',
   'all_members',
 ];
+const NOTEBOOK_AUDIENCES: readonly NotebookAudience[] = ['de-DE', 'de-AT', 'all'];
 
 function normalizeShareMode(raw: unknown): NotebookShareMode {
   return NOTEBOOK_SHARE_MODES.includes(raw as NotebookShareMode)
@@ -45,6 +47,10 @@ function normalizeEditPolicy(raw: unknown): NotebookEditPolicy {
   return NOTEBOOK_EDIT_POLICIES.includes(raw as NotebookEditPolicy)
     ? (raw as NotebookEditPolicy)
     : 'owner_only';
+}
+
+function normalizeAudience(raw: unknown): NotebookAudience {
+  return NOTEBOOK_AUDIENCES.includes(raw as NotebookAudience) ? (raw as NotebookAudience) : 'all';
 }
 
 interface NotebookCollectionData {
@@ -67,6 +73,14 @@ interface NotebookCollectionData {
   public_ownership?: PublicOwnership | null;
   share_mode?: NotebookShareMode;
   edit_policy?: NotebookEditPolicy;
+  /**
+   * Locale audience for `share_mode='authenticated'` listings. When set to
+   * 'de-DE' / 'de-AT' the notebook is hidden from viewers whose `users.locale`
+   * doesn't match; 'all' (the default for legacy rows) shows it everywhere.
+   * Has no effect on owners or group-share recipients — those are explicit
+   * grants and bypass the audience filter.
+   */
+  audience?: NotebookAudience;
   /**
    * 6-char URL-safe tail used in Notion-style slugs (`my-notes-Ab3xK9`).
    * Assigned at creation, immutable afterwards — rename rewrites the name
@@ -99,6 +113,7 @@ interface NotebookCollection {
   public_ownership: PublicOwnership | null;
   share_mode: NotebookShareMode;
   edit_policy: NotebookEditPolicy;
+  audience: NotebookAudience;
   slug_suffix: string | null;
   notebook_collection_documents?: CollectionDocument[];
 }
@@ -247,6 +262,7 @@ class NotebookQdrantHelper {
           public_ownership: collectionData.public_ownership ?? null,
           share_mode: normalizeShareMode(collectionData.share_mode),
           edit_policy: normalizeEditPolicy(collectionData.edit_policy),
+          audience: normalizeAudience(collectionData.audience),
           slug_suffix: slugSuffix,
         },
       };
@@ -717,6 +733,7 @@ class NotebookQdrantHelper {
       public_ownership: publicOwnership,
       share_mode: normalizeShareMode(payload.share_mode),
       edit_policy: normalizeEditPolicy(payload.edit_policy),
+      audience: normalizeAudience(payload.audience),
       slug_suffix:
         typeof payload.slug_suffix === 'string' && payload.slug_suffix.length > 0
           ? payload.slug_suffix

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -66,6 +66,16 @@ function getUserId(req: Request): string {
   return user.id;
 }
 
+/**
+ * Resolve the calling user's locale for audience-filter decisions.
+ * Falls back to 'de-DE' when the column is unset (matches the database
+ * default in apps/api/database/schema/core.ts).
+ */
+function getUserLocale(req: Request): 'de-DE' | 'de-AT' {
+  const user = req.user as UserProfile | undefined;
+  return user?.locale === 'de-AT' ? 'de-AT' : 'de-DE';
+}
+
 // ── Helpers copied from collectionsController ──────────────────────────────
 
 async function resolveWolkeLinksToDocuments(
@@ -192,6 +202,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         public_ownership?: 'owner' | 'public_data' | null;
         share_mode?: 'private' | 'groups' | 'authenticated';
         edit_policy?: 'owner_only' | 'group_admins' | 'all_members';
+        audience?: 'de-DE' | 'de-AT' | 'all';
       };
 
       const owned = (await notebookHelper.getUserNotebookCollections(
@@ -219,12 +230,21 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       ).filter((c) => c.share_mode === 'groups');
       const groupSharedIdsSet = new Set(groupShared.map((c) => c.id));
 
-      // Notebooks visible to any authenticated user — excluding ones we already have.
+      // Notebooks visible to any authenticated user — excluding ones we already
+      // have AND respecting the audience filter so an AT viewer doesn't get a
+      // DE-targeted notebook (and vice versa). Legacy rows have no `audience`
+      // → normaliser returns 'all' → always visible.
+      const viewerLocale = getUserLocale(args.req);
       const authShared = (
         (await notebookHelper.getNotebookCollectionsByShareMode(
           'authenticated'
         )) as NotebookCollectionFromQdrantRaw[]
-      ).filter((c) => !ownedIds.has(c.id) && !groupSharedIdsSet.has(c.id));
+      ).filter(
+        (c) =>
+          !ownedIds.has(c.id) &&
+          !groupSharedIdsSet.has(c.id) &&
+          (c.audience === undefined || c.audience === 'all' || c.audience === viewerLocale)
+      );
 
       const tagged: Array<{
         collection: NotebookCollectionFromQdrantRaw;
@@ -396,7 +416,12 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         is_public,
         public_ownership,
         wolke_folders: wolkeFoldersRaw,
+        audience: audienceRaw,
       } = args.body;
+      // Default audience to the creator's locale so an Austrian user creating
+      // a notebook ships AT-targeted by default. Caller can override via the
+      // share modal (PUT /share/audience) or by sending an explicit value.
+      const audience = audienceRaw ?? getUserLocale(args.req);
 
       const selection_mode = selectionModeRaw ?? 'documents';
       const document_ids = documentIdsRaw ?? [];
@@ -497,6 +522,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         },
         is_public: is_public === true,
         public_ownership: is_public === true ? (public_ownership ?? null) : null,
+        audience,
       };
 
       const result = await notebookHelper.storeNotebookCollection(collectionData);

--- a/apps/api/routes/notebook/notebookSharingContractRouter.ts
+++ b/apps/api/routes/notebook/notebookSharingContractRouter.ts
@@ -99,7 +99,11 @@ export const notebookSharingContractRouter = s.router(notebookSharingContract, {
       }
       return {
         status: 200 as const,
-        body: { share_mode: collection.share_mode, edit_policy: collection.edit_policy },
+        body: {
+          share_mode: collection.share_mode,
+          edit_policy: collection.edit_policy,
+          audience: collection.audience,
+        },
       };
     } catch (error) {
       log.error('[notebookSharingContract.getShareSettings] Error:', error);
@@ -149,6 +153,29 @@ export const notebookSharingContractRouter = s.router(notebookSharingContract, {
       };
     } catch (error) {
       log.error('[notebookSharingContract.setEditPolicy] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  setAudience: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collection = await notebookHelper.getNotebookCollection(args.params.id);
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (collection.user_id !== userId) {
+        return { status: 403 as const, body: { error: 'Nur Eigentümer*in erlaubt' } };
+      }
+      await notebookHelper.updateNotebookCollection(args.params.id, {
+        audience: args.body.audience,
+      });
+      return {
+        status: 200 as const,
+        body: { success: true, message: 'Zielgruppe aktualisiert' },
+      };
+    } catch (error) {
+      log.error('[notebookSharingContract.setAudience] Error:', error);
       return { status: 500 as const, body: { error: 'Internal server error' } };
     }
   },

--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -30,11 +30,16 @@ import {
   useNotebookGroupShares,
   useNotebookShareSettings,
   useRemoveNotebookGroupShare,
+  useSetNotebookAudience,
   useSetNotebookEditPolicy,
   useSetNotebookShareMode,
 } from '../hooks/useNotebookSharing';
 
-import type { NotebookEditPolicy, NotebookShareMode } from '@gruenerator/contracts';
+import type {
+  NotebookAudience,
+  NotebookEditPolicy,
+  NotebookShareMode,
+} from '@gruenerator/contracts';
 
 interface NotebookShareModalProps {
   notebookId: string;
@@ -54,6 +59,12 @@ const EDIT_POLICY_LABELS: Record<NotebookEditPolicy, string> = {
   all_members: 'Alle Mitglieder der geteilten Gruppen',
 };
 
+const AUDIENCE_LABELS: Record<NotebookAudience, string> = {
+  all: 'Beide Länder (DE & AT)',
+  'de-DE': 'Nur Deutschland',
+  'de-AT': 'Nur Österreich',
+};
+
 export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookShareModalProps) {
   const settingsQuery = useNotebookShareSettings(notebookId, open);
   const groupSharesQuery = useNotebookGroupShares(notebookId, open);
@@ -61,11 +72,13 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
 
   const setShareMode = useSetNotebookShareMode(notebookId);
   const setEditPolicy = useSetNotebookEditPolicy(notebookId);
+  const setAudience = useSetNotebookAudience(notebookId);
   const addGroupShare = useAddNotebookGroupShare(notebookId);
   const removeGroupShare = useRemoveNotebookGroupShare(notebookId);
 
   const shareMode = settingsQuery.data?.share_mode ?? 'private';
   const editPolicy = settingsQuery.data?.edit_policy ?? 'owner_only';
+  const audience = settingsQuery.data?.audience ?? 'all';
 
   const sharedGroupIds = useMemo(
     () => new Set((groupSharesQuery.data ?? []).map((g) => g.group_id)),
@@ -170,6 +183,32 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
                 ) : null}
               </div>
             ) : null}
+
+            <Separator />
+
+            <div>
+              <p className="mb-xs text-sm font-semibold">Zielgruppe</p>
+              <Select
+                value={audience}
+                onValueChange={(v) => setAudience.mutate(v as NotebookAudience)}
+                disabled={setAudience.isPending}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(AUDIENCE_LABELS) as NotebookAudience[]).map((a) => (
+                    <SelectItem key={a} value={a}>
+                      {AUDIENCE_LABELS[a]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="mt-xs text-xs text-grey-500">
+                Wirkt nur in &quot;Mit Anmeldung&quot;: Nutzer*innen aus dem anderen Land sehen das
+                Notebook dann nicht. Gruppen-Mitglieder und Eigentümer*in sind nicht betroffen.
+              </p>
+            </div>
 
             <Separator />
 

--- a/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
@@ -6,6 +6,7 @@
  * at compile time and responses are status-narrowed.
  */
 import {
+  type NotebookAudience,
   type NotebookEditPolicy,
   type NotebookShareMode,
   type NotebookUserGroup,
@@ -82,6 +83,27 @@ export function useSetNotebookShareMode(notebookId: string) {
       });
       if (result.status !== 200) {
         throw new Error(`Failed to set share mode (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
+      void qc.invalidateQueries({ queryKey: ['notebookCollections'] });
+    },
+  });
+}
+
+export function useSetNotebookAudience(notebookId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (audience: NotebookAudience) => {
+      const client = getContractsClient();
+      const result = await client.notebookSharing.setAudience({
+        params: { id: notebookId },
+        body: { audience },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to set audience (HTTP ${result.status})`);
       }
       return result.body;
     },

--- a/packages/contracts/src/contracts/notebookSharingContract.ts
+++ b/packages/contracts/src/contracts/notebookSharingContract.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import { notebookErrorResponseSchema } from '../schemas/notebook.js';
 import {
   notebookAddGroupShareBodySchema,
+  notebookAudienceBodySchema,
   notebookEditPolicyBodySchema,
   notebookGroupSharesResponseSchema,
   notebookShareErrorResponseSchema,
@@ -101,6 +102,28 @@ export const notebookSharingContract = c.router(
         500: notebookErrorResponseSchema,
       },
       summary: 'Set notebook edit policy',
+    },
+
+    /**
+     * PUT /api/auth/notebook-collections/:id/share/audience
+     * Update locale audience (de-DE | de-AT | all). Owner only.
+     * Only filters the `share_mode='authenticated'` listing — owners and
+     * explicit group-share viewers always see the notebook regardless of
+     * audience.
+     */
+    setAudience: {
+      method: 'PUT',
+      path: '/api/auth/notebook-collections/:id/share/audience',
+      pathParams: z.object({ id: z.string() }),
+      body: notebookAudienceBodySchema,
+      responses: {
+        200: notebookSimpleSuccessSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Set notebook locale audience',
     },
 
     /**

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -20,6 +20,17 @@ export const notebookEditPolicySchema = z.enum(['owner_only', 'group_admins', 'a
 export type NotebookEditPolicy = z.infer<typeof notebookEditPolicySchema>;
 
 /**
+ * Locale audience for a notebook. Only constrains the visibility of
+ * `share_mode='authenticated'` listings: 'de-DE' / 'de-AT' hide the notebook
+ * from viewers whose `users.locale` doesn't match; 'all' shows it everywhere.
+ * Owner + explicit group-share viewers always bypass the audience filter.
+ *
+ * Convention mirrors `AgentAudience` (`packages/shared/src/agents/types.ts`).
+ */
+export const notebookAudienceSchema = z.enum(['de-DE', 'de-AT', 'all']);
+export type NotebookAudience = z.infer<typeof notebookAudienceSchema>;
+
+/**
  * Tag every notebook in a list response with how the calling user can reach it.
  * Lets the UI render a "Mit dir geteilt" section without re-querying access.
  */
@@ -79,6 +90,7 @@ export const createCollectionBodySchema = z.object({
   public_ownership: publicOwnershipSchema.nullish(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
   linked_docs: z.array(linkedDocRefSchema).nullish(),
+  audience: notebookAudienceSchema.nullish(),
 });
 
 export const updateCollectionBodySchema = z.object({
@@ -95,6 +107,7 @@ export const updateCollectionBodySchema = z.object({
   public_ownership: publicOwnershipSchema.nullish(),
   wolke_folders: z.array(wolkeFolderRefSchema).nullish(),
   linked_docs: z.array(linkedDocRefSchema).nullish(),
+  audience: notebookAudienceSchema.nullish(),
 });
 
 export const bulkDeleteBodySchema = z.object({
@@ -180,6 +193,7 @@ export const transformedCollectionSchema = z.object({
   likes_count: z.number().nullish(),
   share_mode: notebookShareModeSchema.nullish(),
   edit_policy: notebookEditPolicySchema.nullish(),
+  audience: notebookAudienceSchema.nullish(),
   access_source: notebookAccessSourceSchema.nullish(),
   slug_suffix: z.string().nullish(),
 });

--- a/packages/contracts/src/schemas/notebookSharing.ts
+++ b/packages/contracts/src/schemas/notebookSharing.ts
@@ -9,13 +9,18 @@
  */
 import { z } from 'zod';
 
-import { notebookEditPolicySchema, notebookShareModeSchema } from './notebookCollections.js';
+import {
+  notebookAudienceSchema,
+  notebookEditPolicySchema,
+  notebookShareModeSchema,
+} from './notebookCollections.js';
 
 // ── Settings shape ──────────────────────────────────────────────────────────
 
 export const notebookShareSettingsSchema = z.object({
   share_mode: notebookShareModeSchema,
   edit_policy: notebookEditPolicySchema,
+  audience: notebookAudienceSchema,
 });
 export type NotebookShareSettings = z.infer<typeof notebookShareSettingsSchema>;
 
@@ -27,6 +32,10 @@ export const notebookShareModeBodySchema = z.object({
 
 export const notebookEditPolicyBodySchema = z.object({
   policy: notebookEditPolicySchema,
+});
+
+export const notebookAudienceBodySchema = z.object({
+  audience: notebookAudienceSchema,
 });
 
 export const notebookAddGroupShareBodySchema = z.object({


### PR DESCRIPTION
## Why

User notebooks shared via `share_mode='authenticated'` are visible to every logged-in user across both countries, which dilutes the listing for the locale that's not the notebook's target. Adds an `audience` axis (`de-DE` | `de-AT` | `all`) so the "Mit Anmeldung" view divides cleanly between AT and DE.

- New notebooks default to the **creator's locale** so an Austrian user creating a notebook ships AT-targeted by default — they can flip to "Beide Länder" in the share modal.
- Legacy notebooks have no `audience` payload key → `normalizeAudience` returns `'all'` → no behavior change for existing data.
- Owners and explicit group-share recipients **always bypass** the filter. Audience suppresses unsolicited discovery only; direct URL access still works (matches how system-agent `audience` behaves).

## Surface

- New endpoint: `PUT /api/auth/notebook-collections/:id/share/audience` (owner-only)
- `getShareSettings` response now carries `audience`
- `transformedCollectionSchema` and `createCollectionBodySchema` extended
- Share modal adds a "Zielgruppe" Select with copy explaining its effect is limited to the authenticated listing