### PR TITLE
fix(notebook): direct-URL access works for share_mode=authenticated across locales

### DIFF
--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -118,6 +118,90 @@ async function validateWolkeShareLinks(
   return true;
 }
 
+/**
+ * Shape of a notebook collection as it comes back from Qdrant before
+ * enrichment. Matches the inline type previously duplicated inside
+ * listCollections + getCollection handlers.
+ */
+type NotebookCollectionFromQdrantRaw = {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  custom_prompt: string | null;
+  selection_mode?: string | undefined;
+  wolke_share_link_ids?: string[] | null | undefined;
+  auto_sync?: boolean | undefined;
+  remove_missing_on_sync?: boolean | undefined;
+  created_at: string;
+  updated_at: string;
+  settings?: Record<string, unknown> | undefined;
+  notebook_collection_documents?: Array<{ document_id: string }>;
+  is_public?: boolean;
+  public_ownership?: 'owner' | 'public_data' | null;
+  share_mode?: 'private' | 'groups' | 'authenticated';
+  edit_policy?: 'owner_only' | 'group_admins' | 'all_members';
+  audience?: 'de-DE' | 'de-AT';
+};
+
+/**
+ * Enrich a raw Qdrant notebook collection with the derived fields the API
+ * contract response expects (documents, wolke_share_links, labels parsed
+ * out of settings, etc.). Caller picks `accessSource` based on how the
+ * viewer reached the collection.
+ *
+ * Used by both listCollections (per-entry) and getCollection (one entry).
+ */
+async function enrichNotebookCollection(
+  collection: NotebookCollectionFromQdrantRaw,
+  accessSource: 'owned' | 'shared' | 'authenticated'
+) {
+  const postgres = getPostgresInstance();
+  const documentIds = (collection.notebook_collection_documents || []).map(
+    (qcd) => qcd.document_id
+  );
+
+  let documents: DocumentRecord[] = [];
+  if (documentIds.length > 0) {
+    documents = await postgres.query<DocumentRecord>(
+      'SELECT id, title, page_count, created_at, source_type, wolke_share_link_id FROM documents WHERE id = ANY($1)',
+      [documentIds]
+    );
+  }
+
+  let wolke_share_links: WolkeShareLink[] = [];
+  if (collection.wolke_share_link_ids) {
+    try {
+      wolke_share_links = collection.wolke_share_link_ids.map((id) => ({ id }));
+    } catch (error) {
+      log.error('[notebookCollectionsContract] Error fetching Wolke share links:', error);
+    }
+  }
+
+  const settings = (collection.settings as Record<string, unknown>) || {};
+  const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
+  const wolke_folders = Array.isArray(settings.wolke_folders)
+    ? (settings.wolke_folders as WolkeFolderRef[])
+    : [];
+
+  return {
+    ...collection,
+    documents,
+    document_count: documents.length,
+    selection_mode: collection.selection_mode || 'documents',
+    wolke_share_links,
+    has_wolke_sources: wolke_share_links.length > 0,
+    documents_from_wolke: documents.filter((doc) => doc.source_type === 'wolke').length,
+    auto_sync: !!collection.auto_sync,
+    remove_missing_on_sync: !!collection.remove_missing_on_sync,
+    labels,
+    wolke_folders,
+    is_public: collection.is_public === true,
+    public_ownership: collection.public_ownership ?? null,
+    access_source: accessSource,
+  };
+}
+
 // ── Contract router ────────────────────────────────────────────────────────
 
 const s = initServer();
@@ -182,27 +266,6 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       const userId = getUserId(args.req);
       const postgres = getPostgresInstance();
 
-      type NotebookCollectionFromQdrantRaw = {
-        id: string;
-        user_id: string;
-        name: string;
-        description: string | null;
-        custom_prompt: string | null;
-        selection_mode?: string | undefined;
-        wolke_share_link_ids?: string[] | null | undefined;
-        auto_sync?: boolean | undefined;
-        remove_missing_on_sync?: boolean | undefined;
-        created_at: string;
-        updated_at: string;
-        settings?: Record<string, unknown> | undefined;
-        notebook_collection_documents?: Array<{ document_id: string }>;
-        is_public?: boolean;
-        public_ownership?: 'owner' | 'public_data' | null;
-        share_mode?: 'private' | 'groups' | 'authenticated';
-        edit_policy?: 'owner_only' | 'group_admins' | 'all_members';
-        audience?: 'de-DE' | 'de-AT';
-      };
-
       const owned = (await notebookHelper.getUserNotebookCollections(
         userId
       )) as NotebookCollectionFromQdrantRaw[];
