### PR TITLE
feat(notebook): one-click full-sync for Wolke + Docs

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -12,7 +12,7 @@ import {
 import { buildNotebookSlug, extractSlugSuffix } from '@gruenerator/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
-import { HiArrowLeft, HiShare } from 'react-icons/hi';
+import { HiArrowLeft, HiRefresh, HiShare } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import withAuthRequired from '../../../components/common/LoginRequired/withAuthRequired';
@@ -25,6 +25,7 @@ import { webAppDocsAdapter } from '../../docs/docsAdapter';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 
 import NotebookEditor from './NotebookEditor';
+import { NotebookFullSyncModal } from './NotebookFullSyncModal';
 import { NotebookShareModal } from './NotebookShareModal';
 
 import type { NotebookCollection } from '../../../types/notebook';
@@ -43,6 +44,7 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
     useNotebookCollections({ isActive: true });
   const [editingField, setEditingField] = useState<'name' | 'desc' | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
+  const [fullSyncOpen, setFullSyncOpen] = useState(false);
 
   const collections = useMemo<NotebookCollection[]>(() => query.data ?? [], [query.data]);
   const editingCollection = useMemo<NotebookCollection | null>(() => {
@@ -165,15 +167,29 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
             editingCollection &&
             currentUserId &&
             editingCollection.user_id === currentUserId ? (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setShareOpen(true)}
-                className="gap-xs"
-              >
-                <HiShare size={14} />
-                Teilen
-              </Button>
+              <div className="flex items-center gap-xs">
+                {((editingCollection.wolke_folders?.length ?? 0) > 0 ||
+                  (editingCollection.linked_docs?.length ?? 0) > 0) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setFullSyncOpen(true)}
+                    className="gap-xs"
+                  >
+                    <HiRefresh size={14} />
+                    Alle Quellen aktualisieren
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShareOpen(true)}
+                  className="gap-xs"
+                >
+                  <HiShare size={14} />
+                  Teilen
+                </Button>
+              </div>
             ) : null}
           </div>
           {mode === 'edit' && editingCollection ? (
@@ -181,6 +197,13 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
               notebookId={editingCollection.id}
               open={shareOpen}
               onOpenChange={setShareOpen}
+            />
+          ) : null}
+          {mode === 'edit' && editingCollection && fullSyncOpen ? (
+            <NotebookFullSyncModal
+              collection={editingCollection}
+              open={fullSyncOpen}
+              onOpenChange={setFullSyncOpen}
             />
           ) : null}
 

