### PR TITLE
fix(mobile): log logout endpoint failures instead of swallowing them

### DIFF
--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -197,9 +197,15 @@ export async function logout(): Promise<void> {
     useAuthStore.getState().setLoggingOut(true);
 
     const apiClient = getGlobalApiClient();
-    await apiClient.post(API_ENDPOINTS.AUTH_MOBILE_LOGOUT).catch(() => {
+    await apiClient.post(API_ENDPOINTS.AUTH_MOBILE_LOGOUT).catch((err: unknown) => {
       // Server-side session invalidation is best-effort; local cleanup is
-      // what actually logs the user out on the device.
+      // what actually logs the user out on the device. The previous
+      // empty-arrow .catch hid every server-side logout failure (Better Auth
+      // 500s, network drops, expired bearer tokens) — log to surface in the
+      // React Native console + Metro logs. Server-side captures land in
+      // GlitchTip via the `onAPIError` hook in `apps/api/config/betterAuth.ts`
+      // (PR #974), so we don't need a client-side Sentry SDK here.
+      console.error('[Auth] Logout endpoint failed (proceeding with local cleanup):', err);
     });
   } finally {
     await secureStorage.clearAll();


### PR DESCRIPTION
## Why

The mobile logout API call had an empty-arrow `.catch(() => {})` that hid every server-side logout failure — Better Auth 500s, network drops, expired bearer tokens — and left no signal anywhere on device or in logs that the server-side session might still be live.

Local cleanup still runs in the `finally` block, so user-perceived logout behavior is unchanged. Adding a `console.error` is enough to surface failures in the RN console + Metro logs; the corresponding server-side errors are already captured to GlitchTip via the `onAPIError` hook on Better Auth (#974), so a full `@sentry/react-native` install isn't needed for visibility on this specific path.

## What this PR is NOT

It is **not** a `@sentry/react-native` install. That's deferred until 2 weeks of #974 + #976 data show whether mobile-specific blind spots (token storage, biometric, deep-link) need a dedicated client SDK. The plan called this approach "silent-catch fixes only".

## Verification

- `pnpm --filter @gruenerator/mobile exec tsc --noEmit` — clean
- Lint warnings on the touched file are all pre-existing `no-console` (the mobile codebase already uses `console.error` throughout for diagnostics)

## Builds on

- #974 (backend auth coverage — server-side logout failures already captured there)
- #976 (frontend auth coverage)