### PR TITLE
feat(notebook): show creator name on Von der Basis cards

### DIFF
--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -366,6 +366,20 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         collections.map((c) => c.id)
       );
 
+      const userIds = Array.from(new Set(collections.map((c) => c.user_id)));
+      const profileRows = userIds.length
+        ? await postgres.query<{
+            id: string;
+            display_name: string | null;
+            email: string | null;
+          }>('SELECT id::text AS id, display_name, email FROM profiles WHERE id::text = ANY($1)', [
+            userIds,
+          ])
+        : [];
+      const nameByUserId = new Map(
+        profileRows.map((p) => [p.id, p.display_name ?? p.email?.split('@')[0] ?? null] as const)
+      );
+
       const transformedData = await Promise.all(
         collections.map(async (collection) => {
           const documentIds = (collection.notebook_collection_documents || []).map(
@@ -401,6 +415,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
             is_public: collection.is_public === true,
             public_ownership: collection.public_ownership ?? null,
             likes_count: likeCounts.get(collection.id) ?? 0,
+            creator_name: nameByUserId.get(collection.user_id) ?? null,
           };
         })
       );

--- a/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
+++ b/apps/web/src/features/notebook/components/VonDerBasisSection.tsx
@@ -58,6 +58,11 @@ const VonDerBasisCard = memo(function VonDerBasisCard({
             {collection.description}
           </div>
         ) : null}
+        {collection.creator_name ? (
+          <div className="truncate text-xs text-grey-500 dark:text-grey-400">
+            von {collection.creator_name}
+          </div>
+        ) : null}
       </div>
       <LikeButton
         liked={liked}

--- a/apps/web/src/types/notebook.ts
+++ b/apps/web/src/types/notebook.ts
@@ -33,6 +33,7 @@ export type NotebookAccessSource = 'owned' | 'shared' | 'authenticated';
 export interface NotebookCollection {
   id: string;
   user_id: string;
+  creator_name?: string | null;
   name: string;
   description?: string;
   custom_prompt?: string;

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -195,6 +195,7 @@ export const transformedCollectionSchema = z.object({
   audience: notebookAudienceSchema.nullish(),
   access_source: notebookAccessSourceSchema.nullish(),
   slug_suffix: z.string().nullish(),
+  creator_name: z.string().nullish(),
 });
 
 // ── Response schemas ────────────────────────────────────────────────────────


### PR DESCRIPTION
A community listing without attribution leaves visitors with no way to recognize trusted publishers. Each public-notebook card now shows "von <Name>", sourced from `profiles.display_name` with the email local-part as fallback for users who haven't set a name.

The Postgres lookup is one batched `SELECT id, display_name, email FROM profiles WHERE id::text = ANY($1)` after the Qdrant scroll — same pattern already used by `docsContractRouter.ts:161`. No new query path.

Schema-wise, `creator_name` is added once on the shared `transformedCollectionSchema` and only populated on the public listing today. The private listing leaves it `undefined`, which is fine for the `.nullish()` field. This means a future "shared with me, by X" surface gets the field for free.

Privacy: this exposes a `display_name` to every logged-in viewer of `/notebooks`, but only for notebooks the owner explicitly published via `is_public=true`. Using the email *local-part* (not the full address) as fallback avoids leaking full emails to strangers.

## Follow-up (separate PR)

`apps/web/src/types/notebook.ts` has 9 already-drifting fields vs the Zod schema (`audience`, `has_wolke_sources`, `documents_from_wolke`, `public_url_token`, etc.). Worth deriving `NotebookCollection` from `z.infer<typeof transformedCollectionSchema>` in its own PR — 65 usage sites + an `undefined`→`null` semantic cascade make it too large to bundle here.

## Test plan
- [ ] Visit `/notebooks` — Von der Basis cards show "von <Name>" on the third line under the description.
- [ ] Cards for users without `display_name` show their email local-part (e.g. "von moritzwaechter97" rather than the full address).
- [ ] Owner of a non-public notebook sees no `creator_name` on their private listing — schema field stays optional, no UI changes there.
- [ ] Network response from `GET /api/auth/notebook-collections/public` includes `creator_name` on each collection.