### PR TITLE
fix(docs/signal): Bild-Placeholder aus Clipboard entfernen

### DIFF
--- a/documentation/src/components/SignalMessage/index.tsx
+++ b/documentation/src/components/SignalMessage/index.tsx
@@ -86,10 +86,8 @@ function nodeToSignal(node: Node): string {
     case 'blockquote':
       return inner;
 
-    case 'img': {
-      const alt = el.getAttribute('alt') || 'Bild';
-      return `[${alt} — Bild separat in Signal anhängen]\n\n`;
-    }
+    case 'img':
+      return '';
 
     default:
       return inner;


### PR DESCRIPTION
Der "[Alt-Text — Bild separat in Signal anhängen]"-Marker im kopierten Signal-Text ist redundant: das Bild wird in Signal ohnehin oberhalb des Texts angehängt, und der Download-Button daneben ist die visuelle Aufforderung. Der Marker macht das Einfügen unnötig nervig.

Transformer gibt für `<img>` jetzt einen leeren String aus; die Leerzeile um das Bild bleibt durch den umgebenden `<p>`-Wrapper und den `\n{3,}`-Collapse erhalten.