### PR TITLE
feat(workplace): "Bild begrünen" sub-mode

### DIFF
--- a/apps/web/src/features/image-studio/services/imageEditingService.ts
+++ b/apps/web/src/features/image-studio/services/imageEditingService.ts
@@ -4,15 +4,18 @@ interface UniversalEditResponse {
   image: string | { base64: string; filename?: string };
 }
 
+export type ImageEditType = 'universal' | 'green-edit';
+
 export async function editAiImage(
   image: File,
-  instruction: string
+  instruction: string,
+  editType: ImageEditType = 'universal'
 ): Promise<{ file: File; objectUrl: string; base64: string }> {
   const form = new FormData();
   form.append('image', image);
   form.append('text', instruction);
   form.append('precision', 'true');
-  form.append('type', 'universal');
+  form.append('type', editType);
 
   const response = await apiClient.post<UniversalEditResponse>('/flux/green-edit/prompt', form, {
     headers: { 'Content-Type': 'multipart/form-data' },

--- a/apps/web/src/features/texte/modes/bildBegruenen.ts
+++ b/apps/web/src/features/texte/modes/bildBegruenen.ts
@@ -1,0 +1,20 @@
+import type { ModeDefinition } from './types';
+
+export const bildBegruenenMode: ModeDefinition = {
+  id: 'bild-begruenen',
+  endpoint: '/flux/green-edit/prompt',
+  instructionType: 'universal',
+  componentName: 'bild-begruenen',
+  defaultMode: 'balanced',
+  searchQueryFields: ['editPrompt'],
+  placeholder:
+    'Beschreibe, wie das Bild begrünt werden soll (z.B. Bäume, Radweg, Fußgängerzone)...',
+  useCustomSubmit: true,
+  useMarkdown: false,
+  promptField: 'editPrompt',
+  examples: [
+    { label: 'Mehr Bäume', text: 'Pflanze viele große Straßenbäume entlang der Fahrbahn' },
+    { label: 'Radweg', text: 'Füge einen geschützten Radweg mit grüner Trennung hinzu' },
+    { label: 'Fußgängerzone', text: 'Mache daraus eine grüne Fußgängerzone mit Sitzgelegenheiten' },
+  ],
+};

--- a/apps/web/src/features/texte/modes/index.ts
+++ b/apps/web/src/features/texte/modes/index.ts
@@ -1,5 +1,6 @@
 import { antragMode } from './antrag';
 import { bildBearbeitenMode } from './bildBearbeiten';
+import { bildBegruenenMode } from './bildBegruenen';
 import { bildVergroessernMode } from './bildVergroessern';
 import { boardsMode } from './boards';
 import { imagineMode } from './imagine';
@@ -22,6 +23,7 @@ const ALL_MODES: ModeDefinition[] = [
   boardsMode,
   imagineMode,
   bildBearbeitenMode,
+  bildBegruenenMode,
   bildVergroessernMode,
   textEditorMode,
 ];

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -24,7 +24,7 @@ import { MODE_MAP } from '../../texte/modes';
 
 import { cn } from '@/utils/cn';
 
-type SubMode = 'erstellen' | 'bearbeiten' | 'vergroessern';
+type SubMode = 'erstellen' | 'bearbeiten' | 'begruenen' | 'vergroessern';
 
 const SUB_MODE_CONFIG: SettingConfig = {
   key: 'subMode',
@@ -32,6 +32,7 @@ const SUB_MODE_CONFIG: SettingConfig = {
   options: [
     { id: 'erstellen', label: 'Erstellen' },
     { id: 'bearbeiten', label: 'Bearbeiten' },
+    { id: 'begruenen', label: '🌳 Begrünen' },
     { id: 'vergroessern', label: 'Vergrößern' },
   ],
   multiple: false,
@@ -39,6 +40,7 @@ const SUB_MODE_CONFIG: SettingConfig = {
 
 const ERSTELLEN_MODE_ID = 'imagine';
 const BEARBEITEN_MODE_ID = 'bild-bearbeiten';
+const BEGRUENEN_MODE_ID = 'bild-begruenen';
 const VERGROESSERN_MODE_ID = 'bild-vergroessern';
 
 const IMAGE_FAMILY_CONFIG: SettingConfig = {
@@ -116,6 +118,8 @@ const BilderInner: React.FC = memo(() => {
 
   const [editError, setEditError] = useState<string | null>(null);
   const [editLoading, setEditLoading] = useState(false);
+  const [greenEditError, setGreenEditError] = useState<string | null>(null);
+  const [greenEditLoading, setGreenEditLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const queryClient = useQueryClient();
@@ -124,11 +128,19 @@ const BilderInner: React.FC = memo(() => {
 
   const erstellenDef = MODE_MAP[ERSTELLEN_MODE_ID];
   const bearbeitenDef = MODE_MAP[BEARBEITEN_MODE_ID];
+  const begruenenDef = MODE_MAP[BEGRUENEN_MODE_ID];
   const vergroessernDef = MODE_MAP[VERGROESSERN_MODE_ID];
   const isErstellen = subMode === 'erstellen';
   const isBearbeiten = subMode === 'bearbeiten';
+  const isBegruenen = subMode === 'begruenen';
   const isVergroessern = subMode === 'vergroessern';
-  const activeDef = isErstellen ? erstellenDef : isBearbeiten ? bearbeitenDef : vergroessernDef;
+  const activeDef = isErstellen
+    ? erstellenDef
+    : isBearbeiten
+      ? bearbeitenDef
+      : isBegruenen
+        ? begruenenDef
+        : vergroessernDef;
 
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
   const [outpaintLoading, setOutpaintLoading] = useState(false);
@@ -275,6 +287,35 @@ const BilderInner: React.FC = memo(() => {
     }
   }, [prompt, sourceFile, editLoading, setResult, createImageShare, queryClient]);
 
+  const handleSubmitGreenEdit = useCallback(async () => {
+    const trimmed = prompt.trim();
+    if (!sourceFile || !trimmed || greenEditLoading) return;
+    setGreenEditLoading(true);
+    setGreenEditError(null);
+    try {
+      const { objectUrl, base64 } = await editAiImage(sourceFile, trimmed, 'green-edit');
+      setResult(objectUrl, true);
+      createImageShare({
+        imageData: base64,
+        title: trimmed.slice(0, 100),
+        imageType: 'edit',
+        status: 'ready',
+        metadata: {
+          prompt: trimmed,
+          sourceFilename: sourceFile.name,
+          editType: 'green-edit',
+        },
+      })
+        .then(() => queryClient.invalidateQueries({ queryKey: ['recent-activity'] }))
+        .catch(() => {});
+    } catch (err) {
+      console.error('[BilderInner:begruenen] Green edit failed:', err);
+      setGreenEditError(err instanceof Error ? err.message : 'Begrünung fehlgeschlagen');
+    } finally {
+      setGreenEditLoading(false);
+    }
+  }, [prompt, sourceFile, greenEditLoading, setResult, createImageShare, queryClient]);
+
   const handleSubmitOutpaint = useCallback(async () => {
     if (!sourceFile || outpaintLoading) return;
     setOutpaintLoading(true);
@@ -316,19 +357,35 @@ const BilderInner: React.FC = memo(() => {
       void handleSubmitCreate();
     } else if (isBearbeiten) {
       void handleSubmitEdit();
+    } else if (isBegruenen) {
+      void handleSubmitGreenEdit();
     } else {
       void handleSubmitOutpaint();
     }
-  }, [isErstellen, isBearbeiten, handleSubmitCreate, handleSubmitEdit, handleSubmitOutpaint]);
+  }, [
+    isErstellen,
+    isBearbeiten,
+    isBegruenen,
+    handleSubmitCreate,
+    handleSubmitEdit,
+    handleSubmitGreenEdit,
+    handleSubmitOutpaint,
+  ]);
 
   const handleDownload = useCallback(() => {
     if (!resultImage) return;
     const link = document.createElement('a');
     link.href = resultImage;
-    const slug = isErstellen ? 'bild' : isBearbeiten ? 'bearbeitet' : 'vergroessert';
+    const slug = isErstellen
+      ? 'bild'
+      : isBearbeiten
+        ? 'bearbeitet'
+        : isBegruenen
+          ? 'begruent'
+          : 'vergroessert';
     link.download = `gruenerator-${slug}-${Date.now()}.png`;
     link.click();
-  }, [resultImage, isErstellen, isBearbeiten]);
+  }, [resultImage, isErstellen, isBearbeiten, isBegruenen]);
 
   const filePickerPill = useMemo(
     () =>
@@ -410,7 +467,7 @@ const BilderInner: React.FC = memo(() => {
             onChange={(val) => handleFluxVariantChange(val as ImageModelId)}
           />
         )}
-        {(isBearbeiten || isVergroessern) && filePickerPill}
+        {(isBearbeiten || isBegruenen || isVergroessern) && filePickerPill}
         {isVergroessern && (
           <SettingsDropdown
             config={ASPECT_RATIO_CONFIG}
@@ -425,6 +482,7 @@ const BilderInner: React.FC = memo(() => {
       subMode,
       isErstellen,
       isBearbeiten,
+      isBegruenen,
       isVergroessern,
       erstellenDef?.settings,
       modeState,
@@ -439,19 +497,29 @@ const BilderInner: React.FC = memo(() => {
     ]
   );
 
-  const loading = isErstellen ? createLoading : isBearbeiten ? editLoading : outpaintLoading;
+  const loading = isErstellen
+    ? createLoading
+    : isBearbeiten
+      ? editLoading
+      : isBegruenen
+        ? greenEditLoading
+        : outpaintLoading;
   const error = isErstellen
     ? createError
       ? String(createError)
       : null
     : isBearbeiten
       ? editError
-      : outpaintError;
+      : isBegruenen
+        ? greenEditError
+        : outpaintError;
   const altText = isErstellen
     ? 'Generiertes Bild'
     : isBearbeiten
       ? 'Bearbeitetes Bild'
-      : 'Vergrößertes Bild';
+      : isBegruenen
+        ? 'Begrüntes Bild'
+        : 'Vergrößertes Bild';
 
   return (
     <div className="flex flex-col gap-md">


### PR DESCRIPTION
## Why

Workplace `Bilder` tab is one step behind chat: `@stadtbegruenen` exists with full ChatGraph wiring (`forcedTools: ['image_edit']` → `imageEditStyle: 'green-edit'` → `buildGreenEditPrompt`), but the same auto-greenify path isn't reachable from the composer. Users who want a quick "make this scene green" without writing the prompt themselves had to switch contexts.

This adds a fourth dropdown entry that reuses `POST /flux/green-edit/prompt` with `type='green-edit'`, surfacing the existing brand-tuned behaviour on the workplace side. Zero backend changes — the Zod enum already accepted the value.

The dispatcher in `BilderInner.tsx` was extended from 3- to 4-way (sub-mode union, toolbar, `onSubmit`, loading/error/altText), and `editAiImage` gained a discriminator parameter (`editType: 'universal' | 'green-edit'`) so existing call sites are unaffected.