### PR TITLE
fix(chat): narrow ModelId/MODEL_BY_ID to text-only types

### DIFF
--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -8,7 +8,7 @@ import {
   ResponsiveMenuSection,
   ResponsiveMenuItem,
 } from '@gruenerator/ui';
-import { isModelEnabledByDefault, MODEL_BY_ID } from '@gruenerator/shared/models';
+import { isModelEnabledByDefault, TEXT_MODEL_BY_ID } from '@gruenerator/shared/models';
 import { getSystemAgent } from '@gruenerator/shared/agents';
 
 import { composerToolbarButtonClass } from '../../lib/utils';
@@ -58,7 +58,7 @@ export const ModelPicker = memo(function ModelPicker() {
   const resolvedAuto = useMemo(() => {
     if (selectedModel !== AUTO_MODEL_ID) return null;
     const agent = selectedAgentId ? (getSystemAgent(selectedAgentId) ?? null) : null;
-    return MODEL_BY_ID[resolveAutoModel({ threadMode, agent })];
+    return TEXT_MODEL_BY_ID[resolveAutoModel({ threadMode, agent })];
   }, [selectedModel, selectedAgentId, threadMode]);
 
   const fallback = visibleCatalogModels[0] ?? MODEL_OPTIONS[0];

--- a/packages/chat/src/lib/resolveAutoModel.ts
+++ b/packages/chat/src/lib/resolveAutoModel.ts
@@ -1,18 +1,18 @@
-import type { ModelId } from '@gruenerator/shared/models';
+import type { TextModelId } from '@gruenerator/shared/models';
 import type { Agent } from '@gruenerator/shared/agents';
 import type { ThreadMode } from '../stores/chatStore';
 
 export const AUTO_MODEL_ID = 'auto' as const;
 export type AutoModelId = typeof AUTO_MODEL_ID;
 
-export type SelectedModel = ModelId | AutoModelId;
+export type SelectedModel = TextModelId | AutoModelId;
 
 export interface AutoResolverContext {
   threadMode: ThreadMode;
   agent: Agent | null;
 }
 
-export function resolveAutoModel(ctx: AutoResolverContext): ModelId {
+export function resolveAutoModel(ctx: AutoResolverContext): TextModelId {
   if (ctx.threadMode === 'notebook') return 'mistral-medium-3.5';
   if (ctx.agent?.autoRoutingHint === 'creative') return 'gemma-litellm';
   return 'litellm';

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -21,7 +21,7 @@ import {
   RuntimeAdapterProvider,
   ExportedMessageRepository,
 } from '@assistant-ui/react';
-import { type ModelId } from '@gruenerator/shared/models';
+import { type TextModelId } from '@gruenerator/shared/models';
 import { getSystemAgent } from '@gruenerator/shared/agents';
 import { createChatApiClient } from '../context/ChatContext';
 import { useAgentStore } from '../stores/chatStore';
@@ -61,7 +61,7 @@ interface GrueneratorChatProviderProps {
   getExternalThreads?: () => ExternalThreadEntry[];
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
-  enabledModelIds?: ReadonlySet<ModelId> | null;
+  enabledModelIds?: ReadonlySet<TextModelId> | null;
 }
 
 interface PersistedToolCall {

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -1,17 +1,21 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import {
-  MODEL_OPTIONS,
-  MODEL_BY_ID,
-  type ModelId,
-  type ModelOption,
-  type Provider,
+  TEXT_MODELS,
+  TEXT_MODEL_BY_ID,
+  type TextModelId,
+  type TextModelOption,
+  type TextProvider,
 } from '@gruenerator/shared/models';
 import { AUTO_MODEL_ID, type AutoModelId, type SelectedModel } from '../lib/resolveAutoModel';
 import type { ChatApiClient } from '../context/ChatContext';
 
-export { MODEL_OPTIONS, AUTO_MODEL_ID };
-export type { ModelId, ModelOption, Provider, AutoModelId, SelectedModel };
+export const MODEL_OPTIONS = TEXT_MODELS;
+export { AUTO_MODEL_ID };
+export type ModelId = TextModelId;
+export type ModelOption = TextModelOption;
+export type Provider = TextProvider;
+export type { AutoModelId, SelectedModel };
 
 export interface CompactionState {
   summary: string | null;
@@ -172,7 +176,7 @@ export const useAgentStore = create<AgentState>()(
           set({ selectedModel: model });
           return;
         }
-        const modelOption = MODEL_OPTIONS.find((m) => m.id === model);
+        const modelOption = model in TEXT_MODEL_BY_ID ? TEXT_MODEL_BY_ID[model as TextModelId] : undefined;
         if (modelOption) {
           set({ selectedModel: model, selectedProvider: modelOption.provider });
         }
@@ -393,7 +397,7 @@ export const useAgentStore = create<AgentState>()(
         }
         if (version < 8) {
           const current = state.selectedModel as string | undefined;
-          const def = current ? MODEL_BY_ID[current as ModelId] : undefined;
+          const def = current ? TEXT_MODEL_BY_ID[current as TextModelId] : undefined;
           if (def?.offByDefault) {
             state.selectedModel = 'gemma-litellm';
             state.selectedProvider = 'litellm';


### PR DESCRIPTION
PR #951 (auto-model routing) landed in parallel with the #948–#952 image-model stack and widened the chat package back to the union ModelId / MODEL_BY_ID / ModelOption. After #952 merged, CI typecheck on master broke with six errors — .provider and .offByDefault don't exist on the discriminated union.

Local was clean because each PR shared a Turbo cache and the conflict only surfaces once both land on master.

Restore the narrowing: chat re-exports MODEL_OPTIONS as TEXT_MODELS, the type aliases point at their text-only counterparts, and resolveAutoModel returns TextModelId.