### PR TITLE
fix(notebook): show real indexing state instead of pretending uploads are done

### DIFF
--- a/apps/api/services/OcrService/databaseOperations.ts
+++ b/apps/api/services/OcrService/databaseOperations.ts
@@ -97,8 +97,7 @@ export async function generateAndStoreEmbeddings(
     });
 
     if (!chunks || chunks.length === 0) {
-      console.warn('[OcrService] No chunks generated from document');
-      return { chunksProcessed: 0, embeddings: 0 };
+      throw new Error('No chunks generated from document — extracted text is unusable');
     }
 
     console.log(`[OcrService] Generated ${chunks.length} chunks from document`);
@@ -112,8 +111,9 @@ export async function generateAndStoreEmbeddings(
     console.log(`[OcrService] ${qualityChunks.length} high-quality chunks after filtering`);
 
     if (qualityChunks.length === 0) {
-      console.warn('[OcrService] No high-quality chunks after filtering');
-      return { chunksProcessed: 0, embeddings: 0 };
+      throw new Error(
+        `No high-quality chunks after filtering (${chunks.length} raw chunks rejected)`
+      );
     }
 
     // Step 3: Generate embeddings in batches

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -14,6 +14,7 @@
  * - AI worker pool for draft generation
  */
 
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import {
   buildDraftPromptGrundsatz,
   buildDraftPromptGeneral,
@@ -73,6 +74,19 @@ import type {
 
 const log = createLogger('NotebookQAService');
 const documentSearchService = new DocumentSearchService();
+
+interface CorpusDocSummary {
+  id: string;
+  title: string | null;
+}
+
+interface CorpusStateInspection {
+  state: 'indexing' | 'failed' | 'ready';
+  indexing: CorpusDocSummary[];
+  failed: CorpusDocSummary[];
+  ready: CorpusDocSummary[];
+  total: number;
+}
 
 export class NotebookQAService {
   /**
@@ -354,9 +368,12 @@ export class NotebookQAService {
     const sorted = filterAndSortResults(deduped, { threshold: 0.35, limit: 30 });
 
     if (sorted.length === 0) {
+      const corpus =
+        !isSystem && documentIds ? await this._inspectCorpusState(documentIds, userId) : null;
+      const answer = this._buildEmptyResultMessage(collection.name, corpus);
       return {
         success: true,
-        answer: `Leider konnte ich in der Sammlung "${collection.name}" keine passenden Stellen zu Ihrer Frage finden.`,
+        answer,
         citations: [],
         sources: [],
         allSources: [],
@@ -367,7 +384,8 @@ export class NotebookQAService {
           effectiveFilters,
           0,
           0,
-          fastMode
+          fastMode,
+          corpus
         ),
       };
     }
@@ -941,7 +959,8 @@ export class NotebookQAService {
     filters: RequestFilters,
     totalResults: number,
     citationsCount: number,
-    fastMode?: boolean
+    fastMode?: boolean,
+    corpus?: CorpusStateInspection | null
   ): SingleCollectionMetadata {
     return {
       collection_id: collectionId,
@@ -951,7 +970,91 @@ export class NotebookQAService {
       citations_count: citationsCount,
       subcategory_filters_applied: Object.keys(filters).length > 0 ? filters : null,
       fast_mode: fastMode || false,
+      ...(corpus && {
+        corpus_state: corpus.state,
+        corpus_state_detail: {
+          indexing_count: corpus.indexing.length,
+          failed_count: corpus.failed.length,
+          ready_count: corpus.ready.length,
+          total_count: corpus.total,
+        },
+      }),
     };
+  }
+
+  /**
+   * Inspect the Postgres state of the requested documents so we can tell the
+   * user *why* a search came back empty (still indexing / failed / genuine miss).
+   */
+  private async _inspectCorpusState(
+    documentIds: readonly string[],
+    userId: string
+  ): Promise<CorpusStateInspection> {
+    if (documentIds.length === 0) {
+      return { state: 'ready', indexing: [], failed: [], ready: [], total: 0 };
+    }
+
+    try {
+      const postgres = getPostgresInstance();
+      const rows = (await postgres.query(
+        `SELECT id, title, status, vector_count
+         FROM documents
+         WHERE id = ANY($1) AND user_id = $2`,
+        [documentIds, userId]
+      )) as Array<{ id: string; title: string | null; status: string; vector_count: number | null }>;
+
+      const indexing: CorpusDocSummary[] = [];
+      const failed: CorpusDocSummary[] = [];
+      const ready: CorpusDocSummary[] = [];
+
+      for (const row of rows) {
+        const summary: CorpusDocSummary = { id: row.id, title: row.title };
+        if (row.status === 'uploaded' || row.status === 'processing' || row.status === 'pending') {
+          indexing.push(summary);
+        } else if (row.status === 'failed') {
+          failed.push(summary);
+        } else if (row.status === 'completed' && (row.vector_count ?? 0) > 0) {
+          ready.push(summary);
+        } else {
+          // status='completed' but vector_count=0 — treat as failed for UX purposes
+          failed.push(summary);
+        }
+      }
+
+      const state: CorpusStateInspection['state'] =
+        indexing.length > 0 ? 'indexing' : failed.length > 0 ? 'failed' : 'ready';
+
+      return { state, indexing, failed, ready, total: rows.length };
+    } catch (error) {
+      log.warn(`[QA Single] _inspectCorpusState failed: ${(error as Error).message}`);
+      return { state: 'ready', indexing: [], failed: [], ready: [], total: 0 };
+    }
+  }
+
+  private _buildEmptyResultMessage(
+    collectionName: string,
+    corpus: CorpusStateInspection | null
+  ): string {
+    if (corpus && corpus.indexing.length > 0) {
+      const total = corpus.total || corpus.indexing.length;
+      return (
+        `Die Dokumente in der Sammlung "${collectionName}" werden gerade indexiert ` +
+        `(${corpus.ready.length}/${total} bereit). ` +
+        `Bitte probier es in ein bis zwei Minuten erneut.`
+      );
+    }
+    if (corpus && corpus.failed.length > 0) {
+      const names = corpus.failed
+        .map((d) => d.title)
+        .filter((t): t is string => !!t)
+        .slice(0, 3);
+      const namePart = names.length > 0 ? ` (${names.join(', ')})` : '';
+      return (
+        `Bei der Verarbeitung von ${corpus.failed.length} Dokument(en)${namePart} ist ein Fehler aufgetreten. ` +
+        `Bitte lade die betroffenen Dateien erneut hoch.`
+      );
+    }
+    return `Leider konnte ich in der Sammlung "${collectionName}" keine passenden Stellen zu deiner Frage finden.`;
   }
 
   /**

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -1001,7 +1001,12 @@ export class NotebookQAService {
          FROM documents
          WHERE id = ANY($1) AND user_id = $2`,
         [documentIds, userId]
-      )) as Array<{ id: string; title: string | null; status: string; vector_count: number | null }>;
+      )) as Array<{
+        id: string;
+        title: string | null;
+        status: string;
+        vector_count: number | null;
+      }>;
 
       const indexing: CorpusDocSummary[] = [];
       const failed: CorpusDocSummary[] = [];

--- a/apps/api/services/notebook/types.ts
+++ b/apps/api/services/notebook/types.ts
@@ -66,6 +66,17 @@ export interface SingleCollectionMetadata {
   citations_count: number;
   subcategory_filters_applied: Record<string, unknown> | null;
   fast_mode?: boolean | undefined;
+  // Set on empty-result responses for user collections so callers (and the
+  // chat respondNode) can distinguish "still indexing" / "failed" / "ready".
+  corpus_state?: 'indexing' | 'failed' | 'ready' | undefined;
+  corpus_state_detail?:
+    | {
+        indexing_count: number;
+        failed_count: number;
+        ready_count: number;
+        total_count: number;
+      }
+    | undefined;
 }
 
 /**

--- a/apps/web/src/stores/documentsStore.ts
+++ b/apps/web/src/stores/documentsStore.ts
@@ -30,6 +30,7 @@ interface DocumentUploadResponse {
 interface DocumentStatusResponse {
   data?: {
     status: DocumentStatus;
+    vectorCount?: number;
   };
 }
 
@@ -417,8 +418,13 @@ export const useDocumentsStore = create<DocumentsStore>()(
         }
       },
 
-      // Poll document status until it reaches a terminal state
+      // Poll document status until it reaches a terminal state.
+      // Terminal = chunks queryable in Qdrant: status='completed' && vectorCount>0, or 'failed'.
+      // 'uploaded' is transient (attach triggers processing); soft-timeout below bounds it.
       pollDocumentStatus: async (documentId, onStatusChange) => {
+        const STUCK_UPLOADED_TIMEOUT_MS = 30_000;
+        const startedAt = Date.now();
+
         const poll = (): Promise<DocumentStatus> =>
           new Promise((resolve, reject) => {
             const interval = setInterval(async () => {
@@ -427,19 +433,27 @@ export const useDocumentsStore = create<DocumentsStore>()(
                   `/documents/${documentId}/status`
                 );
                 const status = (response.data?.data?.status ?? 'pending') as DocumentStatus;
-                console.debug('[notebook-upload] poll', { documentId, status });
+                const vectorCount = response.data?.data?.vectorCount ?? 0;
+                console.debug('[notebook-upload] poll', { documentId, status, vectorCount });
 
                 if (onStatusChange) onStatusChange(status);
 
-                // Update store
                 set((state) => {
                   const idx = state.documents.findIndex((d) => d.id === documentId);
                   if (idx !== -1) state.documents[idx].status = status;
                 });
 
-                // 'uploaded' = staged on disk, awaiting notebook save before processing
-                // kicks off — terminal from the spinner's perspective.
-                if (status === 'uploaded' || status === 'completed' || status === 'failed') {
+                const isQueryable = status === 'completed' && vectorCount > 0;
+                if (isQueryable || status === 'failed') {
+                  clearInterval(interval);
+                  resolve(status);
+                  return;
+                }
+
+                if (status === 'uploaded' && Date.now() - startedAt > STUCK_UPLOADED_TIMEOUT_MS) {
+                  console.warn(
+                    `[notebook-upload] doc ${documentId} stuck in 'uploaded' >${STUCK_UPLOADED_TIMEOUT_MS}ms — releasing spinner`
+                  );
                   clearInterval(interval);
                   resolve(status);
                 }


### PR DESCRIPTION
## Why

Users reported that notebook search returned "Leider konnte ich keine passenden Stellen finden" *seconds after* uploading a PDF that the UI clearly marked as "fertig". Three concentric defects collude:

1. **Stale spinner contract** — `documentsStore.ts:442` resolved the poll on `status='uploaded'`. This was correct before #927 (`b96876534`), which made attach imply process — `'uploaded'` is now a transient state that flips to `'processing'` within ~1s. The spinner was lying. A 41 MB / 48-page PDF needs 30–90s of real OCR + embedding; the spinner stopped within seconds.
2. **Silent OCR failures** — `OcrService/databaseOperations.ts` returned `{ chunksProcessed: 0 }` instead of throwing when chunking produced nothing, leaving documents in a half-ingested state with no error signal.
3. **Collapsed empty-result states** — `NotebookQAService` returned the same miss message whether the corpus genuinely missed, was still indexing, or had failed.

Three commits, each independently revertable:

- Spinner now waits for `status='completed' && vector_count>0` (the true "queryable in Qdrant" signal already returned atomically by `GET /documents/:id/status`); 30s soft-timeout safety on stranded `'uploaded'`.
- Zero-chunk OCR throws so the existing `fileProcessing.ts` catch flips the doc to `status='failed'` — failures now surface end-to-end.
- Empty-result branch introspects Postgres for the requested document IDs and tells the user *why* the search came back empty (indexing / failed / genuine miss). `corpus_state` is added to `SingleCollectionMetadata` so the ChatGraph respondNode reads it verbatim.

## Test plan
- [ ] Upload a > 20-page PDF into a notebook; spinner runs continuously through OCR + embedding, stops only on `vector_count > 0`.
- [ ] Search mid-indexing → new "wird gerade indexiert" message, not "keine passenden Stellen".
- [ ] After completion, search for an in-doc term → real hits.
- [ ] Search for something not in the doc → existing miss message.
- [ ] Image-only PDF (no extractable text) → status flips to `'failed'`, search returns the "Verarbeitungsfehler" message.
- [ ] Wizard add-doc-then-save flow (the regression target of 2bc172c25) still works.