### PR TITLE
refactor(notebook): extract triggerPendingDocProcessing helper

### DIFF
--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -13,9 +13,8 @@ import express, { type Response } from 'express';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import authMiddleware from '../../middleware/authMiddleware.js';
-import { processUploadedDocument } from '../../services/document-services/DocumentProcessingService/index.js';
+import { triggerPendingDocProcessing } from '../../services/document-services/DocumentProcessingService/index.js';
 import { getQdrantDocumentService } from '../../services/document-services/DocumentSearchService/index.js';
-import { getPostgresDocumentService } from '../../services/document-services/PostgresDocumentService/index.js';
 import { createLogger } from '../../utils/logger.js';
 import { fromParam, type DocumentId, type NotebookId } from '../../utils/types/branded.js';
 
@@ -285,28 +284,13 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       return res.status(500).json({ error: 'Failed to add documents to collection' });
     }
 
-    // Fire-and-forget: process any documents that are still in 'uploaded' state
-    if (selection_mode !== 'wolke' && allDocumentIds.length > 0) {
-      const pendingDocs = (await postgres.query(
-        `SELECT id FROM documents WHERE id = ANY($1) AND user_id = $2 AND status = 'uploaded'`,
-        [allDocumentIds, userId]
-      )) as Array<{ id: string }>;
-
-      if (pendingDocs.length > 0) {
-        const pgDocService = getPostgresDocumentService();
-        const qdrantDocService = getQdrantDocumentService();
-        for (const doc of pendingDocs) {
-          processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
-            log.error(
-              `[Notebook Collections] Background processing failed for doc ${doc.id}:`,
-              err
-            );
-          });
-        }
-        log.debug(
-          `[Notebook Collections] Kicked off background processing for ${pendingDocs.length} document(s)`
-        );
-      }
+    if (selection_mode !== 'wolke') {
+      await triggerPendingDocProcessing({
+        documentIds: allDocumentIds,
+        userId,
+        logScope: 'Notebook Collections',
+        collectionId,
+      });
     }
 
     return res.status(201).json({

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -21,9 +21,8 @@ import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
-import { processUploadedDocument } from '../../services/document-services/DocumentProcessingService/index.js';
+import { triggerPendingDocProcessing } from '../../services/document-services/DocumentProcessingService/index.js';
 import { getQdrantDocumentService } from '../../services/document-services/DocumentSearchService/index.js';
-import { getPostgresDocumentService } from '../../services/document-services/PostgresDocumentService/index.js';
 import {
   getLikeCountsForEntities,
   getLikedEntityIdsForUser,
@@ -537,29 +536,13 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return { status: 500 as const, body: { error: 'Failed to add documents to collection' } };
       }
 
-      // Fire-and-forget: process any documents still in 'uploaded' state
-      if (selection_mode !== 'wolke' && allDocumentIds.length > 0) {
-        const pendingDocs = (await postgres.query(
-          `SELECT id FROM documents WHERE id = ANY($1) AND user_id = $2 AND status = 'uploaded'`,
-          [allDocumentIds, userId]
-        )) as Array<{ id: string }>;
-
-        log.info(
-          `[notebookCollectionsContract.createCollection] firing processUploadedDocument for ${pendingDocs.length} doc(s) in collection ${collectionId}`
-        );
-
-        if (pendingDocs.length > 0) {
-          const pgDocService = getPostgresDocumentService();
-          const qdrantDocService = getQdrantDocumentService();
-          for (const doc of pendingDocs) {
-            processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
-              log.error(
-                `[notebookCollectionsContract.createCollection] Background processing failed for doc ${doc.id} in collection ${collectionId}:`,
-                err
-              );
-            });
-          }
-        }
+      if (selection_mode !== 'wolke') {
+        await triggerPendingDocProcessing({
+          documentIds: allDocumentIds,
+          userId,
+          logScope: 'notebookCollectionsContract.createCollection',
+          collectionId,
+        });
       }
 
       return {
@@ -747,31 +730,13 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
 
       await notebookHelper.addDocumentsToCollection(collectionId, allDocumentIds, userId);
 
-      // Fire-and-forget: process any newly-added documents still in 'uploaded'
-      // state. Mirrors createCollection — without this, files added via the
-      // edit-existing-notebook flow stay at status='uploaded' forever.
-      if (selection_mode !== 'wolke' && allDocumentIds.length > 0) {
-        const pendingDocs = (await postgres.query(
-          `SELECT id FROM documents WHERE id = ANY($1) AND user_id = $2 AND status = 'uploaded'`,
-          [allDocumentIds, userId]
-        )) as Array<{ id: string }>;
-
-        log.info(
-          `[notebookCollectionsContract.updateCollection] firing processUploadedDocument for ${pendingDocs.length} doc(s) in collection ${collectionId}`
-        );
-
-        if (pendingDocs.length > 0) {
-          const pgDocService = getPostgresDocumentService();
-          const qdrantDocService = getQdrantDocumentService();
-          for (const doc of pendingDocs) {
-            processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
-              log.error(
-                `[notebookCollectionsContract.updateCollection] Background processing failed for doc ${doc.id} in collection ${collectionId}:`,
-                err
-              );
-            });
-          }
-        }
+      if (selection_mode !== 'wolke') {
+        await triggerPendingDocProcessing({
+          documentIds: allDocumentIds,
+          userId,
+          logScope: 'notebookCollectionsContract.updateCollection',
+          collectionId,
+        });
       }
 
       return {

--- a/apps/api/services/document-services/DocumentProcessingService/index.ts
+++ b/apps/api/services/document-services/DocumentProcessingService/index.ts
@@ -27,6 +27,8 @@ export { chunkAndEmbedText } from './chunkingPipeline.js';
 
 export { processFileUpload, processUploadedDocument } from './fileProcessing.js';
 
+export { triggerPendingDocProcessing } from './triggerPendingDocProcessing.js';
+
 export { processTextContent } from './textProcessing.js';
 
 export { processUrlContent } from './urlProcessing.js';

--- a/apps/api/services/document-services/DocumentProcessingService/triggerPendingDocProcessing.ts
+++ b/apps/api/services/document-services/DocumentProcessingService/triggerPendingDocProcessing.ts
@@ -1,0 +1,57 @@
+import { getPostgresInstance } from '../../../database/services/PostgresService.js';
+import { createLogger } from '../../../utils/logger.js';
+import { getPostgresDocumentService } from '../PostgresDocumentService/index.js';
+import { getQdrantDocumentService } from '../DocumentSearchService/index.js';
+
+import { processUploadedDocument } from './fileProcessing.js';
+
+const log = createLogger('document-processing:trigger');
+
+interface TriggerPendingDocProcessingParams {
+  documentIds: readonly string[];
+  userId: string;
+  logScope: string;
+  collectionId?: string;
+}
+
+/**
+ * Fire-and-forget: kick off deferred processing for any of `documentIds` that
+ * are still in 'uploaded' state. Returns the number of docs whose processing
+ * was triggered (already-completed/processing docs are skipped).
+ *
+ * Callers are responsible for upstream gating (e.g. selection_mode !== 'wolke').
+ */
+export async function triggerPendingDocProcessing({
+  documentIds,
+  userId,
+  logScope,
+  collectionId,
+}: TriggerPendingDocProcessingParams): Promise<{ pendingCount: number }> {
+  if (documentIds.length === 0) return { pendingCount: 0 };
+
+  const postgres = getPostgresInstance();
+  const pendingDocs = (await postgres.query(
+    `SELECT id FROM documents WHERE id = ANY($1) AND user_id = $2 AND status = 'uploaded'`,
+    [documentIds, userId]
+  )) as Array<{ id: string }>;
+
+  const collectionSuffix = collectionId ? ` in collection ${collectionId}` : '';
+  log.info(
+    `[${logScope}] firing processUploadedDocument for ${pendingDocs.length} doc(s)${collectionSuffix}`
+  );
+
+  if (pendingDocs.length === 0) return { pendingCount: 0 };
+
+  const pgDocService = getPostgresDocumentService();
+  const qdrantDocService = getQdrantDocumentService();
+  for (const doc of pendingDocs) {
+    processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
+      log.error(
+        `[${logScope}] Background processing failed for doc ${doc.id}${collectionSuffix}:`,
+        err
+      );
+    });
+  }
+
+  return { pendingCount: pendingDocs.length };
+}


