### PR TITLE
fix(groups): verify notebook ownership via Qdrant when sharing to a group

### DIFF
--- a/apps/api/routes/auth/groups/groupContent.ts
+++ b/apps/api/routes/auth/groups/groupContent.ts
@@ -11,6 +11,7 @@ import express, { type Router, type Response } from 'express';
 
 import { notebook_collections } from '../../../database/schema/notebooks.js';
 import { getDrizzleInstance } from '../../../database/services/DrizzleService.js';
+import { NotebookQdrantHelper } from '../../../database/services/NotebookQdrantHelper.js';
 import authMiddlewareModule from '../../../middleware/authMiddleware.js';
 import { validateBody, type TypedRequest } from '../../../middleware/validateBody.js';
 import { NextcloudShareManager } from '../../../utils/integrations/nextcloud/index.js';
@@ -32,6 +33,8 @@ import { getPostgresAndCheckMembership } from './groupCore.js';
 
 const log = createLogger('groupContent');
 const { requireAuth: ensureAuthenticated } = authMiddlewareModule;
+
+const notebookHelper = new NotebookQdrantHelper();
 
 const router: Router = express.Router();
 
@@ -242,11 +245,31 @@ router.post(
         }
       }
 
+      // User notebooks live in Qdrant, not Postgres — verify ownership there.
+      if (contentType === 'notebook_collections') {
+        const collection = await notebookHelper.getNotebookCollection(contentId);
+        if (!collection) {
+          res.status(404).json({
+            success: false,
+            message: 'Inhalt nicht gefunden.',
+          });
+          return;
+        }
+        if (collection.user_id !== userId) {
+          res.status(403).json({
+            success: false,
+            message: 'Du bist nicht Besitzer*in dieses Inhalts.',
+          });
+          return;
+        }
+      }
+
       // System content (notebooks/agents) is globally available — skip ownership check
       if (
         contentType !== 'system_notebooks' &&
         contentType !== 'system_agents' &&
-        contentType !== 'nextcloud_share_link'
+        contentType !== 'nextcloud_share_link' &&
+        contentType !== 'notebook_collections'
       ) {
         const tableName = tableNameMap[contentType] || contentType;
         const ownerColumn =


### PR DESCRIPTION
## Why

Sharing a user notebook to a group from the Gruppen page failed with `404 Inhalt nicht gefunden` on every attempt.

The generic group-share handler (`POST /api/auth/groups/:groupId/share`) verified content ownership with a Postgres query `SELECT user_id FROM notebook_collections WHERE id = $1`. But user notebooks live in **Qdrant** — the Postgres `notebook_collections` table is a vestigial, never-populated Drizzle type-only schema. So the ownership lookup found zero rows and rejected the share as not-found.

This routes `contentType === 'notebook_collections'` ownership through `NotebookQdrantHelper.getNotebookCollection()`, matching the pattern already used by the dedicated notebook-share contract endpoint (`addGroupShare`). System notebooks (`system_notebooks`) were unaffected — they already skip the ownership check.

The unshare/DELETE path needed no change; it operates directly on `group_content_shares`, which is storage-agnostic.