### PR TITLE
fix(notebook): stop upload spinner and process docs added on edit

### DIFF
--- a/apps/api/routes/documents/manualController.ts
+++ b/apps/api/routes/documents/manualController.ts
@@ -81,6 +81,9 @@ router.post(
   async (req: DocumentRequest, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;
+      log.info(
+        `[POST /upload-only] start user=${userId ?? 'anon'} file=${req.file?.originalname ?? 'none'} size=${req.file?.size ?? 0}`
+      );
       if (!userId) {
         res.status(401).json({ error: 'Unauthorized' });
         return;
@@ -158,6 +161,10 @@ router.get(
         res.status(404).json({ success: false, message: 'Document not found' });
         return;
       }
+
+      log.debug(
+        `[GET /:id/status] poll user=${userId} doc=${req.params.id} status=${document.status}`
+      );
 
       res.json({
         success: true,

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -544,6 +544,10 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
           [allDocumentIds, userId]
         )) as Array<{ id: string }>;
 
+        log.info(
+          `[notebookCollectionsContract.createCollection] firing processUploadedDocument for ${pendingDocs.length} doc(s) in collection ${collectionId}`
+        );
+
         if (pendingDocs.length > 0) {
           const pgDocService = getPostgresDocumentService();
           const qdrantDocService = getQdrantDocumentService();
@@ -742,6 +746,33 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       }
 
       await notebookHelper.addDocumentsToCollection(collectionId, allDocumentIds, userId);
+
+      // Fire-and-forget: process any newly-added documents still in 'uploaded'
+      // state. Mirrors createCollection — without this, files added via the
+      // edit-existing-notebook flow stay at status='uploaded' forever.
+      if (selection_mode !== 'wolke' && allDocumentIds.length > 0) {
+        const pendingDocs = (await postgres.query(
+          `SELECT id FROM documents WHERE id = ANY($1) AND user_id = $2 AND status = 'uploaded'`,
+          [allDocumentIds, userId]
+        )) as Array<{ id: string }>;
+
+        log.info(
+          `[notebookCollectionsContract.updateCollection] firing processUploadedDocument for ${pendingDocs.length} doc(s) in collection ${collectionId}`
+        );
+
+        if (pendingDocs.length > 0) {
+          const pgDocService = getPostgresDocumentService();
+          const qdrantDocService = getQdrantDocumentService();
+          for (const doc of pendingDocs) {
+            processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
+              log.error(
+                `[notebookCollectionsContract.updateCollection] Background processing failed for doc ${doc.id} in collection ${collectionId}:`,
+                err
+              );
+            });
+          }
+        }
+      }
 
       return {
         status: 200 as const,

--- a/apps/web/src/features/notebook/components/NotebookEditor/useNotebookEditorState.ts
+++ b/apps/web/src/features/notebook/components/NotebookEditor/useNotebookEditorState.ts
@@ -118,7 +118,16 @@ export function useNotebookEditorState({
 
       try {
         for (const file of filesToUpload) {
+          console.debug('[notebook-upload] uploading', {
+            filename: file.name,
+            size: file.size,
+          });
           const doc = await uploadFileOnly(file, file.name);
+          console.debug('[notebook-upload] uploaded', {
+            docId: doc.id,
+            title: doc.title,
+            status: doc.status,
+          });
           newDocs.push({ id: doc.id, title: doc.title || file.name });
         }
         if (newDocs.length > 0) {

--- a/apps/web/src/stores/documentsStore.ts
+++ b/apps/web/src/stores/documentsStore.ts
@@ -427,6 +427,7 @@ export const useDocumentsStore = create<DocumentsStore>()(
                   `/documents/${documentId}/status`
                 );
                 const status = (response.data?.data?.status ?? 'pending') as DocumentStatus;
+                console.debug('[notebook-upload] poll', { documentId, status });
 
                 if (onStatusChange) onStatusChange(status);
 
@@ -436,7 +437,9 @@ export const useDocumentsStore = create<DocumentsStore>()(
                   if (idx !== -1) state.documents[idx].status = status;
                 });
 
-                if (status === 'completed' || status === 'failed') {
+                // 'uploaded' = staged on disk, awaiting notebook save before processing
+                // kicks off — terminal from the spinner's perspective.
+                if (status === 'uploaded' || status === 'completed' || status === 'failed') {
                   clearInterval(interval);
                   resolve(status);
                 }


### PR DESCRIPTION
## Summary

Two defects both surface as the upload card stuck on "Wird verarbeitet…" with no backend activity. Both fixed; precise debug logs added across the pipeline so the next regression is easier to triage.

**Frontend — spinner ran forever during the create-notebook wizard.** The two-step upload flow stages files at `status='uploaded'` and only kicks off `processUploadedDocument` *after* the user clicks Speichern. The poll's terminal-state check was `'completed' | 'failed'`, so `'uploaded'` never resolved and the spinner spun indefinitely. Treat `'uploaded'` as terminal — the file is staged; the spinner shouldn't be claiming "processing" until processing actually starts.

**Backend — `updateCollection` (PUT) never fired processing for newly-added docs.** `createCollection` (POST) has a fire-and-forget block that queries for docs in `'uploaded'` state and calls `processUploadedDocument`. The matching PUT handler called `addDocumentsToCollection` but skipped the trigger entirely — so files added via the edit-existing-notebook path stayed at `'uploaded'` forever. Mirror the create-path block.

**Debug logs** — five boundaries: upload start/end (client), poll tick (client), `/upload-only` entry (server), `/:id/status` entry (server), and `processUploadedDocument` trigger-fire on both create and update paths. The existing `[DocumentProcessingService] Deferred processing for document` log inside `processUploadedDocument` completes the trace.

## Test plan

- [ ] Create-notebook wizard: upload PDF, observe spinner clears once poll resolves at `'uploaded'`; save notebook and watch backend log `firing processUploadedDocument` followed by `[DocumentProcessingService] Deferred processing`.
- [ ] Edit-existing-notebook: add a new PDF, save; backend should log the trigger-fire (would have been silent before this PR) and the doc should reach `'completed'`.
- [ ] Wolke-mode notebooks unaffected (trigger block is gated on `selection_mode !== 'wolke'` on both paths).
- [ ] `pnpm --filter @gruenerator/api typecheck` — passes.
- [ ] `pnpm --filter @gruenerator/web typecheck` — passes.