### PR TITLE
feat(workplace): compact toolbar + vergrößern drop-zone & free-size picker

### DIFF
--- a/apps/api/routes/flux/outpaint.ts
+++ b/apps/api/routes/flux/outpaint.ts
@@ -18,16 +18,28 @@ const router = express.Router();
 const upload = multer({ storage: multer.memoryStorage() });
 const imageCounter = new ImageGenerationCounter(redisClient);
 
-const aspectRatioSchema = z.enum(['16:9', '4:3', '1:1', '3:4', '9:16']);
-type AspectRatio = z.infer<typeof aspectRatioSchema>;
+const presetAspectSchema = z.enum(['16:9', '4:3', '1:1', '3:4', '9:16']);
+type PresetAspect = z.infer<typeof presetAspectSchema>;
 
-const bodySchema = z.object({
-  aspectRatio: aspectRatioSchema,
-});
+const MAX_AREA_PIXELS = 4_194_304; // BFL's 4MP cap
+
+const bodySchema = z.union([
+  z.object({ aspectRatio: presetAspectSchema }),
+  z
+    .object({
+      aspectRatio: z.literal('custom'),
+      width: z.coerce.number().int().min(256).max(2048),
+      height: z.coerce.number().int().min(256).max(2048),
+    })
+    .refine((d) => d.width * d.height <= MAX_AREA_PIXELS, {
+      message: `Bild zu groß — maximal ${MAX_AREA_PIXELS / 1_000_000} Megapixel (Breite × Höhe).`,
+      path: ['width'],
+    }),
+]);
 
 // Target canvas dimensions per aspect — keeps the output under BFL's 4MP cap
 // while staying close to typical social-media sizes.
-const ASPECT_DIMENSIONS: Record<AspectRatio, { width: number; height: number }> = {
+const ASPECT_DIMENSIONS: Record<PresetAspect, { width: number; height: number }> = {
   '16:9': { width: 1600, height: 896 },
   '4:3': { width: 1408, height: 1056 },
   '1:1': { width: 1280, height: 1280 },
@@ -68,7 +80,10 @@ router.post(
         });
       }
 
-      const target = ASPECT_DIMENSIONS[parsed.data.aspectRatio];
+      const target =
+        parsed.data.aspectRatio === 'custom'
+          ? { width: parsed.data.width, height: parsed.data.height }
+          : ASPECT_DIMENSIONS[parsed.data.aspectRatio];
       log.debug(
         `[Outpaint] User ${userId} expanding ${Math.round(req.file.size / 1024)}KB image to ${target.width}x${target.height} (${parsed.data.aspectRatio})`
       );

--- a/apps/web/src/features/texte/modes/bildBearbeiten.ts
+++ b/apps/web/src/features/texte/modes/bildBearbeiten.ts
@@ -11,9 +11,5 @@ export const bildBearbeitenMode: ModeDefinition = {
   useCustomSubmit: true,
   useMarkdown: false,
   promptField: 'editPrompt',
-  examples: [
-    { label: 'Mehr Grün', text: 'Füge Bäume, Sträucher und Fahrradwege hinzu' },
-    { label: 'Plakat-Stil', text: 'Mache das Bild zu einem grünen Wahlplakat mit ' },
-    { label: 'Hintergrund', text: 'Tausche den Hintergrund gegen ' },
-  ],
+  examples: [{ label: 'Mehr Grün', text: 'Füge Bäume, Sträucher und Fahrradwege hinzu' }],
 };

--- a/apps/web/src/features/texte/modes/bildBegruenen.ts
+++ b/apps/web/src/features/texte/modes/bildBegruenen.ts
@@ -14,7 +14,5 @@ export const bildBegruenenMode: ModeDefinition = {
   promptField: 'editPrompt',
   examples: [
     { label: 'Mehr Bäume', text: 'Pflanze viele große Straßenbäume entlang der Fahrbahn' },
-    { label: 'Radweg', text: 'Füge einen geschützten Radweg mit grüner Trennung hinzu' },
-    { label: 'Fußgängerzone', text: 'Mache daraus eine grüne Fußgängerzone mit Sitzgelegenheiten' },
   ],
 };

