### PR TITLE
feat(notebook): branded empty-state for 403/404/error on notebook page

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookAccessError.tsx
+++ b/apps/web/src/features/notebook/components/NotebookAccessError.tsx
@@ -1,0 +1,81 @@
+/**
+ * Branded empty-state for the three terminal failure modes of
+ * `useNotebookCollection`:
+ *
+ *  - forbidden  → notebook exists but the viewer has no read access
+ *  - not-found  → slug/UUID resolves to nothing
+ *  - unknown    → network/server hiccup; retryable
+ *
+ * Uses the canonical `@gruenerator/ui` Empty primitive so the layout and
+ * spacing match the rest of the workplace (admin "Kein Zugriff" page,
+ * generic 404, etc.).
+ */
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@gruenerator/ui';
+import { FaExclamationTriangle, FaLock, FaSearch } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
+
+import type { NotebookCollectionFetchError } from '../hooks/useNotebookCollection';
+
+interface NotebookAccessErrorProps {
+  variant: NotebookCollectionFetchError;
+  onRetry?: () => void;
+}
+
+const COPY: Record<
+  NotebookCollectionFetchError,
+  { icon: React.ReactNode; title: string; description: string }
+> = {
+  forbidden: {
+    icon: <FaLock aria-hidden />,
+    title: 'Kein Zugriff auf dieses Notebook',
+    description:
+      'Du bist eingeloggt, aber dieses Notebook ist nicht für dich freigegeben. Frag die Person, die es geteilt hat, um Zugriff – oder schau in deinen eigenen Notebooks weiter.',
+  },
+  'not-found': {
+    icon: <FaSearch aria-hidden />,
+    title: 'Notebook nicht gefunden',
+    description:
+      'Den Link gibt es nicht (mehr). Vielleicht wurde das Notebook gelöscht oder die Adresse hat sich vertippt.',
+  },
+  unknown: {
+    icon: <FaExclamationTriangle aria-hidden />,
+    title: 'Notebook konnte nicht geladen werden',
+    description:
+      'Beim Laden ist etwas schiefgelaufen. Probier es gleich noch einmal – falls es weiter klemmt, schau später wieder rein.',
+  },
+};
+
+export function NotebookAccessError({ variant, onRetry }: NotebookAccessErrorProps) {
+  const { icon, title, description } = COPY[variant];
+  return (
+    <div className="flex flex-1 items-center justify-center p-md">
+      <Empty className="max-w-lg border bg-card">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">{icon}</EmptyMedia>
+          <EmptyTitle>{title}</EmptyTitle>
+          <EmptyDescription>{description}</EmptyDescription>
+        </EmptyHeader>
+        <EmptyContent>
+          <div className="flex flex-wrap items-center justify-center gap-sm">
+            {variant === 'unknown' && onRetry && (
+              <Button variant="brand-outline" size="brand" onClick={onRetry}>
+                Erneut versuchen
+              </Button>
+            )}
+            <Button variant="brand" size="brand" asChild>
+              <Link to="/notebooks">Zu deinen Notebooks</Link>
+            </Button>
+          </div>
+        </EmptyContent>
+      </Empty>
+    </div>
+  );
+}

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -30,6 +30,7 @@ import { useNotebookChatBridge } from '../hooks/useNotebookChatBridge';
 import { useNotebookCollection } from '../hooks/useNotebookCollection';
 import useNotebookStore from '../stores/notebookStore';
 
+import { NotebookAccessError } from './NotebookAccessError';
 import { NotebookStartpage } from './NotebookStartpage';
 
 interface NotebookCollection {
@@ -446,7 +447,7 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
   // Single-collection fetch gated by checkNotebookAccess — works for direct
   // URL access to a `share_mode='authenticated'` notebook regardless of the
   // viewer's locale (audience is a discovery-listing hint, not an access wall).
-  const { data, isLoading } = useNotebookCollection(id);
+  const { data, isLoading, refetch } = useNotebookCollection(id);
   const collection = data?.collection ?? null;
   const fetchError = data?.error ?? null;
 
@@ -458,17 +459,7 @@ export const DynamicNotebookPage = ({ id: idProp }: DynamicNotebookPageProps = {
     );
 
   if (!collection) {
-    const message =
-      fetchError === 'forbidden'
-        ? 'Du hast keinen Zugriff auf dieses Notebook.'
-        : fetchError === 'not-found'
-          ? 'Dieses Notebook existiert nicht.'
-          : 'Notebook konnte nicht geladen werden.';
-    return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-sm p-md text-foreground-muted">
-        <p>{message}</p>
-      </div>
-    );
+    return <NotebookAccessError variant={fetchError ?? 'unknown'} onRetry={() => void refetch()} />;
   }
 
   const config: NotebookConfig = {


### PR DESCRIPTION
## Why

Follow-up to #939: that PR split the conflated \"Notebook nicht gefunden oder keine Berechtigung\" into three discriminated states (`forbidden` / `not-found` / `unknown`) but kept them rendered as bare text. This promotes them to a proper empty-state matching the rest of the workplace.

- **403 forbidden** — `FaLock` + \"Kein Zugriff auf dieses Notebook\" + softer copy nudging the viewer to ask the sharer or visit their own notebooks.
- **404 not-found** — `FaSearch` + \"Notebook nicht gefunden\".
- **Unknown error** — `FaExclamationTriangle` + \"Erneut versuchen\" secondary button that refetches via React Query (no full page reload).

Built on the canonical `@gruenerator/ui` `Empty` primitive — same vocabulary the admin \"Kein Zugriff\" page already uses. Every variant gets a primary CTA back to `/notebooks`.

## Test plan
- [ ] Open another user's `share_mode='private'` notebook URL → 403 empty-state with lock icon
- [ ] Open a non-existent slug → 404 empty-state with search icon
- [ ] Open a notebook while backend is down → unknown empty-state with retry; pressing retry triggers a refetch without reloading
- [ ] All three CTAs route to `/notebooks`