--- a/apps/web/src/features/notebook/components/NotebookFullSyncModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookFullSyncModal.tsx
@@ -1,0 +1,156 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@gruenerator/ui';
+import { useEffect, useRef } from 'react';
+import { HiCheck, HiCloud, HiDocumentText, HiExclamation } from 'react-icons/hi';
+
+import { cn } from '../../../utils/cn';
+import {
+  useNotebookFullSync,
+  type SyncProgressRow,
+  type SyncProgressStatus,
+} from '../hooks/useNotebookFullSync';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+interface Props {
+  collection: NotebookCollection;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function StatusIcon({ status }: { status: SyncProgressStatus }) {
+  if (status === 'pending') {
+    return (
+      <span className="size-3 shrink-0 rounded-full bg-grey-300 dark:bg-grey-700" aria-hidden />
+    );
+  }
+  if (status === 'running') {
+    return (
+      <span
+        className="size-3 shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500"
+        aria-hidden
+      />
+    );
+  }
+  if (status === 'done') {
+    return <HiCheck size={16} className="shrink-0 text-green-600 dark:text-green-400" aria-hidden />;
+  }
+  return (
+    <HiExclamation size={16} className="shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />
+  );
+}
+
+function SyncRow({ row }: { row: SyncProgressRow }) {
+  const accentClass =
+    row.kind === 'wolke'
+      ? 'via-secondary-400/50 dark:via-secondary-500/40'
+      : 'via-amber-400/50 dark:via-amber-500/40';
+  const Icon = row.kind === 'wolke' ? HiCloud : HiDocumentText;
+  return (
+    <div className="relative flex items-center gap-sm overflow-hidden rounded-lg border border-grey-200 bg-background px-md py-sm dark:border-grey-800">
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-transparent to-transparent',
+          accentClass
+        )}
+        aria-hidden
+      />
+      <Icon size={14} className="shrink-0 text-grey-400" aria-hidden />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium text-foreground">{row.title}</span>
+        {row.summary && <span className="text-xs text-grey-500">{row.summary}</span>}
+        {row.errorMessage && (
+          <span className="text-xs text-amber-700 dark:text-amber-300">{row.errorMessage}</span>
+        )}
+      </div>
+      <StatusIcon status={row.status} />
+    </div>
+  );
+}
+
+export function NotebookFullSyncModal({ collection, open, onOpenChange }: Props) {
+  const { run, isRunning, progress, totals, error, reset } = useNotebookFullSync();
+  const triggered = useRef(false);
+
+  useEffect(() => {
+    if (!triggered.current) {
+      triggered.current = true;
+      void run({ collection }).catch(() => {
+        /* surfaced via error state */
+      });
+    }
+    return () => {
+      reset();
+    };
+  }, [run, collection, reset]);
+
+  const rows = Object.values(progress);
+  const finished = totals !== null && !isRunning;
+  const noWork = rows.length === 0;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!isRunning) onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Alle Quellen aktualisieren</DialogTitle>
+          <DialogDescription>
+            Wolke-Ordner und verknüpfte Docs werden neu importiert. Fehlende Inhalte werden
+            entfernt.
+          </DialogDescription>
+        </DialogHeader>
+
+        {noWork ? (
+          <p className="text-sm text-grey-500">Keine Wolke-Ordner oder Docs verknüpft.</p>
+        ) : (
+          <div className="flex max-h-[60vh] flex-col gap-xs overflow-y-auto">
+            {rows.map((row) => (
+              <SyncRow key={row.key} row={row} />
+            ))}
+          </div>
+        )}
+
+        {finished && (
+          <div className="mt-md rounded-lg border border-grey-200 bg-background-alt p-md dark:border-grey-800">
+            <p className="m-0 text-sm font-medium text-foreground">
+              Fertig — {totals.added} neu, {totals.updated} aktualisiert, {totals.removed} entfernt
+            </p>
+            {totals.errors > 0 && (
+              <p className="m-0 mt-xs text-sm text-amber-700 dark:text-amber-300">
+                {totals.errors} Quelle{totals.errors === 1 ? '' : 'n'} konnten nicht aktualisiert
+                werden — Inhalt unverändert.
+              </p>
+            )}
+          </div>
+        )}
+
+        {error && (
+          <p className="text-sm text-red-700 dark:text-red-300">
+            {error instanceof Error ? error.message : 'Unbekannter Fehler'}
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant={finished ? 'default' : 'ghost'}
+            onClick={() => onOpenChange(false)}
+            disabled={isRunning}
+          >
+            {finished ? 'Schließen' : isRunning ? 'Bitte warten…' : 'Abbrechen'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/notebook/hooks/syncLinkedDoc.ts
+++ b/apps/web/src/features/notebook/hooks/syncLinkedDoc.ts
@@ -1,0 +1,81 @@
+import { type LinkedDocRef } from '@gruenerator/contracts';
+
+import { type useDocumentsStore } from '../../../stores/documentsStore';
+
+export type LinkedDocSyncResult =
+  | {
+      kind: 'updated';
+      docId: string;
+      newRef: LinkedDocRef;
+      newDocumentId: string;
+      oldDocumentId: string | null;
+    }
+  | { kind: 'vanished'; docId: string; oldDocumentId: string | null }
+  | { kind: 'error'; docId: string; message: string };
+
+interface SyncContext {
+  documentsStore: ReturnType<typeof useDocumentsStore.getState>;
+}
+
+export async function syncLinkedDoc(
+  ref: LinkedDocRef,
+  ctx: SyncContext
+): Promise<LinkedDocSyncResult> {
+  let res: Response;
+  try {
+    res = await fetch(`/api/docs/${ref.docId}/export/markdown`, { credentials: 'include' });
+  } catch (e) {
+    return {
+      kind: 'error',
+      docId: ref.docId,
+      message: e instanceof Error ? e.message : 'Netzwerkfehler',
+    };
+  }
+
+  if (res.status === 404 || res.status === 403) {
+    return { kind: 'vanished', docId: ref.docId, oldDocumentId: ref.documentId ?? null };
+  }
+
+  if (!res.ok) {
+    return {
+      kind: 'error',
+      docId: ref.docId,
+      message: `Markdown-Export fehlgeschlagen (${res.status})`,
+    };
+  }
+
+  let markdown: string;
+  try {
+    markdown = await res.text();
+  } catch (e) {
+    return {
+      kind: 'error',
+      docId: ref.docId,
+      message: e instanceof Error ? e.message : 'Lesefehler',
+    };
+  }
+
+  try {
+    const safeName = ref.docTitle.replace(/[^\p{L}\p{N}\s.-]+/gu, '_').slice(0, 80) || 'Dokument';
+    const file = new File([markdown], `${safeName}.md`, { type: 'text/markdown' });
+    const uploaded = await ctx.documentsStore.uploadFileOnly(file, file.name);
+
+    return {
+      kind: 'updated',
+      docId: ref.docId,
+      newRef: {
+        ...ref,
+        documentId: uploaded.id,
+        lastSyncedAt: new Date().toISOString(),
+      },
+      newDocumentId: uploaded.id,
+      oldDocumentId: ref.documentId ?? null,
+    };
+  } catch (e) {
+    return {
+      kind: 'error',
+      docId: ref.docId,
+      message: e instanceof Error ? e.message : 'Import fehlgeschlagen',
+    };
+  }
+}

--- a/apps/web/src/features/notebook/hooks/syncWolkeFolder.ts
+++ b/apps/web/src/features/notebook/hooks/syncWolkeFolder.ts
@@ -1,0 +1,98 @@
+import { type WolkeFolderRef } from '@gruenerator/contracts';
+
+import { type useDocumentsStore } from '../../../stores/documentsStore';
+
+export interface ImportedWolkeDocument {
+  id: string;
+  title: string;
+}
+
+export type WolkeFolderSyncResult =
+  | {
+      kind: 'success';
+      shareLinkId: string;
+      folderPath: string;
+      /** All documentIds present in this folder after sync (newly imported + already-imported). */
+      currentDocumentIds: string[];
+      /** Subset newly created on this sync — caller may want to poll for indexing. */
+      newlyImported: ImportedWolkeDocument[];
+      updatedLastSyncedAt: string;
+      skippedDueToSlotsFull: number;
+    }
+  | {
+      kind: 'error';
+      shareLinkId: string;
+      folderPath: string;
+      message: string;
+    };
+
+interface SyncContext {
+  documentsStore: ReturnType<typeof useDocumentsStore.getState>;
+  remainingSlots: number;
+}
+
+export async function syncWolkeFolder(
+  folder: WolkeFolderRef,
+  ctx: SyncContext
+): Promise<WolkeFolderSyncResult> {
+  try {
+    const browseResult = await ctx.documentsStore.browseWolkeFiles(folder.shareLinkId);
+    const supported = browseResult.files.filter((f) => f.isSupported);
+
+    if (supported.length === 0) {
+      return {
+        kind: 'success',
+        shareLinkId: folder.shareLinkId,
+        folderPath: folder.folderPath,
+        currentDocumentIds: [],
+        newlyImported: [],
+        updatedLastSyncedAt: new Date().toISOString(),
+        skippedDueToSlotsFull: 0,
+      };
+    }
+
+    const sliced = supported.slice(0, Math.max(0, ctx.remainingSlots));
+    const skippedDueToSlotsFull = supported.length - sliced.length;
+
+    if (sliced.length === 0) {
+      return {
+        kind: 'error',
+        shareLinkId: folder.shareLinkId,
+        folderPath: folder.folderPath,
+        message: 'Notebook ist voll — Ordner übersprungen.',
+      };
+    }
+
+    const result = await ctx.documentsStore.importWolkeFiles(folder.shareLinkId, sliced);
+    const results = result.results ?? [];
+
+    const newlyImported: ImportedWolkeDocument[] = results
+      .filter((r) => r.success === true && !r.skipped && typeof r.documentId === 'string')
+      .map((r) => ({ id: r.documentId as string, title: r.filename }));
+
+    const alreadyImportedIds = results
+      .filter(
+        (r) => r.skipped === true && r.reason === 'already_imported' && typeof r.documentId === 'string'
+      )
+      .map((r) => r.documentId as string);
+
+    const currentDocumentIds = [...newlyImported.map((d) => d.id), ...alreadyImportedIds];
+
+    return {
+      kind: 'success',
+      shareLinkId: folder.shareLinkId,
+      folderPath: folder.folderPath,
+      currentDocumentIds,
+      newlyImported,
+      updatedLastSyncedAt: new Date().toISOString(),
+      skippedDueToSlotsFull,
+    };
+  } catch (e) {
+    return {
+      kind: 'error',
+      shareLinkId: folder.shareLinkId,
+      folderPath: folder.folderPath,
+      message: e instanceof Error ? e.message : 'Synchronisation fehlgeschlagen.',
+    };
+  }
+}

--- a/apps/web/src/features/notebook/hooks/useNotebookFullSync.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookFullSync.ts
@@ -1,0 +1,181 @@
+import { type LinkedDocRef, type WolkeFolderRef } from '@gruenerator/contracts';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+
+import { useDocumentsStore } from '../../../stores/documentsStore';
+import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+
+import { syncLinkedDoc, type LinkedDocSyncResult } from './syncLinkedDoc';
+import { syncWolkeFolder, type WolkeFolderSyncResult } from './syncWolkeFolder';
+
+import type { NotebookCollection } from '../../../types/notebook';
+
+const MAX_DOCUMENTS = 100;
+
+export type SyncProgressStatus = 'pending' | 'running' | 'done' | 'error';
+
+export interface SyncProgressRow {
+  key: string;
+  kind: 'wolke' | 'doc';
+  title: string;
+  status: SyncProgressStatus;
+  summary?: string;
+  errorMessage?: string;
+}
+
+export interface FullSyncTotals {
+  added: number;
+  updated: number;
+  removed: number;
+  errors: number;
+}
+
+export function useNotebookFullSync() {
+  const documentsStoreApi = useDocumentsStore;
+  const { updateQACollection, isUpdating } = useNotebookCollections({ isActive: true });
+  const [progress, setProgress] = useState<Record<string, SyncProgressRow>>({});
+  const [totals, setTotals] = useState<FullSyncTotals | null>(null);
+
+  const setRow = useCallback((key: string, patch: Partial<SyncProgressRow>) => {
+    setProgress((prev) => ({ ...prev, [key]: { ...prev[key], ...patch } }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setProgress({});
+    setTotals(null);
+  }, []);
+
+  const mutation = useMutation({
+    mutationFn: async ({ collection }: { collection: NotebookCollection }) => {
+      const wolkeFolders = collection.wolke_folders ?? [];
+      const linkedDocs = collection.linked_docs ?? [];
+      const priorDocuments = collection.documents ?? [];
+
+      const initial: Record<string, SyncProgressRow> = {};
+      for (const f of wolkeFolders) {
+        const key = `wolke-${f.shareLinkId}-${f.folderPath}`;
+        initial[key] = { key, kind: 'wolke', title: f.folderName, status: 'pending' };
+      }
+      for (const d of linkedDocs) {
+        const key = `doc-${d.docId}`;
+        initial[key] = { key, kind: 'doc', title: d.docTitle, status: 'pending' };
+      }
+      setProgress(initial);
+
+      // ===== Wolke phase =====
+      const priorWolkeIds = new Set(
+        priorDocuments.filter((d) => d.source_type === 'wolke').map((d) => String(d.id))
+      );
+      const wolkeResults: WolkeFolderSyncResult[] = [];
+      const updatedFolders: WolkeFolderRef[] = [];
+      let remainingSlots = MAX_DOCUMENTS - priorDocuments.length;
+
+      for (const folder of wolkeFolders) {
+        const key = `wolke-${folder.shareLinkId}-${folder.folderPath}`;
+        setRow(key, { status: 'running' });
+        const result = await syncWolkeFolder(folder, {
+          documentsStore: documentsStoreApi.getState(),
+          remainingSlots: Math.max(0, remainingSlots),
+        });
+        wolkeResults.push(result);
+
+        if (result.kind === 'success') {
+          remainingSlots -= result.newlyImported.length;
+          updatedFolders.push({ ...folder, lastSyncedAt: result.updatedLastSyncedAt });
+          const added = result.newlyImported.length;
+          const totalNow = result.currentDocumentIds.length;
+          const summary =
+            added > 0 ? `${added} neu · ${totalNow} insgesamt` : `${totalNow} unverändert`;
+          setRow(key, { status: 'done', summary });
+        } else {
+          updatedFolders.push(folder);
+          setRow(key, { status: 'error', errorMessage: result.message });
+        }
+      }
+
+      // Only conclude "vanished" when ALL folders synced successfully — otherwise we can't be sure.
+      const allWolkeFoldersOk =
+        wolkeResults.length === 0 || wolkeResults.every((r) => r.kind === 'success');
+      const allWolkeNow = new Set<string>();
+      for (const r of wolkeResults) {
+        if (r.kind === 'success') r.currentDocumentIds.forEach((id) => allWolkeNow.add(id));
+      }
+      const removedWolkeIds = allWolkeFoldersOk
+        ? [...priorWolkeIds].filter((id) => !allWolkeNow.has(id))
+        : [];
+
+      // ===== Docs phase =====
+      const docsResults: LinkedDocSyncResult[] = [];
+      const updatedLinkedDocs: LinkedDocRef[] = [];
+      const removedManualIds: string[] = [];
+      const addedManualIds: string[] = [];
+
+      for (const ref of linkedDocs) {
+        const key = `doc-${ref.docId}`;
+        setRow(key, { status: 'running' });
+        const result = await syncLinkedDoc(ref, {
+          documentsStore: documentsStoreApi.getState(),
+        });
+        docsResults.push(result);
+
+        if (result.kind === 'updated') {
+          updatedLinkedDocs.push(result.newRef);
+          if (result.oldDocumentId) removedManualIds.push(result.oldDocumentId);
+          addedManualIds.push(result.newDocumentId);
+          setRow(key, { status: 'done', summary: 'Aktualisiert' });
+        } else if (result.kind === 'vanished') {
+          if (result.oldDocumentId) removedManualIds.push(result.oldDocumentId);
+          setRow(key, { status: 'done', summary: 'Nicht erreichbar — entfernt' });
+        } else {
+          updatedLinkedDocs.push(ref);
+          setRow(key, { status: 'error', errorMessage: result.message });
+        }
+      }
+
+      // ===== Build new documents list =====
+      const priorIds = priorDocuments.map((d) => String(d.id));
+      const remove = new Set<string>([...removedWolkeIds, ...removedManualIds]);
+      const finalIds = new Set<string>();
+      for (const id of priorIds) if (!remove.has(id)) finalIds.add(id);
+      for (const r of wolkeResults) {
+        if (r.kind === 'success') r.newlyImported.forEach((d) => finalIds.add(d.id));
+      }
+      for (const id of addedManualIds) finalIds.add(id);
+
+      await updateQACollection(collection.id, {
+        name: collection.name,
+        ...(collection.description != null ? { description: collection.description } : {}),
+        ...(collection.custom_prompt != null ? { custom_prompt: collection.custom_prompt } : {}),
+        selectionMode: collection.selection_mode ?? 'documents',
+        documents: [...finalIds],
+        labels: collection.labels ?? [],
+        is_public: collection.is_public,
+        public_ownership: collection.public_ownership ?? null,
+        wolkeFolders: updatedFolders,
+        linkedDocs: updatedLinkedDocs,
+      });
+
+      const newWolkeCount = wolkeResults.reduce(
+        (acc, r) => acc + (r.kind === 'success' ? r.newlyImported.length : 0),
+        0
+      );
+      setTotals({
+        added: newWolkeCount + addedManualIds.length,
+        updated: docsResults.filter((r) => r.kind === 'updated').length,
+        removed: removedWolkeIds.length + removedManualIds.length,
+        errors:
+          wolkeResults.filter((r) => r.kind === 'error').length +
+          docsResults.filter((r) => r.kind === 'error').length,
+      });
+    },
+  });
+
+  return {
+    run: mutation.mutateAsync,
+    isRunning: mutation.isPending || isUpdating,
+    progress,
+    totals,
+    error: mutation.error,
+    reset,
+  };
+}


### PR DESCRIPTION
Per-item Sync buttons on Wolke folders and linked Docs only ADD content — neither removes files that vanished from a Wolke folder, nor drops linked Docs whose source was deleted. Users today must Sync every card one by one and then manually prune stale entries.

This adds **"Alle Quellen aktualisieren"** on the notebook edit page (visible only when there's something to sync). One click runs sync across every attached Wolke folder + linked Doc, drops vanished items, and persists once at the end. The orchestrator is conservative: it only concludes "this Wolke doc vanished" when **every** folder synced successfully — if any folder erred, vanished-detection is suppressed so we never wrongly drop a doc when we couldn't enumerate its source. Linked-Doc 404/403 cleanly maps to "vanished → drop ref".

Pure client-side orchestration over existing primitives (`browseWolkeFiles` / `importWolkeFiles` / `uploadFileOnly` / collection PATCH). No new backend endpoints. The pre-existing orphan Document row leak on the Docs re-import path is inherited (not introduced) and tracked as a follow-up.

Vanished-file removal is scoped to the orchestrator only, not the existing per-folder Sync button — adding it there would require threading `wolke_share_link_id` through `UploadedDocument` (4 type sites, separate concern). Per-folder Sync behavior is unchanged.

## Test plan
- Edit a notebook with Wolke folders + linked Docs → click "Alle Quellen aktualisieren" → modal walks each row, shows per-source summary, ends with totals
- Delete a file from a Wolke folder server-side → re-run sync → file disappears from the editor
- Soft-delete a linked Doc → re-run → "Nicht erreichbar — entfernt" + ref drops
- Notebook with 0 folders + 0 docs → button is not rendered