### PR TITLE
fix(notebook): auto-mode defaults to Mistral on notebook surfaces

### DIFF
--- a/packages/chat/src/components/notebook/NotebookComposer.tsx
+++ b/packages/chat/src/components/notebook/NotebookComposer.tsx
@@ -273,6 +273,7 @@ export function NotebookComposer({
       showMentions={false}
       showPlusMenu={false}
       showToolToggles={false}
+      modelPickerThreadModeOverride="notebook"
       toolbarExtra={
         <NotebookSettingsDropdown
           mode={mode}

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -13,7 +13,7 @@ import { ArrowUp, Mic, Square, X } from 'lucide-react';
 import { RiVoiceAiFill } from 'react-icons/ri';
 import { cn } from '@gruenerator/ui';
 import { useScopedAgentId } from '../../lib/useScopedAgentState';
-import { useAgentStore } from '../../stores/chatStore';
+import { useAgentStore, type ThreadMode } from '../../stores/chatStore';
 import { ToolToggles } from '../ToolToggles';
 import { SearchDepthToggle } from '../SearchDepthToggle';
 import { getSystemAgent } from '@gruenerator/shared/agents';
@@ -49,6 +49,10 @@ interface GrueneratorComposerProps {
   showPlusMenu?: boolean;
   showToolToggles?: boolean;
   showModelPicker?: boolean;
+  /** Forwarded to ModelPicker for surfaces without a ChatSurfaceProvider
+   * (e.g. NotebookChatProvider) so auto-mode resolves to the surface's
+   * implicit thread mode. */
+  modelPickerThreadModeOverride?: ThreadMode;
   insideAgent?: boolean;
   /** Render-prop slots for surface-specific UI. */
   slots?: {
@@ -219,6 +223,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
   showPlusMenu = true,
   showToolToggles = true,
   showModelPicker = true,
+  modelPickerThreadModeOverride,
   insideAgent = false,
   slots,
   requireProfileHydration = false,
@@ -586,7 +591,13 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
             {toolbarExtra}
           </div>
           <div className="flex items-center gap-0.5">
-            {showModelPicker && <ModelPicker />}
+            {showModelPicker && (
+              <ModelPicker
+                {...(modelPickerThreadModeOverride && {
+                  threadModeOverride: modelPickerThreadModeOverride,
+                })}
+              />
+            )}
             {/* TODO: re-enable when realtime voice agent is ready for users
             <ComposerVoiceToggle />
             */}

--- a/packages/chat/src/components/thread/ModelPicker.tsx
+++ b/packages/chat/src/components/thread/ModelPicker.tsx
@@ -13,7 +13,7 @@ import { getSystemAgent } from '@gruenerator/shared/agents';
 
 import { composerToolbarButtonClass } from '../../lib/utils';
 import { useChatDensity } from './chatDensityContext';
-import { MODEL_OPTIONS } from '../../stores/chatStore';
+import { MODEL_OPTIONS, type ThreadMode } from '../../stores/chatStore';
 import {
   useScopedAgentId,
   useScopedSelectedModel,
@@ -35,12 +35,22 @@ const AUTO_OPTION: AutoOption = {
   description: 'Modell passend zum Kontext',
 };
 
-export const ModelPicker = memo(function ModelPicker() {
+interface ModelPickerProps {
+  /** When the picker is mounted on a non-/chat surface that lacks a
+   * ChatSurfaceProvider (e.g. NotebookChatProvider), pass the implicit
+   * thread mode here so `resolveAutoModel` picks the right default. */
+  threadModeOverride?: ThreadMode;
+}
+
+export const ModelPicker = memo(function ModelPicker({
+  threadModeOverride,
+}: ModelPickerProps = {}) {
   const [menuOpen, setMenuOpen] = useState(false);
   const selectedModel = useScopedSelectedModel();
   const setSelectedModel = useScopedSetSelectedModel();
   const selectedAgentId = useScopedAgentId();
-  const threadMode = useScopedThreadMode();
+  const scopedThreadMode = useScopedThreadMode();
+  const threadMode = threadModeOverride ?? scopedThreadMode;
   const { enabledModelIds } = useModelPreferencesContext();
   const isCompact = useChatDensity() === 'compact';
 

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -9,6 +9,7 @@ import {
   type FallbackInfo,
 } from '../hooks/useChatGraphStream';
 import { parseSSELine } from '../lib/sseParser';
+import { AUTO_MODEL_ID, resolveAutoModel } from '../lib/resolveAutoModel';
 import { useAgentStore } from '../stores/chatStore';
 import { useChatConfigStore } from '../stores/chatConfigStore';
 import { streamErrorMessage } from './streamErrorMessage';
@@ -152,7 +153,13 @@ export function createNotebookModelAdapter(
         (config.collectionIds && config.collectionIds.length > 1) ||
         (!config.collectionId && config.collectionIds && config.collectionIds.length === 1);
 
-      const selectedModel = useAgentStore.getState().selectedModel;
+      const rawSelectedModel = useAgentStore.getState().selectedModel;
+      // Notebook surfaces are always notebook-scoped; pre-resolve 'auto' here so
+      // the backend doesn't fall back to its generic DEFAULT_MODEL (gpt-oss).
+      const selectedModel =
+        rawSelectedModel === AUTO_MODEL_ID
+          ? resolveAutoModel({ threadMode: 'notebook', agent: null })
+          : rawSelectedModel;
 
       // Resolve optional sharepic context (canvas-editor in-section chat).
       // Captured before the request so image data + structured text travel with

--- a/packages/shared/src/models/catalog.ts
+++ b/packages/shared/src/models/catalog.ts
@@ -70,7 +70,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
   {
     modality: 'text',
     id: 'mistral-medium-3.5',
-    name: '⭐ Mistral Medium',
+    name: '⭐ Mistral',
     description: 'Bester Allrounder',
     model: 'mistral-medium-2604',
     provider: 'mistral',


### PR DESCRIPTION
On `/notebooks` (and `/notebooks/:slug`), picking **Automatisch** silently ran GPT-OSS instead of Mistral:

- `NotebookModelAdapter` shipped `model: 'auto'` raw; the notebook stream's `DEFAULT_MODEL` is `gpt-oss:120b`, which is what got selected when `resolveModelTuple` skips `'auto'`.
- `ModelPicker` resolved auto via `useScopedThreadMode()`, which falls through to the global store (default `'chat'`) because `NotebookChatProvider` doesn't wrap a `ChatSurfaceProvider`.

Fix both by pre-resolving `'auto'` client-side in `NotebookModelAdapter` (mirroring how `GrueneratorChatProvider` already does it on `/chat`) and threading a `modelPickerThreadModeOverride="notebook"` from `NotebookComposer` into `ModelPicker`.

Also shortens the picker label from "⭐ Mistral Medium" to "⭐ Mistral".