### PR TITLE
fix(api): RFC 5987-encode Content-Disposition for non-ASCII filenames

### DIFF
--- a/apps/api/routes/auth/templates/templateGallery.ts
+++ b/apps/api/routes/auth/templates/templateGallery.ts
@@ -18,6 +18,7 @@ import {
   likeEntity,
   unlikeEntity,
 } from '../../../services/entityLikes/EntityLikesService.js';
+import { setContentDisposition } from '../../../utils/http/contentDisposition.js';
 import { createLogger } from '../../../utils/logger.js';
 
 import type { AuthRequest } from '../types.js';
@@ -638,7 +639,7 @@ router.get(
       }
 
       // Set content disposition for download
-      res.setHeader('Content-Disposition', `attachment; filename="${decodedFileName}"`);
+      setContentDisposition(res, decodedFileName);
 
       // Set content type based on file extension
       const ext = path.extname(decodedFileName).toLowerCase();

--- a/apps/api/routes/docs/exportController.ts
+++ b/apps/api/routes/docs/exportController.ts
@@ -5,6 +5,7 @@ import { Router, type Request, type Response } from 'express';
 import * as Y from 'yjs';
 
 import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 
 import { DOCS_SUBTYPES } from './constants.js';
 
@@ -235,7 +236,7 @@ router.get('/:id/export/html', async (req: Request, res: Response) => {
 </html>`;
 
     res.setHeader('Content-Type', 'text/html; charset=utf-8');
-    res.setHeader('Content-Disposition', `attachment; filename="${document.title}.html"`);
+    setContentDisposition(res, `${document.title}.html`);
     return res.send(html);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -305,7 +306,7 @@ router.get('/:id/export/markdown', async (req: Request, res: Response) => {
     const markdown = `# ${document.title}\n\n${content}`;
 
     res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
-    res.setHeader('Content-Disposition', `attachment; filename="${document.title}.md"`);
+    setContentDisposition(res, `${document.title}.md`);
     return res.send(markdown);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
@@ -381,7 +382,7 @@ router.get('/:id/export/text', async (req: Request, res: Response) => {
     const text = `${document.title}\n\n${content}`;
 
     res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-    res.setHeader('Content-Disposition', `attachment; filename="${document.title}.txt"`);
+    setContentDisposition(res, `${document.title}.txt`);
     return res.send(text);
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/api/routes/exports/canvasPdfController.ts
+++ b/apps/api/routes/exports/canvasPdfController.ts
@@ -13,6 +13,7 @@ import express, { type Request, type Response } from 'express';
 import { PDFDocument } from 'pdf-lib';
 
 import { rateLimitMiddleware, incrementRateLimit } from '../../middleware/rateLimitMiddleware.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 import { getServerFormat, paperSizeForFormat } from './pageConstants.js';
@@ -96,7 +97,7 @@ router.post('/', rateLimitMiddleware('pdf_export'), async (req: Request, res: Re
     const filename = `${formatId}-${safeTitle}.pdf`;
 
     res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+    setContentDisposition(res, filename);
     res.send(Buffer.from(pdfBytes));
 
     await incrementRateLimit(req);

--- a/apps/api/routes/exports/chatMessageExport.ts
+++ b/apps/api/routes/exports/chatMessageExport.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { PRIMARY_DOMAIN } from '../../utils/domainUtils.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { sanitizeFilename as sanitizeFilenameCentral } from '../../utils/validation/index.js';
 
@@ -301,7 +302,7 @@ router.post(
         'Content-Type',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       );
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
       return res.status(200).send(buffer);
     } catch (err) {
       const error = err as Error;

--- a/apps/api/routes/exports/docxController.ts
+++ b/apps/api/routes/exports/docxController.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { PRIMARY_DOMAIN } from '../../utils/domainUtils.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { sanitizeFilename as sanitizeFilenameCentral } from '../../utils/validation/index.js';
 
@@ -225,7 +226,7 @@ router.post(
         'Content-Type',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       );
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
       return res.status(200).send(buffer);
     } catch (err) {
       const error = err as Error;

--- a/apps/api/routes/exports/exportsContractRouter.ts
+++ b/apps/api/routes/exports/exportsContractRouter.ts
@@ -22,6 +22,7 @@ import { exportsContract } from '@gruenerator/contracts';
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 import { generateDocxBuffer, sanitizeDocxFilename } from './docxController.js';
@@ -44,7 +45,7 @@ export const exportsContractRouter = s.router(exportsContract, {
         'Content-Type',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       );
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
 
       // Return a stream so @ts-rest/express pipes the raw bytes instead of
       // running them through res.json() (which would corrupt the binary).
@@ -73,7 +74,7 @@ export const exportsContractRouter = s.router(exportsContract, {
       const filename = `${sanitizePdfFilename(title || 'Dokument')}.pdf`;
 
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
 
       return {
         status: 200 as const,

--- a/apps/api/routes/exports/pdfController.ts
+++ b/apps/api/routes/exports/pdfController.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import fontkit from '@pdf-lib/fontkit';
 import express, { type Request, type Response } from 'express';
 
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { sanitizeFilename as sanitizeFilenameCentral } from '../../utils/validation/index.js';
 
@@ -235,7 +236,7 @@ router.post(
       const filename = `${sanitizeFilename(title || 'Dokument')}.pdf`;
 
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
       return res.status(200).send(buffer);
     } catch (err) {
       const error = err as Error;

--- a/apps/api/routes/exports/pdfSlidesController.ts
+++ b/apps/api/routes/exports/pdfSlidesController.ts
@@ -7,6 +7,7 @@
 import express, { type Request, type Response } from 'express';
 import { PDFDocument } from 'pdf-lib';
 
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('exportPdfSlides');
@@ -104,7 +105,7 @@ router.post(
       const filename = `${title.replace(/[^a-zA-Z0-9äöüÄÖÜß\s-]/g, '').trim() || 'Praesentation'}-${timestamp}.pdf`;
 
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
       res.send(Buffer.from(pdfBytes));
 
       log.info(`[exportPdfSlides] PDF created with ${images.length} pages`);

--- a/apps/api/routes/exports/zipController.ts
+++ b/apps/api/routes/exports/zipController.ts
@@ -6,6 +6,7 @@
 import archiver from 'archiver';
 import express, { type Request, type Response } from 'express';
 
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('exportZip');
@@ -62,7 +63,7 @@ router.post(
       const filename = `gruenerator-${canvasType}-${timestamp}.zip`;
 
       res.setHeader('Content-Type', 'application/zip');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
 
       // Create archiver instance
       const archive = archiver('zip', {

--- a/apps/api/routes/mem0/mem0Controller.ts
+++ b/apps/api/routes/mem0/mem0Controller.ts
@@ -2,6 +2,7 @@ import express, { type Router, type Response } from 'express';
 
 import { getMem0Instance, normalizeCategory } from '../../services/mem0/index.js';
 import { invalidatePersona } from '../../services/mem0/personaService.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 import type { MemoryCategory } from '../../services/mem0/categories.js';
@@ -261,7 +262,7 @@ router.get(
 
       const filename = `gruenerator-erinnerungen-${new Date().toISOString().slice(0, 10)}.json`;
       res.setHeader('Content-Type', 'application/json');
-      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      setContentDisposition(res, filename);
       res.json(exportData);
     } catch (error) {
       const err = error as Error;

--- a/apps/api/routes/share/shareController.ts
+++ b/apps/api/routes/share/shareController.ts
@@ -16,6 +16,7 @@ import { requireAuth } from '../../middleware/authMiddleware.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { transferService } from '../../services/transferService.js';
 import { type SharedMediaRow, type ShareResult } from '../../types/media.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { parseJSON } from '../../utils/parseJSON.js';
 import { redisClient } from '../../utils/redis/index.js';
@@ -1208,10 +1209,7 @@ router.get(
             result.mimeType || share.mime_type || 'application/octet-stream'
           );
           res.setHeader('Content-Length', result.size);
-          res.setHeader(
-            'Content-Disposition',
-            `attachment; filename="${encodeURIComponent(result.fileName)}"`
-          );
+          setContentDisposition(res, result.fileName);
 
           log.info(`Transfer download: ${(shareToken as string).substring(0, 8)} (public)`);
           res.send(result.buffer);
@@ -1292,7 +1290,7 @@ router.get(
           share.mime_type || (share.media_type === 'video' ? 'video/mp4' : 'image/png')
         );
         res.setHeader('Content-Length', fileSize);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        setContentDisposition(res, filename);
 
         log.info(`Download started: ${shareToken} by user ${userId} (${userEmail})`);
 

--- a/apps/api/routes/subtitler/processingController.ts
+++ b/apps/api/routes/subtitler/processingController.ts
@@ -56,6 +56,7 @@ import {
   getOriginalFilename,
 } from '../../services/subtitler/tusService.js';
 import { getVideoMetadata } from '../../services/subtitler/videoUploadService.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { redisClient } from '../../utils/redis/index.js';
 
@@ -344,7 +345,7 @@ router.get(
           .replace(/[^a-zA-Z0-9_-]/g, '_') + '_gruenerator.mp4';
       res.setHeader('Content-Type', 'video/mp4');
       res.setHeader('Content-Length', stats.size);
-      res.setHeader('Content-Disposition', `attachment; filename=${filename}`);
+      setContentDisposition(res, filename);
 
       const stream = fs.createReadStream(exportData.outputPath);
       stream.pipe(res);
@@ -780,10 +781,7 @@ router.get(
       const stats = await fsPromises.stat(parsed.outputPath);
       res.setHeader('Content-Type', 'video/mp4');
       res.setHeader('Content-Length', stats.size);
-      res.setHeader(
-        'Content-Disposition',
-        `attachment; filename=video_${uploadId}_gruenerator.mp4`
-      );
+      setContentDisposition(res, `video_${uploadId}_gruenerator.mp4`);
       fs.createReadStream(parsed.outputPath).pipe(res);
     } catch (e: unknown) {
       if (!res.headersSent)

--- a/apps/api/routes/subtitler/shareController.ts
+++ b/apps/api/routes/subtitler/shareController.ts
@@ -17,6 +17,7 @@ import express, { type Response, type Router } from 'express';
 import { requireAuth } from '../../middleware/authMiddleware.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { parseExportProgress } from '../../services/subtitler/redisCodecs.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { redisClient } from '../../utils/redis/index.js';
 
@@ -491,7 +492,7 @@ router.get(
 
         res.setHeader('Content-Type', 'video/mp4');
         res.setHeader('Content-Length', stat.size);
-        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        setContentDisposition(res, filename);
 
         log.info(`Download started: ${shareToken} by user ${userId}`);
         fs.createReadStream(videoPath).pipe(res);

--- a/apps/api/routes/voice/ttsController.ts
+++ b/apps/api/routes/voice/ttsController.ts
@@ -1,6 +1,7 @@
 import express, { type Request, type Response, type Router } from 'express';
 
 import ttsService from '../../services/voice/ttsService.js';
+import { buildContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('ttsController');
@@ -44,7 +45,7 @@ router.post('/generate', async (req: GenerateRequest, res: Response) => {
     res.set({
       'Content-Type': 'audio/wav',
       'Content-Length': String(wavBuffer.length),
-      'Content-Disposition': 'inline; filename="speech.wav"',
+      'Content-Disposition': buildContentDisposition('speech.wav', 'inline'),
     });
     return res.send(wavBuffer);
   } catch (error) {

--- a/apps/api/services/subtitler/downloadUtils.ts
+++ b/apps/api/services/subtitler/downloadUtils.ts
@@ -13,6 +13,7 @@ import { type Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type VideoMetadata } from '../../routes/subtitler/types.js';
+import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { redisClient } from '../../utils/redis/index.js';
 
@@ -461,7 +462,7 @@ async function streamVideoFile(
 
   res.setHeader('Content-Type', 'video/mp4');
   res.setHeader('Content-Length', fileSize);
-  res.setHeader('Content-Disposition', `attachment; filename=${sanitizedFilename}`);
+  setContentDisposition(res, sanitizedFilename);
   res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
   res.setHeader('Connection', 'keep-alive');
 

--- a/apps/api/utils/http/contentDisposition.ts
+++ b/apps/api/utils/http/contentDisposition.ts
@@ -1,0 +1,46 @@
+import type { Response } from 'express';
+
+type Disposition = 'attachment' | 'inline';
+
+/**
+ * Build an RFC 6266 / RFC 5987 `Content-Disposition` header value.
+ *
+ * Node's `res.setHeader` rejects non-ASCII per RFC 7230 — any Umlaut in the
+ * filename throws `ERR_INVALID_CHAR`. We emit an ASCII-sanitized `filename="…"`
+ * for legacy parsers plus the standards `filename*=UTF-8''…` that modern
+ * browsers prefer.
+ */
+export function buildContentDisposition(
+  filename: string,
+  disposition: Disposition = 'attachment'
+): string {
+  const ascii = sanitizeAsciiFilename(filename);
+  const utf8 = encodeRfc5987(filename);
+  return `${disposition}; filename="${ascii}"; filename*=UTF-8''${utf8}`;
+}
+
+export function setContentDisposition(
+  res: Response,
+  filename: string,
+  disposition: Disposition = 'attachment'
+): void {
+  res.setHeader('Content-Disposition', buildContentDisposition(filename, disposition));
+}
+
+function sanitizeAsciiFilename(filename: string): string {
+  const cleaned = filename
+    // eslint-disable-next-line no-control-regex -- intentional: strip control chars Node rejects in headers
+    .replace(/[\x00-\x1F\x7F]/g, '')
+    .replace(/[^\x20-\x7E]/g, '_')
+    .replace(/["\\]/g, '_');
+  return cleaned.length > 0 ? cleaned : 'download';
+}
+
+// RFC 5987 §3.2.1 attr-char excludes a few chars that encodeURIComponent leaves
+// unescaped: ' ( ) *. Escape them manually so picky parsers don't choke.
+function encodeRfc5987(value: string): string {
+  return encodeURIComponent(value).replace(
+    /['()*]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase()
+  );
+}

--- a/apps/api/utils/http/contentDisposition.vitest.ts
+++ b/apps/api/utils/http/contentDisposition.vitest.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { buildContentDisposition, setContentDisposition } from './contentDisposition.js';
+
+import type { Response } from 'express';
+
+describe('buildContentDisposition', () => {
+  it('passes through pure ASCII filenames in both params', () => {
+    expect(buildContentDisposition('report.pdf')).toBe(
+      `attachment; filename="report.pdf"; filename*=UTF-8''report.pdf`
+    );
+  });
+
+  it('sanitizes German Umlauts in the ASCII fallback and percent-encodes them in filename*', () => {
+    const header = buildContentDisposition('Grüße aus Wien.md');
+    expect(header).toBe(
+      `attachment; filename="Gr__e aus Wien.md"; filename*=UTF-8''Gr%C3%BC%C3%9Fe%20aus%20Wien.md`
+    );
+  });
+
+  it('strips control characters that would crash res.setHeader', () => {
+    const header = buildContentDisposition('foo\r\nbar.txt');
+    expect(header).not.toMatch(/[\r\n]/);
+    expect(header).toContain('filename="foobar.txt"');
+  });
+
+  it('escapes double-quote and backslash in the ASCII fallback', () => {
+    const header = buildContentDisposition('weird"name\\.pdf');
+    expect(header).toContain('filename="weird_name_.pdf"');
+  });
+
+  it('falls back to "download" when sanitization empties the string', () => {
+    expect(buildContentDisposition('\x00\x01\x02')).toContain('filename="download"');
+  });
+
+  it('encodes the RFC 5987 attr-char gaps that encodeURIComponent misses', () => {
+    const header = buildContentDisposition(`a'b(c)d*e.txt`);
+    expect(header).toContain(`filename*=UTF-8''a%27b%28c%29d%2Ae.txt`);
+  });
+
+  it('supports inline disposition', () => {
+    expect(buildContentDisposition('speech.wav', 'inline')).toBe(
+      `inline; filename="speech.wav"; filename*=UTF-8''speech.wav`
+    );
+  });
+
+  it('produces a header value that Node will accept via setHeader', () => {
+    const res = { setHeader: vi.fn() } as unknown as Response;
+    setContentDisposition(res, 'Müll & Späße.json');
+    const [name, value] = vi.mocked(res.setHeader).mock.calls[0];
+    expect(name).toBe('Content-Disposition');
+    expect(value).toMatch(/^[\x20-\x7E]+$/);
+  });
+});


### PR DESCRIPTION
## Why

Reported via the docs → notebook export flow: exporting a document with an Umlaut in its title 500'd with
`TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Content-Disposition"]`.

Node's `res.setHeader` enforces RFC 7230's printable-ASCII header-value grammar. Any non-ASCII byte (every German Umlaut, every `ä/ö/ü/ß`) in a download filename throws synchronously. The reported file was the most visible offender, but the same `attachment; filename="${x}"` pattern is duplicated across 14 other download routes — every one of them is one Umlaut away from the same crash.

Best long-term fix is a single shared helper rather than 15 ad-hoc string concatenations. The helper emits the RFC 5987 / RFC 6266 standards-conformant form:

```
Content-Disposition: attachment; filename="Gr__e aus Wien.md"; filename*=UTF-8''Gr%C3%BC%C3%9Fe%20aus%20Wien.md
```

— an ASCII-sanitized `filename=` for legacy parsers plus `filename*=UTF-8''…` that all modern browsers prefer (and decode to "Grüße aus Wien.md" in the save-as dialog). One previous site (`shareController.ts:1212`) had hand-rolled `encodeURIComponent` *inside* the quoted-string as a workaround, which technically didn't crash but showed users literal `%C3%A4` as the filename; the helper supersedes that too.

Covered by `apps/api/utils/http/contentDisposition.vitest.ts` (8 cases: Umlauts, control chars, quotes/backslash, empty-after-sanitize, the 5987 attr-char gaps, inline disposition, integration with `res.setHeader`).