### PR TITLE
fix(notebook): bypass named max-w scale for share modal width

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookShareModal.tsx
+++ b/apps/web/src/features/notebook/components/NotebookShareModal.tsx
@@ -113,7 +113,7 @@ export function NotebookShareModal({ notebookId, open, onOpenChange }: NotebookS
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="sm:max-w-[42rem]">
         <DialogHeader>
           <DialogTitle>Notebook teilen</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
Follow-up to #933. The merged change (`sm:max-w-2xl`) was visibly still rendering the modal at ~150px wide on the live build — text wrapped per-word, the signature of `max-width` collapsing to a single-digit pixel value while `min-content` width takes over. Root cause is the Tailwind v4 spacing-vs-container token collision: `max-w-<named>` reads from both `--container-*` and `--spacing-*`, and even though `apps/web/src/assets/styles/index.css` defines `--container-2xl: 42rem`, *something* in the deployed CSS path (HMR cache, package CSS load order, or a downstream `@theme` override) was dropping it for this modal.

Switching to an arbitrary value (`sm:max-w-[42rem]`) bypasses the named scale entirely — Tailwind v4 emits the literal `42rem` with no `var()` lookup, so the width can't be broken by any token-level regression. Same shape `packages/ui/src/components/dialog.tsx` uses for its base `sm:max-w-[32rem]`, presumably for the same reason.

Target width unchanged (672px on desktop); only the resolution path differs.

## Test plan
- [ ] Open the share modal on desktop — width is 672px, not ~150px
- [ ] Diagnostic: `getComputedStyle(document.documentElement).getPropertyValue('--container-2xl')` — if this is empty in the running build, that's the underlying token-loss bug worth investigating separately; this PR makes the modal resilient to it either way