### PR TITLE
fix(notebook): share-modal UX — pin audience, fix dead dropdowns, rebuild docs picker

### DIFF
--- a/apps/web/src/features/docs/DocumentCard.tsx
+++ b/apps/web/src/features/docs/DocumentCard.tsx
@@ -3,6 +3,7 @@ import { cn } from '@gruenerator/ui';
 import { memo } from 'react';
 import {
   FiCalendar,
+  FiCheck,
   FiCheckSquare,
   FiClipboard,
   FiEdit3,
@@ -75,16 +76,34 @@ export const DocumentCard = memo(function DocumentCard({
   onDelete,
   onRename,
   onShare,
+  mode = 'navigate',
+  isSelected = false,
+  isDisabled = false,
+  onSelect,
 }: {
   doc: DocumentCardDoc;
   adapter: ReturnType<typeof useDocsAdapter>;
-  onDelete: (id: string, e: React.MouseEvent) => void;
-  onRename: (doc: { id: string; title: string }, e: React.MouseEvent) => void;
-  onShare: (doc: { id: string; title: string }) => void;
+  onDelete?: (id: string, e: React.MouseEvent) => void;
+  onRename?: (doc: { id: string; title: string }, e: React.MouseEvent) => void;
+  onShare?: (doc: { id: string; title: string }) => void;
+  mode?: 'navigate' | 'select';
+  isSelected?: boolean;
+  isDisabled?: boolean;
+  onSelect?: (id: string) => void;
 }) {
   const style = DOC_TYPE_STYLE[doc.document_subtype] || DOC_TYPE_STYLE.blank;
   const TypeIcon = style.icon;
   const hasContent = !!doc.content?.trim();
+  const isSelectMode = mode === 'select';
+
+  const handleClick = () => {
+    if (isDisabled) return;
+    if (isSelectMode) {
+      onSelect?.(doc.id);
+    } else {
+      adapter.navigateToDocument(doc.id);
+    }
+  };
 
   return (
     <div
@@ -94,10 +113,23 @@ export const DocumentCard = memo(function DocumentCard({
         'hover:shadow-md hover:border-grey-300',
         'dark:border-grey-700 dark:hover:border-grey-500',
         'md:hover:-translate-y-0.5',
-        'max-sm:aspect-[4/3]'
+        'max-sm:aspect-[4/3]',
+        isSelected && 'border-primary-500 ring-2 ring-primary-400 dark:border-primary-400',
+        isDisabled && 'pointer-events-none opacity-60'
       )}
-      onClick={() => adapter.navigateToDocument(doc.id)}
+      onClick={handleClick}
+      role={isSelectMode ? 'button' : undefined}
+      aria-pressed={isSelectMode ? isSelected : undefined}
+      aria-disabled={isDisabled || undefined}
     >
+      {isSelectMode && isSelected ? (
+        <div
+          className="absolute right-2 top-2 z-10 flex size-6 items-center justify-center rounded-full bg-primary-500 text-white shadow-sm"
+          aria-hidden
+        >
+          <FiCheck size={14} />
+        </div>
+      ) : null}
       {hasContent ? (
         <div className="relative flex-1 overflow-hidden bg-grey-50 dark:bg-grey-800/50">
           <div
@@ -138,15 +170,17 @@ export const DocumentCard = memo(function DocumentCard({
               )}
             </div>
           </div>
-          <CardActionMenu
-            ariaLabel="Dokumentoptionen"
-            onRename={(e) => onRename(doc, e)}
-            onDelete={(e) => onDelete(doc.id, e)}
-            onShare={(e) => {
-              e.stopPropagation();
-              onShare({ id: doc.id, title: doc.title });
-            }}
-          />
+          {!isSelectMode && onRename && onDelete && onShare ? (
+            <CardActionMenu
+              ariaLabel="Dokumentoptionen"
+              onRename={(e) => onRename(doc, e)}
+              onDelete={(e) => onDelete(doc.id, e)}
+              onShare={(e) => {
+                e.stopPropagation();
+                onShare({ id: doc.id, title: doc.title });
+              }}
+            />
+          ) : null}
         </div>
       </div>
     </div>

--- a/apps/web/src/features/notebook/components/NotebookEditorDocsSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorDocsSection.tsx
@@ -1,12 +1,24 @@
 import { type LinkedDocRef } from '@gruenerator/contracts';
-import { useDocuments, type Document } from '@gruenerator/docs';
-import { Badge, Button, SectionHeader } from '@gruenerator/ui';
-import { useState, useCallback, useMemo } from 'react';
-import { HiDocumentText, HiExclamation, HiRefresh, HiX } from 'react-icons/hi';
+import { useDocuments, useDocsAdapter, type Document } from '@gruenerator/docs';
+import {
+  Badge,
+  Button,
+  Input,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  SectionHeader,
+} from '@gruenerator/ui';
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { HiDocumentText, HiExclamation, HiRefresh, HiSearch, HiX } from 'react-icons/hi';
 import { Link } from 'react-router-dom';
 
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
+import { DocumentCard } from '../../docs/DocumentCard';
 
 export interface ImportedLinkedDoc {
   id: string;
@@ -23,6 +35,8 @@ interface Props {
   onUploadedDocumentRemoved: (documentId: string) => void;
   disabled: boolean;
 }
+
+const DOCS_PER_PAGE = 12;
 
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return 'Noch nicht importiert';
@@ -61,16 +75,38 @@ const NotebookEditorDocsSection = ({
   disabled,
 }: Props) => {
   const docsQuery = useDocuments();
+  const docsAdapter = useDocsAdapter();
   const { uploadFileOnly } = useDocumentsStore();
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [syncingId, setSyncingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
 
   const attachedIds = useMemo(() => new Set(linkedDocs.map((d) => d.docId)), [linkedDocs]);
   const availableDocs = useMemo(
     () => (docsQuery.data ?? []).filter((d) => !attachedIds.has(d.id)),
     [docsQuery.data, attachedIds]
+  );
+
+  const filteredDocs = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return availableDocs;
+    return availableDocs.filter((d) => d.title.toLowerCase().includes(q));
+  }, [availableDocs, searchQuery]);
+
+  // Reset to page 1 whenever the filter result changes — keeps the user from
+  // landing on an empty late page after typing a query.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [searchQuery, availableDocs.length]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredDocs.length / DOCS_PER_PAGE));
+  const safePage = Math.min(currentPage, totalPages);
+  const paginatedDocs = filteredDocs.slice(
+    (safePage - 1) * DOCS_PER_PAGE,
+    safePage * DOCS_PER_PAGE
   );
 
   const importDoc = useCallback(
@@ -102,7 +138,6 @@ const NotebookEditorDocsSection = ({
           lastSyncedAt: new Date().toISOString(),
         };
         onLinkedDocsChange([...linkedDocs, newRef]);
-        setPickerOpen(false);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Import fehlgeschlagen.');
       } finally {
@@ -173,8 +208,8 @@ const NotebookEditorDocsSection = ({
     <section>
       <SectionHeader
         title="Docs"
-        onCreate={hasAnyDocs && linkedDocs.length > 0 ? () => setPickerOpen((v) => !v) : undefined}
-        createLabel="Doc hinzufügen"
+        onCreate={hasAnyDocs ? () => setPickerOpen((v) => !v) : undefined}
+        createLabel={pickerOpen ? 'Schließen' : 'Doc hinzufügen'}
         actions={headerActions}
       />
 
@@ -192,27 +227,80 @@ const NotebookEditorDocsSection = ({
         </div>
       ) : (
         <>
-          {(pickerOpen || linkedDocs.length === 0) && availableDocs.length > 0 && (
-            <div className="mb-md flex flex-col gap-1 rounded-xl border border-grey-200 bg-background p-xs dark:border-grey-700">
-              <p className="m-0 px-1 pb-1 text-xs uppercase tracking-wide text-grey-500">
-                Deine Docs
-              </p>
-              {availableDocs.map((doc) => (
-                <button
-                  key={doc.id}
-                  type="button"
-                  disabled={disabled || syncingId === doc.id}
-                  className="flex items-center gap-sm rounded-md px-sm py-xs text-left transition-colors hover:bg-background-alt disabled:opacity-60"
-                  onClick={() => void handleAttach(doc)}
-                >
-                  {syncingId === doc.id ? (
-                    <span className="size-3.5 shrink-0 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-                  ) : (
-                    <HiDocumentText size={14} className="shrink-0 text-grey-400" aria-hidden />
+          {pickerOpen && (
+            <div className="mb-md flex flex-col gap-md rounded-xl border border-grey-200 bg-background p-md dark:border-grey-700">
+              <div className="relative">
+                <HiSearch
+                  size={14}
+                  className="pointer-events-none absolute left-sm top-1/2 -translate-y-1/2 text-grey-400"
+                  aria-hidden
+                />
+                <Input
+                  type="search"
+                  placeholder="Docs durchsuchen…"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-8"
+                  aria-label="Docs durchsuchen"
+                />
+              </div>
+
+              {filteredDocs.length === 0 ? (
+                <p className="text-xs text-grey-500">
+                  {availableDocs.length === 0
+                    ? 'Alle deine Docs sind bereits hinzugefügt.'
+                    : 'Keine Treffer für deine Suche.'}
+                </p>
+              ) : (
+                <>
+                  <div className="grid grid-cols-1 gap-sm sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+                    {paginatedDocs.map((doc) => (
+                      <DocumentCard
+                        key={doc.id}
+                        doc={doc}
+                        adapter={docsAdapter}
+                        mode="select"
+                        isSelected={syncingId === doc.id}
+                        isDisabled={disabled || (syncingId !== null && syncingId !== doc.id)}
+                        onSelect={() => void handleAttach(doc)}
+                      />
+                    ))}
+                  </div>
+
+                  {totalPages > 1 && (
+                    <Pagination>
+                      <PaginationContent>
+                        <PaginationItem>
+                          <PaginationPrevious
+                            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                            className={cn(safePage <= 1 && 'pointer-events-none opacity-50')}
+                            aria-disabled={safePage <= 1}
+                          />
+                        </PaginationItem>
+                        {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                          <PaginationItem key={page}>
+                            <PaginationLink
+                              isActive={page === safePage}
+                              onClick={() => setCurrentPage(page)}
+                            >
+                              {page}
+                            </PaginationLink>
+                          </PaginationItem>
+                        ))}
+                        <PaginationItem>
+                          <PaginationNext
+                            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                            className={cn(
+                              safePage >= totalPages && 'pointer-events-none opacity-50'
+                            )}
+                            aria-disabled={safePage >= totalPages}
+                          />
+                        </PaginationItem>
+                      </PaginationContent>
+                    </Pagination>
                   )}
-                  <span className="truncate text-sm text-foreground">{doc.title}</span>
-                </button>
-              ))}
+                </>
+              )}
             </div>
           )}
 

--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -211,9 +211,8 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
                     <span>Sichtbar für: {COUNTRY_DISPLAY[userLocale].label}</span>
                   </div>
                   <p className="mt-xs text-xs text-grey-500">
-                    Automatisch nach deinem Land festgelegt. Nutzer*innen aus dem anderen Land
-                    sehen das Notebook nicht. Gruppen-Mitglieder und Eigentümer*in sind nicht
-                    betroffen.
+                    Automatisch nach deinem Land festgelegt. Nutzer*innen aus dem anderen Land sehen
+                    das Notebook nicht. Gruppen-Mitglieder und Eigentümer*in sind nicht betroffen.
                   </p>
                 </div>
               </>

--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -21,9 +21,10 @@ import {
   SelectValue,
   Separator,
 } from '@gruenerator/ui';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { HiTrash } from 'react-icons/hi';
 
+import { useAuthStore, type SupportedLocale } from '../../../stores/authStore';
 import {
   useAddNotebookGroupShare,
   useMyGroupsForSharing,
@@ -35,11 +36,7 @@ import {
   useSetNotebookShareMode,
 } from '../hooks/useNotebookSharing';
 
-import type {
-  NotebookAudience,
-  NotebookEditPolicy,
-  NotebookShareMode,
-} from '@gruenerator/contracts';
+import type { NotebookEditPolicy, NotebookShareMode } from '@gruenerator/contracts';
 
 interface NotebookShareModalProps {
   notebookId: string;
@@ -59,10 +56,9 @@ const EDIT_POLICY_LABELS: Record<NotebookEditPolicy, string> = {
   all_members: 'Alle Mitglieder der geteilten Gruppen',
 };
 
-const AUDIENCE_LABELS: Record<NotebookAudience, string> = {
-  all: 'Beide Länder (DE & AT)',
-  'de-DE': 'Nur Deutschland',
-  'de-AT': 'Nur Österreich',
+const COUNTRY_DISPLAY: Record<SupportedLocale, { flag: string; label: string }> = {
+  'de-DE': { flag: '🇩🇪', label: 'Deutschland' },
+  'de-AT': { flag: '🇦🇹', label: 'Österreich' },
 };
 
 export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookShareModalProps) {
@@ -76,9 +72,9 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
   const addGroupShare = useAddNotebookGroupShare(notebookId);
   const removeGroupShare = useRemoveNotebookGroupShare(notebookId);
 
+  const userLocale = useAuthStore((s) => s.locale);
   const shareMode = settingsQuery.data?.share_mode ?? 'private';
   const editPolicy = settingsQuery.data?.edit_policy ?? 'owner_only';
-  const audience = settingsQuery.data?.audience ?? 'all';
 
   const sharedGroupIds = useMemo(
     () => new Set((groupSharesQuery.data ?? []).map((g) => g.group_id)),
@@ -90,6 +86,24 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
   );
 
   const editPolicyMeaningful = shareMode === 'groups';
+
+  // Auto-pin audience to the owner's locale: legacy rows persist 'all' or even
+  // the wrong country; the UI no longer offers a choice. Run at most once per
+  // open() so we never thrash on refetch.
+  const correctedRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      correctedRef.current = false;
+      return;
+    }
+    if (correctedRef.current) return;
+    if (settingsQuery.isLoading || !settingsQuery.data) return;
+    if (settingsQuery.data.share_mode !== 'authenticated') return;
+    if (settingsQuery.data.audience === userLocale) return;
+    if (setAudience.isPending) return;
+    correctedRef.current = true;
+    setAudience.mutate(userLocale);
+  }, [open, settingsQuery.data, settingsQuery.isLoading, userLocale, setAudience]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -184,31 +198,26 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
               </div>
             ) : null}
 
-            <Separator />
+            {shareMode === 'authenticated' ? (
+              <>
+                <Separator />
 
-            <div>
-              <p className="mb-xs text-sm font-semibold">Zielgruppe</p>
-              <Select
-                value={audience}
-                onValueChange={(v) => setAudience.mutate(v as NotebookAudience)}
-                disabled={setAudience.isPending}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {(Object.keys(AUDIENCE_LABELS) as NotebookAudience[]).map((a) => (
-                    <SelectItem key={a} value={a}>
-                      {AUDIENCE_LABELS[a]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="mt-xs text-xs text-grey-500">
-                Wirkt nur in &quot;Mit Anmeldung&quot;: Nutzer*innen aus dem anderen Land sehen das
-                Notebook dann nicht. Gruppen-Mitglieder und Eigentümer*in sind nicht betroffen.
-              </p>
-            </div>
+                <div>
+                  <p className="mb-xs text-sm font-semibold">Zielgruppe</p>
+                  <div className="flex items-center gap-xs rounded-md border border-grey-200 bg-background px-sm py-xs text-sm dark:border-grey-700">
+                    <span aria-hidden className="text-base">
+                      {COUNTRY_DISPLAY[userLocale].flag}
+                    </span>
+                    <span>Sichtbar für: {COUNTRY_DISPLAY[userLocale].label}</span>
+                  </div>
+                  <p className="mt-xs text-xs text-grey-500">
+                    Automatisch nach deinem Land festgelegt. Nutzer*innen aus dem anderen Land
+                    sehen das Notebook nicht. Gruppen-Mitglieder und Eigentümer*in sind nicht
+                    betroffen.
+                  </p>
+                </div>
+              </>
+            ) : null}
 
             <Separator />
 

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -54,7 +54,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-background-pure text-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'relative z-[1020] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-background-pure text-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           className


### PR DESCRIPTION
Three related share-modal/notebook-editor issues, bundled per request.

### 1 — Audience auto-pin to user locale

`share_mode='authenticated'` was offering three options (Beide Länder DE & AT / Nur Deutschland / Nur Österreich). Per the project's Austria-first-class rule the only sensible audience is the **owner's own country** — `'all'` doesn't match how Landesverbände actually share content, and picking the *other* country is a footgun. Dropdown is replaced with a static "Sichtbar für: … " line. On modal open, a stale audience is silently corrected to the user's locale (guarded by a ref so refetches don't loop).

### 2 — All four share-modal dropdowns were unresponsive

`DialogOverlay`/`DialogContent` sit at `z-[1010]` (intentional, to clear sidebars at 1001/1005). `SelectContent` stayed at the Radix default `z-50`, so the portal opened **behind** the overlay — every trigger click looked dead. Bumped `SelectContent` to `z-[1020]`. Primitive-level fix, heals every future Select-in-Dialog consumer.

### 3 — NotebookEditor docs picker had no pagination + auto-expanded

Picker previously auto-opened whenever `linkedDocs.length === 0` and rendered an unpaginated `<button>` list. Now: opens only on explicit toggle, uses `DocumentCard` (new `mode='select'` variant) for visual parity with `/docs`, paginates at 12 / page, and has a search field. Reuses the pagination wiring from `AddContentToGroupModal`.

### Follow-up PR

A separate PR will drop `'all'` from `notebookAudienceSchema`, migrate legacy Qdrant payloads to the owner's locale, narrow `normalizeAudience`, and tighten the listing filter to require an exact locale match. Sequencing matters there — done after this UI-only change ships and stops writing `'all'`.

## Test plan

- [ ] Open the share modal on any owned notebook → click each of Sichtbarkeit / Wer-darf-bearbeiten / (when in groups mode) Gruppe-hinzufügen → all dropdowns open above the dialog overlay.
- [ ] Set share mode to "Mit Anmeldung" → confirm the static Zielgruppe line shows the user's own country and no dropdown is rendered.
- [ ] In a notebook with a legacy `audience='all'`, open the share modal in "Mit Anmeldung" → one `PUT /share/audience` fires with the user's locale; re-opening does not fire it again.
- [ ] Switch share mode away from "Mit Anmeldung" → audience block disappears (no longer relevant).
- [ ] On a notebook editor: docs section starts collapsed when zero linked docs; "Doc hinzufügen" toggles a card grid; search filters; pagination shows when > 12 unattached docs; clicking a card attaches it and the grid refreshes.
- [ ] CI green.