### PR TITLE
chore(notebook): clear three pre-existing lint warnings in VonDerBasisSection

### DIFF
--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -61,12 +61,14 @@ const VonDerBasisCard = memo(function VonDerBasisCard({
   );
 });
 
+const SKELETON_KEYS = ['skeleton-0', 'skeleton-1', 'skeleton-2'];
+
 export function VonDerBasisSection() {
   const { data, isLoading } = usePublicNotebookCollections({ enabled: true });
   const { likedIds, toggleLike, isToggling, canLike } = useEntityLikes('notebook');
   const [query, setQuery] = useState('');
 
-  const collections = data ?? [];
+  const collections = useMemo(() => data ?? [], [data]);
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return collections;
@@ -86,9 +88,9 @@ export function VonDerBasisSection() {
 
       {isLoading ? (
         <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">
-          {Array.from({ length: 3 }).map((_, i) => (
+          {SKELETON_KEYS.map((key) => (
             <div
-              key={i}
+              key={key}
               className="flex min-h-[4rem] items-center gap-sm rounded-md border border-grey-200 px-md py-md dark:border-grey-700"
             >
               <Skeleton className="size-5 shrink-0 rounded" />
@@ -103,7 +105,7 @@ export function VonDerBasisSection() {
         </p>
       ) : filtered.length === 0 ? (
         <p className="rounded-md border border-dashed border-grey-300 px-md py-lg text-center text-sm text-grey-500 dark:border-grey-700 dark:text-grey-400">
-          Keine Treffer für „{query}".
+          Keine Treffer für „{query}“.
         </p>
       ) : (
         <div className="grid grid-cols-3 gap-sm max-lg:grid-cols-2 max-sm:grid-cols-1">


### PR DESCRIPTION
## Why

Follow-up to #941 — those three react-hooks/exhaustive-deps, react/no-array-index-key, and react/no-unescaped-entities warnings have been sitting in `VonDerBasisSection.tsx` since the file was written. None affect runtime, but they show up every time the file is touched and add to the lint backlog. Clearing them now keeps future diffs noise-free.

- **`react-hooks/exhaustive-deps`**: `const collections = data ?? []` produced a fresh `[]` per render when `data` was undefined, marking the downstream filter `useMemo` as suspicious. Hoisted into its own memo.
- **`react/no-array-index-key`**: replaced `key={i}` on the three skeleton tiles with `SKELETON_KEYS = ['skeleton-0','skeleton-1','skeleton-2']`. Stable identity, no behavioural change.
- **`react/no-unescaped-entities`**: opening `„` (low-9) was paired with an ASCII `"` close; now uses the proper German closing curly `"` (U+201C). Also nicer typography.

Zero behaviour change.