### PR TITLE
fix(api): surface auth 4xx failures to Sentry/GlitchTip

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -10,6 +10,7 @@ import * as schema from '../database/schema/index.js';
 import { loadConfig } from '../database/services/PostgresService/config.js';
 import { mobileTokenExchange } from '../plugins/mobileTokenExchange.js';
 import { createLogger } from '../utils/logger.js';
+import { captureAuthIssue } from '../utils/observability/captureAuthIssue.js';
 import { redisClient } from '../utils/redis/client.js';
 
 import { ALLOWED_DOMAINS } from './domains.js';
@@ -318,6 +319,28 @@ export const auth = betterAuth({
           );
         },
       },
+    },
+  },
+
+  // Forward Better Auth's caught endpoint errors (sign-in, sign-up, callback,
+  // token-exchange, etc.) to GlitchTip. Without this, errors that Better Auth
+  // handles internally (responding 400/401 to the client) never reach the
+  // Express error middleware and never reach Sentry. The "Failed to parse
+  // state" warn-downgrade in the `logger:` block above still suppresses
+  // benign OAuth replays; `isBenignAuthError` inside `captureAuthIssue`
+  // catches any that slip through, and the sentinel on already-captured
+  // errors prevents double-capture from plugin endpoints that have already
+  // called `captureAuthIssue` before re-throwing.
+  onAPIError: {
+    onError: (error, ctx) => {
+      const path = (ctx as { path?: unknown } | undefined)?.path;
+      const pathStr = typeof path === 'string' ? path : 'unknown';
+      const stage = pathStr.includes('token-exchange')
+        ? 'token-exchange'
+        : pathStr.includes('callback')
+          ? 'oauth-callback'
+          : 'better-auth';
+      captureAuthIssue({ stage, cause: error, extras: { path: pathStr } });
     },
   },
 

--- a/apps/api/middleware/authMiddleware.ts
+++ b/apps/api/middleware/authMiddleware.ts
@@ -11,6 +11,7 @@ import { auth, type BetterAuthUser } from '../config/betterAuth.js';
 import { env } from '../config/env.js';
 import { BRAND } from '../utils/domainUtils.js';
 import { createLogger } from '../utils/logger.js';
+import { captureAuthIssue } from '../utils/observability/captureAuthIssue.js';
 import { UserId, type UserId as UserIdBrand } from '../utils/types/branded.js';
 
 import { type AuthenticatedRequest } from './types.js';
@@ -118,7 +119,12 @@ async function tryResolveUser(req: Request): Promise<Express.User | null> {
       req.headers.authorization ? 'present' : 'absent'
     );
   } catch (err) {
-    log.error('[Auth] Session check threw for %s: %s', req.originalUrl, (err as Error).message);
+    // Silent-catch boundary: returning `null` below produces a generic 401
+    // for the user without any error reaching Express's error middleware,
+    // so Sentry's `setupExpressErrorHandler` would never see this. Capture
+    // explicitly to surface session-resolution failures (DB errors, Redis
+    // outages, malformed cookies) that would otherwise be invisible.
+    captureAuthIssue({ stage: 'session-resolve', cause: err, req });
   }
 
   return null;

--- a/apps/api/plugins/mobileTokenExchange.ts
+++ b/apps/api/plugins/mobileTokenExchange.ts
@@ -3,6 +3,7 @@ import { createRemoteJWKSet, jwtVerify } from 'jose';
 
 import { env } from '../config/env.js';
 import { createLogger } from '../utils/logger.js';
+import { captureAuthIssue } from '../utils/observability/captureAuthIssue.js';
 
 import type { BetterAuthPlugin } from 'better-auth';
 
@@ -65,6 +66,11 @@ export const mobileTokenExchange = () => {
               authSource ?? 'unknown',
               (err as Error).message
             );
+            captureAuthIssue({
+              stage: 'token-exchange',
+              cause: err,
+              extras: { issuer: KC_ISSUER, authSource: authSource ?? 'unknown', path: 'idToken' },
+            });
             throw err;
           }
 
@@ -165,6 +171,15 @@ export const mobileTokenExchange = () => {
               '[TokenExchangeCode] Invalid or expired login code: %s',
               (err as Error).message
             );
