### PR TITLE
refactor(notebook): make attach imply process

### DIFF
--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -9,6 +9,7 @@ import { generateSlugSuffix } from '@gruenerator/shared/utils';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getSystemCollectionConfig } from '../../config/systemCollectionsConfig.js';
+import { triggerPendingDocProcessing } from '../../services/document-services/DocumentProcessingService/index.js';
 import { mistralEmbeddingService } from '../../services/mistral/index.js';
 import { createLogger } from '../../utils/logger.js';
 
@@ -585,7 +586,13 @@ class NotebookQdrantHelper {
   }
 
   /**
-   * Add documents to Notebook collection
+   * Add documents to a Notebook collection.
+   *
+   * Also kicks off deferred processing for any attached docs still at
+   * status='uploaded'. The SQL filter inside `triggerPendingDocProcessing`
+   * is the natural gate — already-processed docs (e.g. Wolke imports at
+   * status='completed') are a no-op. Skipped when `addedBy` is null because
+   * the processing query needs a user_id.
    */
   async addDocumentsToCollection(
     collectionId: string,
@@ -612,6 +619,16 @@ class NotebookQdrantHelper {
       );
 
       logger.info(`Added ${documentIds.length} documents to collection: ${collectionId}`);
+
+      if (addedBy && documentIds.length > 0) {
+        await triggerPendingDocProcessing({
+          documentIds,
+          userId: addedBy,
+          logScope: 'NotebookQdrantHelper.addDocumentsToCollection',
+          collectionId,
+        });
+      }
+
       return { success: true, added_count: documentIds.length };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/apps/api/routes/notebook/collectionsController.ts
+++ b/apps/api/routes/notebook/collectionsController.ts
@@ -13,7 +13,6 @@ import express, { type Response } from 'express';
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import authMiddleware from '../../middleware/authMiddleware.js';
-import { triggerPendingDocProcessing } from '../../services/document-services/DocumentProcessingService/index.js';
 import { getQdrantDocumentService } from '../../services/document-services/DocumentSearchService/index.js';
 import { createLogger } from '../../utils/logger.js';
 import { fromParam, type DocumentId, type NotebookId } from '../../utils/types/branded.js';
@@ -282,15 +281,6 @@ router.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) =
       log.error('[Notebook Collections] Error adding documents:', docError);
       await notebookHelper.deleteNotebookCollection(collectionId);
       return res.status(500).json({ error: 'Failed to add documents to collection' });
-    }
-
-    if (selection_mode !== 'wolke') {
-      await triggerPendingDocProcessing({
-        documentIds: allDocumentIds,
-        userId,
-        logScope: 'Notebook Collections',
-        collectionId,
-      });
     }
 
     return res.status(201).json({

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -21,7 +21,6 @@ import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
-import { triggerPendingDocProcessing } from '../../services/document-services/DocumentProcessingService/index.js';
 import { getQdrantDocumentService } from '../../services/document-services/DocumentSearchService/index.js';
 import {
   getLikeCountsForEntities,
@@ -536,15 +535,6 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         return { status: 500 as const, body: { error: 'Failed to add documents to collection' } };
       }
 
-      if (selection_mode !== 'wolke') {
-        await triggerPendingDocProcessing({
-          documentIds: allDocumentIds,
-          userId,
-          logScope: 'notebookCollectionsContract.createCollection',
-          collectionId,
-        });
-      }
-
       return {
         status: 201 as const,
         body: {
@@ -729,15 +719,6 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       }
 
       await notebookHelper.addDocumentsToCollection(collectionId, allDocumentIds, userId);
-
-      if (selection_mode !== 'wolke') {
-        await triggerPendingDocProcessing({
-          documentIds: allDocumentIds,
-          userId,
-          logScope: 'notebookCollectionsContract.updateCollection',
-          collectionId,
-        });
-      }
 
       return {
         status: 200 as const,


### PR DESCRIPTION
## Summary

Follow-up to #924 / #926. Picks the long-term architectural fix after evaluating six variants (helper, data-layer push, background worker, eager processing, state-machine types, outbox, composite use-case fn).

**The chosen variant: push the trigger inside `NotebookQdrantHelper.addDocumentsToCollection`.** After this PR, attaching documents to a notebook collection structurally implies kicking off processing for any that are still at `status='uploaded'`. There is no separate primitive a future handler can forget to call.

### Why this is the right boundary

The earlier helper extraction kept `triggerPendingDocProcessing` as a public function callers had to remember to invoke. Six call sites, each gated by `selection_mode !== 'wolke'`. That gate was redundant defensive code — Wolke docs land at `status='completed'` from the import path, and the trigger's SQL filter `WHERE status='uploaded'` already excludes them. Once you see that, the precondition "should this attach also process?" is unconditional, which means it belongs inside `addDocumentsToCollection`, not at every call site.

### Why not the other variants

- **Composite `attachDocumentsToCollection` at the use-case level** — still leaves the primitive callable around it; bug class survives.
- **Background worker scanning for `'uploaded'` docs** — new infrastructure, latency cost, overkill at current scale.
- **Eager processing inside `/upload-only`** — wastes work on wizard abandon, produces orphan vectors.
- **State-machine types** — best end state but a much larger migration; this PR doesn't preclude it.
- **Outbox/domain events** — massive overengineering.

### Behavior

- Six callers benefit automatically: legacy `collectionsController` (create/update/sync) and contract `notebookCollectionsContractRouter` (create/update/sync).
- Sync paths pay one extra SQL no-op per call (negligible).
- `addedBy` null short-circuits the trigger — no user context to filter by. Behavior preserved for that edge case.
- Self-healing: if any code path ever attaches an `'uploaded'` doc (e.g. a future bulk-import that misses processing), it gets processed correctly.

Net: −12 lines.

## Test plan

- [x] `pnpm --filter @gruenerator/api typecheck` — passes.
- [ ] Create notebook with PDFs: backend log `[NotebookQdrantHelper.addDocumentsToCollection] firing processUploadedDocument for N doc(s)` fires once, docs reach `'completed'`.
- [ ] Edit existing notebook + add PDFs: same log fires.
- [ ] Wolke sync: log fires with `0 doc(s)` (SQL no-op), no extra processing kicked off.
- [ ] Verify nothing breaks in `collectionsController.ts` legacy paths.