@@ -252,51 +315,9 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
       ];
 
       const transformedData = await Promise.all(
-        tagged.map(async ({ collection, access_source }) => {
-          const documentIds = (collection.notebook_collection_documents || []).map(
-            (qcd) => qcd.document_id
-          );
-
-          let documents: DocumentRecord[] = [];
-          if (documentIds.length > 0) {
-            documents = await postgres.query<DocumentRecord>(
-              'SELECT id, title, page_count, created_at, source_type, wolke_share_link_id FROM documents WHERE id = ANY($1)',
-              [documentIds]
-            );
-          }
-
-          let wolke_share_links: WolkeShareLink[] = [];
-          if (collection.wolke_share_link_ids) {
-            try {
-              wolke_share_links = collection.wolke_share_link_ids.map((id) => ({ id }));
-            } catch (error) {
-              log.error('[notebookCollectionsContract] Error fetching Wolke share links:', error);
-            }
-          }
-
-          const settings = (collection.settings as Record<string, unknown>) || {};
-          const labels = Array.isArray(settings.labels) ? (settings.labels as string[]) : [];
-          const wolke_folders = Array.isArray(settings.wolke_folders)
-            ? (settings.wolke_folders as WolkeFolderRef[])
-            : [];
-
-          return {
-            ...collection,
-            documents,
-            document_count: documents.length,
-            selection_mode: collection.selection_mode || 'documents',
-            wolke_share_links,
-            has_wolke_sources: wolke_share_links.length > 0,
-            documents_from_wolke: documents.filter((doc) => doc.source_type === 'wolke').length,
-            auto_sync: !!collection.auto_sync,
-            remove_missing_on_sync: !!collection.remove_missing_on_sync,
-            labels,
-            wolke_folders,
-            is_public: collection.is_public === true,
-            public_ownership: collection.public_ownership ?? null,
-            access_source,
-          };
-        })
+        tagged.map(({ collection, access_source }) =>
+          enrichNotebookCollection(collection, access_source)
+        )
       );
 
       const totalWolkeFolders = transformedData.reduce((acc, c) => acc + c.wolke_folders.length, 0);
@@ -1036,6 +1057,59 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
           error: err.message || 'Failed to perform bulk delete of Notebook collections',
         },
       };
+    }
+  },
+
+  getCollection: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const input = args.params.slugOrId;
+
+      let collectionId: string | null = null;
+      if (UUID_RE.test(input)) {
+        collectionId = input;
+      } else {
+        const suffix = extractSlugSuffix(input);
+        if (suffix) {
+          const bySlug = await notebookHelper.getNotebookCollectionBySlugSuffix(suffix);
+          collectionId = bySlug?.id ?? null;
+        }
+      }
+
+      if (!collectionId) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+
+      const access = await checkNotebookAccess(collectionId, userId);
+      if (!access.exists) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+      if (!access.canRead) {
+        return { status: 403 as const, body: { error: 'Keine Berechtigung' } };
+      }
+
+      const collection = (await notebookHelper.getNotebookCollection(
+        collectionId
+      )) as NotebookCollectionFromQdrantRaw | null;
+      if (!collection) {
+        return { status: 404 as const, body: { error: 'Notebook nicht gefunden' } };
+      }
+
+      const accessSource: 'owned' | 'shared' | 'authenticated' = access.isOwner
+        ? 'owned'
+        : collection.share_mode === 'groups'
+          ? 'shared'
+          : 'authenticated';
+
+      const enriched = await enrichNotebookCollection(collection, accessSource);
+
+      return {
+        status: 200 as const,
+        body: { success: true, collection: enriched },
+      };
+    } catch (error) {
+      log.error('[notebookCollectionsContract.getCollection] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
     }
   },
 });

--- a/apps/web/src/features/auth/hooks/useProfileData.ts
+++ b/apps/web/src/features/auth/hooks/useProfileData.ts
@@ -208,6 +208,7 @@ export const useNotebookCollections = ({ isActive, enabled = true }: TabHookOpti
     mutationFn: profileApiService.createQACollection,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notebookCollections(user?.id) });
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 
@@ -221,6 +222,7 @@ export const useNotebookCollections = ({ isActive, enabled = true }: TabHookOpti
     }) => profileApiService.updateQACollection(collectionId, collectionData),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notebookCollections(user?.id) });
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 
@@ -228,6 +230,7 @@ export const useNotebookCollections = ({ isActive, enabled = true }: TabHookOpti
     mutationFn: profileApiService.deleteQACollection,
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notebookCollections(user?.id) });
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 
@@ -235,6 +238,7 @@ export const useNotebookCollections = ({ isActive, enabled = true }: TabHookOpti
     mutationFn: (collectionId: string | number) => profileApiService.syncQACollection(collectionId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEYS.notebookCollections(user?.id) });
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -24,10 +24,10 @@ import withAuthRequired from '../../../components/common/LoginRequired/withAuthR
 import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useAuthStore } from '../../../stores/authStore';
 import { useExportStore } from '../../../stores/core/exportStore';
