### PR TITLE
fix(workplace): outpaint FormData needs explicit multipart Content-Type

### DIFF
--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -418,7 +418,9 @@ const BilderInner: React.FC = memo(() => {
         success: boolean;
         image?: { base64?: string };
         error?: string;
-      }>('/imagine/outpaint', form);
+      }>('/imagine/outpaint', form, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
       if (!res.data.success || !res.data.image?.base64) {
         throw new Error(res.data.error || 'Vergrößerung fehlgeschlagen');
       }
@@ -441,7 +443,14 @@ const BilderInner: React.FC = memo(() => {
         .catch(() => {});
     } catch (err) {
       console.error('[BilderInner:vergroessern] Outpaint failed:', err);
-      setOutpaintError(err instanceof Error ? err.message : 'Vergrößerung fehlgeschlagen');
+      const axiosBody = (err as { response?: { data?: { error?: string; details?: unknown } } })
+        ?.response?.data;
+      const serverMessage =
+        axiosBody?.error ||
+        (axiosBody?.details ? `Validierung: ${JSON.stringify(axiosBody.details)}` : null);
+      setOutpaintError(
+        serverMessage ?? (err instanceof Error ? err.message : 'Vergrößerung fehlgeschlagen')
+      );
     } finally {
       setOutpaintLoading(false);
     }


### PR DESCRIPTION
## Why

POST `/api/imagine/outpaint` returns 400 with no backend log when the user clicks submit in Vergrößern mode. Root cause:

The global axios client at `packages/shared/src/api/client.ts:25-27` sets `Content-Type: application/json` as a default header. When the request body is `FormData`, axios 1.x's `defaultTransformRequest` sees the JSON content type, walks down the FormData transformer branch, and JSON-serializes the FormData via `formDataToJSON()`. The actual multipart body never reaches the wire. On the server, `multer.single('image')` sees no body fields → `req.body` is empty → the Zod schema rejects on the missing `aspectRatio` → handler returns 400 BEFORE its log line, so the user sees nothing in the backend logs.

This bug has been latent since the original outpaint commit (`b8d27f05c`) — outpainting was likely never exercised end-to-end before. Every other working FormData call in `apps/web/src/` (`editAiImage`, `removeImageBackground`, `uploadFileAndGetText`) overrides `Content-Type: multipart/form-data` explicitly for exactly this reason. This PR makes outpaint do the same.

Also extracts the backend `error`/`details` from `AxiosError.response.data` so any future 4xx response surfaces the real reason in the toolbar error pill, not a generic "Vergrößerung fehlgeschlagen".