### PR TITLE
refactor(mobile): derive reel response types from @gruenerator/contracts

### DIFF
--- a/apps/mobile/components/reel/ProcessingProgress.tsx
+++ b/apps/mobile/components/reel/ProcessingProgress.tsx
@@ -5,7 +5,7 @@ import { PROCESSING_STAGES } from '../../hooks/useReelProcessing';
 import { colors, spacing, borderRadius, typography } from '../../theme';
 
 interface ProcessingProgressProps {
-  currentStage: 1 | 2 | 3 | 4;
+  currentStage: number;
   stageName: string;
   stageProgress: number;
   overallProgress: number;

--- a/apps/mobile/hooks/useReelProcessing.ts
+++ b/apps/mobile/hooks/useReelProcessing.ts
@@ -17,7 +17,7 @@ export type ReelStatus =
 export interface ReelProcessingState {
   status: ReelStatus;
   uploadProgress: number;
-  processingStage: 1 | 2 | 3 | 4;
+  processingStage: number;
   stageName: string;
   stageProgress: number;
   overallProgress: number;
@@ -127,11 +127,15 @@ export function useReelProcessing() {
 
         if (!isMountedRef.current) return;
 
+        const stage = progress.stage ?? 1;
         updateState({
-          processingStage: progress.stage,
-          stageName: progress.stageName || PROCESSING_STAGES[progress.stage]?.name || '',
-          stageProgress: progress.stageProgress,
-          overallProgress: progress.overallProgress,
+          processingStage: stage,
+          stageName:
+            progress.stageName ||
+            PROCESSING_STAGES[stage as keyof typeof PROCESSING_STAGES]?.name ||
+            '',
+          stageProgress: progress.stageProgress ?? 0,
+          overallProgress: progress.overallProgress ?? 0,
         });
 
         if (progress.status === 'complete') {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,6 +36,7 @@
     "@gruenerator/canvas-editor": "workspace:*",
     "@gruenerator/chat": "workspace:*",
     "@gruenerator/collab": "workspace:*",
+    "@gruenerator/contracts": "workspace:*",
     "@gruenerator/docs": "workspace:^",
     "@gruenerator/shared": "workspace:*",
     "@react-native-async-storage/async-storage": "3.0.2",

--- a/apps/mobile/services/reel.ts
+++ b/apps/mobile/services/reel.ts
@@ -1,3 +1,4 @@
+import { type AutoProgress, type ExportProgress } from '@gruenerator/contracts';
 import { Paths, File as ExpoFile } from 'expo-file-system';
 import * as tus from 'tus-js-client';
 
@@ -5,16 +6,7 @@ import { secureStorage } from './storage';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://gruenerator.eu/api';
 
-export interface AutoProgressResponse {
-  status: 'processing' | 'processing_done' | 'complete' | 'error';
-  stage: 1 | 2 | 3 | 4;
-  stageName: string;
-  stageProgress: number;
-  overallProgress: number;
-  error: string | null;
-  outputPath: string | null;
-  duration: number | null;
-}
+export type AutoProgressResponse = AutoProgress;
 
 export interface ManualResultResponse {
   status: 'processing' | 'complete' | 'error';
@@ -207,11 +199,7 @@ export async function getManualResult(
   };
 }
 
-export interface ExportProgressResponse {
-  status: 'exporting' | 'complete' | 'error';
-  progress: number;
-  error: string | null;
-}
+export type ExportProgressResponse = ExportProgress;
 
 /**
  * Start video export with burned-in subtitles

--- a/packages/contracts/src/schemas/subtitler.ts
+++ b/packages/contracts/src/schemas/subtitler.ts
@@ -305,6 +305,7 @@ export const autoProcessStartResponseSchema = z.object({
 export const autoProgressSchema = z.object({
   status: z.enum(['processing', 'complete', 'error']),
   stage: z.number().nullish(),
+  stageName: z.string().nullish(),
   stageProgress: z.number().nullish(),
   overallProgress: z.number().nullish(),
   outputPath: z.string().nullish(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,9 @@ importers:
       '@gruenerator/collab':
         specifier: workspace:*
         version: link:../../packages/collab
+      '@gruenerator/contracts':
+        specifier: workspace:*
+        version: link:../../packages/contracts
       '@gruenerator/docs':
         specifier: workspace:^
         version: link:../../packages/docs


### PR DESCRIPTION
## Why

Follow-up to #932. That PR fixed an enum drift between `apps/api/services/subtitler/autoProcessingService.ts` (producer) and `autoProgressSchema` (validator) — drift that nothing caught at compile time because mobile's `apps/mobile/services/reel.ts` hand-rolled its own `AutoProgressResponse` and `ExportProgressResponse` instead of importing from `@gruenerator/contracts`. The wire boundary was declared in three independent places (producer, schema, mobile interface) with no link between them, so any one of them could drift without a TS error.

This PR collapses the three declarations to one source of truth.

## Changes

- **`packages/contracts/src/schemas/subtitler.ts`** — adds `stageName: z.string().nullish()` to `autoProgressSchema`. The producer writes `stageName` (e.g. `'Untertitel werden generiert...'`) but the schema didn't list it; since `z.object()` defaults to `.strip()`, `parseAutoProgress()` was silently dropping the field on the wire. Mobile already defended with a fallback so no behavior change today, but the schema is now honest about what's preserved.
- **`apps/mobile/package.json`** — declares `@gruenerator/contracts` as a direct workspace dep. Mobile's `metro.config.js` already routes `@gruenerator/contracts` through the `development` export condition for source-TS resolution; the package was previously available transitively via `@gruenerator/shared`, but per the repo's "declare imports explicitly" convention (pnpm prod install is strict) the dep is now first-class.
- **`apps/mobile/services/reel.ts`** — `AutoProgressResponse` / `ExportProgressResponse` become `z.infer`-derived aliases (`type AutoProgressResponse = AutoProgress`). `ManualResultResponse` stays local: it's mobile's transformed shape, not the wire shape (the wire is `processResultResponseSchema` with a wider status enum).
- **`apps/mobile/hooks/useReelProcessing.ts`** — widens `ReelProcessingState.processingStage` from `1 | 2 | 3 | 4` to `number`. The server writes `stage: 5` as a post-completion sentinel (`processingController.ts:707`), which made the narrow union a runtime lie. Adds `?? 0` / `?? 1` nullish fallbacks in the polling consumer to match the schema's optional fields.
- **`apps/mobile/components/reel/ProcessingProgress.tsx`** — widens `currentStage` prop to `number` to match the hook. The component already used `stage: number` internally in `getStageStatus`.

## Verification

- `pnpm --filter @gruenerator/contracts typecheck` — clean
- `pnpm --filter @gruenerator/mobile typecheck` — clean
- `pnpm --filter @gruenerator/api typecheck` — clean

## Merge note

This PR and #932 both edit `autoProgressSchema` but on different lines (status enum vs. new `stageName` field) — merge order doesn't matter.