+            // Suppression for expired/replayed codes happens inside
+            // `captureAuthIssue` via the benign-message regex; genuine
+            // tampering (bad signature, wrong audience/issuer) still
+            // surfaces.
+            captureAuthIssue({
+              stage: 'token-exchange',
+              cause: err,
+              extras: { path: 'login-code' },
+            });
             throw new Error('Login code is invalid or expired');
           }
 

--- a/apps/api/routes/auth/appLogin.ts
+++ b/apps/api/routes/auth/appLogin.ts
@@ -35,6 +35,7 @@ import { auth } from '../../config/betterAuth.js';
 import { env } from '../../config/env.js';
 import { forwardBetterAuthCookies } from '../../utils/betterAuthBridge.js';
 import { createLogger } from '../../utils/logger.js';
+import { captureAuthIssue } from '../../utils/observability/captureAuthIssue.js';
 import { parseJSON } from '../../utils/parseJSON.js';
 import redisClient from '../../utils/redis/client.js';
 
@@ -150,11 +151,17 @@ router.get('/login', loginLimiter, async (req: AuthRequest, res: Response): Prom
     const { url } = (await response.json()) as { url?: string };
 
     if (!url) {
-      log.error(
-        '[AppLogin] No URL returned from Better Auth signInWithOAuth2 (provider=%s, callbackURL=%s)',
-        providerId,
-        callbackURL
+      const noUrlErr = new Error(
+        `signInWithOAuth2 returned no URL (provider=${providerId}, callbackURL=${callbackURL})`
       );
+      noUrlErr.name = 'OAuthInitNoURL';
+      log.error('[AppLogin] %s', noUrlErr.message);
+      captureAuthIssue({
+        stage: 'oauth-init',
+        cause: noUrlErr,
+        req,
+        extras: { source, providerId, callbackURL },
+      });
       res.status(500).json({ error: 'Failed to initiate OAuth flow' });
       return;
     }
@@ -168,6 +175,12 @@ router.get('/login', loginLimiter, async (req: AuthRequest, res: Response): Prom
     res.redirect(url);
   } catch (error) {
     log.error('[AppLogin] Error initiating OAuth:', error);
+    captureAuthIssue({
+      stage: 'oauth-init',
+      cause: error,
+      req,
+      extras: { source, providerId },
+    });
     res.status(500).json({ error: 'Failed to initiate login' });
   }
 });
@@ -201,6 +214,14 @@ router.get('/app-callback', async (req: AuthRequest, res: Response): Promise<voi
 
     if (!session?.user) {
       log.error('[AppCallback] No session found after OAuth callback');
+      const noSessionErr = new Error('No session after OAuth callback');
+      noSessionErr.name = 'AppCallbackNoSession';
+      captureAuthIssue({
+        stage: 'oauth-no-session',
+        cause: noSessionErr,
+        req,
+        extras: { redirectTo },
+      });
       const errorRedirect = appendQueryParam(redirectTo, 'error', 'no_session');
       res.redirect(errorRedirect);
       return;
@@ -229,6 +250,12 @@ router.get('/app-callback', async (req: AuthRequest, res: Response): Promise<voi
     res.redirect(redirectWithCode);
   } catch (error) {
     log.error('[AppCallback] Error processing callback:', error);
+    captureAuthIssue({
+      stage: 'oauth-callback',
+      cause: error,
+      req,
+      extras: { stateNonce },
+    });
     res.status(500).json({ error: 'Failed to process callback' });
   }
 });

--- a/apps/api/routes/auth/authCore.ts
+++ b/apps/api/routes/auth/authCore.ts
@@ -16,6 +16,7 @@ import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
 import authMiddlewareModule from '../../middleware/authMiddleware.js';
 import * as chatMemory from '../../services/chat/ChatMemoryService.js';
 import { createLogger } from '../../utils/logger.js';
+import { captureAuthIssue } from '../../utils/observability/captureAuthIssue.js';
 
 import type { AuthRequest, LocaleUpdateBody } from './types.js';
 
@@ -52,6 +53,7 @@ async function signOutAndForwardCookies(req: Request, res: Response): Promise<vo
     if (cookies.length) res.setHeader('Set-Cookie', cookies);
   } catch (err) {
     log.warn('[Auth Logout] auth.api.signOut threw: %s', (err as Error).message);
+    captureAuthIssue({ stage: 'logout', cause: err, req });
   }
 }
 
