### PR TITLE
chore(notebook): prettier --write on full-sync files

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookFullSyncModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookFullSyncModal.tsx
@@ -40,7 +40,9 @@ function StatusIcon({ status }: { status: SyncProgressStatus }) {
     );
   }
   if (status === 'done') {
-    return <HiCheck size={16} className="shrink-0 text-green-600 dark:text-green-400" aria-hidden />;
+    return (
+      <HiCheck size={16} className="shrink-0 text-green-600 dark:text-green-400" aria-hidden />
+    );
   }
   return (
     <HiExclamation size={16} className="shrink-0 text-amber-600 dark:text-amber-400" aria-hidden />

--- a/apps/web/src/features/notebook/hooks/syncWolkeFolder.ts
+++ b/apps/web/src/features/notebook/hooks/syncWolkeFolder.ts
@@ -72,7 +72,8 @@ export async function syncWolkeFolder(
 
     const alreadyImportedIds = results
       .filter(
-        (r) => r.skipped === true && r.reason === 'already_imported' && typeof r.documentId === 'string'
+        (r) =>
+          r.skipped === true && r.reason === 'already_imported' && typeof r.documentId === 'string'
       )
       .map((r) => r.documentId as string);
 


### PR DESCRIPTION
Fixes red CI on master after PR #917 merge — two new files I added didn't pass `prettier --check` (pure line-wrap reformats, zero semantic change). Forgot to run `pnpm format` locally before committing.

Same shape as PR #915 — a one-shot prettier sweep to make the format gate green again.