### PR TITLE
fix(chat): show rejected-attachment notice inline in thread

### DIFF
--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useRef, useState, useCallback } from 'react';
+import { memo, useRef, useState, useCallback, useEffect } from 'react';
 import {
   AuiIf,
   ComposerPrimitive,
@@ -36,6 +36,7 @@ import { useChatDensity } from './chatDensityContext';
 import type { Mentionable } from '../../lib/mentionables';
 import type { DocumentMention } from '../../lib/documentMentionables';
 import { useUserProfileStore } from '../../stores/userProfileStore';
+import { handleAttachmentAddError } from '../../lib/attachmentErrorHandler';
 
 interface GrueneratorComposerProps {
   isRunning?: boolean;
@@ -238,6 +239,14 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
   // Composer mount drives lazy fetching of mentionable data (custom agents,
   // boards, docs). The query is deduplicated across consumers via React Query.
   useMentionablesQuery();
+
+  // AUI's file-input handler validates against the adapter's `accept` list and
+  // throws a raw English error before our adapter's add() runs. Subscribe to
+  // the structured event so the user sees a clean German toast instead.
+  useEffect(
+    () => composerRuntime.unstable_on('attachmentAddError', handleAttachmentAddError),
+    [composerRuntime]
+  );
 
   const dismissPopover = useCallback(() => setMention(INITIAL_MENTION_STATE), []);
 

--- a/packages/chat/src/components/thread/GrueneratorThread.tsx
+++ b/packages/chat/src/components/thread/GrueneratorThread.tsx
@@ -16,6 +16,7 @@ import { UserMessage } from './UserMessage';
 import { AssistantMessage } from './AssistantMessage';
 import { GrueneratorComposer } from './GrueneratorComposer';
 import { AutoMessageSender } from './AutoMessageSender';
+import { InlineAttachmentNotice } from './InlineAttachmentNotice';
 import { ChatDensityContext, type ChatDensity } from './chatDensityContext';
 import { useChatCollaborationContext } from '../../context/ChatCollaborationContext';
 import { useActiveAgentMeta } from '../../lib/useActiveAgentMeta';
@@ -125,6 +126,8 @@ export function GrueneratorThread({
             </ThreadPrimitive.Empty>
 
             <ThreadPrimitive.Messages components={messageComponents} />
+
+            <InlineAttachmentNotice />
 
             {collab && collab.typingUsers.length > 0 && (
               <TypingIndicator names={collab.typingUsers} />

--- a/packages/chat/src/components/thread/InlineAttachmentNotice.tsx
+++ b/packages/chat/src/components/thread/InlineAttachmentNotice.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useAttachmentNoticeStore } from '../../stores/attachmentNoticeStore';
+import { GrueneratorHomeIconLoading } from '../icons';
+import { useChatDensity } from './chatDensityContext';
+
+export function InlineAttachmentNotice() {
+  const notice = useAttachmentNoticeStore((s) => s.notice);
+  const dismiss = useAttachmentNoticeStore((s) => s.dismiss);
+  const isCompact = useChatDensity() === 'compact';
+
+  if (!notice) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={
+        isCompact
+          ? 'group mx-auto flex w-full min-w-0 items-start gap-2'
+          : 'group mx-auto flex w-full min-w-0 max-w-3xl items-start gap-4'
+      }
+    >
+      <GrueneratorHomeIconLoading
+        width={isCompact ? 24 : 32}
+        height={isCompact ? 24 : 32}
+        className="flex-shrink-0"
+      />
+      <div className="min-w-0 flex-1">
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-100">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="font-medium">{notice.title}</p>
+              <p className="mt-0.5 text-amber-900/80 dark:text-amber-100/80">
+                {notice.description}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label="Hinweis schließen"
+              className="-mr-1 -mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded text-amber-900/60 hover:bg-amber-100 hover:text-amber-900 dark:text-amber-100/60 dark:hover:bg-amber-900/40 dark:hover:text-amber-100"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/chat/src/lib/attachmentErrorHandler.ts
+++ b/packages/chat/src/lib/attachmentErrorHandler.ts
@@ -1,22 +1,17 @@
 import type { AttachmentAddErrorEvent } from '@assistant-ui/core';
+import { useAttachmentNoticeStore } from '../stores/attachmentNoticeStore';
 
 const FRIENDLY_ACCEPTED_SUMMARY =
   'PDF, Word, Excel, PowerPoint, Bilder (JPG, PNG, WebP), Text- und Code-Dateien';
 
-function showAttachmentToast(title: string, description: string): void {
-  void import('sonner')
-    .then(({ toast }) => {
-      toast.error(title, { description });
-    })
-    .catch(() => {
-      // sonner not installed in host app — fall back to console only
-    });
+function pushNotice(title: string, description: string): void {
+  useAttachmentNoticeStore.getState().setNotice({ title, description });
 }
 
 export function handleAttachmentError(error: unknown): void {
   const message = error instanceof Error ? error.message : 'Datei konnte nicht hinzugefügt werden.';
   console.warn('[Attachment]', error);
-  showAttachmentToast('Anhang nicht möglich', message);
+  pushNotice('Anhang nicht möglich', message);
 }
 
 // Extracts the rejected MIME type from AUI's English error message
@@ -26,16 +21,17 @@ function extractRejectedContentType(message: string): string | null {
   return match ? match[1] : null;
 }
 
-// Subscribes to assistant-ui's `attachmentAddError` event and renders a
-// clean German toast in place of AUI's raw English message. The original
-// rejection still bubbles to window.onunhandledrejection so GlitchTip
-// keeps capturing rejected file types as telemetry.
+// Subscribes to assistant-ui's `attachmentAddError` event and surfaces a
+// clean German notice inline in the thread (rendered by
+// InlineAttachmentNotice) in place of AUI's raw English message. The
+// original rejection still bubbles to window.onunhandledrejection so
+// GlitchTip keeps capturing rejected file types as telemetry.
 export function handleAttachmentAddError(event: AttachmentAddErrorEvent): void {
   console.warn('[Attachment]', event);
 
   if (event.reason === 'not-accepted') {
     const contentType = extractRejectedContentType(event.message) ?? 'unbekannt';
-    showAttachmentToast(
+    pushNotice(
       'Dateityp nicht unterstützt',
       `"${contentType}" kann nicht angehängt werden. Unterstützt: ${FRIENDLY_ACCEPTED_SUMMARY}.`
     );
@@ -43,11 +39,11 @@ export function handleAttachmentAddError(event: AttachmentAddErrorEvent): void {
   }
 
   if (event.reason === 'no-adapter') {
-    showAttachmentToast('Anhänge deaktiviert', 'In diesem Chat sind keine Anhänge möglich.');
+    pushNotice('Anhänge deaktiviert', 'In diesem Chat sind keine Anhänge möglich.');
     return;
   }
 
-  showAttachmentToast(
+  pushNotice(
     'Anhang fehlgeschlagen',
     'Die Datei konnte nicht angehängt werden. Bitte erneut versuchen.'
   );

--- a/packages/chat/src/lib/attachmentErrorHandler.ts
+++ b/packages/chat/src/lib/attachmentErrorHandler.ts
@@ -1,11 +1,54 @@
-export function handleAttachmentError(error: unknown): void {
-  const message = error instanceof Error ? error.message : 'Datei konnte nicht hinzugefügt werden.';
-  console.warn('[Attachment]', error);
+import type { AttachmentAddErrorEvent } from '@assistant-ui/core';
+
+const FRIENDLY_ACCEPTED_SUMMARY =
+  'PDF, Word, Excel, PowerPoint, Bilder (JPG, PNG, WebP), Text- und Code-Dateien';
+
+function showAttachmentToast(title: string, description: string): void {
   void import('sonner')
     .then(({ toast }) => {
-      toast.error('Anhang nicht möglich', { description: message });
+      toast.error(title, { description });
     })
     .catch(() => {
       // sonner not installed in host app — fall back to console only
     });
+}
+
+export function handleAttachmentError(error: unknown): void {
+  const message = error instanceof Error ? error.message : 'Datei konnte nicht hinzugefügt werden.';
+  console.warn('[Attachment]', error);
+  showAttachmentToast('Anhang nicht möglich', message);
+}
+
+// Extracts the rejected MIME type from AUI's English error message
+// ("File type X is not accepted. ..."). Returns null for any other shape.
+function extractRejectedContentType(message: string): string | null {
+  const match = /^File type (.+?) is not accepted/.exec(message);
+  return match ? match[1] : null;
+}
+
+// Subscribes to assistant-ui's `attachmentAddError` event and renders a
+// clean German toast in place of AUI's raw English message. The original
+// rejection still bubbles to window.onunhandledrejection so GlitchTip
+// keeps capturing rejected file types as telemetry.
+export function handleAttachmentAddError(event: AttachmentAddErrorEvent): void {
+  console.warn('[Attachment]', event);
+
+  if (event.reason === 'not-accepted') {
+    const contentType = extractRejectedContentType(event.message) ?? 'unbekannt';
+    showAttachmentToast(
+      'Dateityp nicht unterstützt',
+      `"${contentType}" kann nicht angehängt werden. Unterstützt: ${FRIENDLY_ACCEPTED_SUMMARY}.`
+    );
+    return;
+  }
+
+  if (event.reason === 'no-adapter') {
+    showAttachmentToast('Anhänge deaktiviert', 'In diesem Chat sind keine Anhänge möglich.');
+    return;
+  }
+
+  showAttachmentToast(
+    'Anhang fehlgeschlagen',
+    'Die Datei konnte nicht angehängt werden. Bitte erneut versuchen.'
+  );
 }

--- a/packages/chat/src/stores/attachmentNoticeStore.ts
+++ b/packages/chat/src/stores/attachmentNoticeStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+export interface AttachmentNotice {
+  id: string;
+  title: string;
+  description: string;
+}
+
+interface AttachmentNoticeState {
+  notice: AttachmentNotice | null;
+  setNotice: (notice: Omit<AttachmentNotice, 'id'>) => void;
+  dismiss: () => void;
+}
+
+export const useAttachmentNoticeStore = create<AttachmentNoticeState>((set) => ({
+  notice: null,
+  setNotice: (notice) => set({ notice: { ...notice, id: crypto.randomUUID() } }),
+  dismiss: () => set({ notice: null }),
+}));


### PR DESCRIPTION
## Why

GlitchTip captured an `Error: File type message/rfc822 is not accepted. Accepted types: …` from the chat composer when a user picked an unsupported file. The user saw no UI feedback because assistant-ui's `ComposerRuntimeCore.addAttachment` validates `file.type` against the adapter's `accept` string *before* our `GrueneratorAttachmentAdapter.add()` runs, throws synchronously, and AUI's internal file-input `onchange` handler is fire-and-forget — so the rejection bubbles straight to `window.onunhandledrejection`.

This change subscribes to AUI's structured `attachmentAddError` event and surfaces a clean German notice **inline in the thread** (rendered just above the composer, styled to match an assistant message: Grünerator avatar + amber-tinted bubble + dismiss button). Both error paths route through the same Zustand store: AUI's pre-validation event AND our adapter's `validateFile` throw (for too-large files).

The unhandled rejection still flows into GlitchTip so we retain telemetry on which file types users try.

No allow-list changes — `.eml` / `message/rfc822` remains rejected as before; the fix is purely UX.

## Files

- `packages/chat/src/stores/attachmentNoticeStore.ts` (new) — tiny dedicated Zustand store for the transient notice.
- `packages/chat/src/components/thread/InlineAttachmentNotice.tsx` (new) — assistant-styled notice rendered inside `ThreadPrimitive.Viewport`.
- `packages/chat/src/lib/attachmentErrorHandler.ts` — both error handlers push to the store (no longer toast).
- `packages/chat/src/components/thread/GrueneratorComposer.tsx` — subscribes to AUI's `attachmentAddError` event.
- `packages/chat/src/components/thread/GrueneratorThread.tsx` — mounts `<InlineAttachmentNotice />` after the message list.

## Test plan

- [ ] On `/workplace`, open the composer, click the upload button, pick an unsupported file (e.g. `.eml`). Verify an amber bubble appears just above the composer reading *"Dateityp nicht unterstützt — 'message/rfc822' kann nicht angehängt werden. Unterstützt: PDF, Word, Excel, PowerPoint, Bilder (JPG, PNG, WebP), Text- und Code-Dateien."*
- [ ] Click the X in the bubble — notice dismisses.
- [ ] Drag a too-large supported file (>25 MB PDF) — same bubble appears with the size-limit message.
- [ ] Verify a supported, sized file (e.g. `.pdf`, `.png`) still attaches normally with no notice.
- [ ] Confirm the underlying rejection still appears in GlitchTip (telemetry preserved).