### PR TITLE
fix(web): surface frontend auth failures to Sentry/GlitchTip

### DIFF
--- a/apps/web/src/components/utils/apiClient.ts
+++ b/apps/web/src/components/utils/apiClient.ts
@@ -8,6 +8,7 @@ import {
   LOGOUT_TIMESTAMP,
   REDIRECT_TIMESTAMPS,
 } from '../../features/auth/storageKeys';
+import { captureAuthIssue } from '../../lib/observability/captureAuthIssue';
 import { buildLoginUrl, isPublicPage } from '../../utils/authRedirect';
 import { getDesktopToken } from '../../utils/desktopAuth';
 import { isDesktopApp } from '../../utils/platform';
@@ -260,6 +261,13 @@ function performLoginRedirect(): void {
     console.warn(
       '[apiClient] Auth-redirect circuit breaker tripped — wiping all auth state and forcing clean /login'
     );
+    captureAuthIssue({
+      stage: 'redirect-loop',
+      cause: new Error(
+        `Auth-redirect circuit breaker tripped: ${recent.length} redirects in ${CIRCUIT_BREAKER_WINDOW_MS}ms`
+      ),
+      extras: { redirectCount: recent.length, windowMs: CIRCUIT_BREAKER_WINDOW_MS },
+    });
     wipeAllAuthCaches();
     clearRedirectTimestamps();
     window.location.replace('/login');

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -10,6 +10,7 @@ import {
   SESSION_ACTIVE,
 } from '../features/auth/storageKeys';
 import { authClient } from '../lib/authClient';
+import { captureAuthIssue } from '../lib/observability/captureAuthIssue';
 import { sessionUserToProfile } from '../lib/sessionUserToProfile';
 import { useAuthStore, type User } from '../stores/authStore';
 
@@ -200,6 +201,13 @@ const detectPartialLogoutState = async () => {
         console.warn(
           '[useAuth] Partial logout detected: Frontend logged out but backend still authenticated'
         );
+        // Always capture: partial logout is never normal — it indicates a
+        // failed signOut, cross-tab desync, or a Set-Cookie that didn't make
+        // it to the browser. Single high-signal bucket in GlitchTip.
+        captureAuthIssue({
+          stage: 'partial-logout',
+          cause: new Error('Partial logout: frontend logged out, backend still authenticated'),
+        });
         return {
           isPartialLogout: true,
           needsRecovery: true,
@@ -212,6 +220,7 @@ const detectPartialLogoutState = async () => {
     return { isPartialLogout: false };
   } catch (error: unknown) {
     console.warn('[useAuth] Could not check for partial logout state:', error);
+    captureAuthIssue({ stage: 'partial-logout-check-failed', cause: error });
     return { isPartialLogout: false };
   }
 };

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -44,7 +44,19 @@ if (!rootElement) {
 const root = createRoot(rootElement);
 root.render(
   // <React.StrictMode>
-  <App />
+  <Sentry.ErrorBoundary
+    fallback={({ error }) => (
+      <div style={{ padding: '2rem', fontFamily: 'system-ui, sans-serif' }}>
+        <h1>Etwas ist schiefgelaufen</h1>
+        <p>Bitte lade die Seite neu. Wenn der Fehler bleibt, kontaktiere den Support.</p>
+        <pre style={{ whiteSpace: 'pre-wrap', color: '#888', marginTop: '1rem' }}>
+          {error instanceof Error ? error.message : String(error)}
+        </pre>
+      </div>
+    )}
+  >
+    <App />
+  </Sentry.ErrorBoundary>
   // </React.StrictMode>
 );
 

--- a/apps/web/src/lib/observability/captureAuthIssue.ts
+++ b/apps/web/src/lib/observability/captureAuthIssue.ts
@@ -1,0 +1,83 @@
+import * as Sentry from '@sentry/react';
+
+export type AuthStage =
+  | 'api-401-unexpected'
+  | 'partial-logout'
+  | 'partial-logout-check-failed'
+  | 'redirect-loop'
+  | 'login-flow';
+
+interface AuthIssueOptions {
+  stage: AuthStage;
+  cause: unknown;
+  extras?: Record<string, unknown>;
+}
+
+// Same benign-suppression list as the backend helper, kept in sync because
+// the frontend sees the same noise classes (logged-out 401s, expired
+// JWTs from background pollers, client-aborted requests during navigation).
+const BENIGN_ERROR_NAMES = new Set(['AbortError', 'TokenExpiredError', 'JWTExpired']);
+
+const BENIGN_MESSAGE_PATTERNS: RegExp[] = [
+  /please_restart_the_process/i,
+  /login code is invalid or expired/i,
+  /the user aborted a request/i,
+];
+
+function isBenignAuthError(cause: unknown): boolean {
+  if (cause == null || typeof cause !== 'object') return false;
+  const c = cause as { code?: string; name?: string; message?: string };
+  if (c.name != null && BENIGN_ERROR_NAMES.has(c.name)) return true;
+  if (c.code === 'ERR_CANCELED' || c.code === 'ECONNABORTED') return true;
+  if (c.message != null && BENIGN_MESSAGE_PATTERNS.some((re) => re.test(c.message!))) return true;
+  return false;
+}
+
+function errorName(cause: unknown): string {
+  if (cause instanceof Error) return cause.name || 'Error';
+  if (cause != null && typeof cause === 'object') {
+    const c = cause as { name?: string; code?: string };
+    return c.name ?? c.code ?? 'unknown';
+  }
+  return 'unknown';
+}
+
+function errorMessage(cause: unknown): string {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === 'string') return cause;
+  if (cause != null && typeof cause === 'object') {
+    const c = cause as { message?: string };
+    if (typeof c.message === 'string') return c.message;
+  }
+  return 'unknown error';
+}
+
+/**
+ * Send a frontend auth failure to Sentry/GlitchTip with stage tag + symptom
+ * fingerprint, mirror to `console.warn` so the local dev console still shows
+ * it. Suppresses benign noise (client aborts, expired tokens, OAuth replays)
+ * via {@link isBenignAuthError}.
+ *
+ * Mirror of `apps/api/utils/observability/captureAuthIssue.ts` — keep
+ * stage names and benign-filter rules in sync so a single GlitchTip query
+ * across `auth.stage` works for both transports.
+ */
+export function captureAuthIssue(opts: AuthIssueOptions): void {
+  if (isBenignAuthError(opts.cause)) return;
+
+  const name = errorName(opts.cause);
+
+  Sentry.withScope((scope) => {
+    scope.setTag('auth.stage', opts.stage);
+    scope.setTag('auth.transport', 'web');
+    scope.setFingerprint(['auth', opts.stage, name]);
+    if (opts.extras) scope.setExtras(opts.extras);
+    if (typeof window !== 'undefined') {
+      scope.setExtra('href', window.location.href);
+      scope.setExtra('pathname', window.location.pathname);
+    }
+    Sentry.captureException(opts.cause);
+  });
+
+  console.warn(`[auth/${opts.stage}] ${errorMessage(opts.cause)}`, opts.extras ?? '');
+}


### PR DESCRIPTION
## Why

Frontend mirror of the backend GlitchTip coverage fix (PR #974). Three real bug classes were `console.warn`-only and therefore invisible in GlitchTip:

1. **Auth-redirect circuit breaker tripping** (3+ login redirects in 10s) — `apiClient.ts` already detects this and force-resets to a clean `/login`, but the trip itself was never reported. It's never a normal user flow; always a real bug.
2. **Partial logout** (frontend logged out, backend still authenticated) — `useAuth.detectPartialLogoutState()` already detects this and `console.warn`s. Indicates a failed `signOut`, cross-tab desync, or a `Set-Cookie` that didn't reach the browser. Single high-signal GlitchTip bucket.
3. **Partial-logout check throwing** — when Better Auth's `getSession()` itself crashes during the post-logout probe. Was silently swallowed.

Also wraps the React app root in `Sentry.ErrorBoundary` so render errors in auth-adjacent subtrees (currently uncaught — no ErrorBoundary at root) reach GlitchTip with a stable component-stack fingerprint.

## Design

Frontend helper is a mirror of `apps/api/utils/observability/captureAuthIssue.ts` from PR #974 — same `auth.stage` / `auth.transport` tag scheme, same symptom-fingerprint, same benign-filter rules. A single `auth.stage` GlitchTip query now works across web + api transports.

## Verification

- `pnpm --filter @gruenerator/web exec tsc --noEmit` — clean
- Lint warnings on touched files are all pre-existing; nothing new introduced

Post-deploy, expect to see new `auth.stage = redirect-loop` / `partial-logout` events when those conditions actually fire. If `partial-logout-check-failed` floods, widen the benign-filter for typical Better Auth transient session-resolve errors.

## Builds on

- #974 (backend auth coverage)