-import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 import { getNotebookConfig } from '../config/notebookPagesConfig';
 import { getNotebookById } from '../config/notebooksConfig';
 import { useNotebookChatBridge } from '../hooks/useNotebookChatBridge';
+import { useNotebookCollection } from '../hooks/useNotebookCollection';
 import useNotebookStore from '../stores/notebookStore';
 
 import { NotebookStartpage } from './NotebookStartpage';
@@ -434,7 +434,6 @@ interface DynamicNotebookPageProps {
 export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {}) => {
   const { id: idFromParams } = useParams<{ id: string }>();
   const id = idProp ?? idFromParams;
-  const user = useAuthStore((s) => s.user);
 
   // Reset agent to the default (universal). NotebookPage warms a system
   // notebook's agent into the persisted store; without a counterpart here,
@@ -444,9 +443,12 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
     setSelectedAgent(null);
   }, [id, setSelectedAgent]);
 
-  const { query, getQACollection } = useNotebookCollections({ isActive: true });
-  const collection = id ? getQACollection(id) : undefined;
-  const { isLoading, isError, data: qaCollections } = query;
+  // Single-collection fetch gated by checkNotebookAccess — works for direct
+  // URL access to a `share_mode='authenticated'` notebook regardless of the
+  // viewer's locale (audience is a discovery-listing hint, not an access wall).
+  const { data, isLoading } = useNotebookCollection(id);
+  const collection = data?.collection ?? null;
+  const fetchError = data?.error ?? null;
 
   if (isLoading)
     return (
@@ -455,13 +457,16 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
       </div>
     );
 
-  if (isError || !collection) {
+  if (!collection) {
+    const message =
+      fetchError === 'forbidden'
+        ? 'Du hast keinen Zugriff auf dieses Notebook.'
+        : fetchError === 'not-found'
+          ? 'Dieses Notebook existiert nicht.'
+          : 'Notebook konnte nicht geladen werden.';
     return (
       <div className="flex flex-1 flex-col items-center justify-center gap-sm p-md text-foreground-muted">
-        <p>Notebook nicht gefunden oder keine Berechtigung.</p>
-        <p className="text-xs">
-          Collection ID: {id} · User ID: {user?.id} · Collections: {qaCollections?.length || 0}
-        </p>
+        <p>{message}</p>
       </div>
     );
   }

--- a/apps/web/src/features/notebook/hooks/useNotebookCollection.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookCollection.ts
@@ -1,0 +1,36 @@
+/**
+ * Fetch a single notebook collection by UUID or slug-with-suffix.
+ *
+ * Backs DynamicNotebookPage's access decision so a notebook shared with
+ * `share_mode='authenticated'` is reachable via direct URL regardless of the
+ * audience filter on the list endpoint. The list query stays audience-scoped
+ * for discovery; this hook is the authoritative source for "can I render
+ * this notebook page right now?".
+ */
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useQuery } from '@tanstack/react-query';
+
+export type NotebookCollectionFetchError = 'not-found' | 'forbidden' | 'unknown';
+
+export function useNotebookCollection(slugOrId: string | undefined) {
+  return useQuery({
+    queryKey: ['notebook', 'collection', slugOrId],
+    enabled: !!slugOrId,
+    retry: false,
+    queryFn: async () => {
+      if (!slugOrId) {
+        throw new Error('slugOrId is required');
+      }
+      const client = getContractsClient();
+      const result = await client.notebookCollections.getCollection({
+        params: { slugOrId },
+      });
+      if (result.status === 200) {
+        return { collection: result.body.collection, error: null as null };
+      }
+      const error: NotebookCollectionFetchError =
+        result.status === 404 ? 'not-found' : result.status === 403 ? 'forbidden' : 'unknown';
+      return { collection: null, error };
+    },
+  });
+}

--- a/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
+++ b/apps/web/src/features/notebook/hooks/useNotebookSharing.ts
@@ -90,6 +90,7 @@ export function useSetNotebookShareMode(notebookId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
       void qc.invalidateQueries({ queryKey: ['notebookCollections'] });
+      void qc.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 }
@@ -111,6 +112,7 @@ export function useSetNotebookAudience(notebookId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
       void qc.invalidateQueries({ queryKey: ['notebookCollections'] });
+      void qc.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 }
@@ -132,6 +134,7 @@ export function useSetNotebookIsPublic(notebookId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: SHARE_SETTINGS_KEY(notebookId) });
       void qc.invalidateQueries({ queryKey: ['notebookCollections'] });
