### PR TITLE
fix(ci): point content-sync paths to workspace root after pnpm --filter cwd shift

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -220,7 +220,8 @@ jobs:
           merge-multiple: true
 
       - name: Aggregate summaries
-        run: pnpm --filter @gruenerator/api run sync:aggregate -- --dir summaries/
+        # pnpm --filter sets cwd to apps/api/, so pass an absolute path.
+        run: pnpm --filter @gruenerator/api run sync:aggregate -- --dir "${{ github.workspace }}/summaries/"
         env:
           BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
           BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
@@ -321,6 +322,8 @@ jobs:
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           QDRANT_BASIC_AUTH_USERNAME: ${{ secrets.QDRANT_BASIC_AUTH_USERNAME }}
           QDRANT_BASIC_AUTH_PASSWORD: ${{ secrets.QDRANT_BASIC_AUTH_PASSWORD }}
+          # pnpm --filter sets cwd to apps/api/; override the cwd-relative default.
+          STATS_OUTPUT_PATH: ${{ github.workspace }}/documentation/docs/ueber-den-gruenerator/inhaltsdatenbank.md
 
       - name: Create PR for stats page update
         if: always()
@@ -418,6 +421,8 @@ jobs:
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           QDRANT_BASIC_AUTH_USERNAME: ${{ secrets.QDRANT_BASIC_AUTH_USERNAME }}
           QDRANT_BASIC_AUTH_PASSWORD: ${{ secrets.QDRANT_BASIC_AUTH_PASSWORD }}
+          # pnpm --filter sets cwd to apps/api/; override the cwd-relative default.
+          STATS_OUTPUT_PATH: ${{ github.workspace }}/documentation/docs/ueber-den-gruenerator/inhaltsdatenbank.md
 
       - name: Create PR for stats page update
         if: always()

--- a/.github/workflows/social-media-sync.yml
+++ b/.github/workflows/social-media-sync.yml
@@ -89,6 +89,8 @@ jobs:
           QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
           QDRANT_BASIC_AUTH_USERNAME: ${{ secrets.QDRANT_BASIC_AUTH_USERNAME }}
           QDRANT_BASIC_AUTH_PASSWORD: ${{ secrets.QDRANT_BASIC_AUTH_PASSWORD }}
+          # pnpm --filter sets cwd to apps/api/; override the cwd-relative default.
+          STATS_OUTPUT_PATH: ${{ github.workspace }}/documentation/docs/ueber-den-gruenerator/inhaltsdatenbank.md
 
       - name: Create PR for stats page update
         if: always()


### PR DESCRIPTION
## Why

Every scheduled `Content Sync` run since #7cee7343c has failed in the `Aggregate & Report` job, leaving the hourly LV sync without its digest mail and the docs `inhaltsdatenbank.md` stats page un-refreshed.

That commit routed the tsx invocations through `pnpm --filter @gruenerator/api run ...`, which silently changes the script's cwd to `apps/api/`. Two cwd-relative paths broke:

- `aggregate-sync-summaries.ts:33` does `readdirSync('summaries/')` — `download-artifact` writes to `${{ github.workspace }}/summaries/`, but the script now scans `apps/api/summaries/`. Result: `ENOENT: scandir 'summaries/'`.
- `generate-content-stats.ts:191` writes to `process.cwd() + documentation/docs/...` — now resolves to `apps/api/documentation/...` which doesn't exist. Result: `ENOENT: open '.../apps/api/documentation/docs/ueber-den-gruenerator/inhaltsdatenbank.md'`.

The LV sub-jobs themselves survived because their `SYNC_SUMMARY_PATH` was already passed as an absolute path via `${{ github.workspace }}` (and `update-all-content.ts` resolves the contacts file relative to its own `__dirname`).

This PR passes absolute paths from the workflow for the two remaining cwd-relative spots, and fixes the identical `stats:content` regression in `social-media-sync.yml` so next Monday's run doesn't break the same way.

Failing run that motivated this: https://github.com/netzbegruenung/Gruenerator/actions/runs/26101574831

## Test plan
- [ ] Manually dispatch `Content Sync` with a single LV (e.g. BE) and confirm `Aggregate & Report` reaches `success`
- [ ] Confirm `inhaltsdatenbank.md` stats PR is opened (or no-op commits cleanly)
- [ ] Watch next scheduled hourly run for green status