### PR TITLE
fix(contracts): allow 'processing_done' in autoProgress status enum

### DIFF
--- a/packages/contracts/src/schemas/subtitler.ts
+++ b/packages/contracts/src/schemas/subtitler.ts
@@ -303,7 +303,7 @@ export const autoProcessStartResponseSchema = z.object({
  * pipeline. Read by GET /auto-progress and GET /auto-download.
  */
 export const autoProgressSchema = z.object({
-  status: z.enum(['processing', 'complete', 'error']),
+  status: z.enum(['processing', 'processing_done', 'complete', 'error']),
   stage: z.number().nullish(),
   stageProgress: z.number().nullish(),
   overallProgress: z.number().nullish(),


### PR DESCRIPTION
## Why

The subtitler auto-processing pipeline writes a transient `'processing_done'` state to the `auto:${uploadId}` Redis key in the window between FFmpeg export completing and `autoSaveProject` flipping the key to `'complete'` (producer: `apps/api/services/subtitler/autoProcessingService.ts:375`). The shared `autoProgressSchema` enum only listed `['processing', 'complete', 'error']`, so `parseAutoProgress()` rejected the value at the Redis read boundary and `GET /auto-progress/:uploadId` returned HTTP 500 throughout the save window — surfaced in logs as:

```
WARN [subtitler-redis] [auto-progress:…] Zod validation failed: …
"received": "processing_done",
"options": ["processing","complete","error"]
```

Mobile's hand-rolled `AutoProgressResponse` type in `apps/mobile/services/reel.ts:9` already includes `'processing_done'`, so the schema was the lone lagging layer in a producer→schema→consumer alignment. Web's poller treats unknown statuses as "still processing" (only switches on `'complete'`/`'error'`), so widening the enum is safe there too.

## Follow-up (out of scope for this PR)

`apps/mobile/services/reel.ts` should derive `AutoProgressResponse` from `z.infer<typeof autoProgressSchema>` instead of hand-rolling the union, so the next drift between layers fails at compile time. Logged as a separate concern per Surgical Changes.