+      void qc.invalidateQueries({ queryKey: ['notebook', 'collection'] });
     },
   });
 }

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -24,6 +24,7 @@ import {
   unlikeCollectionResponseSchema,
   listMyLikedCollectionsResponseSchema,
   resolveCollectionResponseSchema,
+  getCollectionResponseSchema,
 } from '../schemas/notebookCollections.js';
 
 const c = initContract();
@@ -270,6 +271,32 @@ export const notebookCollectionsContract = c.router(
         500: notebookErrorResponseSchema,
       },
       summary: 'Unlike a notebook collection',
+    },
+
+    /**
+     * GET /api/auth/notebook-collections/:slugOrId
+     * Fetch a single collection by UUID or slug-with-suffix, gated by
+     * checkNotebookAccess. Used by DynamicNotebookPage so direct URL access
+     * to a notebook shared with `share_mode='authenticated'` works regardless
+     * of the audience filter that gates listCollections (audience is a
+     * discovery-curation hint, not an access wall).
+     *
+     * Declared LAST among GET routes on this prefix so literal-segment paths
+     * (`/public`, `/likes`, `/resolve/...`) keep matching first; the
+     * `:slugOrId` pattern would otherwise capture them.
+     */
+    getCollection: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/:slugOrId',
+      pathParams: z.object({ slugOrId: z.string() }),
+      responses: {
+        200: getCollectionResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Fetch a single notebook collection by UUID or slug',
     },
   },
   { pathPrefix: '' }

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -205,6 +205,18 @@ export const collectionsListResponseSchema = z.object({
 });
 
 /**
+ * Single-collection response used by GET /:slugOrId. Same enriched shape as
+ * one entry in collectionsListResponseSchema.collections, but reached via a
+ * dedicated access check (checkNotebookAccess) so direct URL visits succeed
+ * for `share_mode='authenticated'` notebooks regardless of the audience
+ * filter that gates the list-style discovery.
+ */
+export const getCollectionResponseSchema = z.object({
+  success: z.boolean(),
+  collection: transformedCollectionSchema,
+});
+
+/**
  * Create collection response.
  * The `collection` sub-object is loosely typed for `settings` and arbitrary
  * extra fields written by `storeNotebookCollection`.


### PR DESCRIPTION
## Why

User A shares a notebook with **\"mit Anmeldung\"** (`share_mode='authenticated'`), expecting any logged-in user to be able to open the link. User B (different locale, e.g. de-AT when the notebook is de-DE) opens the URL and gets:

> Notebook nicht gefunden oder keine Berechtigung.

Root cause: `DynamicNotebookPage` was using the audience-filtered `useNotebookCollections` list as its implicit access check. Because `audience` was designed as a *discovery-listing curation hint* (so cross-locale notebooks don't clutter each user's list), the locale-mismatched notebook simply wasn't in User B's list — and the page conflated \"not in my list\" with \"no permission\". The backend's `checkNotebookAccess` was already correct: any authenticated viewer can read a `share_mode='authenticated'` notebook.

Decision (confirmed with the user before implementing): audience stays a curation hint — the list filter still keeps cross-locale clutter out of the default notebook list. Direct URL access is the explicit-handoff path and must work regardless of locale.

## What this PR does

- New endpoint `GET /api/auth/notebook-collections/:slugOrId` that returns the same enriched collection shape as one entry of `listCollections`, but gated solely by `checkNotebookAccess`.
- Extracts the per-collection enrichment into `enrichNotebookCollection()` so the list endpoint and the new single-fetch endpoint stay in sync.
- New `useNotebookCollection(slugOrId)` hook on the frontend; `DynamicNotebookPage` now consumes it. The 403/404 cases now show distinct messages (\"Du hast keinen Zugriff…\" vs. \"Dieses Notebook existiert nicht.\") instead of the conflated one.
- Cache invalidations on existing share/update/delete/sync mutations also invalidate the new per-collection key prefix.

## Out of scope

- Renaming/relabeling `share_mode='authenticated'` to surface that audience narrows discovery.
- Cross-locale \"Von der Basis\" opt-in.
- Per-user explicit sharing.

## Test plan
- [ ] As de-DE user, set notebook to `share_mode='authenticated'`. Open from a de-AT account via slug URL → renders the notebook page (read-only).
- [ ] Same flow via UUID URL → renders.
- [ ] Open a `share_mode='private'` notebook URL as a non-owner → \"Du hast keinen Zugriff auf dieses Notebook.\"
- [ ] Open a non-existent slug → \"Dieses Notebook existiert nicht.\"
- [ ] Owner edits sharing/audience → the notebook page reflects the change after the mutation (cache invalidation).
- [ ] de-DE user's default notebook list does NOT now contain de-AT authenticated notebooks (audience filter on listCollections is preserved).