### PR TITLE
ci(lint): ignore packages/shared/scripts/** in lint scope

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,7 @@ export default [
       'pnpm-lock.yaml',
       'apps/wordpress/**',
       'apps/api/scripts/**',
+      'packages/shared/scripts/**',
     ],
   },
 ];

--- a/packages/shared/eslint.config.js
+++ b/packages/shared/eslint.config.js
@@ -20,6 +20,6 @@ export default [
     },
   },
   {
-    ignores: ['dist/**'],
+    ignores: ['dist/**', 'scripts/**'],
   },
 ];


### PR DESCRIPTION
Adding any \`.ts\` file under \`packages/shared/scripts/\` currently fails CI with:

> Parsing error: ... was not found by the project service. Consider either including it in the tsconfig.json or including it in allowDefaultProject.

The shared package's \`tsconfig.json\` is rooted at \`src/\`, so anything outside (e.g. codegen scripts) isn't covered by the TS project service. Mirror the same ignore the repo already applies for \`apps/api/scripts/**\`. Two places, because turbo runs \`eslint .\` inside each package — the per-package config is the load-bearing one; the root entry covers repo-root invocations.

Unblocks #965 (which introduces a \`scripts/build-skills.ts\` codegen) and any future maintenance scripts in that directory.