### PR TITLE
docs(newsletter): Mai 2026 auf Original-Mailtext setzen

### DIFF
--- a/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
+++ b/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
@@ -1,53 +1,51 @@
 ---
 sidebar_position: 0
-title: 'Mai 2026: Erstelle dein Notebook'
+title: 'Mai 2026: Das Notebook-Update'
 ---
 
-# Erstelle dein Notebook
+# Das Notebook-Update
 
 _Newsletter Mai 2026_
 
 ---
 
-Kennst du NotebookLM von Google? Du wirfst Dokumente rein und kannst sie anschließend befragen, durchsuchen, zusammenfassen lassen. Praktisch. Aber wie immer gilt: Daten bei Google? Schwierig. Also gibt es ab heute die grüne Variante – direkt im Grünerator.
+Hallo zusammen,
 
-## Eigene Notebooks – Grünes NotebookLM
+ab sofort kannst du im Grünerator deine eigenen Notebooks erstellen – mit eigenen Quellen, eigenen Fragen, eigenen Antworten.
 
-Ab sofort kannst du im Grünerator deine eigenen **Notebooks** erstellen – mit eigenen Quellen, eigenen Fragen, eigenen Antworten. Ein Notebook ist im Grunde dein persönliches Archiv: Du wirfst Dokumente rein, und der Grünerator beantwortet deine Fragen ausschließlich auf Basis dieser Dokumente – mit nachprüfbaren Quellenangaben. Lade einfach Dokumente hoch, verbinde einen Ordner aus der Grünen Wolke oder importiere eigene Grünerator Docs als Quelle.
+Ein Notebook ist im Grunde dein persönliches Archiv: Du wirfst Dokumente rein, und der Grünerator beantwortet deine Fragen ausschließlich auf Basis dieser Dokumente – mit nachprüfbaren Quellenangaben. Lade einfach Dokumente hoch, verbinde einen Ordner aus der Grünen Wolke oder importiere eigene Grünerator Docs als Quelle.
 
-Offen gesagt: Ich glaube, Notebooks können die Art und Weise, wie wir Parteiarbeit machen, für immer verändern. Wissen wird durchsuchbar und verständlich wie nie.
+Offen gesagt: Ich glaube, Notebooks können die Art und Weise, wie wir Parteiarbeit machen, für immer verändern. Wissen wird durchsuchbar und verständlich wie nie. Um dieses Feature dauerhaft für uns als Basis kostenfrei und unbegrenzt verfügbar zu machen, können sich Landesverbände (in Österreich der Bundesverband) spezielle Notebooks einkaufen, die über 1.000 Dokumente beinhalten, die sich automatisiert aus den öffentlichen Beschlüssen und Pressemitteilungen speisen. Cool, oder? Die bestehenden Notebooks findest du online. Wenn das für deinen Landesverband interessant ist, melde dich gern!
 