### PR DESCRIPTION
## Summary

Follow-up to #924. Three call sites repeated the same fire-and-forget block (legacy `collectionsController`, contract `createCollection`, and the newly-added block in contract `updateCollection`). The duplication had already produced the symmetric-handler omission that caused #924's regression. Rule-of-three hit — extracting now prevents the next forgotten block on `syncCollection` or any new mutation endpoint.

Helper lives next to `processUploadedDocument` in `DocumentProcessingService`. Signature is intentionally minimal:

```ts
triggerPendingDocProcessing({
  documentIds, userId, logScope, collectionId?
}): Promise<{ pendingCount }>
```

Callers remain responsible for upstream gating (the `selection_mode !== 'wolke'` check stays at the call site since it's a contract concern, not a processing concern).

**Base branch**: this PR is stacked on `fix/notebook-upload-stuck-spinner` (#924). Merge #924 first, then this rebases cleanly onto master.

## Test plan

- [ ] `pnpm --filter @gruenerator/api typecheck` — passes (verified locally).
- [ ] Create-notebook flow: helper fires `firing processUploadedDocument for N doc(s) in collection X` log, processing kicks off as before.
- [ ] Edit-existing-notebook flow: same log fires under `updateCollection` scope.
- [ ] Legacy `collectionsController` POST path: same log fires under `Notebook Collections` scope.
- [ ] Wolke-mode notebooks unaffected (gate still at call site).