### PR TITLE
docs(newsletter): Mai 2026 – Erstelle dein Notebook

### DIFF
--- a/documentation/docs/newsletter/2025-03-gruugo.md
+++ b/documentation/docs/newsletter/2025-03-gruugo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: 'März 2025: Kennst du schon Gruugo?'
 ---
 

--- a/documentation/docs/newsletter/2025-05-testlabor.md
+++ b/documentation/docs/newsletter/2025-05-testlabor.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: 'Mai 2025: Komm ins Testlabor!'
 ---
 

--- a/documentation/docs/newsletter/2025-10-reimagined.md
+++ b/documentation/docs/newsletter/2025-10-reimagined.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: 'Oktober 2025: Grünerator Reimagined'
 ---
 

--- a/documentation/docs/newsletter/2025-12-weihnachtszeit.md
+++ b/documentation/docs/newsletter/2025-12-weihnachtszeit.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: 'Dezember 2025: Grünerator zur Weihnachtszeit'
 ---
 

--- a/documentation/docs/newsletter/2026-01-jahr-der-daten.md
+++ b/documentation/docs/newsletter/2026-01-jahr-der-daten.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: 'Januar 2026: Jahr der Daten'
 ---
 

--- a/documentation/docs/newsletter/2026-03-ki-chat-launch.md
+++ b/documentation/docs/newsletter/2026-03-ki-chat-launch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: 'März 2026: Grünerator Chat'
 ---
 

--- a/documentation/docs/newsletter/2026-04-work-update.md
+++ b/documentation/docs/newsletter/2026-04-work-update.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 title: 'April 2026: Das große Work-Update'
 ---
 

