### PR TITLE
chore: apply prettier format to chat and BilderInner files

### DIFF
--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -9,12 +9,7 @@ import {
   type ImageModelId,
 } from '@gruenerator/shared/models';
 import { useShareStore } from '@gruenerator/shared/share';
-import {
-  AIPromptInput,
-  Button,
-  SettingsDropdown,
-  type SettingConfig,
-} from '@gruenerator/ui';
+import { AIPromptInput, Button, SettingsDropdown, type SettingConfig } from '@gruenerator/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Download, ImagePlus, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -21,11 +21,7 @@ import {
   useScopedThreadMode,
 } from '../../lib/useScopedAgentState';
 import { useModelPreferencesContext } from '../../context/ModelPreferencesContext';
-import {
-  AUTO_MODEL_ID,
-  resolveAutoModel,
-  type SelectedModel,
-} from '../../lib/resolveAutoModel';
+import { AUTO_MODEL_ID, resolveAutoModel, type SelectedModel } from '../../lib/resolveAutoModel';
 
 interface AutoOption {
   id: typeof AUTO_MODEL_ID;

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -176,7 +176,8 @@ export const useAgentStore = create<AgentState>()(
           set({ selectedModel: model });
           return;
         }
-        const modelOption = model in TEXT_MODEL_BY_ID ? TEXT_MODEL_BY_ID[model as TextModelId] : undefined;
+        const modelOption =
+          model in TEXT_MODEL_BY_ID ? TEXT_MODEL_BY_ID[model as TextModelId] : undefined;
         if (modelOption) {
           set({ selectedModel: model, selectedProvider: modelOption.provider });
         }


### PR DESCRIPTION
Three files drifted out of prettier formatting after the #952 (Bilder mode dropdown) and #953 (chat type narrowing) merges. The CI prettier check on master @ 9e0550150 flagged them. Pure formatting changes, no semantic edits.