### PR TITLE
feat(images): fine-grained Flux model selection in workplace composer

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -9,6 +9,7 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import authMiddleware from './middleware/authMiddleware.js';
 import { rateLimitMiddleware } from './middleware/rateLimitMiddleware.js';
 import antraegeRouter from './routes/antraege/index.js';
+import { mountImageModelPreferenceContractRouter } from './routes/auth/imageModelPreferenceContractRouter.js';
 import authInitRouter from './routes/auth/initController.js';
 import { mountModelPreferencesContractRouter } from './routes/auth/modelPreferencesContractRouter.js';
 import { mountAdminVorlagenContractRouter } from './routes/auth/templates/adminVorlagenContractRouter.js';
@@ -559,6 +560,7 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/auth/profile', requireAuth);
   mountNotificationsContractRouter(app);
   mountModelPreferencesContractRouter(app);
+  mountImageModelPreferenceContractRouter(app);
   app.use('/api/notifications', requireAuth, publicReadLimiter, notificationsRouter);
   app.use('/api/media', requireAuth, authenticatedReadLimiter, mediaRouter);
   app.use('/api/og/docs', publicReadLimiter, ogDocsRouter);

--- a/apps/api/routes/auth/imageModelPreferenceContractRouter.ts
+++ b/apps/api/routes/auth/imageModelPreferenceContractRouter.ts
@@ -1,0 +1,50 @@
+import { imageModelPreferenceContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import {
+  getImageModelForUser,
+  setImageModelForUser,
+} from '../../services/user/imageModelPreference.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { getAuthedUser } from '../../utils/getAuthedUser.js';
+import { createLogger } from '../../utils/logger.js';
+
+import type { ImageModelId } from '@gruenerator/shared/models';
+import type { Application } from 'express';
+
+const log = createLogger('imageModelPreferenceContractRouter');
+
+const s = initServer();
+
+export const imageModelPreferenceContractRouter = s.router(imageModelPreferenceContract, {
+  getPreference: async (args) => {
+    try {
+      const userId = getAuthedUser(args.req).id;
+      const defaultImageModel = await getImageModelForUser(userId);
+      return { status: 200 as const, body: { success: true, defaultImageModel } };
+    } catch (error) {
+      log.error('[imageModelPreferenceContract.getPreference] Error:', error);
+      return { status: 500 as const, body: { error: 'Failed to load image model preference' } };
+    }
+  },
+
+  updatePreference: async (args) => {
+    try {
+      const userId = getAuthedUser(args.req).id;
+      const defaultImageModel = await setImageModelForUser(
+        userId,
+        args.body.modelId as ImageModelId
+      );
+      return { status: 200 as const, body: { success: true, defaultImageModel } };
+    } catch (error) {
+      log.error('[imageModelPreferenceContract.updatePreference] Error:', error);
+      return { status: 500 as const, body: { error: 'Failed to update image model preference' } };
+    }
+  },
+});
+
+export function mountImageModelPreferenceContractRouter(app: Application): void {
+  createExpressEndpoints(imageModelPreferenceContract, imageModelPreferenceContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'imageModelPreferenceContract'),
+  });
+}

--- a/apps/api/routes/flux/imaginePure.ts
+++ b/apps/api/routes/flux/imaginePure.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { IMAGE_MODEL_BY_ID, IMAGE_MODEL_IDS, type ImageModelId } from '@gruenerator/shared/models';
 import express, { type Response } from 'express';
 import { z } from 'zod';
 
@@ -8,6 +9,7 @@ import { requireAuth } from '../../middleware/authMiddleware.js';
 import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
 import { ImageGenerationCounter } from '../../services/counters/index.js';
 import { FluxImageService, buildFluxPrompt } from '../../services/flux/index.js';
+import { getImageModelForUser } from '../../services/user/imageModelPreference.js';
 import { createLogger } from '../../utils/logger.js';
 import { redisClient } from '../../utils/redis/index.js';
 import { addKiLabel } from '../sharepic/sharepic_canvas/imagine_label_canvas.js';
@@ -22,13 +24,13 @@ const imageCounter = new ImageGenerationCounter(redisClient);
 
 type PureImageVariant = 'illustration-pure' | 'realistic-pure' | 'pixel-pure' | 'editorial-pure';
 
