### PR TITLE
fix(notebooks): trim manuelle Recherche filter row + hide Chat pill on index

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
+++ b/apps/web/src/features/notebook/components/NotebookManualSearch.tsx
@@ -230,6 +230,10 @@ export function NotebookManualSearch({ collectionIds, notebookId }: NotebookManu
 
   const filterControls = hideFilters ? undefined : (
     <div className="flex flex-wrap items-center gap-xs">
+      {/* Hidden 2026-05-18: Typ / Primärkategorie / Unterkategorien / Region facet
+          dropdowns removed from manuelle Recherche on the /notebooks index per UX
+          request. The underlying filter plumbing stays — only the UI is suppressed.
+          To restore, delete the surrounding JSX block-comment wrapper.
       {contentTypeConfig && (contentTypeConfig.values ?? []).length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -301,6 +305,7 @@ export function NotebookManualSearch({ collectionIds, notebookId }: NotebookManu
           </DropdownMenu>
         );
       })}
+      */}
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -90,6 +90,12 @@ interface NotebookPageContentProps {
   /** Disable the manual research tab (dynamic user notebooks have no system collection scope). Defaults to true. */
   showManualSearch?: boolean;
   /**
+   * Suppress the global-chat ("Chat") tab even when a notebook mention is available.
+   * Used by aggregate surfaces (e.g. the /notebooks index) where the chat tab
+   * doesn't correspond to a specific notebook the user picked. Defaults to false.
+   */
+  hideGlobalChat?: boolean;
+  /**
    * When set, the manual research tab scopes to a single user-owned notebook
    * (ownership-checked, no facet filter UI). Forwarded to `NotebookManualSearch`.
    */
@@ -139,6 +145,7 @@ export const NotebookPageContent = ({
   showLastAdded = true,
   showExamples = true,
   showManualSearch = true,
+  hideGlobalChat = false,
   manualSearchNotebookId,
 }: NotebookPageContentProps): React.ReactElement => {
   const isMulti = config.collectionType === 'multi';
@@ -357,6 +364,7 @@ export const NotebookPageContent = ({
                   showStats={showStats}
                   showLastAdded={showLastAdded}
                   showManualSearch={showManualSearch}
+                  hideGlobalChat={hideGlobalChat}
                   manualSearchNotebookId={manualSearchNotebookId}
                   notebookMention={notebookMention}
                   footer={startpageFooter}

--- a/apps/web/src/features/notebook/components/NotebookStartpage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookStartpage.tsx
@@ -40,6 +40,12 @@ interface NotebookStartpageProps {
   showLastAdded?: boolean;
   showManualSearch?: boolean;
   /**
+   * Suppresses the global-chat ("Chat") tab even when a `notebookMention` is set.
+   * Used by aggregate surfaces (e.g. the /notebooks index) where routing into the
+   * global chat doesn't correspond to a specific notebook the user picked.
+   */
+  hideGlobalChat?: boolean;
+  /**
    * When set, the manual-research tab scopes search to a single user-owned notebook
    * (ownership-checked, no facet filters). Forwarded to `NotebookManualSearch`.
    */
@@ -85,13 +91,14 @@ export function NotebookStartpage({
   showStats = true,
   showLastAdded = true,
   showManualSearch = true,
+  hideGlobalChat = false,
   manualSearchNotebookId,
   notebookMention,
   footer,
 }: NotebookStartpageProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('ki');
   const manualSearchAvailable = showManualSearch && recentCollectionIds.length > 0;
-  const globalChatAvailable = !!notebookMention;
+  const globalChatAvailable = !!notebookMention && !hideGlobalChat;
   const anyExtraTabAvailable = manualSearchAvailable || globalChatAvailable;
 
   // Force-fall-through to 'ki' if the currently selected tab isn't available

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -469,6 +469,7 @@ function NotebooksIndexPage() {
       showLastAdded={false}
       showStats={false}
       showExamples={false}
+      hideGlobalChat
     />
   );
 }


### PR DESCRIPTION
Two small UX rules for the `/notebooks` aggregate index:

**Manuelle Recherche filter row** — the four leading facet dropdowns (Typ, Primärkategorie, Unterkategorien, Region) added visual noise without being load-bearing for the common discovery flow on the aggregate index. Hiding them leaves `Sort · Zeitraum · Suchmodus`, which reads as "how do you want it ordered / over which time window". The JSX is commented out rather than deleted so the dropdowns can be restored quickly if needed; the underlying filter plumbing (state, URL params, programmatic setters) is untouched.

**Chat mode pill** — the global-chat tab made sense when a specific notebook was selected, but on the aggregate index the user hasn't picked a notebook, so the chat entry point doesn't correspond to anything. New `hideGlobalChat` opt-in prop threaded through `NotebookPageContent` so any future aggregate-style caller can opt in the same way. Specific notebook pages are unaffected.