--- a/apps/web/src/features/texte/modes/imagine.ts
+++ b/apps/web/src/features/texte/modes/imagine.ts
@@ -30,9 +30,5 @@ export const imagineMode: ModeDefinition = {
     variant: '',
     imageModel: DEFAULT_IMAGE_MODEL_ID,
   },
-  examples: [
-    { label: 'Plakat', text: 'Ein grünes Wahlplakat mit Sonnenblumen und dem Slogan ' },
-    { label: 'Social Media', text: 'Ein Instagram-Bild zum Thema Klimaschutz mit ' },
-    { label: 'Illustration', text: 'Eine Illustration im Stil einer Infografik über ' },
-  ],
+  examples: [{ label: 'Plakat', text: 'Ein grünes Wahlplakat mit Sonnenblumen und dem Slogan ' }],
 };

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -67,7 +67,7 @@ const FLUX_VARIANT_CONFIG: SettingConfig = {
   multiple: false,
 };
 
-type AspectRatio = '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+type AspectRatio = '16:9' | '4:3' | '1:1' | '3:4' | '9:16' | 'custom';
 
 const ASPECT_RATIO_CONFIG: SettingConfig = {
   key: 'aspectRatio',
@@ -78,9 +78,14 @@ const ASPECT_RATIO_CONFIG: SettingConfig = {
     { id: '1:1', label: 'Quadrat 1:1' },
     { id: '3:4', label: 'Hochformat 3:4' },
     { id: '9:16', label: 'Hochformat 9:16' },
+    { id: 'custom', label: 'Frei (Pixel)' },
   ],
   multiple: false,
 };