-type ImageBackend = 'hosted' | 'regolo' | 'ionos';
-
 const imaginePureSchema = z.object({
   prompt: z.string().min(5),
   variant: z
     .enum(['illustration-pure', 'realistic-pure', 'pixel-pure', 'editorial-pure'])
     .nullish(),
+  imageModel: z.enum(IMAGE_MODEL_IDS as [ImageModelId, ...ImageModelId[]]).nullish(),
+  // Deprecated legacy alias kept for one release for non-UI callers.
   backend: z.enum(['hosted', 'regolo', 'ionos']).nullish(),
   seed: z.number().nullish(),
   width: z.number().nullish(),
@@ -119,9 +121,31 @@ router.post(
       // .nullish() on optional body fields so the frontend can send null;
       // destructuring defaults only fire for undefined, not null, so we
       // explicitly coalesce to the fallback here.
-      const { prompt, variant: rawVariant, backend: rawBackend, seed, width, height } = req.body;
+      const {
+        prompt,
+        variant: rawVariant,
+        imageModel: rawImageModel,
+        backend: rawBackend,
+        seed,
+        width,
+        height,
+      } = req.body;
       const variant: PureImageVariant = rawVariant ?? 'illustration-pure';
-      const backend = rawBackend ?? undefined;
+
+      // Resolve the image model: explicit request → legacy `backend` alias → profile default.
+      let selectedModelId: ImageModelId | null =
+        rawImageModel && IMAGE_MODEL_BY_ID[rawImageModel as ImageModelId]
+          ? (rawImageModel as ImageModelId)
+          : null;
+      if (!selectedModelId && rawBackend) {
+        if (rawBackend === 'regolo') selectedModelId = 'regolo-image';
+        else if (rawBackend === 'ionos') selectedModelId = 'ionos-image';
+        else if (rawBackend === 'hosted') selectedModelId = 'flux-pro';
+      }
+      if (!selectedModelId) {
+        selectedModelId = await getImageModelForUser(userId);
+      }
+      const selectedModel = IMAGE_MODEL_BY_ID[selectedModelId];
 
       if (!prompt || typeof prompt !== 'string' || prompt.trim().length < 5) {
         return res.status(400).json({
@@ -176,9 +200,11 @@ router.post(
         `[ImaginePure] Calling FLUX API with dimensions ${dimensions.width}x${dimensions.height}${width && height ? ' (custom)' : ' (variant default)'}`
       );
 
-      const validBackends: ImageBackend[] = ['hosted', 'regolo', 'ionos'];
-      const selectedBackend = backend && validBackends.includes(backend) ? backend : undefined;
-      const flux = await FluxImageService.create(selectedBackend);
+      log.debug(
+        `[ImaginePure] Using image model ${selectedModelId} (backend: ${selectedModel.backend}, cost: ${selectedModel.costMultiplier}×)`
+      );
+
+      const flux = await FluxImageService.create(selectedModel.backend, selectedModel.modelPath);
       const fluxOptions: {
         width: number;
         height: number;
@@ -221,7 +247,8 @@ router.post(
       const filePath = path.join(baseDir, filename);
       fs.writeFileSync(filePath, labeledBuffer);
 
-      await imageCounter.incrementCount(userId);
+      const costUnits = Math.round(selectedModel.costMultiplier * 100);
+      await imageCounter.incrementCount(userId, costUnits);
       const updatedLimitStatus = await imageCounter.checkLimit(userId);
 
       log.debug(
@@ -243,11 +270,13 @@ router.post(
           dimensions: { width: dimensions.width, height: dimensions.height },
           prompt: fluxPrompt,
           variant: selectedVariant,
+          imageModel: selectedModelId,
+          costMultiplier: selectedModel.costMultiplier,
           timestamp: now.toISOString(),
         },
         usage: {
           count: updatedLimitStatus.count,
-          remaining: updatedLimitStatus.limit - updatedLimitStatus.count,
+          remaining: updatedLimitStatus.remaining,
           limit: updatedLimitStatus.limit,
         },
       });

--- a/apps/api/services/counters/ImageGenerationCounter.ts
+++ b/apps/api/services/counters/ImageGenerationCounter.ts
@@ -1,21 +1,27 @@
 /**
  * Image Generation Counter
- * Manages Redis-based daily limits for image generation per user
+ *
+ * Tracks daily image-generation usage per user in Redis. Internally the
+ * counter stores **centi-credits** (1/100 of an image) so per-model cost
+ * multipliers (e.g. flux-klein = 0.5×, flux-max = 2×) can be represented
+ * as integers (50 / 100 / 200) — keeping Redis INCRBY arithmetic precise.
+ * Public API still speaks in image units (count / remaining / limit are
+ * fractional images).
  */
 
-import type { RedisClient, ImageGenerationStatus, ImageGenerationResult } from './types.js';
+import type { RedisIncrByClient, ImageGenerationStatus, ImageGenerationResult } from './types.js';
+
+const UNITS_PER_IMAGE = 100;
+const DEFAULT_DAILY_IMAGES = 10;
 
 export class ImageGenerationCounter {
-  private redis: RedisClient;
-  private DAILY_LIMIT = 10; // Maximum images per day per user
+  private redis: RedisIncrByClient;
+  private dailyLimitUnits = DEFAULT_DAILY_IMAGES * UNITS_PER_IMAGE;
 
-  constructor(redisClient: RedisClient) {
+  constructor(redisClient: RedisIncrByClient) {
     this.redis = redisClient;
   }
 
-  /**
-   * Get seconds until next midnight (for TTL)
-   */
   private getSecondsUntilMidnight(): number {
     const now = new Date();
     const tomorrow = new Date(now);
@@ -24,54 +30,31 @@ export class ImageGenerationCounter {
     return Math.floor((tomorrow.getTime() - now.getTime()) / 1000);
   }
 
-  /**
-   * Get today's date string for Redis key
-   */
   private getTodayDateString(): string {
     return new Date().toISOString().split('T')[0];
   }
 
-  /**
-   * Check current count and remaining generations for user
-   */
-  async checkLimit(userId: string): Promise<ImageGenerationStatus> {
-    if (!userId) {
-      return { count: 0, remaining: 0, limit: this.DAILY_LIMIT, canGenerate: false };
-    }
-
-    try {
-      const today = this.getTodayDateString();
-      const redisKey = `image_generation:${userId}:${today}`;
-
-      const countResult = await this.redis.get(redisKey);
-      const count = typeof countResult === 'string' ? countResult : null;
-      const currentCount = parseInt(count || '0') || 0;
-      const remaining = Math.max(0, this.DAILY_LIMIT - currentCount);
-      const canGenerate = remaining > 0;
-
-      return {
-        count: currentCount,
-        remaining,
-        limit: this.DAILY_LIMIT,
-        canGenerate,
-      };
-    } catch (error) {
-      console.error('[ImageGenerationCounter] Error checking limit:', error);
-      // On error, deny generation to be safe
-      return { count: this.DAILY_LIMIT, remaining: 0, limit: this.DAILY_LIMIT, canGenerate: false };
-    }
+  private toImageUnits(centiCredits: number): number {
+    return Math.round((centiCredits / UNITS_PER_IMAGE) * 10) / 10;
   }
 
-  /**
-   * Increment counter for user and return new status
-   */
-  async incrementCount(userId: string): Promise<ImageGenerationResult> {
+  private statusFromUnits(rawUnits: number): ImageGenerationStatus {
+    const limit = this.dailyLimitUnits / UNITS_PER_IMAGE;
+    const remaining = Math.max(0, this.toImageUnits(this.dailyLimitUnits - rawUnits));
+    return {
+      count: this.toImageUnits(rawUnits),
+      remaining,
+      limit,
+      canGenerate: rawUnits < this.dailyLimitUnits,
+    };
+  }
+
+  async checkLimit(userId: string): Promise<ImageGenerationStatus> {
     if (!userId) {
       return {
-        success: false,
         count: 0,
         remaining: 0,
-        limit: this.DAILY_LIMIT,
+        limit: this.dailyLimitUnits / UNITS_PER_IMAGE,
         canGenerate: false,
       };
     }
@@ -80,20 +63,57 @@ export class ImageGenerationCounter {
       const today = this.getTodayDateString();
       const redisKey = `image_generation:${userId}:${today}`;
 
-      // Check current limit before incrementing
+      const raw = await this.redis.get(redisKey);
+      const rawUnits = parseInt(raw ?? '0') || 0;
+      return this.statusFromUnits(rawUnits);
+    } catch (error) {
+      console.error('[ImageGenerationCounter] Error checking limit:', error);
+      return {
+        count: this.dailyLimitUnits / UNITS_PER_IMAGE,
+        remaining: 0,
+        limit: this.dailyLimitUnits / UNITS_PER_IMAGE,
+        canGenerate: false,
+      };
+    }
+  }
+
+  /**
+   * Increment the user's daily counter by `costUnits` centi-credits.
+   * Default of 100 (= 1 image) preserves legacy call-sites that don't yet
+   * pass a model-specific cost.
+   */
+  async incrementCount(
+    userId: string,
+    costUnits: number = UNITS_PER_IMAGE
+  ): Promise<ImageGenerationResult> {
+    if (!userId) {
+      return {
+        success: false,
+        count: 0,
+        remaining: 0,
+        limit: this.dailyLimitUnits / UNITS_PER_IMAGE,
+        canGenerate: false,
+      };
+    }
+
+    const units = Math.max(1, Math.round(costUnits));
+
+    try {
+      const today = this.getTodayDateString();
+      const redisKey = `image_generation:${userId}:${today}`;
+
       const currentStatus = await this.checkLimit(userId);
-      if (!currentStatus.canGenerate) {
+      const currentRawUnits = Math.round(currentStatus.count * UNITS_PER_IMAGE);
+      if (currentRawUnits + units > this.dailyLimitUnits) {
         console.log(
-          `[ImageGenerationCounter] User ${userId} has reached daily limit (${currentStatus.count}/${this.DAILY_LIMIT})`
+          `[ImageGenerationCounter] User ${userId} cannot afford ${units} units (have ${this.dailyLimitUnits - currentRawUnits} left of ${this.dailyLimitUnits})`
         );
         return { success: false, ...currentStatus };
       }
 
-      // Increment counter atomically
-      const newCount = await this.redis.incr(redisKey);
+      const newRawUnits = await this.redis.incrBy(redisKey, units);
 
-      // Set TTL only on first request (when count becomes 1)
-      if (newCount === 1) {
+      if (newRawUnits === units) {
         const ttlSeconds = this.getSecondsUntilMidnight();
         await this.redis.expire(redisKey, ttlSeconds);
         console.log(
@@ -101,43 +121,29 @@ export class ImageGenerationCounter {
         );
       }
 
-      const remaining = Math.max(0, this.DAILY_LIMIT - newCount);
-      const canGenerate = remaining > 0;
-
+      const status = this.statusFromUnits(newRawUnits);
       console.log(
-        `[ImageGenerationCounter] User ${userId}: Image #${newCount}/${this.DAILY_LIMIT}, remaining: ${remaining}`
+        `[ImageGenerationCounter] User ${userId}: +${units} units (${this.toImageUnits(units)} image), total ${status.count}/${status.limit}`
       );
 
-      return {
-        success: true,
-        count: newCount,
-        remaining,
-        limit: this.DAILY_LIMIT,
-        canGenerate,
-      };
+      return { success: true, ...status };
     } catch (error) {
       console.error('[ImageGenerationCounter] Error incrementing count:', error);
       return {
         success: false,
         count: 0,
         remaining: 0,
-        limit: this.DAILY_LIMIT,
+        limit: this.dailyLimitUnits / UNITS_PER_IMAGE,
         canGenerate: false,
       };
     }
   }
 
-  /**
-   * Get remaining generations for user
-   */
   async getRemainingGenerations(userId: string): Promise<number> {
     const status = await this.checkLimit(userId);
     return status.remaining;
   }
 
-  /**
-   * Reset counter for a user (useful for testing/admin)
-   */
   async resetUserCounter(userId: string): Promise<boolean> {
     if (!userId) return false;
 
@@ -153,9 +159,6 @@ export class ImageGenerationCounter {
     }
   }
 
-  /**
-   * Get time until reset (for UI display)
-   */
   getTimeUntilReset(): string {
     const secondsUntilMidnight = this.getSecondsUntilMidnight();
     const hours = Math.floor(secondsUntilMidnight / 3600);

--- a/apps/api/services/counters/types.ts
+++ b/apps/api/services/counters/types.ts
@@ -15,6 +15,16 @@ export interface RedisClient {
 }
 
 /**
+ * Extension required by ImageGenerationCounter to support per-call increment
+ * amounts (centi-credits per model). node-redis exposes `incrBy`; ioredis
+ * uses lowercase `incrby`. We keep this off the base RedisClient interface so
+ * other counters remain structurally compatible with both clients.
+ */
+export interface RedisIncrByClient extends RedisClient {
+  incrBy(key: string, increment: number): Promise<number>;
+}
+
+/**
  * Message object for token counting
  */
 export interface Message {

--- a/apps/api/services/flux/FluxImageService.ts
+++ b/apps/api/services/flux/FluxImageService.ts
@@ -122,7 +122,7 @@ class FluxImageService {
   private retryableErrors: Set<string>;
   private circuitBreaker: CircuitBreaker;
 
-  static async create(backend?: FluxBackend): Promise<FluxImageService> {
+  static async create(backend?: FluxBackend, modelPath?: string): Promise<FluxImageService> {
     const useBackend = backend || (env.FLUX_BACKEND as FluxBackend) || 'hosted';
 
     if (useBackend === 'regolo') {
@@ -137,8 +137,10 @@ class FluxImageService {
       return new mod.IonosImageService() as unknown as FluxImageService;
     }
 
-    console.log('[FluxImageService] Using hosted BFL API backend');
-    return new FluxImageService();
+    console.log(
+      `[FluxImageService] Using hosted BFL API backend${modelPath ? ` (${modelPath})` : ''}`
+    );
+    return new FluxImageService(modelPath ? { modelPath } : {});
   }
 
   constructor(options: FluxImageServiceOptions = {}) {
@@ -458,7 +460,7 @@ class FluxImageService {
     mimeType: string = 'image/jpeg',
     options: GenerateFromImageOptions = {}
   ): Promise<GenerateResult> {
-    const modelPath = options.modelPathOverride || '/v1/flux-2-pro';
+    const modelPath = options.modelPathOverride || this.modelPath;
     const url = `${this.baseUrl}${modelPath}`;
     const headers = {
       accept: 'application/json',

--- a/apps/api/services/user/imageModelPreference.ts
+++ b/apps/api/services/user/imageModelPreference.ts
@@ -1,0 +1,41 @@
+import {
+  IMAGE_MODEL_BY_ID,
+  DEFAULT_IMAGE_MODEL_ID,
+  type ImageModelId,
+} from '@gruenerator/shared/models';
+
+import { getProfileService } from './ProfileService.js';
+
+import type { UserProfile } from './types.js';
+
+const USER_DEFAULTS_KEY = 'image_model';
+const DEFAULT_FIELD = 'default';
+
+function isImageModelId(value: unknown): value is ImageModelId {
+  return typeof value === 'string' && value in IMAGE_MODEL_BY_ID;
+}
+
+export async function getImageModelForUser(
+  userId: string,
+  preloadedProfile?: UserProfile | null
+): Promise<ImageModelId> {
+  const profile =
+    preloadedProfile !== undefined
+      ? preloadedProfile
+      : await getProfileService().getProfileById(userId);
+
+  const stored = profile?.user_defaults?.[USER_DEFAULTS_KEY] as Record<string, unknown> | undefined;
+  const value = stored?.[DEFAULT_FIELD];
+  return isImageModelId(value) ? value : DEFAULT_IMAGE_MODEL_ID;
+}
+
+export async function setImageModelForUser(
+  userId: string,
+  modelId: ImageModelId
+): Promise<ImageModelId> {
+  if (!IMAGE_MODEL_BY_ID[modelId]) {
+    throw new Error(`Unknown image modelId: ${modelId}`);
+  }
+  await getProfileService().updateUserDefault(userId, USER_DEFAULTS_KEY, DEFAULT_FIELD, modelId);
+  return modelId;
+}

--- a/apps/api/services/user/modelPreferences.ts
+++ b/apps/api/services/user/modelPreferences.ts
@@ -1,8 +1,8 @@
 import {
-  ALL_MODEL_IDS,
-  MODEL_BY_ID,
+  TEXT_MODEL_IDS,
+  TEXT_MODEL_BY_ID,
   isModelEnabledByDefault,
-  type ModelId,
+  type TextModelId,
 } from '@gruenerator/shared/models';
 
 import { getProfileService } from './ProfileService.js';
@@ -13,7 +13,7 @@ export interface ModelPreference {
   enabled: boolean;
 }
 
-export type ModelPreferencesMap = Record<ModelId, ModelPreference>;
+export type ModelPreferencesMap = Record<TextModelId, ModelPreference>;
 
 const USER_DEFAULTS_KEY = 'models';
 
@@ -26,7 +26,7 @@ function isStoredPreference(value: unknown): value is ModelPreference {
   );
 }
 
-function resolvePreference(stored: unknown, modelId: ModelId): ModelPreference {
+function resolvePreference(stored: unknown, modelId: TextModelId): ModelPreference {
   if (isStoredPreference(stored)) {
     return { enabled: stored.enabled };
   }
@@ -35,7 +35,7 @@ function resolvePreference(stored: unknown, modelId: ModelId): ModelPreference {
 
 export function getDefaultModelPreferences(): ModelPreferencesMap {
   const result = {} as ModelPreferencesMap;
-  for (const id of ALL_MODEL_IDS) {
+  for (const id of TEXT_MODEL_IDS) {
     result[id] = { enabled: isModelEnabledByDefault(id) };
   }
   return result;
@@ -53,7 +53,7 @@ export async function getModelPreferencesForUser(
   const stored = (profile?.user_defaults?.[USER_DEFAULTS_KEY] ?? {}) as Record<string, unknown>;
 
   const result = {} as ModelPreferencesMap;
-  for (const id of ALL_MODEL_IDS) {
+  for (const id of TEXT_MODEL_IDS) {
     result[id] = resolvePreference(stored[id], id);
   }
   return result;
@@ -61,16 +61,16 @@ export async function getModelPreferencesForUser(
 
 export async function setModelPreference(
   userId: string,
-  modelId: ModelId,
+  modelId: TextModelId,
   enabled: boolean
 ): Promise<ModelPreferencesMap> {
-  if (!MODEL_BY_ID[modelId]) {
+  if (!TEXT_MODEL_BY_ID[modelId]) {
     throw new Error(`Unknown modelId: ${modelId}`);
   }
   await getProfileService().updateUserDefault(userId, USER_DEFAULTS_KEY, modelId, { enabled });
   return getModelPreferencesForUser(userId);
 }
 
-export function isModelEnabledForUser(prefs: ModelPreferencesMap, modelId: ModelId): boolean {
+export function isModelEnabledForUser(prefs: ModelPreferencesMap, modelId: TextModelId): boolean {
   return prefs[modelId]?.enabled ?? isModelEnabledByDefault(modelId);
 }

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ImageModelSettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ImageModelSettingsSection.tsx
@@ -1,0 +1,131 @@
+import {
+  IMAGE_MODELS,
+  REGION_LABELS,
+  REGION_ORDER,
+  type ImageModelId,
+  type ImageModelOption,
+  type ModelRegion,
+} from '@gruenerator/shared/models';
+import { Info } from 'lucide-react';
+import React from 'react';
+
+import { useImageModelPreference } from '../../../../../models/hooks/useImageModelPreference';
+
+interface ImageModelSettingsSectionProps {
+  onSuccessMessage: (message: string) => void;
+  onErrorMessage: (message: string) => void;
+}
+
+function groupByRegion(models: ImageModelOption[]): Map<ModelRegion, ImageModelOption[]> {
+  const grouped = new Map<ModelRegion, ImageModelOption[]>();
+  for (const model of models) {
+    const list = grouped.get(model.region) ?? [];
+    list.push(model);
+    grouped.set(model.region, list);
+  }
+  return grouped;
+}
+
+function formatCost(multiplier: number): string {
+  if (multiplier === 1) return '1 Bild pro Generation';
+  if (multiplier === 0.5) return '½ Bild pro Generation';
+  return `${multiplier} Bilder pro Generation`;
+}
+
+const ImageModelSettingsSection = React.memo(
+  ({ onSuccessMessage, onErrorMessage }: ImageModelSettingsSectionProps) => {
+    const { defaultImageModel, isLoading, setDefaultImageModel } = useImageModelPreference();
+    const grouped = groupByRegion(IMAGE_MODELS);
+
+    const handleSelect = async (modelId: ImageModelId, label: string) => {
+      try {
+        await setDefaultImageModel(modelId);
+        onSuccessMessage(`Standard-Bildmodell auf ${label} gesetzt.`);
+      } catch {
+        onErrorMessage('Bildmodell-Einstellung konnte nicht gespeichert werden.');
+      }
+    };
+
+    if (isLoading) {
+      return (
+        <div className="animate-pulse">
+          <div className="h-32 rounded-lg bg-grey-100 dark:bg-grey-800" />
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-md">
+        <div>
+          <h3 className="text-sm font-medium text-foreground mb-xs">Bildmodelle</h3>
+          <p className="text-xs text-grey-500 dark:text-grey-400">
+            Wähle dein Standard-Bildmodell. Im Bild-Generator kannst du es für einzelne Generationen
+            überschreiben.
+          </p>
+        </div>
+
+        <div className="flex items-start gap-sm p-md rounded-lg bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-800">
+          <Info className="w-4 h-4 mt-0.5 text-primary-600 dark:text-primary-400 shrink-0" />
+          <p className="text-sm text-primary-700 dark:text-primary-300">
+            Modelle verbrauchen unterschiedlich viele Bilder vom Tageskontingent (10 Bilder/Tag).
+            Klein verbraucht nur ½ Bild, Max verbraucht 2 Bilder.
+          </p>
+        </div>
+
+        {REGION_ORDER.map((region) => {
+          const models = grouped.get(region);
+          if (!models?.length) return null;
+
+          return (
+            <div
+              key={region}
+              className="rounded-lg border border-grey-200 dark:border-grey-700 overflow-hidden"
+            >
+              <div className="px-md py-sm bg-grey-50 dark:bg-grey-800/50 border-b border-grey-200 dark:border-grey-700">
+                <h4 className="text-sm font-semibold text-foreground">{REGION_LABELS[region]}</h4>
+              </div>
+
+              <div className="divide-y divide-grey-100 dark:divide-grey-800">
+                {models.map((model) => {
+                  const isSelected = defaultImageModel === model.id;
+
+                  return (
+                    <label
+                      key={model.id}
+                      className={`flex items-start gap-md px-md py-sm cursor-pointer hover:bg-grey-50 dark:hover:bg-grey-800/30 transition-colors ${
+                        isSelected ? 'bg-secondary-50 dark:bg-secondary-950/20' : ''
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="default-image-model"
+                        value={model.id}
+                        checked={isSelected}
+                        onChange={() => handleSelect(model.id, model.name)}
+                        className="mt-1 shrink-0 accent-secondary-600"
+                        aria-label={`${model.name} als Standard wählen`}
+                      />
+                      <div className="grow min-w-0">
+                        <p className="text-sm font-medium text-foreground">{model.name}</p>
+                        <p className="text-xs text-grey-500 dark:text-grey-400">
+                          {model.description}
+                        </p>
+                        <p className="text-xs text-grey-400 dark:text-grey-500 mt-xs">
+                          {formatCost(model.costMultiplier)}
+                        </p>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+);
+
+ImageModelSettingsSection.displayName = 'ImageModelSettingsSection';
+
+export default ImageModelSettingsSection;

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ModelSettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ModelSettingsSection.tsx
@@ -1,10 +1,10 @@
 import {
-  MODEL_OPTIONS,
+  TEXT_MODELS,
   QWEN_WARNING,
   REGION_LABELS,
   REGION_ORDER,
-  type ModelId,
-  type ModelOption,
+  type TextModelId,
+  type TextModelOption,
   type ModelRegion,
 } from '@gruenerator/shared/models';
 import { Switch } from '@gruenerator/ui';
@@ -18,8 +18,8 @@ interface ModelSettingsSectionProps {
   onErrorMessage: (message: string) => void;
 }
 
-function groupByRegion(models: ModelOption[]): Map<ModelRegion, ModelOption[]> {
-  const grouped = new Map<ModelRegion, ModelOption[]>();
+function groupByRegion(models: TextModelOption[]): Map<ModelRegion, TextModelOption[]> {
+  const grouped = new Map<ModelRegion, TextModelOption[]>();
   for (const model of models) {
     const list = grouped.get(model.region) ?? [];
     list.push(model);
@@ -31,9 +31,9 @@ function groupByRegion(models: ModelOption[]): Map<ModelRegion, ModelOption[]> {
 const ModelSettingsSection = React.memo(
   ({ onSuccessMessage, onErrorMessage }: ModelSettingsSectionProps) => {
     const { preferences, isLoading, toggleModel } = useModelPreferences();
-    const grouped = groupByRegion(MODEL_OPTIONS);
+    const grouped = groupByRegion(TEXT_MODELS);
 
-    const handleToggle = async (modelId: ModelId, label: string, enabled: boolean) => {
+    const handleToggle = async (modelId: TextModelId, label: string, enabled: boolean) => {
       try {
         await toggleModel(modelId, enabled);
         onSuccessMessage(`${label} ${enabled ? 'aktiviert' : 'deaktiviert'}.`);

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
@@ -8,6 +8,7 @@ import MemoriesSection from '../../../../../../components/profile/MemoriesSectio
 import { useAuthStore, type SupportedLocale } from '../../../../../../stores/authStore';
 import { cn } from '../../../../../../utils/cn';
 
+import ImageModelSettingsSection from './ImageModelSettingsSection';
 import ModelSettingsSection from './ModelSettingsSection';
 import RolesSection from './RolesSection';
 import SettingsSection from './SettingsSection';
@@ -203,6 +204,8 @@ const ProfileView = ({
       <SettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
 
       <ModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
+
+      <ImageModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
 
       <MemoriesSection />
 

--- a/apps/web/src/features/models/hooks/useImageModelPreference.ts
+++ b/apps/web/src/features/models/hooks/useImageModelPreference.ts
@@ -1,0 +1,56 @@
+import { DEFAULT_IMAGE_MODEL_ID, type ImageModelId } from '@gruenerator/shared/models';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  fetchImageModelPreference,
+  updateImageModelPreference,
+} from '../../../hooks/useImageModelPreferenceTyped';
+
+const QUERY_KEY = ['image-model-preference'];
+
+interface ImageModelPreferenceResponse {
+  success: boolean;
+  defaultImageModel: ImageModelId;
+}
+
+export interface UseImageModelPreferenceOptions {
+  enabled?: boolean;
+}
+
+export function useImageModelPreference(options: UseImageModelPreferenceOptions = {}) {
+  const { enabled = true } = options;
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => fetchImageModelPreference() as Promise<ImageModelPreferenceResponse>,
+    staleTime: 60_000,
+    enabled,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (modelId: ImageModelId) =>
+      updateImageModelPreference(modelId) as Promise<ImageModelPreferenceResponse>,
+    onMutate: async (modelId) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEY });
+      const previous = queryClient.getQueryData<ImageModelPreferenceResponse>(QUERY_KEY);
+      queryClient.setQueryData(QUERY_KEY, { success: true, defaultImageModel: modelId });
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(QUERY_KEY, context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
+
+  return {
+    defaultImageModel: query.data?.defaultImageModel ?? DEFAULT_IMAGE_MODEL_ID,
+    isLoading: query.isLoading,
+    setDefaultImageModel: (modelId: ImageModelId) => mutation.mutateAsync(modelId),
+    isSaving: mutation.isPending,
+  };
+}

--- a/apps/web/src/features/models/hooks/useModelPreferences.ts
+++ b/apps/web/src/features/models/hooks/useModelPreferences.ts
@@ -1,6 +1,6 @@
-import { useMemo } from 'react';
+import { type TextModelId } from '@gruenerator/shared/models';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { type ModelId } from '@gruenerator/shared/models';
+import { useMemo } from 'react';
 
 import {
   fetchModelPreferences,
@@ -37,7 +37,7 @@ export function useModelPreferences(options: UseModelPreferencesOptions = {}) {
   });
 
   const mutation = useMutation({
-    mutationFn: async ({ modelId, enabled }: { modelId: ModelId; enabled: boolean }) => {
+    mutationFn: async ({ modelId, enabled }: { modelId: TextModelId; enabled: boolean }) => {
       return updateModelPreference(modelId, enabled) as Promise<ModelPreferencesResponse>;
     },
     onMutate: async ({ modelId, enabled }) => {
@@ -71,9 +71,9 @@ export function useModelPreferences(options: UseModelPreferencesOptions = {}) {
 
   const enabledModelIds = useMemo(() => {
     if (!query.data) return null;
-    const set = new Set<ModelId>();
+    const set = new Set<TextModelId>();
     for (const [id, pref] of Object.entries(preferences)) {
-      if (pref?.enabled) set.add(id as ModelId);
+      if (pref?.enabled) set.add(id as TextModelId);
     }
     return set;
   }, [preferences, query.data]);
@@ -83,7 +83,8 @@ export function useModelPreferences(options: UseModelPreferencesOptions = {}) {
     defaults: query.data?.defaults ?? {},
     enabledModelIds,
     isLoading: query.isLoading,
-    toggleModel: (modelId: ModelId, enabled: boolean) => mutation.mutateAsync({ modelId, enabled }),
+    toggleModel: (modelId: TextModelId, enabled: boolean) =>
+      mutation.mutateAsync({ modelId, enabled }),
     isSaving: mutation.isPending,
   };
 }

--- a/apps/web/src/features/texte/modes/imagine.ts
+++ b/apps/web/src/features/texte/modes/imagine.ts
@@ -1,3 +1,5 @@
+import { IMAGE_MODELS, DEFAULT_IMAGE_MODEL_ID } from '@gruenerator/shared/models';
+
 import type { ModeDefinition } from './types';
 
 export const imagineMode: ModeDefinition = {
@@ -24,18 +26,15 @@ export const imagineMode: ModeDefinition = {
       multiple: false,
     },
     {
-      key: 'backend',
+      key: 'imageModel',
       label: 'Modell',
-      options: [
-        { id: 'regolo', label: 'Standard' },
-        { id: '', label: 'Flux Pro' },
-      ],
+      options: IMAGE_MODELS.map((m) => ({ id: m.id, label: m.name })),
       multiple: false,
     },
   ],
   defaults: {
     variant: '',
-    backend: 'regolo',
+    imageModel: DEFAULT_IMAGE_MODEL_ID,
   },
   examples: [
     { label: 'Plakat', text: 'Ein grünes Wahlplakat mit Sonnenblumen und dem Slogan ' },

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -15,6 +15,7 @@ import useApiSubmit from '../../../components/hooks/useApiSubmit';
 import { Lightbox } from '../../image-studio/components/Lightbox';
 import { useLightbox } from '../../image-studio/hooks/useLightbox';
 import { editAiImage } from '../../image-studio/services/imageEditingService';
+import { useImageModelPreference } from '../../models/hooks/useImageModelPreference';
 import { useModeState } from '../../texte/hooks/useModeState';
 import { MODE_MAP } from '../../texte/modes';
 
@@ -60,6 +61,16 @@ const BilderInner: React.FC = memo(() => {
     loading: createLoading,
     error: createError,
   } = useApiSubmit(erstellenDef?.endpoint ?? '/imagine/pure');
+
+  const { defaultImageModel, isLoading: isPrefLoading } = useImageModelPreference();
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || isPrefLoading) return;
+    seededRef.current = true;
+    if (defaultImageModel !== modeState.imageModel) {
+      updateField('imageModel', defaultImageModel);
+    }
+  }, [isPrefLoading, defaultImageModel, modeState.imageModel, updateField]);
 
   useEffect(
     () => () => {
@@ -115,7 +126,7 @@ const BilderInner: React.FC = memo(() => {
     try {
       const payload: Record<string, unknown> = { prompt: trimmed };
       if (modeState.variant) payload.variant = modeState.variant;
-      if (modeState.backend) payload.backend = modeState.backend;
+      if (modeState.imageModel) payload.imageModel = modeState.imageModel;
       const result = await submitForm(payload);
       const base64 = (result as { image?: { base64?: string } })?.image?.base64;
       if (base64) {
@@ -138,7 +149,7 @@ const BilderInner: React.FC = memo(() => {
     createLoading,
     submitForm,
     modeState.variant,
-    modeState.backend,
+    modeState.imageModel,
     setResult,
     createImageShare,
     queryClient,

--- a/apps/web/src/hooks/useImageModelPreferenceTyped.ts
+++ b/apps/web/src/hooks/useImageModelPreferenceTyped.ts
@@ -1,0 +1,22 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+import { type ImageModelId } from '@gruenerator/shared/models';
+
+export async function fetchImageModelPreference() {
+  const client = getContractsClient();
+  const result = await client.imageModelPreference.getPreference();
+  if (result.status !== 200) {
+    throw new Error(`Failed to fetch image model preference (HTTP ${result.status})`);
+  }
+  return result.body;
+}
+
+export async function updateImageModelPreference(modelId: ImageModelId) {
+  const client = getContractsClient();
+  const result = await client.imageModelPreference.updatePreference({
+    body: { modelId },
+  });
+  if (result.status !== 200) {
+    throw new Error(`Failed to update image model preference (HTTP ${result.status})`);
+  }
+  return result.body;
+}

--- a/apps/web/src/hooks/useModelPreferencesTyped.ts
+++ b/apps/web/src/hooks/useModelPreferencesTyped.ts
@@ -4,7 +4,7 @@
  */
 
 import { getContractsClient } from '@gruenerator/shared/api';
-import { type ModelId } from '@gruenerator/shared/models';
+import { type TextModelId } from '@gruenerator/shared/models';
 
 export async function fetchModelPreferences() {
   const client = getContractsClient();
@@ -15,7 +15,7 @@ export async function fetchModelPreferences() {
   return result.body;
 }
 
-export async function updateModelPreference(modelId: ModelId, enabled: boolean) {
+export async function updateModelPreference(modelId: TextModelId, enabled: boolean) {
   const client = getContractsClient();
   const result = await client.modelPreferences.updatePreference({
     body: { modelId, enabled },

--- a/packages/chat/src/context/ChatSurfaceContext.tsx
+++ b/packages/chat/src/context/ChatSurfaceContext.tsx
@@ -2,14 +2,14 @@
 
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { createStore, useStore, type StoreApi } from 'zustand';
-import type { ModelId } from '@gruenerator/shared/models';
+import type { TextModelId } from '@gruenerator/shared/models';
 import type { SearchMode, ThreadMode } from '../stores/chatStore';
 
 export interface ChatSurfaceState {
   selectedAgentId: string | null;
   threadMode: ThreadMode;
   searchMode: SearchMode;
-  selectedModel: ModelId | null;
+  selectedModel: TextModelId | null;
   selectedNotebookId: string;
   customSystemPrompt: string | null;
   customRoleName: string | null;
@@ -17,7 +17,7 @@ export interface ChatSurfaceState {
   setSelectedAgent: (agentId: string | null) => void;
   setThreadMode: (mode: ThreadMode) => void;
   setSearchMode: (mode: SearchMode) => void;
-  setSelectedModel: (model: ModelId) => void;
+  setSelectedModel: (model: TextModelId) => void;
   setSelectedNotebook: (id: string) => void;
   setCustomSystemPrompt: (prompt: string | null) => void;
   setCustomRoleName: (name: string | null) => void;

--- a/packages/chat/src/context/ModelPreferencesContext.tsx
+++ b/packages/chat/src/context/ModelPreferencesContext.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { type ModelId } from '@gruenerator/shared/models';
+import { type TextModelId } from '@gruenerator/shared/models';
 
 export interface ModelPreferencesContextValue {
-  enabledModelIds: ReadonlySet<ModelId> | null;
+  enabledModelIds: ReadonlySet<TextModelId> | null;
 }
 
 const ModelPreferencesContext = createContext<ModelPreferencesContextValue>({
@@ -13,7 +13,7 @@ const ModelPreferencesContext = createContext<ModelPreferencesContextValue>({
 
 interface ModelPreferencesProviderProps {
   children: ReactNode;
-  enabledModelIds?: ReadonlySet<ModelId> | null;
+  enabledModelIds?: ReadonlySet<TextModelId> | null;
 }
 
 export function ModelPreferencesProvider({

--- a/packages/chat/src/lib/useScopedAgentState.ts
+++ b/packages/chat/src/lib/useScopedAgentState.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { createStore, useStore } from 'zustand';
-import type { ModelId } from '@gruenerator/shared/models';
+import type { TextModelId } from '@gruenerator/shared/models';
 import { useChatSurfaceContext, type ChatSurfaceState } from '../context/ChatSurfaceContext';
 import { useAgentStore, type SearchMode, type ThreadMode } from '../stores/chatStore';
 
@@ -45,9 +45,9 @@ export function useScopedSearchMode(): SearchMode {
   return useScopedField((s) => s.searchMode, global);
 }
 
-export function useScopedSelectedModel(): ModelId | null {
+export function useScopedSelectedModel(): TextModelId | null {
   const global = useAgentStore((s) => s.selectedModel);
-  return useScopedField<ModelId | null>((s) => s.selectedModel, global);
+  return useScopedField<TextModelId | null>((s) => s.selectedModel, global);
 }
 
 export function useScopedSelectedNotebookId(): string {
@@ -88,7 +88,7 @@ export function useScopedSetSearchMode(): (mode: SearchMode) => void {
   return (mode) => ctx.store.getState().setSearchMode(mode);
 }
 
-export function useScopedSetSelectedModel(): (model: ModelId) => void {
+export function useScopedSetSelectedModel(): (model: TextModelId) => void {
   const ctx = useChatSurfaceContext();
   const globalSet = useAgentStore((s) => s.setSelectedModel);
   if (!ctx) return globalSet;

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -21,7 +21,7 @@ import {
   RuntimeAdapterProvider,
   ExportedMessageRepository,
 } from '@assistant-ui/react';
-import { type ModelId } from '@gruenerator/shared/models';
+import { type TextModelId } from '@gruenerator/shared/models';
 import { createChatApiClient } from '../context/ChatContext';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore, type ChatConfig } from '../stores/chatConfigStore';
@@ -59,7 +59,7 @@ interface GrueneratorChatProviderProps {
   getExternalThreads?: () => ExternalThreadEntry[];
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
-  enabledModelIds?: ReadonlySet<ModelId> | null;
+  enabledModelIds?: ReadonlySet<TextModelId> | null;
 }
 
 interface PersistedToolCall {

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -1,16 +1,18 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import {
-  MODEL_OPTIONS,
-  MODEL_BY_ID,
-  type ModelId,
-  type ModelOption,
-  type Provider,
+  TEXT_MODELS,
+  TEXT_MODEL_BY_ID,
+  type TextModelId,
+  type TextModelOption,
+  type TextProvider,
 } from '@gruenerator/shared/models';
 import type { ChatApiClient } from '../context/ChatContext';
 
-export { MODEL_OPTIONS };
-export type { ModelId, ModelOption, Provider };
+export const MODEL_OPTIONS = TEXT_MODELS;
+export type ModelId = TextModelId;
+export type ModelOption = TextModelOption;
+export type Provider = TextProvider;
 
 export interface CompactionState {
   summary: string | null;
@@ -167,7 +169,7 @@ export const useAgentStore = create<AgentState>()(
       setSelectedProvider: (provider) => set({ selectedProvider: provider }),
 
       setSelectedModel: (model) => {
-        const modelOption = MODEL_OPTIONS.find((m) => m.id === model);
+        const modelOption = TEXT_MODEL_BY_ID[model];
         if (modelOption) {
           set({ selectedModel: model, selectedProvider: modelOption.provider });
         }
@@ -388,7 +390,7 @@ export const useAgentStore = create<AgentState>()(
         }
         if (version < 8) {
           const current = state.selectedModel as string | undefined;
-          const def = current ? MODEL_BY_ID[current as ModelId] : undefined;
+          const def = current ? TEXT_MODEL_BY_ID[current as TextModelId] : undefined;
           if (def?.offByDefault) {
             state.selectedModel = 'gemma-litellm';
             state.selectedProvider = 'litellm';

--- a/packages/contracts/src/contracts/imageModelPreferenceContract.ts
+++ b/packages/contracts/src/contracts/imageModelPreferenceContract.ts
@@ -1,0 +1,38 @@
+import { initContract } from '@ts-rest/core';
+
+import {
+  imageModelPreferenceResponseSchema,
+  imageModelPreferenceErrorResponseSchema,
+  updateImageModelPreferenceBodySchema,
+} from '../schemas/imageModelPreference.js';
+
+const c = initContract();
+
+export const imageModelPreferenceContract = c.router(
+  {
+    getPreference: {
+      method: 'GET',
+      path: '/api/auth/profile/image-model-preference',
+      responses: {
+        200: imageModelPreferenceResponseSchema,
+        401: imageModelPreferenceErrorResponseSchema,
+        500: imageModelPreferenceErrorResponseSchema,
+      },
+      summary: 'Get the user-default image model',
+    },
+
+    updatePreference: {
+      method: 'PATCH',
+      path: '/api/auth/profile/image-model-preference',
+      body: updateImageModelPreferenceBodySchema,
+      responses: {
+        200: imageModelPreferenceResponseSchema,
+        400: imageModelPreferenceErrorResponseSchema,
+        401: imageModelPreferenceErrorResponseSchema,
+        500: imageModelPreferenceErrorResponseSchema,
+      },
+      summary: 'Set the user-default image model',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -27,5 +27,6 @@ export { unsplashContract } from './unsplashContract.js';
 export { notificationsContract } from './notificationsContract.js';
 export { emailContract } from './emailContract.js';
 export { modelPreferencesContract } from './modelPreferencesContract.js';
+export { imageModelPreferenceContract } from './imageModelPreferenceContract.js';
 export { adminVorlagenContract } from './adminVorlagenContract.js';
 export { canvasAiContract } from './canvasAi.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -43,6 +43,7 @@ export {
   notificationsContract,
   emailContract,
   modelPreferencesContract,
+  imageModelPreferenceContract,
   adminVorlagenContract,
   canvasAiContract,
 } from './contracts/index.js';
@@ -73,5 +74,6 @@ export * from './schemas/unsplash.js';
 export * from './schemas/notifications.js';
 export * from './schemas/email.js';
 export * from './schemas/modelPreferences.js';
+export * from './schemas/imageModelPreference.js';
 export * from './schemas/adminVorlagen.js';
 export * from './schemas/canvasAi.js';

--- a/packages/contracts/src/schemas/imageModelPreference.ts
+++ b/packages/contracts/src/schemas/imageModelPreference.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const imageModelIdSchema = z.enum([
+  'flux-klein',
+  'flux-pro',
+  'flux-max',
+  'regolo-image',
+  'ionos-image',
+]);
+
+export const imageModelPreferenceResponseSchema = z.object({
+  success: z.boolean(),
+  defaultImageModel: imageModelIdSchema,
+});
+
+export const updateImageModelPreferenceBodySchema = z.object({
+  modelId: imageModelIdSchema,
+});
+
+export const imageModelPreferenceErrorResponseSchema = z.object({
+  error: z.string(),
+});

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -30,6 +30,7 @@ import {
   notificationsContract,
   emailContract,
   modelPreferencesContract,
+  imageModelPreferenceContract,
   adminVorlagenContract,
   docsContract,
   documentsContract,
@@ -140,6 +141,7 @@ const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
 const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS);
 const _emailClient = () => initClient(emailContract, CLIENT_OPTS);
 const _modelPreferencesClient = () => initClient(modelPreferencesContract, CLIENT_OPTS);
+const _imageModelPreferenceClient = () => initClient(imageModelPreferenceContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
 const _docsClient = () => initClient(docsContract, CLIENT_OPTS);
 const _documentsClient = () => initClient(documentsContract, CLIENT_OPTS);
@@ -158,6 +160,7 @@ export interface ContractsClient {
   notifications: ReturnType<typeof _notificationsClient>;
   email: ReturnType<typeof _emailClient>;
   modelPreferences: ReturnType<typeof _modelPreferencesClient>;
+  imageModelPreference: ReturnType<typeof _imageModelPreferenceClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
   docs: ReturnType<typeof _docsClient>;
   documents: ReturnType<typeof _documentsClient>;
@@ -193,6 +196,7 @@ export function getContractsClient(): ContractsClient {
     notifications: _notificationsClient(),
     email: _emailClient(),
     modelPreferences: _modelPreferencesClient(),
+    imageModelPreference: _imageModelPreferenceClient(),
     adminVorlagen: _adminVorlagenClient(),
     docs: _docsClient(),
     documents: _documentsClient(),

--- a/packages/shared/src/models/catalog.ts
+++ b/packages/shared/src/models/catalog.ts
@@ -1,32 +1,54 @@
-export type Provider = 'mistral' | 'litellm' | 'regolo';
+export type TextProvider = 'mistral' | 'litellm' | 'regolo';
+export type ImageBackend = 'hosted' | 'regolo' | 'ionos';
 
-export type ModelId =
+export type Provider = TextProvider;
+
+export type TextModelId =
   | 'mistral-medium-3.5'
   | 'litellm'
   | 'gemma-litellm'
   | 'qwen-regolo'
   | 'qwen3.6-regolo';
 
+export type ImageModelId = 'flux-klein' | 'flux-pro' | 'flux-max' | 'regolo-image' | 'ionos-image';
+
+export type ModelId = TextModelId | ImageModelId;
+
 export type ModelRegion = 'eu' | 'us' | 'cn' | 'self-hosted';
 
 export type ModelIcon = 'sparkles' | 'server' | 'zap' | 'brain';
 
-export interface ModelOption {
-  id: ModelId;
+interface BaseModelOption {
   name: string;
   description: string;
-  model: string;
-  provider: Provider;
   icon: ModelIcon;
   region: ModelRegion;
+}
+
+export interface TextModelOption extends BaseModelOption {
+  modality: 'text';
+  id: TextModelId;
+  provider: TextProvider;
+  model: string;
   offByDefault?: boolean;
 }
+
+export interface ImageModelOption extends BaseModelOption {
+  modality: 'image';
+  id: ImageModelId;
+  backend: ImageBackend;
+  modelPath?: string;
+  costMultiplier: number;
+}
+
+export type ModelOption = TextModelOption | ImageModelOption;
 
 export const QWEN_WARNING =
   'Chinesisches Modell – unterliegt staatlicher Zensur. Antworten zu politisch sensiblen Themen können eingeschränkt sein.';
 
 export const MODEL_OPTIONS: ModelOption[] = [
   {
+    modality: 'text',
     id: 'gemma-litellm',
     name: '🌳 Gemma 4',
     description: 'Leichtgewichtig, antwortet schnell',
@@ -36,6 +58,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     region: 'self-hosted',
   },
   {
+    modality: 'text',
     id: 'mistral-medium-3.5',
     name: '⭐ Mistral Medium',
     description: 'EU-gehostet, ausgewogen für allgemeine Aufgaben',
@@ -45,6 +68,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     region: 'eu',
   },
   {
+    modality: 'text',
     id: 'litellm',
     name: '🌳 GPT-OSS',
     description: 'Selbst gehostet bei Verdigado, Regolo als Overflow',
@@ -54,6 +78,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     region: 'self-hosted',
   },
   {
+    modality: 'text',
     id: 'qwen-regolo',
     name: 'Qwen 120B',
     description: 'Groß & vielseitig, für komplexe Aufgaben',
@@ -64,6 +89,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     offByDefault: true,
   },
   {
+    modality: 'text',
     id: 'qwen3.6-regolo',
     name: 'Qwen 3.6 27B',
     description: 'Kompaktes Reasoning-Modell, denkt sichtbar mit',
@@ -73,7 +99,68 @@ export const MODEL_OPTIONS: ModelOption[] = [
     region: 'cn',
     offByDefault: true,
   },
+  {
+    modality: 'image',
+    id: 'flux-pro',
+    name: '⭐ Flux Pro',
+    description: 'Ausgewogen — Standard für produktive Bildgenerierung',
+    backend: 'hosted',
+    modelPath: '/v1/flux-2-pro',
+    costMultiplier: 1,
+    icon: 'sparkles',
+    region: 'eu',
+  },
+  {
+    modality: 'image',
+    id: 'flux-klein',
+    name: '⚡ Flux Klein',
+    description: 'Schnell & günstig — verbraucht nur ½ Bild pro Generation',
+    backend: 'hosted',
+    modelPath: '/v1/flux-2-klein-9b-preview',
+    costMultiplier: 0.5,
+    icon: 'zap',
+    region: 'eu',
+  },
+  {
+    modality: 'image',
+    id: 'flux-max',
+    name: '👑 Flux Max',
+    description: 'Höchste Qualität & Recherche — verbraucht 2 Bilder pro Generation',
+    backend: 'hosted',
+    modelPath: '/v1/flux-2-max-preview',
+    costMultiplier: 2,
+    icon: 'brain',
+    region: 'eu',
+  },
+  {
+    modality: 'image',
+    id: 'regolo-image',
+    name: '🌳 Qwen-Image',
+    description: 'Selbst gehostet, klimaneutral',
+    backend: 'regolo',
+    costMultiplier: 1,
+    icon: 'server',
+    region: 'self-hosted',
+  },
+  {
+    modality: 'image',
+    id: 'ionos-image',
+    name: 'IONOS Schnell',
+    description: 'EU-Cloud, FLUX.1-schnell',
+    backend: 'ionos',
+    costMultiplier: 1,
+    icon: 'server',
+    region: 'eu',
+  },
 ];
+
+export const TEXT_MODELS: TextModelOption[] = MODEL_OPTIONS.filter(
+  (m): m is TextModelOption => m.modality === 'text'
+);
+
+export const IMAGE_MODELS: ImageModelOption[] = MODEL_OPTIONS.filter(
+  (m): m is ImageModelOption => m.modality === 'image'
+);
 
 export const MODEL_BY_ID: Record<ModelId, ModelOption> = MODEL_OPTIONS.reduce(
   (acc, m) => {
@@ -83,10 +170,30 @@ export const MODEL_BY_ID: Record<ModelId, ModelOption> = MODEL_OPTIONS.reduce(
   {} as Record<ModelId, ModelOption>
 );
 
-export const ALL_MODEL_IDS: ModelId[] = MODEL_OPTIONS.map((m) => m.id);
+export const TEXT_MODEL_BY_ID: Record<TextModelId, TextModelOption> = TEXT_MODELS.reduce(
+  (acc, m) => {
+    acc[m.id] = m;
+    return acc;
+  },
+  {} as Record<TextModelId, TextModelOption>
+);
 
-export function isModelEnabledByDefault(id: ModelId): boolean {
-  return !MODEL_BY_ID[id]?.offByDefault;
+export const IMAGE_MODEL_BY_ID: Record<ImageModelId, ImageModelOption> = IMAGE_MODELS.reduce(
+  (acc, m) => {
+    acc[m.id] = m;
+    return acc;
+  },
+  {} as Record<ImageModelId, ImageModelOption>
+);
+
+export const ALL_MODEL_IDS: ModelId[] = MODEL_OPTIONS.map((m) => m.id);
+export const TEXT_MODEL_IDS: TextModelId[] = TEXT_MODELS.map((m) => m.id);
+export const IMAGE_MODEL_IDS: ImageModelId[] = IMAGE_MODELS.map((m) => m.id);
+
+export const DEFAULT_IMAGE_MODEL_ID: ImageModelId = 'flux-pro';
+
+export function isModelEnabledByDefault(id: TextModelId): boolean {
+  return !TEXT_MODEL_BY_ID[id]?.offByDefault;
 }
 
 export const REGION_LABELS: Record<ModelRegion, string> = {


### PR DESCRIPTION
## Why

The workplace image composer used a coarse 2-option toggle (\"Standard\" / \"Flux Pro\") and the hosted BFL backend was pinned to `/v1/flux-2-pro`. We needed to expose **klein** (fast/cheap) and **max** (highest quality + grounding) and to bill them differently — one max generation should cost as much as two normal images, and two klein generations should cost as much as one. Without per-model pricing the daily 10-image quota over- or under-charges users depending on which variant they pick.

## What changed

- **Shared `catalog.ts`** is now a discriminated union over `modality: 'text' | 'image'`. The text registry is unchanged for consumers; image entries (`flux-klein`, `flux-pro`, `flux-max`, `regolo-image`, `ionos-image`) carry `backend`, `modelPath`, and `costMultiplier`. Chat consumers filter via `TEXT_MODELS`.
- **Profile** gains an *Image models* section (single-select default) below the existing chat-models section, persisting to `profiles.user_defaults.image_model` via a new ts-rest contract.
- **Composer** toolbar dropdown now lists the five image models. Per-generation selection overrides the profile default.
- **`ImageGenerationCounter`** switches to **centi-credits** internally (1 image = 100 units): `incrementCount(userId, costUnits=100)` defaults to 1 image for the four legacy call sites; the workplace path passes `Math.round(model.costMultiplier * 100)`. Public `count`/`remaining`/`limit` stay in image units (so klein renders as `0.5` remaining left of `10`). Redis `INCRBY` keeps the math precise — no floats in storage.
- **`FluxImageService.create(backend, modelPath)`** forwards the path to the BFL service; `generateFromImage` now respects the chosen model instead of hardcoding `/v1/flux-2-pro`.

Persistence intentionally stays split: chat needs per-model `{enabled}` toggles, image needs a single `defaultId`. The TypeScript registry is unified; the JSONB keys are separate.

## Out of scope (follow-ups)

- Cost-aware migration for the 4 other `incrementCount()` call sites (`imagineCreate.ts`, `imageEditing.ts`, ChatGraph image tool + node) — they still deduct 100 units flat via the default param.
- Rendering remaining-credit in the composer UI (the `usage` payload is already returned but not displayed).
- BFL endpoint paths for `flux-2-max-preview` / `flux-2-klein-9b-preview` — confirm against [docs.bfl.ml](https://docs.bfl.ml/llms.txt) before relying on production traffic.

## Test plan

- [ ] Composer: pick each variant, generate, confirm backend log shows the matching BFL path
- [ ] Profile: change default to *Flux Klein*, reload `/workplace`, confirm preselect
- [ ] Quota: `redis-cli del image_generation:<uid>:<today>`; one *Max* generation → `GET` returns `200`; one *Klein* → `250`; 16th *Klein* (`>1000`) → HTTP 429
- [ ] Chat picker still shows only text models; chat-model toggles in profile unchanged
- [ ] Sharepic / ChatGraph image flows still increment by exactly 100 units per generation