### PR TITLE
fix(notebook): widen share modal on desktop, scroll on overflow

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -113,7 +113,7 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Notebook teilen</DialogTitle>
           <DialogDescription>
@@ -130,7 +130,7 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
         {settingsQuery.isLoading ? (
           <p className="text-sm text-grey-500">Wird geladen…</p>
         ) : settingsQuery.data ? (
-          <div className="flex flex-col gap-md">
+          <div className="-mx-2 flex max-h-[70vh] flex-col gap-md overflow-y-auto px-2">
             <div>
               <p className="mb-xs text-sm font-semibold">Sichtbarkeit</p>
               <Select


### PR DESCRIPTION
The previous `max-w-lg` on `NotebookShareModal`'s `DialogContent` was a no-op — it matched the shared primitive's own `sm:max-w-[32rem]` default, so the modal never actually got wider than 512px on desktop. Combined with no `max-height`/`overflow` boundary, the `share_mode='authenticated'` + "Von der Basis" branch (two-card ownership picker) spilled below short viewports with no way to scroll inside the modal.

Bumps to `sm:max-w-2xl` (672px) and caps the body at `max-h-[70vh] overflow-y-auto`. Header + footer stay outside the scroll region so the **Schließen** button remains anchored. Mobile width is untouched — the primitive's `max-w-[calc(100%-2rem)]` continues to apply below `sm`.

## Test plan
- [ ] Open a notebook you own → click Teilen → modal is visibly wider on desktop
- [ ] `share_mode='authenticated'` + toggle public on, with a ~700px-tall window → body scrolls, footer stays anchored
- [ ] `share_mode='groups'` with several groups added → group list scrolls instead of pushing footer off-screen
- [ ] Resize to <640px → modal width unchanged (still hugs viewport)