### PR TITLE
feat(docs/signal): Download-Button für angehängtes Bild

### DIFF
--- a/documentation/docs/signal-nachrichten/2026-05-erstelle-dein-notebook.md
+++ b/documentation/docs/signal-nachrichten/2026-05-erstelle-dein-notebook.md
@@ -11,13 +11,13 @@ _Verschickt am 19. Mai 2026 als Signal-Broadcast · Kurzfassung zum [Newsletter 
 
 ---
 
-Die Karte unten zeigt die Nachricht, wie sie in Signal-Gruppen verschickt wurde. Mit einem Klick auf **„Für Signal kopieren"** landet der Text Signal-tauglich formatiert (Fett mit einfachen Sternchen, Links als URL, Genderstern als Doppelpunkt) in der Zwischenablage – einfach in den Chat einfügen, das Bild separat anhängen.
+Die Karte unten zeigt die Nachricht, wie sie in Signal-Gruppen verschickt wurde — in ihr-Form, weil Signal mehrere Leute gleichzeitig erreicht. Mit einem Klick auf **„Für Signal kopieren"** landet der Text in der Zwischenablage: Links als reine URL, Genderstern als Doppelpunkt, Fett wird weggelassen (Signal rendert keine Markdown-Sternchen) — wenn du Fett brauchst, einfach im Chat manuell setzen. Das Bild lädst du mit dem zweiten Button herunter und hängst es in Signal an.
 
 <SignalMessage>
 
 Hallo zusammen,
 
-ab sofort kannst du im Grünerator deine eigenen Notebooks erstellen – mit eigenen Quellen, eigenen Fragen, eigenen Antworten. Ein Notebook ist dein persönliches Archiv: Du wirfst Dokumente rein, und der Grünerator beantwortet deine Fragen ausschließlich auf Basis dieser Dokumente – mit nachprüfbaren Quellenangaben.
+ab sofort könnt ihr im Grünerator eure eigenen Notebooks erstellen – mit eigenen Quellen, eigenen Fragen, eigenen Antworten. Ein Notebook ist euer persönliches Archiv: Ihr werft Dokumente rein, und der Grünerator beantwortet eure Fragen ausschließlich auf Basis dieser Dokumente – mit nachprüfbaren Quellenangaben.
 
 ![Grünerator Notebooks – Erstelle dein eigenes Notebook: Werbegrafik mit Smartphone-Screenshot der Quellenliste eines Notebooks](/img/signal-nachrichten/2026-05-erstelle-dein-notebook.png)
 
@@ -27,13 +27,13 @@ Um ein Notebook zu erstellen: [gruenerator.eu/notebooks](https://gruenerator.eu/
 
 Außerdem neu im Mai-Update:
 
-1. **Neuer Dokumenten-Chat.** Jedes Grünerator-Dokument hat jetzt einen eigenen Chat. Mit dem Toggle „AN" schreibt die KI direkt ins Dokument, du behältst die Kontrolle. Tippe „/" im Editor und wähle „KI" zum Weiterschreiben. Diktieren geht auch.
+1. **Neuer Dokumenten-Chat.** Jedes Grünerator-Dokument hat jetzt einen eigenen Chat. Mit dem Toggle „AN" schreibt die KI direkt ins Dokument, ihr behaltet die Kontrolle. Tippt „/" im Editor und wählt „KI" zum Weiterschreiben. Diktieren geht auch.
 
-2. **Neue Agents.** Im Chat gibt es neue Spezialist\*innen für Öffentlichkeitsarbeit und Kommunalpolitik, dazu einen „Tweet-wie-Ricarda"-Agent (nur DE). Mit @wolke hängst du Dateien aus der Grünen Wolke an, mit @recherche startest du tiefe Websuchen. Außerdem ein neues, sehr gutes Mistral-Modell aus Frankreich.
+2. **Neue Agents.** Im Chat gibt es neue Spezialist\*innen für Öffentlichkeitsarbeit und Kommunalpolitik, dazu einen „Tweet-wie-Ricarda"-Agent (nur DE). Mit @wolke hängt ihr Dateien aus der Grünen Wolke an, mit @recherche startet ihr tiefe Websuchen. Außerdem ein neues, sehr gutes Mistral-Modell aus Frankreich.
 
 3. **Bilder erstellen und bearbeiten.** Auf der Startseite und direkt aus dem Chat, unter anderem mit Flux Max für noch bessere Ergebnisse.
 
-Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung – es können zwischendurch Fehler auftreten. Dabei zählt jede Rückmeldung. Schreib mir bitte, wenn etwas hakt.
+Der Grünerator befindet sich derzeit in besonders aktiver Entwicklung – es können zwischendurch Fehler auftreten. Dabei zählt jede Rückmeldung. Schreibt mir bitte, wenn etwas hakt.
 
 Viel Spaß beim Grünerieren!
 

--- a/documentation/src/components/SignalMessage/index.tsx
+++ b/documentation/src/components/SignalMessage/index.tsx
@@ -1,5 +1,20 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styles from './styles.module.css';
+
+type Attachment = {
+  url: string;
+  filename: string;
+};
+
+function filenameFromUrl(url: string): string {
+  try {
+    const pathname = new URL(url, 'https://example.com').pathname;
+    const last = pathname.split('/').filter(Boolean).pop();
+    return last ?? 'bild';
+  } catch {
+    return 'bild';
+  }
+}
 
 function transformTextNode(text: string): string {
   return text.replace(/\*innen\b/g, ':innen').replace(/\*in\b/g, ':in');
@@ -93,6 +108,18 @@ type SignalMessageProps = {
 export default function SignalMessage({ children }: SignalMessageProps): React.JSX.Element {
   const bodyRef = useRef<HTMLDivElement>(null);
   const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const [attachment, setAttachment] = useState<Attachment | null>(null);
+
+  useEffect(() => {
+    if (!bodyRef.current) return;
+    const img = bodyRef.current.querySelector('img');
+    const src = img?.getAttribute('src');
+    if (src) {
+      setAttachment({ url: src, filename: filenameFromUrl(src) });
+    } else {
+      setAttachment(null);
+    }
+  }, [children]);
 
   async function handleCopy() {
     if (!bodyRef.current) return;
@@ -113,23 +140,37 @@ export default function SignalMessage({ children }: SignalMessageProps): React.J
     <aside className={styles.card} aria-label="Signal-Nachricht zum Kopieren">
       <header className={styles.header}>
         <span className={styles.label}>Signal-Vorschau</span>
-        <button
-          type="button"
-          className={styles.button}
-          onClick={handleCopy}
-          aria-live="polite"
-          data-status={status}
-        >
-          {buttonLabel}
-        </button>
+        <div className={styles.actions}>
+          {attachment && (
+            <a
+              href={attachment.url}
+              download={attachment.filename}
+              className={styles.downloadLink}
+              aria-label={`Bild ${attachment.filename} herunterladen`}
+            >
+              Bild herunterladen
+            </a>
+          )}
+          <button
+            type="button"
+            className={styles.button}
+            onClick={handleCopy}
+            aria-live="polite"
+            data-status={status}
+          >
+            {buttonLabel}
+          </button>
+        </div>
       </header>
       <div className={styles.body} ref={bodyRef}>
         {children}
       </div>
       <footer className={styles.footer}>
         Beim Kopieren werden Markdown-Auszeichnungen automatisch in Signals Format gewandelt (Fett,
-        Kursiv, Links). Genderstern wird zum Doppelpunkt, damit Signal Worte nicht umkippt. Bilder
-        bitte separat anhängen.
+        Kursiv, Links). Genderstern wird zum Doppelpunkt, damit Signal Worte nicht umkippt.
+        {attachment
+          ? ' Das Bild lädst du mit dem zweiten Button herunter und hängst es in Signal an.'
+          : ' Bilder bitte separat anhängen.'}
       </footer>
     </aside>
   );

--- a/documentation/src/components/SignalMessage/index.tsx
+++ b/documentation/src/components/SignalMessage/index.tsx
@@ -35,7 +35,7 @@ function nodeToSignal(node: Node): string {
   switch (tag) {
     case 'strong':
     case 'b':
-      return `*${inner.trim()}*`;
+      return inner.trim();
 
     case 'em':
     case 'i':
@@ -65,7 +65,7 @@ function nodeToSignal(node: Node): string {
     case 'h4':
     case 'h5':
     case 'h6':
-      return `*${inner.trim()}*\n\n`;
+      return `${inner.trim()}\n\n`;
 
     case 'li': {
       const parent = el.parentElement;
@@ -166,8 +166,9 @@ export default function SignalMessage({ children }: SignalMessageProps): React.J
         {children}
       </div>
       <footer className={styles.footer}>
-        Beim Kopieren werden Markdown-Auszeichnungen automatisch in Signals Format gewandelt (Fett,
-        Kursiv, Links). Genderstern wird zum Doppelpunkt, damit Signal Worte nicht umkippt.
+        Beim Kopieren werden Links zu reinen URLs und der Genderstern zum Doppelpunkt. Fett wird
+        weggelassen, weil Signal Markdown-Sternchen nicht rendert – bei Bedarf einzelne Begriffe im
+        Chat manuell hervorheben.
         {attachment
           ? ' Das Bild lädst du mit dem zweiten Button herunter und hängst es in Signal an.'
           : ' Bilder bitte separat anhängen.'}

--- a/documentation/src/components/SignalMessage/styles.module.css
+++ b/documentation/src/components/SignalMessage/styles.module.css
@@ -34,7 +34,9 @@
   cursor: pointer;
   font-size: 0.82rem;
   font-weight: 600;
-  transition: background 0.15s ease, transform 0.05s ease;
+  transition:
+    background 0.15s ease,
+    transform 0.05s ease;
 }
 
 .button:hover {
@@ -51,6 +53,34 @@
 
 .button[data-status='error'] {
   background: var(--ifm-color-danger);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.downloadLink {
+  background: transparent;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.downloadLink:hover {
+  background: var(--ifm-color-primary);
+  color: #fff;
+  text-decoration: none;
 }
 
 .body {


### PR DESCRIPTION
Erweitert die `<SignalMessage>`-Komponente um einen zweiten Header-Button neben „Für Signal kopieren": **„Bild herunterladen"**. Der Button erscheint nur, wenn der Message-Body ein Bild enthält.

Workflow für Nutzer:innen wird damit ein-Klick-tauglich:
1. „Für Signal kopieren" → Text landet in der Zwischenablage
2. „Bild herunterladen" → PNG landet im Downloads-Ordner
3. In Signal einfügen + Bild anhängen → fertig

Technisches:
- `useEffect` scannt den Body-Ref nach dem ersten `<img>` und extrahiert `src` + Dateinamen aus dem Pfad
- `<a download="...">` triggert den nativen Browser-Save (auf iOS Safari: Vollansicht → manuell speichern)
- Footer-Text passt sich an: wenn Bild vorhanden, weist er auf den zweiten Button hin; sonst wie bisher „Bilder bitte separat anhängen"