-Um das Feature dauerhaft für uns als Basis kostenfrei und unbegrenzt verfügbar zu halten, können sich **Landesverbände** (in Österreich der Bundesverband) spezielle Notebooks einkaufen, die über 1.000 Dokumente enthalten und sich automatisiert aus den öffentlichen Beschlüssen und Pressemitteilungen speisen. Die bereits existierenden Landesverband-Notebooks findest du in der Notebook-Übersicht. Wenn das für deinen Landesverband interessant ist, melde dich gern!
+Um ein Notebook zu erstellen, klicke unten auf [Zu den Notebooks](https://gruenerator.eu/notebooks) und dann rechts bei „Eigene" auf das Plus-Icon.
 
-Um ein eigenes Notebook zu erstellen, klicke auf den Button unten und dann rechts bei „Eigene" auf das Plus-Icon. Aber Achtung: Das Feature ist neu und ich konnte noch nicht jede Kombination aus Quelle, Sichtbarkeit und Gruppenrolle durchtesten. Schreib mir bitte, wenn etwas hakt.
+Aber Achtung: Das Feature ist neu und ich konnte noch nicht jede Kombination aus Quelle, Sichtbarkeit und Gruppenrolle durchtesten. Schreib mir bitte, wenn etwas hakt.
 
 ## Neuer Dokumenten-Chat
 
-Jedes Grünerator-Dokument hat jetzt einen eigenen Chat. Du kannst die KI Fragen zu deinem Text stellen, dir Vorschläge geben lassen oder den Text gemeinsam mit ihr weiterschreiben. Wer will, aktiviert den Toggle **„AN"** – dann schreibt die KI direkt ins Dokument, du behältst aber die Kontrolle und kannst Änderungen ablehnen.
+Jedes Grünerator-Dokument hat jetzt einen eigenen Chat. Du kannst die KI Fragen zu deinem Text stellen, dir Vorschläge geben lassen oder den Text gemeinsam mit ihr weiterschreiben. Wer will, aktiviert den Toggle „AN" – dann schreibt die KI direkt ins Dokument, du behältst aber die Kontrolle und kannst Änderungen ablehnen.
 
-Außerdem kannst du Text markieren und ihn präzise mit KI verändern. Oder du tippst `/` im Dokument, wählst „KI" und lässt dir den Text weiterschreiben. Probier es unbedingt aus und gib mir Feedback – ich bin von den KI-Features im Editor schon sehr überzeugt. Und wer lieber spricht: Im Editor kannst du jetzt auch direkt **diktieren**.
+Außerdem kannst du Text markieren und präzise mit KI verändern. Oder tippe `/` im Dokument und schreibe „KI" und lass dir von KI den Text weiterschreiben.
+
+Probier es unbedingt aus und gib mir Feedback. Ich bin von den KI-Features schon sehr überzeugt. Und wer lieber spricht: Im Editor kannst du jetzt auch direkt diktieren.
 
 ## Neue Agents, besserer Chat
 
-Im Chat sind mehrere neue Spezialist\*innen dazugekommen. Der **Öffentlichkeitsarbeit-Agent** hilft dir bei Pressemitteilungen, Social-Media-Posts und Statements. Der neue **Kommunalpolitik-Assistent** unterstützt dich bei allem, was im kommunalpolitischen Alltag anfällt – von Anträgen über Bürger\*innenanfragen bis hin zu Reden.
+Im Chat sind mehrere neue Spezialist\*innen dazugekommen: Der Öffentlichkeitsarbeit-Agent hilft dir bei Pressemitteilungen, Social-Media-Posts und Statements. Der neue Kommunalpolitik-Assistent unterstützt dich bei allem, was im kommunalpolitischen Alltag anfällt – von Anträgen über Bürger\*innenanfragen bis hin zu Reden. Neu ist auch der „Tweet-wie-Ricarda"-Agent (nur de): Er formuliert Tweets im Stil von Ricarda Lang, basierend auf echten Beispielen. Damit lässt sich gut ausprobieren, was mit personalisierten Agents im Grünerator möglich ist.
 
-Neu ist auch der **„Tweet-wie-Ricarda"-Agent** (nur de). Er formuliert Tweets im Stil von Ricarda Lang, basierend auf echten Beispielen. Damit lässt sich gut ausprobieren, was mit personalisierten Agents im Grünerator möglich ist.
-
-Auch bei den Quellen hat sich einiges getan: Mit `@wolke` hängst du Dateien aus der Grünen Wolke direkt in den Chat (die Wolke vorher im Profil verbinden). Mit `@recherche` startest du eine tiefe Websuche – das Ergebnis erscheint als ausklappbare Recherche-Karte.
-
-Außerdem stehen neue Sprachmodelle zur Auswahl, darunter ein neues, sehr gutes **Mistral-Modell** aus Frankreich. Welches Modell genutzt wird, kannst du im Profil einstellen – oder du lässt den Grünerator entscheiden.
+Auch bei den Quellen hat sich einiges getan: Mit `@wolke` hängst du Dateien aus der Grünen Wolke direkt in den Chat (Wolke vorher im Profil verbinden). Mit `@recherche` startest du eine tiefe Websuche – das Ergebnis erscheint als ausklappbare Recherche-Karte. Außerdem stehen neue Sprachmodelle zur Auswahl, darunter ein neues, sehr gutes Mistral-Modell aus Frankreich. Welches Modell genutzt wird, kannst du im Profil einstellen – oder du lässt den Grünerator entscheiden.
 
 ## Bilder erstellen und bearbeiten
 
-Insbesondere in Österreich gibt es den Wunsch, mehr mit KI-Bildbearbeitung zu arbeiten. Ich habe daher die Bild-Features auf der Startseite verbessert. Wer lieber direkt aus dem Chat heraus arbeitet, findet die gleichen Werkzeuge auch dort. Außerdem könnt ihr mehr Modelle auswählen – unter anderem mit **Flux Max** noch bessere Ergebnisse erzielen (verbraucht 2 Bilder statt eines).
+Insbesondere in Österreich gibt es den Wunsch, mehr mit KI-Bildbearbeitung zu arbeiten. Ich habe daher die Bild-Features auf der Startseite verbessert. Wer lieber direkt aus dem Chat heraus arbeitet, findet die gleichen Werkzeuge auch dort. Außerdem könnt ihr mehr Modelle auswählen, unter anderem mit Flux Max noch bessere Ergebnisse erzielen (verbraucht 2 Bilder statt eines).
 
-Die Bildwerkzeuge sind teilweise noch experimentell – sie werden aber stetig weiterentwickelt. Wenn dir etwas fehlt, schreib mir gern.
+Die Bildwerkzeuge sind teilweise noch experimentell – sie werden aber stetig weiterentwickelt. Ein interessantes Beispiel siehst du unten. Wenn dir etwas fehlt, schreib mir gern.
 
 _(Lieber Robert, wenn du das siehst: Die KI ist schuld!)_
 
-## Jetzt brauche ich dich
+## Jetzt brauche ich deine Hilfe
 
-Viele dieser Features waren Wünsche aus den Landesverbänden, Landesarbeitsgemeinschaften, aus Webinaren und aus Zuschriften von Mitgliedern wie dir. Jetzt brauche ich deine Hilfe: Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung. Es können zwischendurch Fehler auftreten – dabei zählt jede Rückmeldung.
+Viele dieser Features waren Wünsche aus den Landesverbänden, Landesarbeitsgemeinschaften, aus Webinaren und von Zuschriften von Mitgliedern wie dir. Jetzt brauche ich deine Hilfe: Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung. Es können zwischendurch Fehler auftreten. Dabei zählt jede Rückmeldung.
 
 ---
 


### PR DESCRIPTION
Setzt den Mai-2026-Newsletter wörtlich auf den Text der heute verschickten Mail um. Die bisherige NotebookLM-Hook-Variante wird durch das tatsächliche „Hallo zusammen"-Greeting und den vollständigen Original-Text ersetzt (inkl. Landesverband-Pitch, Cool-oder-Frage, Robert-Parenthese).

Titel-Update: „Mai 2026: Das Notebook-Update" — entspricht dem Mail-Subject.

Email-Artefakte (Brevo-Template-Variable, „Im Browser öffnen", „Zu den Notebooks"-Button-Label, Adressblock) sind entfernt; der Button wird zum Markdown-Link auf gruenerator.eu/notebooks.