### PR TITLE
fix(ocr): scope Docling poll fetch signals to prevent listener accumulation

### DIFF
--- a/apps/api/services/OcrService/doclingIntegration.ts
+++ b/apps/api/services/OcrService/doclingIntegration.ts
@@ -27,6 +27,57 @@ const DOCLING_BASE_URL = env.DOCLING_URL ?? 'http://ocr:5001';
 // and long jobs cost ~1 HTTP round-trip per POLL_WAIT_SECONDS.
 const POLL_WAIT_SECONDS = 5;
 
+// Minimum delay between poll iterations. Defends against docling-serve returning
+// immediately (not honoring `wait`) which would otherwise busy-loop the event
+// loop and inflate listener counts on the shared deadline AbortSignal.
+const MIN_POLL_INTERVAL_MS = 1000;
+
+/**
+ * Run `fn` with a fresh child AbortSignal that aborts when `parent` aborts.
+ *
+ * Why: undici's fetch attaches an abort listener to the signal it's given and is
+ * supposed to remove it on settle, but when a single AbortSignal is reused
+ * across many fetches the listener count grows unbounded (observed: 25k+
+ * listeners on the shared deadline signal during long stuck polls). Giving each
+ * fetch its own short-lived signal — derived from the parent via one
+ * once-listener that's explicitly removed in `finally` — keeps the parent at
+ * exactly one outstanding listener per in-flight request.
+ */
+async function withChildSignal<T>(
+  parent: AbortSignal,
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  if (parent.aborted) {
+    throw new Error('Operation aborted');
+  }
+  const controller = new AbortController();
+  const onAbort = (): void => controller.abort();
+  parent.addEventListener('abort', onAbort, { once: true });
+  try {
+    return await fn(controller.signal);
+  } finally {
+    parent.removeEventListener('abort', onAbort);
+  }
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error('Operation aborted'));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new Error('Operation aborted'));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 interface DoclingDoc {
   md_content?: string;
   markdown?: string;
@@ -65,11 +116,13 @@ interface AsyncSubmitResponse {
  * Submit an async conversion job. Returns the task_id assigned by docling-serve.
  */
 async function submitAsyncJob(formData: FormData, signal: AbortSignal): Promise<string> {
-  const res = await fetch(`${DOCLING_BASE_URL}/v1/convert/file/async`, {
-    method: 'POST',
-    body: formData,
-    signal,
-  });
+  const res = await withChildSignal(signal, (s) =>
+    fetch(`${DOCLING_BASE_URL}/v1/convert/file/async`, {
+      method: 'POST',
+      body: formData,
+      signal: s,
+    })
+  );
   if (!res.ok) {
     const errorText = await res.text().catch(() => 'unknown');
     throw new Error(`Docling async submit returned ${res.status}: ${errorText}`);
@@ -83,7 +136,9 @@ async function submitAsyncJob(formData: FormData, signal: AbortSignal): Promise<
 
 /**
  * Long-poll the task status until terminal, then fetch and return the conversion result.
- * The shared AbortSignal lets the outer deadline cancel an in-flight long-poll immediately.
+ * The parent AbortSignal lets the outer deadline cancel an in-flight long-poll
+ * immediately; each fetch runs under a fresh child signal (see withChildSignal).
+ * A small backoff guards against servers that ignore the `wait` parameter.
  */
 async function pollUntilDone(
   taskId: string,
@@ -92,9 +147,11 @@ async function pollUntilDone(
   logPrefix: string
 ): Promise<DoclingResponse> {
   while (Date.now() < deadlineMs) {
-    const statusRes = await fetch(
-      `${DOCLING_BASE_URL}/v1/status/poll/${taskId}?wait=${POLL_WAIT_SECONDS}`,
-      { signal }
+    const iterStart = Date.now();
+    const statusRes = await withChildSignal(signal, (s) =>
+      fetch(`${DOCLING_BASE_URL}/v1/status/poll/${taskId}?wait=${POLL_WAIT_SECONDS}`, {
+        signal: s,
+      })
     );
     if (!statusRes.ok) {
       const errorText = await statusRes.text().catch(() => 'unknown');
@@ -103,7 +160,9 @@ async function pollUntilDone(
     const status = (await statusRes.json()) as TaskStatusResponse;
 
     if (status.task_status === 'success') {
-      const resultRes = await fetch(`${DOCLING_BASE_URL}/v1/result/${taskId}`, { signal });
+      const resultRes = await withChildSignal(signal, (s) =>
+        fetch(`${DOCLING_BASE_URL}/v1/result/${taskId}`, { signal: s })
+      );
       if (!resultRes.ok) {
         const errorText = await resultRes.text().catch(() => 'unknown');
         throw new Error(`Docling result fetch returned ${resultRes.status}: ${errorText}`);
@@ -114,6 +173,12 @@ async function pollUntilDone(
       throw new Error(`Docling task ${taskId} reported failure`);
     }
     console.log(`${logPrefix} task=${taskId} status=${status.task_status ?? 'unknown'}, polling`);
+
+    const elapsed = Date.now() - iterStart;
+    const backoff = MIN_POLL_INTERVAL_MS - elapsed;
+    if (backoff > 0 && Date.now() + backoff < deadlineMs) {
+      await sleep(backoff, signal);
+    }
   }
   throw new Error(`Docling task ${taskId} exceeded client deadline`);
 }


### PR DESCRIPTION
## Why

Production logs from a stuck Docling task showed thousands of `MaxListenersExceededWarning: Possible EventTarget memory leak detected. N abort listeners added to [AbortSignal]` warnings, with N climbing by one per poll iteration into the tens of thousands.

The recent async polling rework (c2eed3a5) reused a single `AbortController.signal` for every fetch in the submit → poll → result flow. Undici's per-fetch abort-listener cleanup is unreliable when one signal is shared across many calls, and when docling-serve returned `status=started` without honoring `wait=5` (the task was stuck), the loop busy-spun and listeners accumulated on the parent signal until the event loop warning fired and the process leaked memory.

## What

- `withChildSignal(parent, fn)` derives a fresh per-fetch `AbortController`, wires one `{ once: true }` listener on the parent that aborts the child, and removes it in `finally`. The parent signal is bounded by *in-flight* fetches, not by *total* fetches ever made; short-lived child signals get GC'd with their fetches.
- A `MIN_POLL_INTERVAL_MS = 1000` backoff between poll iterations defends against servers that ignore the `wait` parameter. The backoff sleep is abortable via the parent signal so the outer `DOCLING_MAX_WAIT_MS` deadline still cancels promptly.

## Test plan

- [ ] Re-upload a large/stuck PDF that previously triggered the leak; confirm log no longer emits `MaxListenersExceededWarning` and listener count stays bounded.
- [ ] Confirm a normal-sized PDF still extracts within seconds (long-poll path unaffected).
- [ ] Confirm hitting `DOCLING_MAX_WAIT_MS` still aborts in-flight fetches promptly and falls back to Mistral OCR.