### PR TITLE
feat(images): unify Bilder modes into composer + Flux family selector

### DIFF
--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ImageModelSettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ImageModelSettingsSection.tsx
@@ -1,9 +1,14 @@
 import {
-  IMAGE_MODELS,
+  FLUX_VARIANT_ORDER,
+  IMAGE_FAMILIES,
+  IMAGE_MODEL_BY_ID,
   REGION_LABELS,
   REGION_ORDER,
+  getDefaultModelForFamily,
+  getImageFamily,
+  type ImageFamilyId,
+  type ImageFamilyOption,
   type ImageModelId,
-  type ImageModelOption,
   type ModelRegion,
 } from '@gruenerator/shared/models';
 import { Info } from 'lucide-react';
@@ -16,12 +21,12 @@ interface ImageModelSettingsSectionProps {
   onErrorMessage: (message: string) => void;
 }
 
-function groupByRegion(models: ImageModelOption[]): Map<ModelRegion, ImageModelOption[]> {
-  const grouped = new Map<ModelRegion, ImageModelOption[]>();
-  for (const model of models) {
-    const list = grouped.get(model.region) ?? [];
-    list.push(model);
-    grouped.set(model.region, list);
+function groupByRegion(families: ImageFamilyOption[]): Map<ModelRegion, ImageFamilyOption[]> {
+  const grouped = new Map<ModelRegion, ImageFamilyOption[]>();
+  for (const family of families) {
+    const list = grouped.get(family.region) ?? [];
+    list.push(family);
+    grouped.set(family.region, list);
   }
   return grouped;
 }
@@ -35,14 +40,26 @@ function formatCost(multiplier: number): string {
 const ImageModelSettingsSection = React.memo(
   ({ onSuccessMessage, onErrorMessage }: ImageModelSettingsSectionProps) => {
     const { defaultImageModel, isLoading, setDefaultImageModel } = useImageModelPreference();
-    const grouped = groupByRegion(IMAGE_MODELS);
+    const grouped = groupByRegion(IMAGE_FAMILIES);
 
-    const handleSelect = async (modelId: ImageModelId, label: string) => {
+    const selectedFamily = getImageFamily(defaultImageModel);
+
+    const handleSelectFamily = async (familyId: ImageFamilyId, label: string) => {
       try {
-        await setDefaultImageModel(modelId);
+        const nextModel = getDefaultModelForFamily(familyId);
+        await setDefaultImageModel(nextModel);
         onSuccessMessage(`Standard-Bildmodell auf ${label} gesetzt.`);
       } catch {
         onErrorMessage('Bildmodell-Einstellung konnte nicht gespeichert werden.');
+      }
+    };
+
+    const handleSelectFluxVariant = async (variantId: ImageModelId) => {
+      try {
+        await setDefaultImageModel(variantId);
+        onSuccessMessage(`Flux-Variante auf ${IMAGE_MODEL_BY_ID[variantId].name} gesetzt.`);
+      } catch {
+        onErrorMessage('Flux-Variante konnte nicht gespeichert werden.');
       }
     };
 
@@ -73,8 +90,8 @@ const ImageModelSettingsSection = React.memo(
         </div>
 
         {REGION_ORDER.map((region) => {
-          const models = grouped.get(region);
-          if (!models?.length) return null;
+          const families = grouped.get(region);
+          if (!families?.length) return null;
 
           return (
             <div
@@ -86,35 +103,63 @@ const ImageModelSettingsSection = React.memo(
               </div>
 
               <div className="divide-y divide-grey-100 dark:divide-grey-800">
-                {models.map((model) => {
-                  const isSelected = defaultImageModel === model.id;
+                {families.map((family) => {
+                  const isSelected = selectedFamily === family.id;
 
                   return (
-                    <label
-                      key={model.id}
-                      className={`flex items-start gap-md px-md py-sm cursor-pointer hover:bg-grey-50 dark:hover:bg-grey-800/30 transition-colors ${
-                        isSelected ? 'bg-secondary-50 dark:bg-secondary-950/20' : ''
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="default-image-model"
-                        value={model.id}
-                        checked={isSelected}
-                        onChange={() => handleSelect(model.id, model.name)}
-                        className="mt-1 shrink-0 accent-secondary-600"
-                        aria-label={`${model.name} als Standard wählen`}
-                      />
-                      <div className="grow min-w-0">
-                        <p className="text-sm font-medium text-foreground">{model.name}</p>
-                        <p className="text-xs text-grey-500 dark:text-grey-400">
-                          {model.description}
-                        </p>
-                        <p className="text-xs text-grey-400 dark:text-grey-500 mt-xs">
-                          {formatCost(model.costMultiplier)}
-                        </p>
-                      </div>
-                    </label>
+                    <div key={family.id}>
+                      <label
+                        className={`flex items-start gap-md px-md py-sm cursor-pointer hover:bg-grey-50 dark:hover:bg-grey-800/30 transition-colors ${
+                          isSelected ? 'bg-secondary-50 dark:bg-secondary-950/20' : ''
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="default-image-family"
+                          value={family.id}
+                          checked={isSelected}
+                          onChange={() => handleSelectFamily(family.id, family.name)}
+                          className="mt-1 shrink-0 accent-secondary-600"
+                          aria-label={`${family.name} als Standard wählen`}
+                        />
+                        <div className="grow min-w-0">
+                          <p className="text-sm font-medium text-foreground">{family.name}</p>
+                          <p className="text-xs text-grey-500 dark:text-grey-400">
+                            {family.description}
+                          </p>
+                        </div>
+                      </label>
+
+                      {isSelected && family.id === 'flux' && (
+                        <div className="px-md pb-sm pl-xl">
+                          <p className="text-xs text-grey-500 dark:text-grey-400 mb-xs">
+                            Flux-Variante:
+                          </p>
+                          <div className="flex flex-wrap gap-xs">
+                            {FLUX_VARIANT_ORDER.map((variantId) => {
+                              const variant = IMAGE_MODEL_BY_ID[variantId];
+                              const isVariantSelected = defaultImageModel === variantId;
+                              return (
+                                <button
+                                  key={variantId}
+                                  type="button"
+                                  onClick={() => handleSelectFluxVariant(variantId)}
+                                  className={`rounded-md border px-sm py-xs text-xs transition-colors ${
+                                    isVariantSelected
+                                      ? 'border-secondary-600 bg-secondary-50 text-secondary-700 dark:bg-secondary-950/30 dark:text-secondary-300'
+                                      : 'border-grey-200 dark:border-grey-700 text-grey-600 dark:text-grey-300 hover:border-grey-300 dark:hover:border-grey-600'
+                                  }`}
+                                  title={formatCost(variant.costMultiplier)}
+                                >
+                                  {variant.name.replace(/^Flux /, '')} ·{' '}
+                                  {formatCost(variant.costMultiplier)}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
               </div>

--- a/apps/web/src/features/texte/modes/imagine.ts
+++ b/apps/web/src/features/texte/modes/imagine.ts
@@ -1,4 +1,4 @@
-import { IMAGE_MODELS, DEFAULT_IMAGE_MODEL_ID } from '@gruenerator/shared/models';
+import { DEFAULT_IMAGE_MODEL_ID } from '@gruenerator/shared/models';
 
 import type { ModeDefinition } from './types';
 
@@ -23,12 +23,6 @@ export const imagineMode: ModeDefinition = {
         { id: 'realistic-pure', label: 'Realistisch' },
         { id: 'pixel-pure', label: 'Pixel Art' },
       ],
-      multiple: false,
-    },
-    {
-      key: 'imageModel',
-      label: 'Modell',
-      options: IMAGE_MODELS.map((m) => ({ id: m.id, label: m.name })),
       multiple: false,
     },
   ],

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -1,12 +1,18 @@
 import { getGlobalApiClient } from '@gruenerator/shared/api';
+import {
+  FLUX_VARIANT_ORDER,
+  IMAGE_FAMILIES,
+  IMAGE_MODEL_BY_ID,
+  getDefaultModelForFamily,
+  getImageFamily,
+  type ImageFamilyId,
+  type ImageModelId,
+} from '@gruenerator/shared/models';
 import { useShareStore } from '@gruenerator/shared/share';
 import {
   AIPromptInput,
   Button,
   SettingsDropdown,
-  pillBase,
-  pillInactive,
-  pillActive,
   type SettingConfig,
 } from '@gruenerator/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -25,15 +31,37 @@ import { cn } from '@/utils/cn';
 
 type SubMode = 'erstellen' | 'bearbeiten' | 'vergroessern';
 
-const SUB_TABS: ReadonlyArray<{ id: SubMode; label: string }> = [
-  { id: 'erstellen', label: 'Erstellen' },
-  { id: 'bearbeiten', label: 'Bearbeiten' },
-  { id: 'vergroessern', label: 'Vergrößern' },
-];
+const SUB_MODE_CONFIG: SettingConfig = {
+  key: 'subMode',
+  label: 'Modus',
+  options: [
+    { id: 'erstellen', label: 'Erstellen' },
+    { id: 'bearbeiten', label: 'Bearbeiten' },
+    { id: 'vergroessern', label: 'Vergrößern' },
+  ],
+  multiple: false,
+};
 
 const ERSTELLEN_MODE_ID = 'imagine';
 const BEARBEITEN_MODE_ID = 'bild-bearbeiten';
 const VERGROESSERN_MODE_ID = 'bild-vergroessern';
+
+const IMAGE_FAMILY_CONFIG: SettingConfig = {
+  key: 'imageFamily',
+  label: 'Modell',
+  options: IMAGE_FAMILIES.map((f) => ({ id: f.id, label: f.name })),
+  multiple: false,
+};
+
+const FLUX_VARIANT_CONFIG: SettingConfig = {
+  key: 'fluxVariant',
+  label: 'Variante',
+  options: FLUX_VARIANT_ORDER.map((id) => ({
+    id,
+    label: IMAGE_MODEL_BY_ID[id].name.replace(/^Flux /, ''),
+  })),
+  multiple: false,
+};
 
 type AspectRatio = '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
 
@@ -307,24 +335,7 @@ const BilderInner: React.FC = memo(() => {
     link.click();
   }, [resultImage, isErstellen, isBearbeiten]);
 
-  const erstellenToolbar = useMemo(() => {
-    if (!erstellenDef?.settings?.length && !usage) return null;
-    return (
-      <>
-        {erstellenDef?.settings?.map((config) => (
-          <SettingsDropdown
-            key={config.key}
-            config={config}
-            value={(modeState[config.key] as string) ?? ''}
-            onChange={(val) => updateField(config.key, val as string)}
-          />
-        ))}
-        {usage && <UsageBadge usage={usage} />}
-      </>
-    );
-  }, [erstellenDef?.settings, modeState, updateField, usage]);
-
-  const bearbeitenToolbar = useMemo(
+  const filePickerPill = useMemo(
     () =>
       sourcePreviewUrl ? (
         <div className="flex items-center gap-1.5 rounded-md border border-grey-200 dark:border-grey-700 bg-background-pure pl-1 pr-1.5 py-0.5">
@@ -354,42 +365,83 @@ const BilderInner: React.FC = memo(() => {
     [sourcePreviewUrl, sourceFile, clearSource]
   );
 
-  const vergroessernToolbar = useMemo(
+  const selectedImageModel = (modeState.imageModel as ImageModelId | undefined) ?? null;
+  const selectedFamily: ImageFamilyId | null = selectedImageModel
+    ? getImageFamily(selectedImageModel)
+    : null;
+
+  const handleFamilyChange = useCallback(
+    (familyId: ImageFamilyId) => {
+      updateField('imageModel', getDefaultModelForFamily(familyId));
+    },
+    [updateField]
+  );
+
+  const handleFluxVariantChange = useCallback(
+    (variantId: ImageModelId) => {
+      updateField('imageModel', variantId);
+    },
+    [updateField]
+  );
+
+  const toolbar = useMemo(
     () => (
       <>
-        {sourcePreviewUrl ? (
-          <div className="flex items-center gap-1.5 rounded-md border border-grey-200 dark:border-grey-700 bg-background-pure pl-1 pr-1.5 py-0.5">
-            <img src={sourcePreviewUrl} alt="" className="size-6 object-cover rounded" />
-            <span className="text-xs text-grey-600 dark:text-grey-300 max-w-[120px] truncate">
-              {sourceFile?.name ?? 'Bild'}
-            </span>
-            <button
-              type="button"
-              onClick={clearSource}
-              className="text-grey-400 hover:text-grey-600 dark:hover:text-grey-200"
-              aria-label="Bild entfernen"
-            >
-              <X className="size-3.5" />
-            </button>
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={() => fileInputRef.current?.click()}
-            className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
-          >
-            <ImagePlus className="size-3.5" />
-            Bild hochladen
-          </button>
-        )}
         <SettingsDropdown
-          config={ASPECT_RATIO_CONFIG}
-          value={aspectRatio}
-          onChange={(val) => setAspectRatio(val as AspectRatio)}
+          config={SUB_MODE_CONFIG}
+          value={subMode}
+          onChange={(val) => setSubMode(val as SubMode)}
         />
+        {isErstellen &&
+          erstellenDef?.settings?.map((config) => (
+            <SettingsDropdown
+              key={config.key}
+              config={config}
+              value={(modeState[config.key] as string) ?? ''}
+              onChange={(val) => updateField(config.key, val as string)}
+            />
+          ))}
+        {isErstellen && (
+          <SettingsDropdown
+            config={IMAGE_FAMILY_CONFIG}
+            value={selectedFamily ?? 'flux'}
+            onChange={(val) => handleFamilyChange(val as ImageFamilyId)}
+          />
+        )}
+        {isErstellen && selectedFamily === 'flux' && (
+          <SettingsDropdown
+            config={FLUX_VARIANT_CONFIG}
+            value={selectedImageModel ?? 'flux-pro'}
+            onChange={(val) => handleFluxVariantChange(val as ImageModelId)}
+          />
+        )}
+        {(isBearbeiten || isVergroessern) && filePickerPill}
+        {isVergroessern && (
+          <SettingsDropdown
+            config={ASPECT_RATIO_CONFIG}
+            value={aspectRatio}
+            onChange={(val) => setAspectRatio(val as AspectRatio)}
+          />
+        )}
+        {usage && <UsageBadge usage={usage} />}
       </>
     ),
-    [sourcePreviewUrl, sourceFile, clearSource, aspectRatio]
+    [
+      subMode,
+      isErstellen,
+      isBearbeiten,
+      isVergroessern,
+      erstellenDef?.settings,
+      modeState,
+      updateField,
+      selectedFamily,
+      selectedImageModel,
+      handleFamilyChange,
+      handleFluxVariantChange,
+      filePickerPill,
+      aspectRatio,
+      usage,
+    ]
   );
 
   const loading = isErstellen ? createLoading : isBearbeiten ? editLoading : outpaintLoading;
@@ -400,11 +452,6 @@ const BilderInner: React.FC = memo(() => {
     : isBearbeiten
       ? editError
       : outpaintError;
-  const toolbar = isErstellen
-    ? erstellenToolbar
-    : isBearbeiten
-      ? bearbeitenToolbar
-      : vergroessernToolbar;
   const altText = isErstellen
     ? 'Generiertes Bild'
     : isBearbeiten
@@ -413,22 +460,6 @@ const BilderInner: React.FC = memo(() => {
 
   return (
     <div className="flex flex-col gap-md">
-      <div className="flex justify-center gap-1.5">
-        {SUB_TABS.map((tab) => {
-          const active = tab.id === subMode;
-          return (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => setSubMode(tab.id)}
-              className={cn(pillBase, active ? pillActive : pillInactive)}
-            >
-              {tab.label}
-            </button>
-          );
-        })}
-      </div>
-
       <input
         ref={fileInputRef}
         type="file"

--- a/packages/shared/src/models/catalog.ts
+++ b/packages/shared/src/models/catalog.ts
@@ -33,12 +33,22 @@ export interface TextModelOption extends BaseModelOption {
   offByDefault?: boolean;
 }
 
+export type ImageFamilyId = 'flux' | 'regolo' | 'ionos';
+
 export interface ImageModelOption extends BaseModelOption {
   modality: 'image';
   id: ImageModelId;
+  family: ImageFamilyId;
   backend: ImageBackend;
   modelPath?: string;
   costMultiplier: number;
+}
+
+export interface ImageFamilyOption {
+  id: ImageFamilyId;
+  name: string;
+  description: string;
+  region: ModelRegion;
 }
 
 export type ModelOption = TextModelOption | ImageModelOption;
@@ -102,8 +112,9 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'image',
     id: 'flux-pro',
-    name: '⭐ Flux Pro',
-    description: 'Ausgewogen — Standard für produktive Bildgenerierung',
+    family: 'flux',
+    name: 'Flux Pro',
+    description: 'Ausgewogen — Standard',
     backend: 'hosted',
     modelPath: '/v1/flux-2-pro',
     costMultiplier: 1,
@@ -113,7 +124,8 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'image',
     id: 'flux-klein',
-    name: '⚡ Flux Klein',
+    family: 'flux',
+    name: 'Flux Klein',
     description: 'Schnell & günstig — verbraucht nur ½ Bild pro Generation',
     backend: 'hosted',
     modelPath: '/v1/flux-2-klein-9b',
@@ -124,7 +136,8 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'image',
     id: 'flux-max',
-    name: '👑 Flux Max',
+    family: 'flux',
+    name: 'Flux Max',
     description: 'Höchste Qualität & Recherche — verbraucht 2 Bilder pro Generation',
     backend: 'hosted',
     modelPath: '/v1/flux-2-max',
@@ -135,6 +148,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'image',
     id: 'regolo-image',
+    family: 'regolo',
     name: '🌳 Qwen-Image',
     description: 'Selbst gehostet, klimaneutral',
     backend: 'regolo',
@@ -145,14 +159,44 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'image',
     id: 'ionos-image',
-    name: 'IONOS Schnell',
-    description: 'EU-Cloud, FLUX.1-schnell',
+    family: 'ionos',
+    name: '🌳 IONOS Schnell',
+    description: 'EU-Cloud, klimaneutral',
     backend: 'ionos',
     costMultiplier: 1,
     icon: 'server',
-    region: 'eu',
+    region: 'self-hosted',
   },
 ];
+
+export const IMAGE_FAMILIES: ImageFamilyOption[] = [
+  { id: 'flux', name: '⭐ Flux', description: 'Black Forest Labs (EU)', region: 'eu' },
+  {
+    id: 'regolo',
+    name: '🌳 Qwen-Image',
+    description: 'Selbst gehostet, klimaneutral',
+    region: 'self-hosted',
+  },
+  {
+    id: 'ionos',
+    name: '🌳 IONOS Schnell',
+    description: 'EU-Cloud, klimaneutral',
+    region: 'self-hosted',
+  },
+];
+
+export const DEFAULT_FLUX_MODEL_ID: ImageModelId = 'flux-pro';
+export const FLUX_VARIANT_ORDER: ImageModelId[] = ['flux-klein', 'flux-pro', 'flux-max'];
+
+export function getImageFamily(id: ImageModelId): ImageFamilyId {
+  return IMAGE_MODEL_BY_ID[id].family;
+}
+
+export function getDefaultModelForFamily(family: ImageFamilyId): ImageModelId {
+  if (family === 'flux') return DEFAULT_FLUX_MODEL_ID;
+  if (family === 'regolo') return 'regolo-image';
+  return 'ionos-image';
+}
 
 export const TEXT_MODELS: TextModelOption[] = MODEL_OPTIONS.filter(
   (m): m is TextModelOption => m.modality === 'text'


### PR DESCRIPTION
## Why

The Bilder tab has been growing in surface area. Three friction points from the most-recent batch:

- The Erstellen / Bearbeiten / Vergrößern selector lived above the composer as pill buttons, separated from the per-mode settings — users had to scan two rows to figure out what they were doing.
- Flux's three variants (klein/pro/max) sat next to two unrelated providers (Regolo, IONOS) as a flat 5-option list. They share the same family but were treated as peers, hiding the natural grouping.
- IONOS Schnell was tagged region: 'eu' even though IONOS markets its hyperscaler as EU green-energy hosting — visually it should have the same 🌳 climate-neutral marker as Regolo Qwen-Image.

## What changed

- **Composer toolbar**: the pill row is gone. First toolbar entry is a 'Modus' dropdown (Erstellen / Bearbeiten / Vergrößern). The pill-row block is removed from BilderInner's render tree entirely.
- **Flux family**: `ImageModelOption.family: 'flux' | 'regolo' | 'ionos'` added to the catalog. The model picker (in both profile and composer) now lists the three families. Selecting Flux exposes a second dropdown with klein / pro / max. Default flux variant is pro (the medium one).
- **IONOS marker**: name updated to '🌳 IONOS Schnell', region moved to 'self-hosted', description switched to 'EU-Cloud, klimaneutral'.
- **Helpers**: new `getImageFamily(id)` and `getDefaultModelForFamily(family)` exported from the catalog so backend services and frontend share the same family logic.

Storage shape is unchanged: `user_defaults.image_model.default` still holds the leaf id (`flux-pro`, `flux-klein`, `flux-max`, `regolo-image`, `ionos-image`). The family is derived, not persisted.

## Test plan

- [ ] Bilder → toolbar shows Modus dropdown first, then mode-specific settings, then usage badge
- [ ] Switching to Bearbeiten/Vergrößern shows the file picker and (for Vergrößern) the aspect-ratio dropdown
- [ ] Picking Flux in the Modell dropdown surfaces the Variante dropdown; picking Regolo or IONOS hides it
- [ ] Profile → Bildmodelle shows three families; expanding Flux reveals klein/pro/max chips with cost hint
- [ ] IONOS appears under 'Klimaneutral' in profile (same group as Qwen-Image)
- [ ] Backend still resolves correct cost multiplier across all 5 leaf models