### PR TITLE
feat(chat): Automatisch model picker variant

### DIFF
--- a/apps/web/src/features/docs/DocsChatProvider.tsx
+++ b/apps/web/src/features/docs/DocsChatProvider.tsx
@@ -9,12 +9,14 @@ import {
   type AssistantRuntime,
 } from '@assistant-ui/react';
 import {
+  AUTO_MODEL_ID,
   ChatCollaborationProvider,
   ChatSurfaceProvider,
   GrueneratorAttachmentAdapter,
   convertToThreadMessageLike,
   createChatSurfaceStore,
   createGrueneratorModelAdapter,
+  resolveAutoModel,
   useChatCollaboration,
   useChatConfigStore,
   type ChatRequestContext,
@@ -22,6 +24,7 @@ import {
   type GrueneratorAdapterConfig,
 } from '@gruenerator/chat';
 import { chatThreadResponseSchema, type ChatThreadResponse } from '@gruenerator/contracts';
+import { getSystemAgent } from '@gruenerator/shared/agents';
 import { invokeDocumentAI, useEditorStore } from '@gruenerator/docs';
 import { getContractsClient } from '@gruenerator/shared/api';
 import { loadedThreadMessagesSchema } from '@gruenerator/shared/chat';
@@ -256,9 +259,18 @@ function DocsChatReadyHost({
   const getConfig = useMemo<() => GrueneratorAdapterConfig>(
     () => () => {
       const surface = surfaceStore.getState();
+      const resolvedModelId =
+        surface.selectedModel === AUTO_MODEL_ID
+          ? resolveAutoModel({
+              threadMode: surface.threadMode,
+              agent: surface.selectedAgentId
+                ? (getSystemAgent(surface.selectedAgentId) ?? null)
+                : null,
+            })
+          : (surface.selectedModel ?? '');
       return {
         agentId: surface.selectedAgentId ?? 'gruenerator-docs-editor',
-        modelId: surface.selectedModel ?? '',
+        modelId: resolvedModelId,
         enabledTools: {
           search: true,
           web: true,

--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -8,58 +8,112 @@ import {
   ResponsiveMenuSection,
   ResponsiveMenuItem,
 } from '@gruenerator/ui';
-import { isModelEnabledByDefault } from '@gruenerator/shared/models';
+import { isModelEnabledByDefault, MODEL_BY_ID } from '@gruenerator/shared/models';
+import { getSystemAgent } from '@gruenerator/shared/agents';
 
 import { composerToolbarButtonClass } from '../../lib/utils';
 import { useChatDensity } from './chatDensityContext';
-import { MODEL_OPTIONS, type ModelId } from '../../stores/chatStore';
-import { useScopedSelectedModel, useScopedSetSelectedModel } from '../../lib/useScopedAgentState';
+import { MODEL_OPTIONS } from '../../stores/chatStore';
+import {
+  useScopedAgentId,
+  useScopedSelectedModel,
+  useScopedSetSelectedModel,
+  useScopedThreadMode,
+} from '../../lib/useScopedAgentState';
 import { useModelPreferencesContext } from '../../context/ModelPreferencesContext';
+import {
+  AUTO_MODEL_ID,
+  resolveAutoModel,
+  type SelectedModel,
+} from '../../lib/resolveAutoModel';
+
+interface AutoOption {
+  id: typeof AUTO_MODEL_ID;
+  name: string;
+  description: string;
+}
+
+const AUTO_OPTION: AutoOption = {
+  id: AUTO_MODEL_ID,
+  name: 'Automatisch',
+  description: 'Wählt automatisch das passende Modell für den Kontext',
+};
 
 export const ModelPicker = memo(function ModelPicker() {
   const [menuOpen, setMenuOpen] = useState(false);
   const selectedModel = useScopedSelectedModel();
   const setSelectedModel = useScopedSetSelectedModel();
+  const selectedAgentId = useScopedAgentId();
+  const threadMode = useScopedThreadMode();
   const { enabledModelIds } = useModelPreferencesContext();
   const isCompact = useChatDensity() === 'compact';
 
-  const visibleModels = useMemo(() => {
+  const visibleCatalogModels = useMemo(() => {
     if (enabledModelIds) {
       return MODEL_OPTIONS.filter((m) => enabledModelIds.has(m.id));
     }
     return MODEL_OPTIONS.filter((m) => isModelEnabledByDefault(m.id));
   }, [enabledModelIds]);
 
-  const fallback = visibleModels[0] ?? MODEL_OPTIONS[0];
-  const current = visibleModels.find((m) => m.id === selectedModel) ?? fallback;
+  const resolvedAuto = useMemo(() => {
+    if (selectedModel !== AUTO_MODEL_ID) return null;
+    const agent = selectedAgentId ? (getSystemAgent(selectedAgentId) ?? null) : null;
+    return MODEL_BY_ID[resolveAutoModel({ threadMode, agent })];
+  }, [selectedModel, selectedAgentId, threadMode]);
+
+  const fallback = visibleCatalogModels[0] ?? MODEL_OPTIONS[0];
+  const current =
+    selectedModel === AUTO_MODEL_ID
+      ? AUTO_OPTION
+      : (visibleCatalogModels.find((m) => m.id === selectedModel) ?? fallback);
 
   useEffect(() => {
-    if (!visibleModels.length) return;
-    if (!visibleModels.some((m) => m.id === selectedModel)) {
-      setSelectedModel(visibleModels[0].id);
+    if (!visibleCatalogModels.length) return;
+    if (selectedModel === AUTO_MODEL_ID) return;
+    if (!visibleCatalogModels.some((m) => m.id === selectedModel)) {
+      setSelectedModel(visibleCatalogModels[0].id);
     }
-  }, [visibleModels, selectedModel, setSelectedModel]);
+  }, [visibleCatalogModels, selectedModel, setSelectedModel]);
 
-  const handleSelect = (id: string) => {
-    setSelectedModel(id as ModelId);
+  const handleSelect = (id: SelectedModel) => {
+    setSelectedModel(id);
     setMenuOpen(false);
   };
 
   const desktopContent = (
     <>
-      {visibleModels.map((model) => {
+      <DropdownMenuItem
+        key={AUTO_OPTION.id}
+        onSelect={() => setSelectedModel(AUTO_OPTION.id)}
+        className={cn(
+          'flex flex-col items-start gap-0.5 py-1.5',
+          selectedModel === AUTO_OPTION.id &&
+            'bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-400'
+        )}
+      >
+        <span className="text-sm font-medium leading-tight">{AUTO_OPTION.name}</span>
+        <span className="text-muted-foreground line-clamp-1 text-xs leading-tight">
+          {AUTO_OPTION.description}
+        </span>
+      </DropdownMenuItem>
+      {visibleCatalogModels.map((model) => {
         const isActive = selectedModel === model.id;
         return (
           <DropdownMenuItem
             key={model.id}
             onSelect={() => setSelectedModel(model.id)}
             className={cn(
-              'flex items-center gap-2 py-1.5',
+              'flex flex-col items-start gap-0.5 py-1.5',
               isActive &&
                 'bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-400'
             )}
           >
             <span className="text-sm font-medium leading-tight">{model.name}</span>
+            {model.description && (
+              <span className="text-muted-foreground line-clamp-1 text-xs leading-tight">
+                {model.description}
+              </span>
+            )}
           </DropdownMenuItem>
         );
       })}
@@ -68,17 +122,45 @@ export const ModelPicker = memo(function ModelPicker() {
 
   const mobileContent = (
     <ResponsiveMenuSection title="Modell">
-      {visibleModels.map((model) => (
+      <ResponsiveMenuItem
+        key={AUTO_OPTION.id}
+        active={selectedModel === AUTO_OPTION.id}
+        onClick={() => handleSelect(AUTO_OPTION.id)}
+      >
+        <span className="block font-medium">{AUTO_OPTION.name}</span>
+        <span className="text-muted-foreground block text-xs">{AUTO_OPTION.description}</span>
+      </ResponsiveMenuItem>
+      {visibleCatalogModels.map((model) => (
         <ResponsiveMenuItem
           key={model.id}
           active={selectedModel === model.id}
           onClick={() => handleSelect(model.id)}
         >
-          <span className="font-medium">{model.name}</span>
+          <span className="block font-medium">{model.name}</span>
+          {model.description && (
+            <span className="text-muted-foreground block text-xs">{model.description}</span>
+          )}
         </ResponsiveMenuItem>
       ))}
     </ResponsiveMenuSection>
   );
+
+  const triggerLabel =
+    selectedModel === AUTO_MODEL_ID && resolvedAuto ? (
+      <span className="flex flex-col items-start leading-tight">
+        <span className="text-sm font-medium">Automatisch</span>
+        <span className="text-muted-foreground text-xs">→ {resolvedAuto.name}</span>
+      </span>
+    ) : (
+      <span>{current.name}</span>
+    );
+
+  const ariaLabel =
+    selectedModel === AUTO_MODEL_ID && resolvedAuto
+      ? `Modell wählen – Automatisch (${resolvedAuto.name})`
+      : 'region' in current && current.region === 'cn'
+        ? `Modell wählen – ${current.name} (Warnhinweis)`
+        : 'Modell wählen';
 
   return (
     <ResponsiveMenu
@@ -91,13 +173,9 @@ export const ModelPicker = memo(function ModelPicker() {
         <button
           type="button"
           className={composerToolbarButtonClass(isCompact)}
-          aria-label={
-            current.region === 'cn'
-              ? `Modell wählen – ${current.name} (Warnhinweis)`
-              : 'Modell wählen'
-          }
+          aria-label={ariaLabel}
         >
-          <span>{current.name}</span>
+          {triggerLabel}
         </button>
       }
       desktopContent={desktopContent}

--- a/packages/chat/src/context/ChatSurfaceContext.tsx
+++ b/packages/chat/src/context/ChatSurfaceContext.tsx
@@ -2,14 +2,14 @@
 
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { createStore, useStore, type StoreApi } from 'zustand';
-import type { TextModelId } from '@gruenerator/shared/models';
+import type { SelectedModel } from '../lib/resolveAutoModel';
 import type { SearchMode, ThreadMode } from '../stores/chatStore';
 
 export interface ChatSurfaceState {
   selectedAgentId: string | null;
   threadMode: ThreadMode;
   searchMode: SearchMode;
-  selectedModel: TextModelId | null;
+  selectedModel: SelectedModel | null;
   selectedNotebookId: string;
   customSystemPrompt: string | null;
   customRoleName: string | null;
@@ -17,7 +17,7 @@ export interface ChatSurfaceState {
   setSelectedAgent: (agentId: string | null) => void;
   setThreadMode: (mode: ThreadMode) => void;
   setSearchMode: (mode: SearchMode) => void;
-  setSelectedModel: (model: TextModelId) => void;
+  setSelectedModel: (model: SelectedModel) => void;
   setSelectedNotebook: (id: string) => void;
   setCustomSystemPrompt: (prompt: string | null) => void;
   setCustomRoleName: (name: string | null) => void;

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -35,6 +35,13 @@ export {
   useScopedSetCustomRoleName,
   getScopedSnapshot,
 } from './lib/useScopedAgentState';
+export {
+  AUTO_MODEL_ID,
+  resolveAutoModel,
+  type AutoModelId,
+  type AutoResolverContext,
+  type SelectedModel,
+} from './lib/resolveAutoModel';
 
 // Context & API Client
 export {

--- a/packages/chat/src/lib/resolveAutoModel.ts
+++ b/packages/chat/src/lib/resolveAutoModel.ts
@@ -1,0 +1,19 @@
+import type { ModelId } from '@gruenerator/shared/models';
+import type { Agent } from '@gruenerator/shared/agents';
+import type { ThreadMode } from '../stores/chatStore';
+
+export const AUTO_MODEL_ID = 'auto' as const;
+export type AutoModelId = typeof AUTO_MODEL_ID;
+
+export type SelectedModel = ModelId | AutoModelId;
+
+export interface AutoResolverContext {
+  threadMode: ThreadMode;
+  agent: Agent | null;
+}
+
+export function resolveAutoModel(ctx: AutoResolverContext): ModelId {
+  if (ctx.threadMode === 'notebook') return 'mistral-medium-3.5';
+  if (ctx.agent?.autoRoutingHint === 'creative') return 'gemma-litellm';
+  return 'litellm';
+}

--- a/packages/chat/src/lib/useScopedAgentState.ts
+++ b/packages/chat/src/lib/useScopedAgentState.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { createStore, useStore } from 'zustand';
-import type { TextModelId } from '@gruenerator/shared/models';
+import type { SelectedModel } from './resolveAutoModel';
 import { useChatSurfaceContext, type ChatSurfaceState } from '../context/ChatSurfaceContext';
 import { useAgentStore, type SearchMode, type ThreadMode } from '../stores/chatStore';
 
@@ -45,9 +45,9 @@ export function useScopedSearchMode(): SearchMode {
   return useScopedField((s) => s.searchMode, global);
 }
 
-export function useScopedSelectedModel(): TextModelId | null {
+export function useScopedSelectedModel(): SelectedModel | null {
   const global = useAgentStore((s) => s.selectedModel);
-  return useScopedField<TextModelId | null>((s) => s.selectedModel, global);
+  return useScopedField<SelectedModel | null>((s) => s.selectedModel, global);
 }
 
 export function useScopedSelectedNotebookId(): string {
@@ -88,7 +88,7 @@ export function useScopedSetSearchMode(): (mode: SearchMode) => void {
   return (mode) => ctx.store.getState().setSearchMode(mode);
 }
 
-export function useScopedSetSelectedModel(): (model: TextModelId) => void {
+export function useScopedSetSelectedModel(): (model: SelectedModel) => void {
   const ctx = useChatSurfaceContext();
   const globalSet = useAgentStore((s) => s.setSelectedModel);
   if (!ctx) return globalSet;

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -21,9 +21,11 @@ import {
   RuntimeAdapterProvider,
   ExportedMessageRepository,
 } from '@assistant-ui/react';
-import { type TextModelId } from '@gruenerator/shared/models';
+import { type ModelId } from '@gruenerator/shared/models';
+import { getSystemAgent } from '@gruenerator/shared/agents';
 import { createChatApiClient } from '../context/ChatContext';
 import { useAgentStore } from '../stores/chatStore';
+import { AUTO_MODEL_ID, resolveAutoModel } from '../lib/resolveAutoModel';
 import { useChatConfigStore, type ChatConfig } from '../stores/chatConfigStore';
 import { getDefaultAgent } from '../lib/agents';
 import { useChatCollaboration } from '../hooks/useChatCollaboration';
@@ -59,7 +61,7 @@ interface GrueneratorChatProviderProps {
   getExternalThreads?: () => ExternalThreadEntry[];
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
-  enabledModelIds?: ReadonlySet<TextModelId> | null;
+  enabledModelIds?: ReadonlySet<ModelId> | null;
 }
 
 interface PersistedToolCall {
@@ -279,10 +281,17 @@ function useGrueneratorThreadRuntime() {
   const compactionState = useAgentStore((s) => s.compactionState);
   const triggerCompaction = useAgentStore((s) => s.triggerCompaction);
 
-  const getConfig = useCallback(
-    (): GrueneratorAdapterConfig => ({
+  const getConfig = useCallback((): GrueneratorAdapterConfig => {
+    const resolvedModelId =
+      selectedModel === AUTO_MODEL_ID
+        ? resolveAutoModel({
+            threadMode,
+            agent: selectedAgentId ? (getSystemAgent(selectedAgentId) ?? null) : null,
+          })
+        : selectedModel;
+    return {
       agentId: selectedAgentId,
-      modelId: selectedModel,
+      modelId: resolvedModelId,
       enabledTools,
       threadId: useAgentStore.getState().currentThreadId,
       selectedNotebookId,
@@ -292,20 +301,19 @@ function useGrueneratorThreadRuntime() {
       customRoleName,
       customEnabledTools,
       activeSkillMention,
-    }),
-    [
-      selectedAgentId,
-      selectedModel,
-      enabledTools,
-      selectedNotebookId,
-      threadMode,
-      searchMode,
-      customSystemPrompt,
-      customRoleName,
-      customEnabledTools,
-      activeSkillMention,
-    ]
-  );
+    };
+  }, [
+    selectedAgentId,
+    selectedModel,
+    enabledTools,
+    selectedNotebookId,
+    threadMode,
+    searchMode,
+    customSystemPrompt,
+    customRoleName,
+    customEnabledTools,
+    activeSkillMention,
+  ]);
 
   const fetchFn = useChatConfigStore((s) => s.fetch);
   const onUnauthorized = useChatConfigStore((s) => s.onUnauthorized);

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -1,18 +1,17 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import {
-  TEXT_MODELS,
-  TEXT_MODEL_BY_ID,
-  type TextModelId,
-  type TextModelOption,
-  type TextProvider,
+  MODEL_OPTIONS,
+  MODEL_BY_ID,
+  type ModelId,
+  type ModelOption,
+  type Provider,
 } from '@gruenerator/shared/models';
+import { AUTO_MODEL_ID, type AutoModelId, type SelectedModel } from '../lib/resolveAutoModel';
 import type { ChatApiClient } from '../context/ChatContext';
 
-export const MODEL_OPTIONS = TEXT_MODELS;
-export type ModelId = TextModelId;
-export type ModelOption = TextModelOption;
-export type Provider = TextProvider;
+export { MODEL_OPTIONS, AUTO_MODEL_ID };
+export type { ModelId, ModelOption, Provider, AutoModelId, SelectedModel };
 
 export interface CompactionState {
   summary: string | null;
@@ -75,7 +74,7 @@ interface ThreadSettings {
 interface AgentState {
   selectedAgentId: string | null;
   selectedProvider: Provider;
-  selectedModel: ModelId;
+  selectedModel: SelectedModel;
   currentThreadId: string | null;
   currentThreadTitle: string | null;
   enabledTools: Record<ToolKey, boolean>;
@@ -100,7 +99,7 @@ interface AgentState {
   setActiveSkillMention: (mention: string | null) => void;
   setSelectedAgent: (agentId: string | null) => void;
   setSelectedProvider: (provider: Provider) => void;
-  setSelectedModel: (model: ModelId) => void;
+  setSelectedModel: (model: SelectedModel) => void;
   setCurrentThread: (threadId: string | null) => void;
   setCurrentThreadTitle: (title: string | null) => void;
   toggleTool: (tool: ToolKey) => void;
@@ -169,7 +168,11 @@ export const useAgentStore = create<AgentState>()(
       setSelectedProvider: (provider) => set({ selectedProvider: provider }),
 
       setSelectedModel: (model) => {
-        const modelOption = TEXT_MODEL_BY_ID[model];
+        if (model === AUTO_MODEL_ID) {
+          set({ selectedModel: model });
+          return;
+        }
+        const modelOption = MODEL_OPTIONS.find((m) => m.id === model);
         if (modelOption) {
           set({ selectedModel: model, selectedProvider: modelOption.provider });
         }
@@ -390,7 +393,7 @@ export const useAgentStore = create<AgentState>()(
         }
         if (version < 8) {
           const current = state.selectedModel as string | undefined;
-          const def = current ? TEXT_MODEL_BY_ID[current as TextModelId] : undefined;
+          const def = current ? MODEL_BY_ID[current as ModelId] : undefined;
           if (def?.offByDefault) {
             state.selectedModel = 'gemma-litellm';
             state.selectedProvider = 'litellm';

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -178,6 +178,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit',
+    autoRoutingHint: 'creative',
     title: 'Öffentlichkeitsarbeit',
     iconKey: 'megaphone',
     pinnedToSidebar: true,
@@ -245,6 +246,7 @@ const BASE_AGENTS = [
   // wrong LV. Skills `/presse-<lv>` and `/social-<lv>` route to these agents.
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-berlin',
+    autoRoutingHint: 'creative',
     slug: 'gruene-berlin',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Berlin',
@@ -286,6 +288,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
+    autoRoutingHint: 'creative',
     slug: 'gruene-hamburg',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Hamburg',
@@ -327,6 +330,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
+    autoRoutingHint: 'creative',
     slug: 'gruene-mv',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit MV',
@@ -368,6 +372,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
+    autoRoutingHint: 'creative',
     slug: 'gruene-thueringen',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Thüringen',
@@ -409,6 +414,7 @@ const BASE_AGENTS = [
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
+    autoRoutingHint: 'creative',
     slug: 'gruene-brandenburg',
     audience: 'de-DE',
     title: 'Öffentlichkeitsarbeit Brandenburg',
@@ -457,6 +463,7 @@ const BASE_AGENTS = [
   // deutscher Landesverbands-PMs.
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-at',
+    autoRoutingHint: 'creative',
     slug: 'gruene-oesterreich',
     audience: 'de-AT',
     title: 'Öffentlichkeitsarbeit Österreich',
@@ -710,6 +717,7 @@ Beispielausgabe:
   {
     iconKey: 'microphone',
     identifier: 'gruenerator-rede-schreiber',
+    autoRoutingHint: 'creative',
     title: 'Rede',
     description:
       'Erstellt überzeugende politische Reden für {{partyName}} mit Einstiegsideen, Kernargumenten und Tipps für die*den Redner*in.',
@@ -766,6 +774,7 @@ Beispielausgabe:
   {
     iconKey: 'book-open-text',
     identifier: 'gruenerator-wahlprogramm',
+    autoRoutingHint: 'creative',
     title: 'Wahlprogramm',
     description:
       'Erstellt strukturierte Wahlprogramm-Kapitel mit konkreten Forderungen und zukunftsorientierter Sprache.',
@@ -1035,6 +1044,7 @@ Schritt 6: Überarbeite bei Score unter 4.`;
 
 const LV_PR_AGENTS: Agent[] = LV_PR_SPECS.map((spec) => ({
   identifier: `gruenerator-oeffentlichkeitsarbeit-${spec.lv}`,
+  autoRoutingHint: 'creative',
   audience: 'de-DE',
   title: `Öffentlichkeitsarbeit (${spec.title})`,
   description: `Erstellt Pressemitteilungen und Social-Media-Inhalte für die Grünen ${spec.title} — mit regionaler Verankerung und LV-spezifischen Vorlagen.`,

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -131,6 +131,13 @@ export interface Agent {
    */
   defaultNotebookId?: string;
   /**
+   * Routing hint for the "Automatisch" model picker. Read by the frontend
+   * resolver (`resolveAutoModel`) to map this agent to a context-appropriate
+   * model without hand-curating ID lists. `'creative'` → Gemma 4 today;
+   * `'research'` is reserved for a future bucket.
+   */
+  autoRoutingHint?: 'creative' | 'research';
+  /**
    * Frontend icon registry key. Maps to a `react-icons` component in
    * `apps/web/src/components/layout/Sidebar/sidebarAgentConfig.ts::ICON_REGISTRY`.
    * Per-LV `gruenerator-oeffentlichkeitsarbeit-*` agents inherit the megaphone


### PR DESCRIPTION
## Why

Users currently have to pick one of 5 concrete models for every conversation, with no signal in the picker about which one fits the task. Most users don't actually know the difference and just leave the default. Adds an "Automatisch" option that resolves the model from context the picker already knows about — notebook mode, agent type — so the right model is picked without users having to think about it.

Routing rules (all live in a single pure resolver, `packages/chat/src/lib/resolveAutoModel.ts`):

| Context | Picked model |
|---|---|
| Notebook conversation (`threadMode === 'notebook'`) | Mistral Medium 3.5 |
| Creative-writing agent (`agent.autoRoutingHint === 'creative'`) | Gemma 4 |
| Everything else | GPT-OSS |

## Type-safety properties

- `'auto'` is a literal-typed sentinel widened into `SelectedModel = ModelId \| 'auto'` — every consumer that exhaustively switches on the union gets a compile error and is forced to handle Automatisch explicitly.
- The resolver consumes typed objects (`Agent \| null`, `ThreadMode`) and returns the exact `ModelId` union — `'auto'` disappears from the type the moment it crosses the resolver, so downstream consumers (request body, network) never see it.
- A new `autoRoutingHint: 'creative' \| 'research'` field on `Agent` replaces what would otherwise be a hand-curated `Set<string>` of magic identifiers (compiles even if you typo). `'research'` is reserved in the union for a future bucket.

## Resolution seam

Resolution happens client-side in `getConfig()` so the picker trigger can show `"Automatisch → Gemma 4"` (user-visible model choice). The backend always receives a concrete `modelId` — its existing `'auto'` short-circuit in `responseStreamingService.ts:71` stays as defensive coverage but isn't on the live path. `DocsChatProvider` gets the same resolver wired in so the docs surface behaves identically.

## v1 scope (deferred)

- Live `@skill`-mention routing (eg. `@insta-hamburg` → Gemma) requires either a composer-side mentions hook or moving the resolver into the adapter. Today, skills route correctly when invoked through a creative-tagged wrapper agent.
- `'research'` consumers (no agent uses it yet).
- Backend intent-classifier-driven routing — considered, rejected for v1 since the 3 rules above are all derivable from frontend state.

## Test plan

- [ ] Open `/chat`, confirm "Automatisch" appears at the top of the picker with the German subtitle
- [ ] Pick it — trigger shows two-line `"Automatisch / → GPT-OSS"` (general agent default)
- [ ] Switch to Rede-Schreiber — trigger updates live to `"→ Gemma 4"`
- [ ] Toggle notebook mode — trigger updates to `"→ Mistral Medium"`
- [ ] Network tab: request body's `modelId` is always the resolved concrete ID, never `'auto'`