### PR TITLE
fix(notebook): Von-der-Basis links use pretty slug + ä→ae transliteration

### DIFF
--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -1,3 +1,4 @@
+import { buildNotebookSlug } from '@gruenerator/shared/utils';
 import { Skeleton, SectionHeader } from '@gruenerator/ui';
 import { memo, useMemo, useState } from 'react';
 import { HiBookOpen } from 'react-icons/hi';
@@ -25,15 +26,24 @@ const VonDerBasisCard = memo(function VonDerBasisCard({
   onToggleLike,
 }: VonDerBasisCardProps) {
   const navigate = useNavigate();
+  // Route prefix is `/notebooks/` (plural); the legacy `/notebook/:id` singular
+  // path only existed to redirect, so building the URL correctly the first time
+  // avoids an extra hop. Use the pretty slug when the row has one, falling back
+  // to the UUID for legacy pre-backfill collections.
+  const href = `/notebooks/${
+    collection.slug_suffix
+      ? buildNotebookSlug(collection.name, collection.slug_suffix)
+      : collection.id
+  }`;
   return (
     <div
       role="button"
       tabIndex={0}
-      onClick={() => void navigate(`/notebook/${collection.id}`)}
+      onClick={() => void navigate(href)}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          void navigate(`/notebook/${collection.id}`);
+          void navigate(href);
         }
       }}
       className="group flex min-h-[4rem] cursor-pointer items-center gap-sm rounded-md border border-grey-200 bg-background px-md py-md transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md dark:border-grey-700"

--- a/packages/shared/src/utils/slug.ts
+++ b/packages/shared/src/utils/slug.ts
@@ -20,16 +20,33 @@ const SUFFIX_RE = new RegExp(`-([${SUFFIX_ALPHABET}]{${SUFFIX_LENGTH}})$`);
 
 /**
  * Turn an arbitrary user-supplied name into a URL-safe slug fragment.
- * Diacritics are stripped, the result is lowercased, non-alphanumerics
- * become `-`, repeats collapsed, length capped at 40 chars.
- * Empty results (e.g. all-emoji titles) fall back to "notebook".
+ * German umlauts and ß are transliterated (ä→ae, ö→oe, ü→ue, ß→ss) so
+ * "Bürger*innen" stays readable as "buerger-innen" instead of collapsing
+ * to "brger-innen". Remaining diacritics (e.g. French accents) are still
+ * stripped via NFD because there's no single-locale transliteration that
+ * makes sense for everything. Non-alphanumerics become `-`, repeats
+ * collapsed, length capped at 40 chars. Empty results (e.g. all-emoji
+ * titles) fall back to "notebook".
  */
+const GERMAN_TRANSLITERATIONS: Array<[RegExp, string]> = [
+  [/ä/g, 'ae'],
+  [/ö/g, 'oe'],
+  [/ü/g, 'ue'],
+  [/Ä/g, 'Ae'],
+  [/Ö/g, 'Oe'],
+  [/Ü/g, 'Ue'],
+  [/ß/g, 'ss'],
+];
+
 export function slugifyName(name: string): string {
-  const normalized = name
+  let transliterated = name;
+  for (const [pattern, replacement] of GERMAN_TRANSLITERATIONS) {
+    transliterated = transliterated.replace(pattern, replacement);
+  }
+  const normalized = transliterated
     .normalize('NFD')
     .replace(COMBINING_DIACRITICS, '')
     .toLowerCase()
-    .replace(/ß/g, 'ss')
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
     .slice(0, 40)


### PR DESCRIPTION
## Why

Two small slug bugs that landed together because they share a root cause (\"the slug is built once at random and never updated\"):

### 1. \"Von der Basis\" links opened with the raw UUID
Owned-notebook links use `/notebooks/${buildNotebookSlug(name, suffix)}` (pretty Notion-style slug), but `VonDerBasisSection` was hardcoded to `/notebook/${collection.id}` — wrong route prefix (singular instead of plural, forcing a redirect hop through the legacy `/notebook/:id` → `/notebooks/:id` Navigate) AND wrong identifier (UUID instead of slug). Pulled the same slug-build pattern in; legacy rows without `slug_suffix` still fall back to the UUID cleanly.

### 2. `slugifyName` stripped German umlauts
`ä` collapsed to `a` (so \"Bürger*innen\" became \"brger-innen\"). The function now transliterates the canonical German long form before the NFD diacritic strip — `ä→ae, ö→oe, ü→ue` plus uppercase variants. `ß→ss` was already there; the new code keeps it in the same table for cohesion.

The slug **prefix** is recomputed on every read (only the 6-char **suffix** is stored), so this fix retroactively prettifies every existing notebook's URL — no migration, no backfill.

## Test plan
- [ ] Click any tile in \"Von der Basis\" → URL bar shows `/notebooks/<name>-<suffix>`, not `/notebook/<uuid>`
- [ ] Rename a notebook to \"Bürger*innen für 2026\" → URL becomes `/notebooks/buerger-innen-fuer-2026-<suffix>` (not `brger-innen-fr-2026-…`)
- [ ] Legacy notebook without `slug_suffix` still navigates with UUID (no crash)