### PR TITLE
fix(ci): prettier --write notebookSharingContractRouter to unblock master

### DIFF
--- a/apps/api/routes/notebook/notebookSharingContractRouter.ts
+++ b/apps/api/routes/notebook/notebookSharingContractRouter.ts
@@ -127,7 +127,11 @@ export const notebookSharingContractRouter = s.router(notebookSharingContract, {
       // share_mode='authenticated'. Stepping down to 'private'/'groups'
       // clears the discovery flag so the listing query and the access
       // check stay in lockstep (the original orphan-listing bug).
-      const updates: { share_mode: typeof args.body.mode; is_public?: boolean; public_ownership?: null } = {
+      const updates: {
+        share_mode: typeof args.body.mode;
+        is_public?: boolean;
+        public_ownership?: null;
+      } = {
         share_mode: args.body.mode,
       };
       if (args.body.mode !== 'authenticated' && collection.is_public === true) {
@@ -167,7 +171,8 @@ export const notebookSharingContractRouter = s.router(notebookSharingContract, {
           return {
             status: 400 as const,
             body: {
-              error: 'Bitte zuerst Sichtbarkeit auf „Mit Anmeldung" setzen, dann auf Von der Basis listen.',
+              error:
+                'Bitte zuerst Sichtbarkeit auf „Mit Anmeldung" setzen, dann auf Von der Basis listen.',
             },
           };
         }


### PR DESCRIPTION
## Why

`apps/api/routes/notebook/notebookSharingContractRouter.ts` landed mis-formatted via PR #930 (`d429430dc`, share-mode consolidation). It makes `Quality Checks → Prettier format check` fail on **every PR opened against master**, blocking unrelated work (e.g. #934 CI bumps, and presumably any other open PR right now).

Pure mechanical `prettier --write` — whitespace/line-break only, no logic changes.

## Verification

`pnpm format:check` (or `npx prettier --check apps/api/routes/notebook/notebookSharingContractRouter.ts`) now passes locally on this branch.

Note: PR #931 was merged with Quality Checks already failing — surfacing the broken-prettier-on-master as a follow-up so the next merge doesn't compound the problem.