+
+const MIN_CUSTOM_SIDE = 256;
+const MAX_CUSTOM_SIDE = 2048;
+const MAX_CUSTOM_AREA = 4_194_304;
 
 interface UsageStatus {
   count: number;
@@ -158,7 +163,17 @@ const BilderInner: React.FC = memo(() => {
           : hintergrundDef;
 
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
+  const [customWidth, setCustomWidth] = useState<number>(1280);
+  const [customHeight, setCustomHeight] = useState<number>(1280);
   const [outpaintLoading, setOutpaintLoading] = useState(false);
+  const isCustomAspect = aspectRatio === 'custom';
+  const customArea = customWidth * customHeight;
+  const customSizeValid =
+    customWidth >= MIN_CUSTOM_SIDE &&
+    customWidth <= MAX_CUSTOM_SIDE &&
+    customHeight >= MIN_CUSTOM_SIDE &&
+    customHeight <= MAX_CUSTOM_SIDE &&
+    customArea <= MAX_CUSTOM_AREA;
   const [outpaintError, setOutpaintError] = useState<string | null>(null);
 
   const { state: modeState, updateField } = useModeState(ERSTELLEN_MODE_ID);
@@ -374,12 +389,22 @@ const BilderInner: React.FC = memo(() => {
 
   const handleSubmitOutpaint = useCallback(async () => {
     if (!sourceFile || outpaintLoading) return;
+    if (isCustomAspect && !customSizeValid) {
+      setOutpaintError(
+        `Ungültige Größe — ${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CUSTOM_AREA / 1_000_000} MP.`
+      );
+      return;
+    }
     setOutpaintLoading(true);
     setOutpaintError(null);
     try {
       const form = new FormData();
       form.append('image', sourceFile);
       form.append('aspectRatio', aspectRatio);
+      if (isCustomAspect) {
+        form.append('width', String(customWidth));
+        form.append('height', String(customHeight));
+      }
       const res = await getGlobalApiClient().post<{
         success: boolean;
         image?: { base64?: string };
@@ -390,13 +415,18 @@ const BilderInner: React.FC = memo(() => {
       }
       const base64 = res.data.image.base64;
       setResult(base64, false);
-      const title = `Vergrößert ${aspectRatio} — ${sourceFile.name}`;
+      const sizeLabel = isCustomAspect ? `${customWidth}×${customHeight}` : aspectRatio;
+      const title = `Vergrößert ${sizeLabel} — ${sourceFile.name}`;
       createImageShare({
         imageData: base64,
         title: title.slice(0, 100),
         imageType: 'imagine',
         status: 'ready',
-        metadata: { sourceFilename: sourceFile.name, aspectRatio },
+        metadata: {
+          sourceFilename: sourceFile.name,
+          aspectRatio,
+          ...(isCustomAspect && { customWidth, customHeight }),
+        },
       })
         .then(() => queryClient.invalidateQueries({ queryKey: ['recent-activity'] }))
         .catch(() => {});
@@ -406,7 +436,18 @@ const BilderInner: React.FC = memo(() => {
     } finally {
       setOutpaintLoading(false);
     }
-  }, [sourceFile, outpaintLoading, aspectRatio, setResult, createImageShare, queryClient]);
+  }, [
+    sourceFile,
+    outpaintLoading,
+    aspectRatio,
+    isCustomAspect,
+    customWidth,
+    customHeight,
+    customSizeValid,
+    setResult,
+    createImageShare,
+    queryClient,
+  ]);
 
   const onSubmit = useCallback(() => {
     if (isErstellen) {
@@ -448,6 +489,43 @@ const BilderInner: React.FC = memo(() => {
     link.download = `gruenerator-${slug}-${Date.now()}.png`;
     link.click();
   }, [resultImage, isErstellen, isBearbeiten, isBegruenen, isVergroessern]);
+
+  const vergroessernDropZone = useMemo(
+    () =>
+      sourcePreviewUrl ? (
+        <div className="flex items-center gap-3 py-1">
+          <img
+            src={sourcePreviewUrl}
+            alt=""
+            className="size-12 object-cover rounded-md border border-grey-200 dark:border-grey-700"
+          />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium truncate text-foreground">
+              {sourceFile?.name ?? 'Bild'}
+            </div>
+            <div className="text-xs text-grey-500">Bereit zum Vergrößern</div>
+          </div>
+          <button
+            type="button"
+            onClick={clearSource}
+            className="text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 p-1"
+            aria-label="Bild entfernen"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="w-full flex items-center gap-2 py-1 text-grey-500 dark:text-grey-400 hover:text-foreground transition-colors"
+        >
+          <ImagePlus className="size-4" />
+          <span className="text-[15px]">Bild zum Vergrößern hochladen</span>
+        </button>
+      ),
+    [sourcePreviewUrl, sourceFile, clearSource]
+  );
 
   const filePickerPill = useMemo(
     () =>
@@ -529,13 +607,47 @@ const BilderInner: React.FC = memo(() => {
             onChange={(val) => handleFluxVariantChange(val as ImageModelId)}
           />
         )}
-        {(isBearbeiten || isBegruenen || isVergroessern || isHintergrund) && filePickerPill}
+        {(isBearbeiten || isBegruenen || isHintergrund) && filePickerPill}
         {isVergroessern && (
           <SettingsDropdown
             config={ASPECT_RATIO_CONFIG}
             value={aspectRatio}
             onChange={(val) => setAspectRatio(val as AspectRatio)}
           />
+        )}
+        {isVergroessern && isCustomAspect && (
+          <span
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs',
+              customSizeValid
+                ? 'border-grey-200 dark:border-grey-700 text-grey-700 dark:text-grey-300'
+                : 'border-red-300 text-red-600 dark:border-red-700 dark:text-red-400'
+            )}
+            title={`${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CUSTOM_AREA / 1_000_000} MP`}
+          >
+            <input
+              type="number"
+              min={MIN_CUSTOM_SIDE}
+              max={MAX_CUSTOM_SIDE}
+              step={8}
+              value={customWidth}
+              onChange={(e) => setCustomWidth(Number(e.target.value) || 0)}
+              className="w-16 bg-transparent text-right outline-none"
+              aria-label="Breite in Pixeln"
+            />
+            <span className="text-grey-400">×</span>
+            <input
+              type="number"
+              min={MIN_CUSTOM_SIDE}
+              max={MAX_CUSTOM_SIDE}
+              step={8}
+              value={customHeight}
+              onChange={(e) => setCustomHeight(Number(e.target.value) || 0)}
+              className="w-16 bg-transparent outline-none"
+              aria-label="Höhe in Pixeln"
+            />
+            <span className="text-grey-400">px</span>
+          </span>
         )}
         {usage && <UsageBadge usage={usage} />}
       </>
@@ -547,6 +659,10 @@ const BilderInner: React.FC = memo(() => {
       isBegruenen,
       isVergroessern,
       isHintergrund,
+      isCustomAspect,
+      customWidth,
+      customHeight,
+      customSizeValid,
       erstellenDef?.settings,
       modeState,
       updateField,
@@ -609,6 +725,10 @@ const BilderInner: React.FC = memo(() => {
         placeholder={activeDef?.placeholder ?? ''}
         examples={activeDef?.examples}
         toolbar={toolbar}
+        inputAreaOverride={isVergroessern ? vergroessernDropZone : undefined}
+        canSubmit={
+          isVergroessern ? !!sourceFile && (!isCustomAspect || customSizeValid) : undefined
+        }
       />
 
       {resultImage && (

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -11,7 +11,7 @@ import {
 import { useShareStore } from '@gruenerator/shared/share';
 import { AIPromptInput, Button, SettingsDropdown, type SettingConfig } from '@gruenerator/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Download, ImagePlus, X } from 'lucide-react';
+import { Download, Image as ImageIcon, ImagePlus, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import useApiSubmit from '../../../components/hooks/useApiSubmit';
@@ -101,14 +101,16 @@ function UsageBadge({ usage }: { usage: UsageStatus }) {
   const isLow = usage.remaining <= 1;
   return (
     <span
-      className={`inline-flex items-center rounded-full px-sm py-xs text-xs font-medium ${
+      className={`inline-flex items-center gap-1 rounded-full px-sm py-xs text-xs font-medium ${
         isLow
           ? 'bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300'
           : 'bg-grey-100 text-grey-700 dark:bg-grey-800 dark:text-grey-300'
       }`}
-      title={`Heutiges Tageskontingent: ${formatImageCount(usage.count)} von ${usage.limit} Bildern verbraucht`}
+      title={`Heutiges Tageskontingent: ${formatImageCount(usage.count)} von ${usage.limit} Bildern heute verbraucht`}
+      aria-label={`${formatImageCount(usage.remaining)} von ${usage.limit} Bildern heute übrig`}
     >
-      {formatImageCount(usage.remaining)} / {usage.limit} Bilder heute
+      <ImageIcon className="size-3.5" aria-hidden="true" />
+      {formatImageCount(usage.remaining)}/{usage.limit}
     </span>
   );
 }

--- a/packages/ui/src/components/ai-prompt-input.tsx
+++ b/packages/ui/src/components/ai-prompt-input.tsx
@@ -26,6 +26,10 @@ export interface AIPromptInputProps {
   rows?: number;
   transparent?: boolean;
   className?: string;
+  /** Replaces the textarea region (e.g. for file-upload sub-modes). */
+  inputAreaOverride?: ReactNode;
+  /** When defined, overrides the default `text.length >= 3` gate for the submit button. */
+  canSubmit?: boolean;
 }
 
 function ActionButton({
@@ -34,12 +38,16 @@ function ActionButton({
   isLoading,
   onDictate,
   onSubmit,
+  noTextInput,
+  canSubmitOverride,
 }: {
   isEmpty: boolean;
   isDictating: boolean;
   isLoading: boolean;
   onDictate: () => void;
   onSubmit: () => void;
+  noTextInput: boolean;
+  canSubmitOverride: boolean | undefined;
 }) {
   const base =
     'flex items-center justify-center size-7 shrink-0 rounded-full border-none cursor-pointer transition-all';
@@ -48,6 +56,26 @@ function ActionButton({
     return (
       <button disabled className={cn(base, 'bg-primary text-primary-foreground cursor-default')}>
         <span className="size-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+      </button>
+    );
+  }
+
+  if (noTextInput) {
+    const allowed = canSubmitOverride === true;
+    return (
+      <button
+        type="button"
+        onClick={allowed ? onSubmit : undefined}
+        disabled={!allowed}
+        className={cn(
+          base,
+          allowed
+            ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+            : 'bg-grey-200 text-grey-400 cursor-not-allowed dark:bg-grey-800 dark:text-grey-600'
+        )}
+        aria-label="Absenden"
+      >
+        <ArrowRight className="size-3.5" />
       </button>
     );
   }
@@ -110,6 +138,8 @@ export const AIPromptInput = React.memo(function AIPromptInput({
   rows = 2,
   transparent = false,
   className,
+  inputAreaOverride,
+  canSubmit,
 }: AIPromptInputProps) {
   const { isDictating, toggle: toggleDictation } = useVoxtralDictation({
     onTranscript: (text) => onChange(text),
@@ -125,8 +155,10 @@ export const AIPromptInput = React.memo(function AIPromptInput({
     [onSubmit]
   );
 
+  const noTextInput = !!inputAreaOverride;
   const isEmpty = value.trim().length < 3;
-  const showInlineExamples = isEmpty && !isLoading && examples && examples.length > 0;
+  const showInlineExamples =
+    !noTextInput && isEmpty && !isLoading && examples && examples.length > 0;
 
   return (
     <div className={cn('w-full max-w-[680px] mx-auto', className)}>
@@ -138,15 +170,19 @@ export const AIPromptInput = React.memo(function AIPromptInput({
         )}
       >
         <div className="px-4 pt-3 pb-1">
-          <textarea
-            value={value}
-            onChange={(e) => onChange(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            rows={rows}
-            disabled={disabled || isLoading}
-            className="w-full min-w-0 text-[15px] outline-none resize-none placeholder:text-grey-400 leading-relaxed bg-transparent border-none p-0"
-          />
+          {noTextInput ? (
+            inputAreaOverride
+          ) : (
+            <textarea
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={placeholder}
+              rows={rows}
+              disabled={disabled || isLoading}
+              className="w-full min-w-0 text-[15px] outline-none resize-none placeholder:text-grey-400 leading-relaxed bg-transparent border-none p-0"
+            />
+          )}
         </div>
 
         <div className="flex items-center gap-1.5 px-3 pb-2.5">
@@ -171,6 +207,8 @@ export const AIPromptInput = React.memo(function AIPromptInput({
             isLoading={isLoading}
             onDictate={toggleDictation}
             onSubmit={onSubmit}
+            noTextInput={noTextInput}
+            canSubmitOverride={canSubmit}
           />
         </div>
       </div>


### PR DESCRIPTION
## Why

Two related Bilder-toolbar UX gaps:
1. The toolbar wrapped to a second row because the usage badge (`10 / 10 Bilder heute`) plus three example pills were wider than one line at typical widths. Trims each Bilder sub-mode to a single representative example and condenses the quota display to an icon + `10/10`.
2. Vergrößern has no prompt — the textarea hid the submit button behind a "3+ chars" gate, so users couldn't fire the request. Swap the textarea for a drop-zone in vergrößern mode and gate submit on the uploaded file plus a valid target size.

Adds a "Frei (Pixel)" aspect option with two inline width/height inputs. The outpaint route now accepts a discriminated body shape: presets OR explicit width/height (256–2048 each, ≤4 MP total).

The input-area swap and submit-gate override are exposed via two pure-additive props on the shared `AIPromptInput` (`inputAreaOverride`, `canSubmit`), so other call sites are unaffected.