--- a/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
+++ b/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 0
+title: 'Mai 2026: Erstelle dein Notebook'
+---
+
+# Erstelle dein Notebook
+
+_Newsletter Mai 2026_
+
+---
+
+Kennst du NotebookLM von Google? Du wirfst Dokumente rein und kannst sie anschließend befragen, durchsuchen, zusammenfassen lassen. Praktisch. Aber wie immer gilt: Daten bei Google? Schwierig. Also gibt es ab heute die grüne Variante – direkt im Grünerator.
+
+## Eigene Notebooks – Grünes NotebookLM
+
+Ab sofort kannst du im Grünerator deine eigenen **Notebooks** erstellen – mit eigenen Quellen, eigenen Fragen, eigenen Antworten. Ein Notebook ist im Grunde dein persönliches Archiv: Du wirfst Dokumente rein, und der Grünerator beantwortet deine Fragen ausschließlich auf Basis dieser Dokumente – mit nachprüfbaren Quellenangaben. Lade einfach Dokumente hoch, verbinde einen Ordner aus der Grünen Wolke oder importiere eigene Grünerator Docs als Quelle.
+
+Offen gesagt: Ich glaube, Notebooks können die Art und Weise, wie wir Parteiarbeit machen, für immer verändern. Wissen wird durchsuchbar und verständlich wie nie.
+
+Um das Feature dauerhaft für uns als Basis kostenfrei und unbegrenzt verfügbar zu halten, können sich **Landesverbände** (in Österreich der Bundesverband) spezielle Notebooks einkaufen, die über 1.000 Dokumente enthalten und sich automatisiert aus den öffentlichen Beschlüssen und Pressemitteilungen speisen. Die bereits existierenden Landesverband-Notebooks findest du in der Notebook-Übersicht. Wenn das für deinen Landesverband interessant ist, melde dich gern!
+
+Um ein eigenes Notebook zu erstellen, klicke auf den Button unten und dann rechts bei „Eigene" auf das Plus-Icon. Aber Achtung: Das Feature ist neu und ich konnte noch nicht jede Kombination aus Quelle, Sichtbarkeit und Gruppenrolle durchtesten. Schreib mir bitte, wenn etwas hakt.
+
+## Neuer Dokumenten-Chat
+
+Jedes Grünerator-Dokument hat jetzt einen eigenen Chat. Du kannst die KI Fragen zu deinem Text stellen, dir Vorschläge geben lassen oder den Text gemeinsam mit ihr weiterschreiben. Wer will, aktiviert den Toggle **„AN"** – dann schreibt die KI direkt ins Dokument, du behältst aber die Kontrolle und kannst Änderungen ablehnen.
+
+Außerdem kannst du Text markieren und ihn präzise mit KI verändern. Oder du tippst `/` im Dokument, wählst „KI" und lässt dir den Text weiterschreiben. Probier es unbedingt aus und gib mir Feedback – ich bin von den KI-Features im Editor schon sehr überzeugt. Und wer lieber spricht: Im Editor kannst du jetzt auch direkt **diktieren**.
+
+## Neue Agents, besserer Chat
+
+Im Chat sind mehrere neue Spezialist\*innen dazugekommen. Der **Öffentlichkeitsarbeit-Agent** hilft dir bei Pressemitteilungen, Social-Media-Posts und Statements. Der neue **Kommunalpolitik-Assistent** unterstützt dich bei allem, was im kommunalpolitischen Alltag anfällt – von Anträgen über Bürger\*innenanfragen bis hin zu Reden.
+
+Neu ist auch der **„Tweet-wie-Ricarda"-Agent** (nur de). Er formuliert Tweets im Stil von Ricarda Lang, basierend auf echten Beispielen. Damit lässt sich gut ausprobieren, was mit personalisierten Agents im Grünerator möglich ist.
+
+Auch bei den Quellen hat sich einiges getan: Mit `@wolke` hängst du Dateien aus der Grünen Wolke direkt in den Chat (die Wolke vorher im Profil verbinden). Mit `@recherche` startest du eine tiefe Websuche – das Ergebnis erscheint als ausklappbare Recherche-Karte.
+
+Außerdem stehen neue Sprachmodelle zur Auswahl, darunter ein neues, sehr gutes **Mistral-Modell** aus Frankreich. Welches Modell genutzt wird, kannst du im Profil einstellen – oder du lässt den Grünerator entscheiden.
+
+## Bilder erstellen und bearbeiten
+
+Insbesondere in Österreich gibt es den Wunsch, mehr mit KI-Bildbearbeitung zu arbeiten. Ich habe daher die Bild-Features auf der Startseite verbessert. Wer lieber direkt aus dem Chat heraus arbeitet, findet die gleichen Werkzeuge auch dort. Außerdem könnt ihr mehr Modelle auswählen – unter anderem mit **Flux Max** noch bessere Ergebnisse erzielen (verbraucht 2 Bilder statt eines).
+
+Die Bildwerkzeuge sind teilweise noch experimentell – sie werden aber stetig weiterentwickelt. Wenn dir etwas fehlt, schreib mir gern.
+
+_(Lieber Robert, wenn du das siehst: Die KI ist schuld!)_
+
+## Jetzt brauche ich dich
+
+Viele dieser Features waren Wünsche aus den Landesverbänden, Landesarbeitsgemeinschaften, aus Webinaren und aus Zuschriften von Mitgliedern wie dir. Jetzt brauche ich deine Hilfe: Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung. Es können zwischendurch Fehler auftreten – dabei zählt jede Rückmeldung.
+
+---
+
+Bei Fragen oder Problemen, insbesondere beim Login, wende dich gerne jederzeit an den Support-Chat (Deutschland) oder an das Helpdesk (Österreich). Du kannst diesen Newsletter gerne weiterleiten, etwa in deinem Orts- oder Kreisverband. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_


### PR DESCRIPTION
Newsletter zum heute versendeten Mai-Update: eigene Notebooks, Dokumenten-Chat mit Slash-Command und Diktat, neue Agents (Öffentlichkeitsarbeit, Kommunalpolitik, Tweet-wie-Ricarda), `@wolke`/`@recherche`, neue Bild-Modelle inkl. Flux Max.

Die `sidebar_position` aller älteren Newsletter wurde um +1 verschoben, damit der neue Eintrag im Docusaurus-Sidebar an Position 0 erscheint.