@@ -78,11 +80,29 @@ router.get('/test', (_req: AuthRequest, res: Response): void => {
 router.get('/error', (req: AuthRequest, res: Response): void => {
   const htmlEscape = (s: string) =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-  const errorCode = htmlEscape(String(req.query.message || 'unknown_error'));
+  const rawMessage = typeof req.query.message === 'string' ? req.query.message : null;
+  const errorCode = htmlEscape(rawMessage ?? 'unknown_error');
   const correlationId = htmlEscape(String(req.query.correlationId || 'N/A'));
   const retry = req.query.retry === 'true';
 
   log.error(`[Auth Error] Code: ${errorCode}, Correlation: ${correlationId}`);
+
+  // Capture the upstream failure with the error code as the synthetic error
+  // name so events cluster per code in GlitchTip (e.g. all `account_not_linked`
+  // failures in one issue). Skip when no `?message=` query is present — that
+  // means a user landed here directly (bookmark, browser back) with no real
+  // signal to report. Benign codes like `please_restart_the_process` are
+  // suppressed by `captureAuthIssue`'s built-in filter.
+  if (rawMessage) {
+    const synthetic = new Error(`auth-error-route: ${rawMessage}`);
+    synthetic.name = rawMessage;
+    captureAuthIssue({
+      stage: 'auth-error-route',
+      cause: synthetic,
+      req,
+      extras: { errorCode: rawMessage, correlationId, retry },
+    });
+  }
 
   if (retry) {
     res.status(401).send(`<!DOCTYPE html>

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -539,8 +539,20 @@ async function startWorker(): Promise<void> {
     next();
   });
 
-  // Sentry error handler (must be before custom error handler)
-  Sentry.setupExpressErrorHandler(app);
+  // Sentry error handler (must be before custom error handler).
+  //
+  // Sentry's default `shouldHandleError` only captures 5xx, which silently
+  // drops every Better Auth credential / OAuth-state / JWT failure (all 4xx).
+  // Widen to also capture 400/401/403 — the auth failure universe — while
+  // still excluding noisy 404s and benign 422 validations.
+  Sentry.setupExpressErrorHandler(app, {
+    shouldHandleError(error) {
+      const raw = error.statusCode ?? error.status ?? error.output?.statusCode ?? 500;
+      const status = typeof raw === 'string' ? Number.parseInt(raw, 10) : raw;
+      if (!Number.isFinite(status)) return true;
+      return status >= 500 || status === 400 || status === 401 || status === 403;
+    },
+  });
 
   // Error handler
   app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {

--- a/apps/api/utils/observability/captureAuthIssue.ts
+++ b/apps/api/utils/observability/captureAuthIssue.ts
@@ -1,0 +1,140 @@
+import * as Sentry from '@sentry/node';
+import { type Request } from 'express';
+
+import { createLogger } from '../logger.js';
+
+const log = createLogger('captureAuthIssue');
+
+export type AuthStage =
+  | 'session-resolve'
+  | 'logout'
+  | 'oauth-init'
+  | 'oauth-callback'
+  | 'oauth-no-session'
+  | 'token-exchange'
+  | 'auth-error-route'
+  | 'better-auth';
+
+interface AuthIssueOptions {
+  stage: AuthStage;
+  cause: unknown;
+  req?: Request;
+  extras?: Record<string, unknown>;
+}
+
+// Benign auth failures we deliberately do NOT page on:
+//   - SESSION_NOT_FOUND / NO_SESSION: the request had no cookie or it expired.
+//     This is the steady-state logged-out flow, not an incident.
+//   - INVALID_STATE / STATE_NOT_FOUND: OAuth callback replay (back-button,
+//     link-preview prefetch, 10-min TTL elapsed). Better Auth already
+//     redirects the user to `?error=please_restart_the_process`.
+//   - TokenExpiredError: JWT expiry; the user is expected to refresh.
+//   - AbortError / ECONNRESET / ECONNABORTED: client disconnected mid-flight.
+const BENIGN_ERROR_CODES = new Set([
+  'SESSION_NOT_FOUND',
+  'NO_SESSION',
+  'INVALID_STATE',
+  'STATE_NOT_FOUND',
+  'ECONNRESET',
+  'ECONNABORTED',
+]);
+
+const BENIGN_ERROR_NAMES = new Set(['AbortError', 'TokenExpiredError', 'JWTExpired']);
+
+const BENIGN_MESSAGE_PATTERNS: RegExp[] = [
+  /please_restart_the_process/i,
+  /login code is invalid or expired/i,
+];
+
+function isBenignAuthError(cause: unknown): boolean {
+  if (cause == null || typeof cause !== 'object') return false;
+  const c = cause as { code?: string; name?: string; message?: string };
+  if (c.code != null && BENIGN_ERROR_CODES.has(c.code)) return true;
+  if (c.name != null && BENIGN_ERROR_NAMES.has(c.name)) return true;
+  if (c.message != null && BENIGN_MESSAGE_PATTERNS.some((re) => re.test(c.message!))) return true;
+  return false;
+}
+
+function resolveTransport(req: Request | undefined): 'web' | 'mobile' | 'api' {
+  if (!req) return 'api';
+  const platform = req.headers['x-app-platform'];
+  if (typeof platform === 'string') {
+    const p = platform.toLowerCase();
+    if (p === 'mobile' || p === 'ios' || p === 'android' || p === 'expo') return 'mobile';
+    if (p === 'web') return 'web';
+  }
+  const ua = req.headers['user-agent'];
+  if (typeof ua === 'string' && /grueneratorApp\/|Expo\//i.test(ua)) return 'mobile';
+  return 'web';
+}
+
+function errorName(cause: unknown): string {
+  if (cause instanceof Error) return cause.name || 'Error';
+  if (cause != null && typeof cause === 'object') {
+    const c = cause as { name?: string; code?: string };
+    return c.name ?? c.code ?? 'unknown';
+  }
+  return 'unknown';
+}
+
+function errorMessage(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string') return cause;
+  if (cause != null && typeof cause === 'object') {
+    const c = cause as { message?: string };
+    if (typeof c.message === 'string') return c.message;
+  }
+  return 'unknown error';
+}
+
+/**
+ * Send an auth failure to Sentry/GlitchTip with stage tag + symptom-based
+ * fingerprint, and mirror to Winston so logs and Sentry correlate.
+ *
+ * Suppresses benign noise (expected logged-out 401s, OAuth state replays,
+ * expired JWTs, client disconnects) via {@link isBenignAuthError}.
+ *
+ * Tag keys are namespaced under `auth.*` so a single Sentry filter
+ * (`auth.stage = oauth-callback`) is enough to scope a query.
+ */
+const SENTINEL_KEY = '__grueneratorAuthSentryCaptured';
+
+interface CapturedMarker {
+  [SENTINEL_KEY]?: boolean;
+}
+
+export function isAlreadyCaptured(cause: unknown): boolean {
+  return (
+    cause != null && typeof cause === 'object' && (cause as CapturedMarker)[SENTINEL_KEY] === true
+  );
+}
+
+export function captureAuthIssue(opts: AuthIssueOptions): void {
+  if (isAlreadyCaptured(opts.cause)) return;
+  if (isBenignAuthError(opts.cause)) {
+    log.debug('[auth/%s] benign error suppressed: %s', opts.stage, errorMessage(opts.cause));
+    return;
+  }
+
+  const transport = resolveTransport(opts.req);
+  const name = errorName(opts.cause);
+
+  Sentry.withScope((scope) => {
+    scope.setTag('auth.stage', opts.stage);
+    scope.setTag('auth.transport', transport);
+    scope.setFingerprint(['auth', opts.stage, name]);
+    if (opts.extras) scope.setExtras(opts.extras);
+    if (opts.req?.originalUrl) scope.setExtra('originalUrl', opts.req.originalUrl);
+    Sentry.captureException(opts.cause);
+  });
+
+  // Mark so that a downstream `onAPIError` hook or error middleware doesn't
+  // re-capture the same error with a coarser stage tag. Works for any
+  // object-shaped throw (Error instances, plain objects); primitives just
+  // skip the marking and may be re-captured (harmless edge case).
+  if (opts.cause != null && typeof opts.cause === 'object') {
+    (opts.cause as CapturedMarker)[SENTINEL_KEY] = true;
+  }
+
+  log.error(`[auth/${opts.stage}] ${errorMessage(opts.cause)}`, opts.extras);
+}

--- a/apps/api/utils/observability/captureAuthIssue.vitest.ts
+++ b/apps/api/utils/observability/captureAuthIssue.vitest.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for the auth-telemetry helper.
+ *
+ * These pin three invariants the GlitchTip auth-observability strategy
+ * depends on:
+ *
+ *   1. `captureAuthIssue` calls `Sentry.captureException` with the right
+ *      `auth.stage` / `auth.transport` tags and a symptom-based fingerprint
+ *      (`['auth', stage, errorName]`), so events cluster predictably.
+ *   2. Benign auth noise (SESSION_NOT_FOUND, INVALID_STATE, expired JWTs,
+ *      OAuth state replays, client disconnects) is suppressed before it
+ *      reaches Sentry — without this the dashboard floods with non-actionable
+ *      logged-out 401s.
+ *   3. The sentinel marker prevents double-capture when a plugin endpoint
+ *      captures explicitly and then re-throws into Better Auth's
+ *      `onAPIError` hook — would otherwise produce two events per failure.
+ *
+ * Run: `pnpm --filter @gruenerator/api test`
+ */
+
+import { type Request } from 'express';
+import { beforeEach, describe, it, expect, vi, afterEach } from 'vitest';
+
+const captureExceptionMock = vi.fn();
+const setTagMock = vi.fn();
+const setFingerprintMock = vi.fn();
+const setExtrasMock = vi.fn();
+const setExtraMock = vi.fn();
+
+vi.mock('@sentry/node', () => ({
+  withScope: (cb: (scope: unknown) => void) => {
+    cb({
+      setTag: setTagMock,
+      setFingerprint: setFingerprintMock,
+      setExtras: setExtrasMock,
+      setExtra: setExtraMock,
+    });
+  },
+  captureException: captureExceptionMock,
+}));
+
+vi.mock('../../config/env.js', () => ({
+  env: { LOG_LEVEL: 'warn', NODE_ENV: 'test' as const },
+}));
+
+const { captureAuthIssue, isAlreadyCaptured } = await import('./captureAuthIssue.js');
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    originalUrl: '/api/test',
+    ...overrides,
+  } as unknown as Request;
+}
+
+beforeEach(() => {
+  captureExceptionMock.mockReset();
+  setTagMock.mockReset();
+  setFingerprintMock.mockReset();
+  setExtrasMock.mockReset();
+  setExtraMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('captureAuthIssue', () => {
+  it('captures with auth.stage + transport tags and symptom fingerprint', () => {
+    const err = new TypeError('boom');
+    captureAuthIssue({ stage: 'session-resolve', cause: err, req: mockReq() });
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(err);
+    expect(setTagMock).toHaveBeenCalledWith('auth.stage', 'session-resolve');
+    expect(setTagMock).toHaveBeenCalledWith('auth.transport', 'web');
+    expect(setFingerprintMock).toHaveBeenCalledWith(['auth', 'session-resolve', 'TypeError']);
+  });
+
+  it('tags transport as mobile when X-App-Platform header is set', () => {
+    captureAuthIssue({
+      stage: 'logout',
+      cause: new Error('x'),
+      req: mockReq({ headers: { 'x-app-platform': 'ios' } as Request['headers'] }),
+    });
+    expect(setTagMock).toHaveBeenCalledWith('auth.transport', 'mobile');
+  });
+
+  it('tags transport as api when no request is provided', () => {
+    captureAuthIssue({ stage: 'better-auth', cause: new Error('x') });
+    expect(setTagMock).toHaveBeenCalledWith('auth.transport', 'api');
+  });
+
+  it('passes extras through and adds originalUrl', () => {
+    const req = mockReq({ originalUrl: '/api/auth/v2/callback/keycloak-x' });
+    captureAuthIssue({
+      stage: 'oauth-callback',
+      cause: new Error('x'),
+      req,
+      extras: { providerId: 'keycloak-x' },
+    });
+    expect(setExtrasMock).toHaveBeenCalledWith({ providerId: 'keycloak-x' });
+    expect(setExtraMock).toHaveBeenCalledWith('originalUrl', '/api/auth/v2/callback/keycloak-x');
+  });
+
+  describe('benign suppression', () => {
+    it('suppresses errors with SESSION_NOT_FOUND code', () => {
+      captureAuthIssue({
+        stage: 'session-resolve',
+        cause: { code: 'SESSION_NOT_FOUND', message: 'no session' },
+      });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses errors with INVALID_STATE code (OAuth replay)', () => {
+      captureAuthIssue({ stage: 'oauth-callback', cause: { code: 'INVALID_STATE' } });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses TokenExpiredError by name', () => {
+      const err = new Error('jwt expired');
+      err.name = 'TokenExpiredError';
+      captureAuthIssue({ stage: 'token-exchange', cause: err });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses AbortError by name (client disconnect)', () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      captureAuthIssue({ stage: 'session-resolve', cause: err });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses ECONNRESET by code', () => {
+      const err = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+      captureAuthIssue({ stage: 'session-resolve', cause: err });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses "Login code is invalid or expired" message', () => {
+      captureAuthIssue({
+        stage: 'token-exchange',
+        cause: new Error('Login code is invalid or expired'),
+      });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('suppresses please_restart_the_process redirect message', () => {
+      captureAuthIssue({
+        stage: 'auth-error-route',
+        cause: new Error('please_restart_the_process'),
+      });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sentinel double-capture prevention', () => {
+    it('marks the error after capturing', () => {
+      const err = new Error('x');
+      captureAuthIssue({ stage: 'logout', cause: err });
+      expect(isAlreadyCaptured(err)).toBe(true);
+    });
+
+    it('skips already-captured errors on the second call', () => {
+      const err = new Error('x');
+      captureAuthIssue({ stage: 'logout', cause: err });
+      captureExceptionMock.mockReset();
+      captureAuthIssue({ stage: 'better-auth', cause: err });
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('isAlreadyCaptured is false for fresh errors and non-objects', () => {
+      expect(isAlreadyCaptured(new Error('x'))).toBe(false);
+      expect(isAlreadyCaptured(null)).toBe(false);
+      expect(isAlreadyCaptured('string-throw')).toBe(false);
+      expect(isAlreadyCaptured(undefined)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Why

GlitchTip was silently missing the majority of login bugs because of three structural gaps in the existing instrumentation. The Sentry SDK is correctly installed (`@sentry/node` + `@sentry/react` v10.52.0) and `setupExpressErrorHandler(app)` is properly mounted, but:

1. **Sentry's default `shouldHandleError` filters 4xx.** Only 5xx are auto-captured. Every Better Auth credential / OAuth-state / JWT failure returns 400/401/403, so the entire auth 4xx universe was invisible to GlitchTip even though those errors reached the error middleware via `next(err)`.
2. **Several auth paths catch and respond inline** without `next(err)` — session-resolve in `authMiddleware`, the logout `signOutAndForwardCookies` helper, and the app-login OAuth init/callback handlers. These never reach the error middleware at all.
3. **Better Auth's own endpoint errors** (sign-in, sign-up, callback) are handled by Better Auth before they reach Express, so the global handler never sees them.

## What this PR does

Adds a thin `captureAuthIssue(opts)` helper that tags events with `auth.stage` and `auth.transport`, fingerprints by symptom (not stack), and suppresses known-benign noise. Wires it into the seven silent-catch boundaries and adds an `onAPIError` hook so Better Auth's internal errors flow through too. Widens the global handler's `shouldHandleError` to also pass 400/401/403 to Sentry. A sentinel marker on the captured error prevents double-capture when an explicit call and `onAPIError` would both fire for the same throw.

Benign suppression covers: `SESSION_NOT_FOUND`, `INVALID_STATE` (OAuth state replays — back-button, link-preview bots, expired TTL), `TokenExpiredError`, `AbortError`, `ECONNRESET`/`ECONNABORTED`, expired login codes, and the `please_restart_the_process` redirect chain.

## Verification

- `pnpm --filter @gruenerator/api exec vitest run utils/observability/captureAuthIssue.vitest.ts` — 14 tests pass (tags + fingerprint, transport detection, 7 benign-suppression cases, sentinel double-capture prevention)
- `pnpm --filter @gruenerator/api exec vitest run middleware/authMiddleware.vitest.ts middleware/authBoundary.vitest.ts config/authRegressions.vitest.ts config/mapKeycloakProfileToUser.vitest.ts` — 49 existing tests still pass
- `pnpm --filter @gruenerator/api exec tsc --noEmit` — clean

Post-deploy, watch GlitchTip for an `auth.stage` tag filter — events should cluster by stage. If `session-resolve` floods, the `isBenignAuthError` predicate may need widening.

## Follow-ups

- PR 2 mirrors this on the frontend (`apiClient` 401, `useAuth.detectPartialLogoutState`, redirect-loop circuit breaker).
- PR 3 fixes the two `.catch(() => {})` in `apps/mobile/services/auth.ts` so mobile silent-stuck-on-loading bugs surface.