### PR TITLE
feat(groups): public groups with request-to-join + admin approval

### DIFF
--- a/apps/api/database/postgres/migrations/add_group_visibility_and_join_requests.sql
+++ b/apps/api/database/postgres/migrations/add_group_visibility_and_join_requests.sql
@@ -1,0 +1,27 @@
+-- Public groups: discoverability + admin-moderated join requests.
+-- Runner wraps this in a transaction (no BEGIN/COMMIT here).
+
+-- 1. Group discoverability ----------------------------------------------------
+ALTER TABLE groups ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE groups ADD COLUMN IF NOT EXISTS audience TEXT NOT NULL DEFAULT 'all'
+    CHECK (audience IN ('de-DE', 'de-AT', 'all'));
+
+-- 2. Join request lifecycle ---------------------------------------------------
+CREATE TABLE IF NOT EXISTS group_join_requests (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'approved', 'denied')),
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reviewed_by UUID REFERENCES profiles(id) ON DELETE SET NULL,
+    reviewed_at TIMESTAMPTZ
+);
+
+-- At most one PENDING request per (group, user); approved/denied rows are history.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_group_join_requests_pending
+    ON group_join_requests (group_id, user_id) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_group_join_requests_group_status
+    ON group_join_requests (group_id, status);
+CREATE INDEX IF NOT EXISTS idx_groups_is_public
+    ON groups (is_public) WHERE is_public = TRUE;

--- a/apps/api/database/schema/groups.ts
+++ b/apps/api/database/schema/groups.ts
@@ -1,0 +1,50 @@
+import {
+  type GroupAudience,
+  type GroupLink,
+  type GroupRole,
+  type JoinRequestStatus,
+} from '@gruenerator/contracts';
+import { type InferSelectModel } from 'drizzle-orm';
+import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+export const groups = pgTable('groups', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  description: text('description'),
+  created_by: uuid('created_by'),
+  created_at: timestamp('created_at', { withTimezone: true }).defaultNow(),
+  updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow(),
+  join_token: text('join_token'),
+  is_active: boolean('is_active').default(true),
+  group_type: text('group_type').default('standard'),
+  settings: jsonb('settings').$type<Record<string, unknown>>().default({}),
+  wolke_share_links: jsonb('wolke_share_links').$type<unknown[]>().default([]),
+  avatar_url: text('avatar_url'),
+  links: jsonb('links').$type<GroupLink[]>().default([]),
+  // Discoverability. TEXT column (no enum DDL) narrowed to a closed union in TS.
+  is_public: boolean('is_public').notNull().default(false),
+  audience: text('audience').$type<GroupAudience>().notNull().default('all'),
+});
+
+export const group_memberships = pgTable('group_memberships', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  group_id: uuid('group_id').notNull(),
+  user_id: uuid('user_id').notNull(),
+  role: text('role').$type<GroupRole>().default('member'),
+  joined_at: timestamp('joined_at', { withTimezone: true }).defaultNow(),
+  is_active: boolean('is_active').default(true),
+});
+
+export const group_join_requests = pgTable('group_join_requests', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  group_id: uuid('group_id').notNull(),
+  user_id: uuid('user_id').notNull(),
+  status: text('status').$type<JoinRequestStatus>().notNull().default('pending'),
+  requested_at: timestamp('requested_at', { withTimezone: true }).notNull().defaultNow(),
+  reviewed_by: uuid('reviewed_by'),
+  reviewed_at: timestamp('reviewed_at', { withTimezone: true }),
+});
+
+export type GroupRow = InferSelectModel<typeof groups>;
+export type GroupMembershipRow = InferSelectModel<typeof group_memberships>;
+export type GroupJoinRequestRow = InferSelectModel<typeof group_join_requests>;

--- a/apps/api/database/schema/index.ts
+++ b/apps/api/database/schema/index.ts
@@ -17,3 +17,4 @@ export * from './yjs.js';
 export * from './sites.js';
 export * from './apiKeys.js';
 export * from './userAgents.js';
+export * from './groups.js';

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -9,6 +9,7 @@ import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import authMiddleware from './middleware/authMiddleware.js';
 import { rateLimitMiddleware } from './middleware/rateLimitMiddleware.js';
 import antraegeRouter from './routes/antraege/index.js';
+import { mountGroupsContractRouter } from './routes/auth/groups/groupsContractRouter.js';
 import { mountImageModelPreferenceContractRouter } from './routes/auth/imageModelPreferenceContractRouter.js';
 import authInitRouter from './routes/auth/initController.js';
 import { mountModelPreferencesContractRouter } from './routes/auth/modelPreferencesContractRouter.js';
@@ -312,6 +313,11 @@ export async function setupRoutes(app: Application): Promise<void> {
   // be `.use`'d before the contract router mounts the GET /api/auth/groups/me
   // handler so the middleware actually runs.
   app.use('/api/auth/groups', requireAuth);
+  // Public-group discovery + join-request endpoints (additive to the legacy
+  // group routes). Mounted under the shared `/api/auth/groups` prefix; its
+  // literal paths (/discover, /:id/visibility, /:id/join-requests) don't
+  // collide with any legacy group route.
+  mountGroupsContractRouter(app);
   // Sharing endpoints (share mode, edit policy, group shares) — mounted BEFORE
   // the CRUD router so :id/share doesn't fall through to the legacy router.
   mountNotebookSharingContractRouter(app);

--- a/apps/api/routes/auth/groups/groupCore.ts
+++ b/apps/api/routes/auth/groups/groupCore.ts
@@ -566,7 +566,8 @@ router.get(
       const row = await postgres.queryOne(
         `SELECT
           gm.role, gm.joined_at,
-          g.id, g.name, g.description, g.created_at, g.created_by, g.join_token, g.settings, g.avatar_url, g.links
+          g.id, g.name, g.description, g.created_at, g.created_by, g.join_token, g.settings, g.avatar_url, g.links,
+          g.is_public, g.audience
         FROM group_memberships gm
         JOIN groups g ON g.id = gm.group_id
         WHERE gm.group_id = $1 AND gm.user_id = $2`,
@@ -596,6 +597,8 @@ router.get(
           settings: row.settings,
           avatar_url: row.avatar_url,
           links: row.links || [],
+          is_public: row.is_public ?? false,
+          audience: row.audience ?? 'all',
         },
         membership: {
           role: row.role,

--- a/apps/api/routes/auth/groups/groupsContractRouter.ts
+++ b/apps/api/routes/auth/groups/groupsContractRouter.ts
@@ -1,0 +1,424 @@
+/**
+ * ts-rest contract router for public-group discovery + admin-moderated join
+ * requests. Mounted alongside the legacy raw group routes; `requireAuth` is
+ * applied at the `/api/auth/groups` prefix in routes.ts.
+ */
+
+import { groupsContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import { getPostgresInstance } from '../../../database/services/PostgresService.js';
+import {
+  createNotification,
+  notifyGroupAdmins,
+  notifyGroupMembers,
+} from '../../../services/notifications/index.js';
+import { logContractValidationError } from '../../../utils/contractValidationLogger.js';
+import { createLogger } from '../../../utils/logger.js';
+
+import { getPostgresAndCheckMembership } from './groupCore.js';
+
+import type { UserProfile } from '../../../services/user/types.js';
+import type { Application, Request } from 'express';
+
+const log = createLogger('groupsContractRouter');
+
+function getUserId(req: Request): string {
+  const user = req.user as UserProfile | undefined;
+  if (!user?.id) {
+    throw new Error('Authentication required');
+  }
+  return user.id;
+}
+
+function getUserLocale(req: Request): 'de-DE' | 'de-AT' {
+  const user = req.user as UserProfile | undefined;
+  return user?.locale === 'de-AT' ? 'de-AT' : 'de-DE';
+}
+
+function toIso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+interface DiscoverRow {
+  id: string;
+  name: string;
+  description: string | null;
+  avatar_url: string | null;
+  member_count: number | string;
+  audience: 'de-DE' | 'de-AT' | 'all';
+  request_status: 'pending' | 'approved' | 'denied' | null;
+}
+
+interface JoinRequestRow {
+  id: string;
+  group_id: string;
+  user_id: string;
+  status: 'pending' | 'approved' | 'denied';
+  requested_at: string | Date;
+  display_name: string | null;
+  first_name: string | null;
+  email: string | null;
+  avatar_robot_id: number | null;
+}
+
+const s = initServer();
+
+export const groupsContractRouter = s.router(groupsContract, {
+  discoverPublicGroups: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const locale = getUserLocale(args.req);
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const rows = (await postgres.query(
+        `SELECT g.id, g.name, g.description, g.avatar_url, g.audience,
+                (SELECT COUNT(*) FROM group_memberships m
+                   WHERE m.group_id = g.id AND m.is_active = TRUE)::int AS member_count,
+                (SELECT r.status FROM group_join_requests r
+                   WHERE r.group_id = g.id AND r.user_id = $1
+                   ORDER BY r.requested_at DESC LIMIT 1) AS request_status
+           FROM groups g
+          WHERE g.is_public = TRUE
+            AND g.is_active = TRUE
+            AND g.audience IN ($2, 'all')
+            AND NOT EXISTS (
+              SELECT 1 FROM group_memberships m2
+               WHERE m2.group_id = g.id AND m2.user_id = $1 AND m2.is_active = TRUE
+            )
+          ORDER BY g.name ASC`,
+        [userId, locale],
+        { table: 'groups' }
+      )) as DiscoverRow[];
+
+      return {
+        status: 200 as const,
+        body: rows.map((r) => ({
+          id: r.id,
+          name: r.name,
+          description: r.description,
+          avatar_url: r.avatar_url,
+          member_count: Number(r.member_count),
+          audience: r.audience,
+          request_status: r.request_status,
+        })),
+      };
+    } catch (error) {
+      log.error('[groupsContract.discoverPublicGroups] Error:', error);
+      return {
+        status: 500 as const,
+        body: { success: false as const, message: 'Interner Fehler.' },
+      };
+    }
+  },
+
+  setVisibility: async (args) => {
+    const { groupId } = args.params;
+    const { is_public, audience } = args.body;
+    try {
+      const userId = getUserId(args.req);
+      const { postgres } = await getPostgresAndCheckMembership(groupId, userId, true);
+
+      const updated = (await postgres.queryOne(
+        `UPDATE groups SET is_public = $1, audience = $2, updated_at = CURRENT_TIMESTAMP
+           WHERE id = $3
+         RETURNING is_public, audience`,
+        [is_public, audience, groupId],
+        { table: 'groups' }
+      )) as { is_public: boolean; audience: 'de-DE' | 'de-AT' | 'all' } | null;
+
+      if (!updated) {
+        return {
+          status: 404 as const,
+          body: { success: false as const, message: 'Gruppe nicht gefunden.' },
+        };
+      }
+
+      return {
+        status: 200 as const,
+        body: { success: true as const, is_public: updated.is_public, audience: updated.audience },
+      };
+    } catch (error) {
+      log.warn('[groupsContract.setVisibility] Denied/failed:', (error as Error).message);
+      return {
+        status: 403 as const,
+        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
+      };
+    }
+  },
+
+  requestToJoin: async (args) => {
+    const { groupId } = args.params;
+    try {
+      const userId = getUserId(args.req);
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const group = (await postgres.queryOne(
+        'SELECT id, name, is_public FROM groups WHERE id = $1 AND is_active = TRUE',
+        [groupId],
+        { table: 'groups' }
+      )) as { id: string; name: string; is_public: boolean } | null;
+
+      if (!group) {
+        return {
+          status: 404 as const,
+          body: { success: false as const, message: 'Gruppe nicht gefunden.' },
+        };
+      }
+      if (!group.is_public) {
+        return {
+          status: 400 as const,
+          body: { success: false as const, message: 'Diese Gruppe ist nicht öffentlich.' },
+        };
+      }
+
+      const existingMembership = await postgres.queryOne(
+        'SELECT group_id FROM group_memberships WHERE group_id = $1 AND user_id = $2 AND is_active = TRUE',
+        [groupId, userId],
+        { table: 'group_memberships' }
+      );
+      if (existingMembership) {
+        return {
+          status: 400 as const,
+          body: { success: false as const, message: 'Du bist bereits Mitglied dieser Gruppe.' },
+        };
+      }
+
+      try {
+        await postgres.exec('INSERT INTO group_join_requests (group_id, user_id) VALUES ($1, $2)', [
+          groupId,
+          userId,
+        ]);
+      } catch (insertErr) {
+        if ((insertErr as { code?: string }).code === '23505') {
+          return {
+            status: 409 as const,
+            body: {
+              success: false as const,
+              message: 'Du hast bereits eine offene Anfrage für diese Gruppe.',
+            },
+          };
+        }
+        throw insertErr;
+      }
+
+      const requesterName = (args.req.user as UserProfile | undefined)?.display_name || 'Jemand';
+      void notifyGroupAdmins({
+        groupId,
+        excludeUserId: userId,
+        type: 'group_join_requested',
+        title: 'Neue Beitrittsanfrage',
+        body: `${requesterName} möchte „${group.name}" beitreten`,
+        actionUrl: `/gruppen/${groupId}`,
+      }).catch(() => {});
+
+      return { status: 201 as const, body: { success: true as const, status: 'pending' as const } };
+    } catch (error) {
+      log.error('[groupsContract.requestToJoin] Error:', error);
+      return {
+        status: 500 as const,
+        body: { success: false as const, message: 'Interner Fehler.' },
+      };
+    }
+  },
+
+  listJoinRequests: async (args) => {
+    const { groupId } = args.params;
+    try {
+      const userId = getUserId(args.req);
+      const { postgres } = await getPostgresAndCheckMembership(groupId, userId, true);
+
+      const rows = (await postgres.query(
+        `SELECT r.id, r.group_id, r.user_id, r.status, r.requested_at,
+                p.display_name, p.first_name, p.email, p.avatar_robot_id
+           FROM group_join_requests r
+           JOIN profiles p ON p.id = r.user_id
+          WHERE r.group_id = $1 AND r.status = 'pending'
+          ORDER BY r.requested_at ASC`,
+        [groupId],
+        { table: 'group_join_requests' }
+      )) as JoinRequestRow[];
+
+      return {
+        status: 200 as const,
+        body: rows.map((r) => ({
+          id: r.id,
+          group_id: r.group_id,
+          user_id: r.user_id,
+          status: r.status,
+          requested_at: toIso(r.requested_at),
+          display_name: r.display_name,
+          first_name: r.first_name,
+          email: r.email,
+          avatar_robot_id: r.avatar_robot_id,
+        })),
+      };
+    } catch (error) {
+      log.warn('[groupsContract.listJoinRequests] Denied/failed:', (error as Error).message);
+      return {
+        status: 403 as const,
+        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
+      };
+    }
+  },
+
+  approveJoinRequest: async (args) => {
+    const { groupId, requestId } = args.params;
+    let reviewerId: string;
+    try {
+      reviewerId = getUserId(args.req);
+      await getPostgresAndCheckMembership(groupId, reviewerId, true);
+    } catch (error) {
+      log.warn('[groupsContract.approveJoinRequest] Denied:', (error as Error).message);
+      return {
+        status: 403 as const,
+        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
+      };
+    }
+
+    try {
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const request = (await postgres.queryOne(
+        `SELECT id, user_id FROM group_join_requests
+           WHERE id = $1 AND group_id = $2 AND status = 'pending'`,
+        [requestId, groupId],
+        { table: 'group_join_requests' }
+      )) as { id: string; user_id: string } | null;
+
+      if (!request) {
+        return {
+          status: 404 as const,
+          body: { success: false as const, message: 'Anfrage nicht gefunden.' },
+        };
+      }
+
+      const group = (await postgres.queryOne('SELECT name FROM groups WHERE id = $1', [groupId], {
+        table: 'groups',
+      })) as { name: string } | null;
+
+      await postgres.transaction(async (client) => {
+        await postgres.transactionExec(
+          client,
+          `UPDATE group_join_requests
+             SET status = 'approved', reviewed_by = $1, reviewed_at = CURRENT_TIMESTAMP
+           WHERE id = $2`,
+          [reviewerId, requestId]
+        );
+        await postgres.transactionExec(
+          client,
+          `INSERT INTO group_memberships (group_id, user_id, role)
+             VALUES ($1, $2, 'member')
+           ON CONFLICT (group_id, user_id) DO UPDATE SET is_active = TRUE`,
+          [groupId, request.user_id]
+        );
+      });
+
+      const groupName = group?.name || 'Gruppe';
+      void createNotification({
+        userId: request.user_id,
+        type: 'group_join_approved',
+        title: 'Beitrittsanfrage angenommen',
+        body: `Du bist jetzt Mitglied von „${groupName}"`,
+        actionUrl: `/gruppen/${groupId}`,
+        metadata: { groupId, groupName },
+        groupKey: `group:${groupId}`,
+      }).catch(() => {});
+      void notifyGroupMembers({
+        groupId,
+        excludeUserId: request.user_id,
+        type: 'group_member_joined',
+        title: 'Neues Mitglied',
+        body: `Ein neues Mitglied ist „${groupName}" beigetreten`,
+        actionUrl: `/gruppen/${groupId}`,
+      }).catch(() => {});
+
+      return {
+        status: 200 as const,
+        body: { success: true as const, message: 'Anfrage angenommen.' },
+      };
+    } catch (error) {
+      log.error('[groupsContract.approveJoinRequest] Error:', error);
+      return {
+        status: 500 as const,
+        body: { success: false as const, message: 'Interner Fehler.' },
+      };
+    }
+  },
+
+  denyJoinRequest: async (args) => {
+    const { groupId, requestId } = args.params;
+    let reviewerId: string;
+    try {
+      reviewerId = getUserId(args.req);
+      await getPostgresAndCheckMembership(groupId, reviewerId, true);
+    } catch (error) {
+      log.warn('[groupsContract.denyJoinRequest] Denied:', (error as Error).message);
+      return {
+        status: 403 as const,
+        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
+      };
+    }
+
+    try {
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const request = (await postgres.queryOne(
+        `SELECT user_id FROM group_join_requests
+           WHERE id = $1 AND group_id = $2 AND status = 'pending'`,
+        [requestId, groupId],
+        { table: 'group_join_requests' }
+      )) as { user_id: string } | null;
+
+      if (!request) {
+        return {
+          status: 404 as const,
+          body: { success: false as const, message: 'Anfrage nicht gefunden.' },
+        };
+      }
+
+      await postgres.exec(
+        `UPDATE group_join_requests
+           SET status = 'denied', reviewed_by = $1, reviewed_at = CURRENT_TIMESTAMP
+         WHERE id = $2`,
+        [reviewerId, requestId]
+      );
+
+      const group = (await postgres.queryOne('SELECT name FROM groups WHERE id = $1', [groupId], {
+        table: 'groups',
+      })) as { name: string } | null;
+      const groupName = group?.name || 'Gruppe';
+
+      void createNotification({
+        userId: request.user_id,
+        type: 'group_join_denied',
+        title: 'Beitrittsanfrage abgelehnt',
+        body: `Deine Anfrage für „${groupName}" wurde abgelehnt`,
+        metadata: { groupId, groupName },
+        groupKey: `group:${groupId}`,
+      }).catch(() => {});
+
+      return {
+        status: 200 as const,
+        body: { success: true as const, message: 'Anfrage abgelehnt.' },
+      };
+    } catch (error) {
+      log.error('[groupsContract.denyJoinRequest] Error:', error);
+      return {
+        status: 500 as const,
+        body: { success: false as const, message: 'Interner Fehler.' },
+      };
+    }
+  },
+});
+
+export function mountGroupsContractRouter(app: Application): void {
+  createExpressEndpoints(groupsContract, groupsContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'groupsContract'),
+  });
+}

--- a/apps/api/services/notifications/groupNotifications.ts
+++ b/apps/api/services/notifications/groupNotifications.ts
@@ -60,3 +60,56 @@ export async function notifyGroupMembers(params: NotifyGroupParams): Promise<voi
     log.warn('Failed to notify group members', { groupId, error: (err as Error).message });
   }
 }
+
+/**
+ * Notify a group's admins (membership role='admin' plus the creator), excluding
+ * one user. Used to surface pending join requests to the people who can act on
+ * them.
+ */
+export async function notifyGroupAdmins(params: NotifyGroupParams): Promise<void> {
+  const { groupId, excludeUserId, type, title, body, actionUrl, metadata } = params;
+
+  try {
+    const db = getPostgresInstance();
+
+    const admins = (await db.query(
+      `SELECT DISTINCT user_id FROM (
+         SELECT user_id FROM group_memberships
+           WHERE group_id = $1 AND role = 'admin' AND is_active = TRUE
+         UNION
+         SELECT created_by AS user_id FROM groups WHERE id = $1 AND created_by IS NOT NULL
+       ) admins
+       WHERE user_id != $2`,
+      [groupId, excludeUserId]
+    )) as Array<{ user_id: string }>;
+
+    if (!admins || admins.length === 0) return;
+
+    const group = (await db.queryOne('SELECT name FROM groups WHERE id = $1', [groupId], {
+      table: 'groups',
+    })) as { name: string } | null;
+    const groupName = group?.name || 'Gruppe';
+
+    await Promise.all(
+      admins.map((a) =>
+        createNotification({
+          userId: a.user_id,
+          type,
+          title,
+          body,
+          actionUrl,
+          metadata: { groupId, groupName, ...metadata },
+          groupKey: `group:${groupId}`,
+        }).catch((err: unknown) => {
+          log.warn('Failed to notify group admin', {
+            userId: a.user_id,
+            groupId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        })
+      )
+    );
+  } catch (err) {
+    log.warn('Failed to notify group admins', { groupId, error: (err as Error).message });
+  }
+}

--- a/apps/api/services/notifications/index.ts
+++ b/apps/api/services/notifications/index.ts
@@ -9,7 +9,7 @@ export {
   deleteOldNotifications,
 } from './NotificationService.js';
 
-export { notifyGroupMembers } from './groupNotifications.js';
+export { notifyGroupMembers, notifyGroupAdmins } from './groupNotifications.js';
 
 export {
   subscribeToUserNotifications,

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -35,6 +35,9 @@ const DEFAULT_CHANNEL_PREFERENCES: Record<NotificationType, ChannelPreferences> 
   group_role_changed: { email: false, push: true, in_app: true },
   group_content_shared: { email: true, push: true, in_app: true },
   group_deleted: { email: false, push: true, in_app: true },
+  group_join_requested: { email: true, push: true, in_app: true },
+  group_join_approved: { email: true, push: true, in_app: true },
+  group_join_denied: { email: false, push: true, in_app: true },
   transfer_downloaded: { email: false, push: true, in_app: true },
   notebook_liked: { email: false, push: false, in_app: true },
 };

--- a/apps/web/src/features/groups/components/GroupDetailSection.tsx
+++ b/apps/web/src/features/groups/components/GroupDetailSection.tsx
@@ -323,6 +323,8 @@ const GroupDetailSection = memo(
           onDeleteLink={deleteLink}
           isAddingLink={isAddingLink}
           isUpdatingLink={isUpdatingLink}
+          onSuccessMessage={onSuccessMessage}
+          onErrorMessage={onErrorMessage}
         />
       </motion.div>
     );

--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -28,6 +28,7 @@ import {
   HiOutlinePhotograph,
   HiOutlineTrash,
   HiOutlineUserGroup,
+  HiOutlineGlobeAlt,
   HiPencil,
   HiCheck,
   HiX,
@@ -36,6 +37,7 @@ import { PiSquaresFour } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 
 import apiClient from '../../../components/utils/apiClient';
+import { type GroupAudience } from '../hooks/useGroupRequests';
 import {
   useCloneCanvasTemplate,
   useGroupMembers,
@@ -44,8 +46,10 @@ import {
 } from '../hooks/useGroups';
 
 import AddContentToGroupModal from './AddContentToGroupModal';
+import GroupJoinRequestsSection from './GroupJoinRequestsSection';
 import GroupLinksSection from './GroupLinksSection';
 import GroupMembersList from './GroupMembersList';
+import GroupVisibilityDialog from './GroupVisibilityDialog';
 
 export interface GroupInfo {
   id?: string;
@@ -54,6 +58,8 @@ export interface GroupInfo {
   created_by?: string;
   avatar_url?: string | null;
   links?: GroupLink[];
+  is_public?: boolean;
+  audience?: GroupAudience;
 }
 
 export interface GroupData {
@@ -124,6 +130,8 @@ interface GroupInfoSectionProps {
   onDeleteLink?: (linkId: string) => void;
   isAddingLink?: boolean;
   isUpdatingLink?: boolean;
+  onSuccessMessage?: (msg: string) => void;
+  onErrorMessage?: (msg: string) => void;
 }
 
 const GroupInfoSection = memo(
@@ -162,12 +170,15 @@ const GroupInfoSection = memo(
     onDeleteLink,
     isAddingLink,
     isUpdatingLink,
+    onSuccessMessage,
+    onErrorMessage,
   }: GroupInfoSectionProps) => {
     const navigate = useNavigate();
     const { members, isLoadingMembers } = useGroupMembers(groupId, { isActive: true });
     const [membersPopoverOpen, setMembersPopoverOpen] = useState(false);
     const [membersDialogOpen, setMembersDialogOpen] = useState(false);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [showVisibilityDialog, setShowVisibilityDialog] = useState(false);
     const cloneTemplate = useCloneCanvasTemplate();
 
     const handleCloneTemplate = useCallback(
@@ -365,6 +376,10 @@ const GroupInfoSection = memo(
                       {joinLinkCopied ? 'Kopiert!' : 'Einladungslink kopieren'}
                     </DropdownMenuItem>
                   )}
+                  <DropdownMenuItem onClick={() => setShowVisibilityDialog(true)}>
+                    <HiOutlineGlobeAlt className="size-4 mr-xs" />
+                    {data?.groupInfo?.is_public ? 'Öffentlich (verwalten)' : 'Öffentlich machen'}
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onClick={() => setShowDeleteConfirm(true)}
@@ -497,6 +512,15 @@ const GroupInfoSection = memo(
             )}
           </div>
         </div>
+
+        {data?.isAdmin && (
+          <GroupJoinRequestsSection
+            groupId={groupId}
+            isAdmin={!!data?.isAdmin}
+            onSuccessMessage={onSuccessMessage ?? (() => {})}
+            onErrorMessage={onErrorMessage ?? (() => {})}
+          />
+        )}
 
         <div>
           <SectionHeader
@@ -760,6 +784,18 @@ const GroupInfoSection = memo(
             }}
             onAddLink={onAddLink}
             isAddingLink={isAddingLink}
+          />
+        )}
+
+        {data?.isAdmin && (
+          <GroupVisibilityDialog
+            groupId={groupId}
+            isOpen={showVisibilityDialog}
+            onClose={() => setShowVisibilityDialog(false)}
+            currentIsPublic={data?.groupInfo?.is_public ?? false}
+            currentAudience={(data?.groupInfo?.audience as GroupAudience) ?? 'all'}
+            onSuccessMessage={onSuccessMessage ?? (() => {})}
+            onErrorMessage={onErrorMessage ?? (() => {})}
           />
         )}
 

--- a/apps/web/src/features/groups/components/GroupJoinRequestsSection.tsx
+++ b/apps/web/src/features/groups/components/GroupJoinRequestsSection.tsx
@@ -1,0 +1,109 @@
+import { getRobotAvatarPath, validateRobotId, getRobotAvatarAlt } from '@gruenerator/shared/avatar';
+import { Button } from '@gruenerator/ui';
+import { memo, useState } from 'react';
+import { HiCheck, HiUserAdd, HiX } from 'react-icons/hi';
+
+import {
+  useGroupJoinRequests,
+  useReviewJoinRequest,
+  type JoinRequest,
+} from '../hooks/useGroupRequests';
+
+interface GroupJoinRequestsSectionProps {
+  groupId: string;
+  isAdmin: boolean;
+  onSuccessMessage: (msg: string) => void;
+  onErrorMessage: (msg: string) => void;
+}
+
+function requesterName(request: JoinRequest): string {
+  return request.display_name || request.first_name || request.email || 'Nutzer*in';
+}
+
+const GroupJoinRequestsSection = memo(
+  ({ groupId, isAdmin, onSuccessMessage, onErrorMessage }: GroupJoinRequestsSectionProps) => {
+    const { data: requests } = useGroupJoinRequests(groupId, isAdmin);
+    const { approve, deny } = useReviewJoinRequest(groupId);
+    const [busyId, setBusyId] = useState<string | null>(null);
+
+    if (!isAdmin || !requests || requests.length === 0) return null;
+
+    const handleApprove = (request: JoinRequest) => {
+      setBusyId(request.id);
+      approve.mutate(request.id, {
+        onSuccess: () => onSuccessMessage(`${requesterName(request)} wurde aufgenommen.`),
+        onError: (error: Error) => onErrorMessage(error.message),
+        onSettled: () => setBusyId(null),
+      });
+    };
+
+    const handleDeny = (request: JoinRequest) => {
+      setBusyId(request.id);
+      deny.mutate(request.id, {
+        onSuccess: () => onSuccessMessage(`Anfrage von ${requesterName(request)} abgelehnt.`),
+        onError: (error: Error) => onErrorMessage(error.message),
+        onSettled: () => setBusyId(null),
+      });
+    };
+
+    return (
+      <div>
+        <div className="sticky top-0 z-10 bg-background-pure flex items-center justify-between py-xs -mx-sm px-sm">
+          <h4 className="flex items-center gap-sm text-xs font-medium uppercase tracking-wide text-grey-500 m-0">
+            <HiUserAdd className="text-base text-primary-500" />
+            Beitrittsanfragen ({requests.length})
+          </h4>
+        </div>
+
+        <div className="flex flex-col gap-xs">
+          {requests.map((request) => {
+            const profileImageNumber = validateRobotId(request.avatar_robot_id);
+            const isBusy = busyId === request.id;
+            return (
+              <div
+                key={request.id}
+                className="flex items-center gap-sm px-sm py-xs rounded-md hover:bg-grey-50 dark:hover:bg-grey-800/50 transition-colors"
+              >
+                <img
+                  src={getRobotAvatarPath(profileImageNumber)}
+                  alt={getRobotAvatarAlt(profileImageNumber)}
+                  className="w-7 h-7 rounded-full shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium text-foreground-heading truncate block">
+                    {requesterName(request)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-xxs shrink-0">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={isBusy}
+                    onClick={() => handleApprove(request)}
+                    aria-label="Anfrage annehmen"
+                  >
+                    <HiCheck className="size-4 text-green-600" />
+                    Annehmen
+                  </Button>
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    disabled={isBusy}
+                    onClick={() => handleDeny(request)}
+                    aria-label="Anfrage ablehnen"
+                  >
+                    <HiX className="size-4 text-red-500" />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);
+
+GroupJoinRequestsSection.displayName = 'GroupJoinRequestsSection';
+
+export default GroupJoinRequestsSection;

--- a/apps/web/src/features/groups/components/GroupVisibilityDialog.tsx
+++ b/apps/web/src/features/groups/components/GroupVisibilityDialog.tsx
@@ -1,0 +1,131 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+} from '@gruenerator/ui';
+import { memo, useEffect, useState } from 'react';
+
+import { useSetGroupVisibility, type GroupAudience } from '../hooks/useGroupRequests';
+
+interface GroupVisibilityDialogProps {
+  groupId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  currentIsPublic: boolean;
+  currentAudience: GroupAudience;
+  onSuccessMessage: (msg: string) => void;
+  onErrorMessage: (msg: string) => void;
+}
+
+const AUDIENCE_LABELS: Record<GroupAudience, string> = {
+  all: 'Alle',
+  'de-DE': 'Deutschland',
+  'de-AT': 'Österreich',
+};
+
+const GroupVisibilityDialog = memo(
+  ({
+    groupId,
+    isOpen,
+    onClose,
+    currentIsPublic,
+    currentAudience,
+    onSuccessMessage,
+    onErrorMessage,
+  }: GroupVisibilityDialogProps) => {
+    const [isPublic, setIsPublic] = useState(currentIsPublic);
+    const [audience, setAudience] = useState<GroupAudience>(currentAudience);
+    const setVisibility = useSetGroupVisibility(groupId);
+
+    // Re-sync local state whenever the dialog opens with fresh server values.
+    useEffect(() => {
+      if (isOpen) {
+        setIsPublic(currentIsPublic);
+        setAudience(currentAudience);
+      }
+    }, [isOpen, currentIsPublic, currentAudience]);
+
+    const handleSave = () => {
+      setVisibility.mutate(
+        { is_public: isPublic, audience },
+        {
+          onSuccess: () => {
+            onSuccessMessage(
+              isPublic
+                ? 'Gruppe ist jetzt öffentlich sichtbar.'
+                : 'Gruppe ist nicht mehr öffentlich.'
+            );
+            onClose();
+          },
+          onError: (error: Error) => onErrorMessage(error.message),
+        }
+      );
+    };
+
+    return (
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Öffentliche Sichtbarkeit</DialogTitle>
+            <DialogDescription>
+              Öffentliche Gruppen erscheinen für andere unter „Öffentliche Gruppen". Nutzer*innen
+              können eine Beitrittsanfrage stellen, die du als Admin bestätigen musst.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-md py-sm">
+            <div className="flex items-center justify-between gap-md">
+              <Label htmlFor="group-public-switch">Öffentlich sichtbar</Label>
+              <Switch id="group-public-switch" checked={isPublic} onCheckedChange={setIsPublic} />
+            </div>
+
+            <div className="flex flex-col gap-xs">
+              <Label htmlFor="group-audience-select">Zielgruppe</Label>
+              <Select
+                value={audience}
+                onValueChange={(value) => setAudience(value as GroupAudience)}
+                disabled={!isPublic}
+              >
+                <SelectTrigger id="group-audience-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">{AUDIENCE_LABELS.all}</SelectItem>
+                  <SelectItem value="de-DE">{AUDIENCE_LABELS['de-DE']}</SelectItem>
+                  <SelectItem value="de-AT">{AUDIENCE_LABELS['de-AT']}</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-grey-500">
+                Steuert, wem die Gruppe angezeigt wird – passend zum Land der Nutzer*innen.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={onClose} disabled={setVisibility.isPending}>
+              Abbrechen
+            </Button>
+            <Button onClick={handleSave} disabled={setVisibility.isPending}>
+              {setVisibility.isPending ? 'Wird gespeichert...' : 'Speichern'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+);
+
+GroupVisibilityDialog.displayName = 'GroupVisibilityDialog';
+
+export default GroupVisibilityDialog;

--- a/apps/web/src/features/groups/components/PublicGroupsSection.tsx
+++ b/apps/web/src/features/groups/components/PublicGroupsSection.tsx
@@ -1,0 +1,99 @@
+import { getGroupInitials } from '@gruenerator/shared/groups';
+import { Badge, Button, CardGrid, SectionHeader } from '@gruenerator/ui';
+import { memo, useMemo, useState } from 'react';
+import { HiUserGroup } from 'react-icons/hi';
+
+import { useDiscoverPublicGroups, useRequestToJoin } from '../hooks/useGroupRequests';
+
+interface PublicGroupsSectionProps {
+  onSuccessMessage: (msg: string) => void;
+  onErrorMessage: (msg: string) => void;
+}
+
+const PublicGroupsSection = memo(
+  ({ onSuccessMessage, onErrorMessage }: PublicGroupsSectionProps) => {
+    const { data: publicGroups } = useDiscoverPublicGroups();
+    const requestToJoin = useRequestToJoin();
+    const [search, setSearch] = useState('');
+    const [pendingId, setPendingId] = useState<string | null>(null);
+
+    const filtered = useMemo(() => {
+      const groups = publicGroups ?? [];
+      const q = search.trim().toLowerCase();
+      if (!q) return groups;
+      return groups.filter((g) => g.name.toLowerCase().includes(q));
+    }, [publicGroups, search]);
+
+    if (!publicGroups || publicGroups.length === 0) return null;
+
+    const handleRequest = (groupId: string) => {
+      setPendingId(groupId);
+      requestToJoin.mutate(groupId, {
+        onSuccess: () => onSuccessMessage('Beitrittsanfrage gesendet.'),
+        onError: (error: Error) => onErrorMessage(error.message),
+        onSettled: () => setPendingId(null),
+      });
+    };
+
+    return (
+      <div className="mt-xl">
+        <SectionHeader
+          title="Öffentliche Gruppen"
+          searchQuery={search}
+          onSearchChange={setSearch}
+        />
+        {filtered.length === 0 ? (
+          <p className="text-sm text-grey-500 dark:text-grey-400 py-md text-center">
+            Keine öffentlichen Gruppen gefunden.
+          </p>
+        ) : (
+          <CardGrid columns="2">
+            {filtered.map((group) => {
+              const isPending = group.request_status === 'pending';
+              const wasDenied = group.request_status === 'denied';
+              const isSubmitting = pendingId === group.id && requestToJoin.isPending;
+              return (
+                <div
+                  key={group.id}
+                  className="flex items-center gap-sm rounded-md border border-grey-200 dark:border-grey-700 bg-background p-sm"
+                >
+                  <div className="flex items-center justify-center size-10 rounded-full bg-primary-50 dark:bg-primary-950/20 shrink-0">
+                    <span className="text-sm font-semibold text-primary-600 dark:text-primary-400">
+                      {getGroupInitials(group.name)}
+                    </span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground truncate m-0">{group.name}</p>
+                    <p className="text-xs text-grey-500 truncate mt-xxs m-0">
+                      {group.member_count} Mitglied{group.member_count === 1 ? '' : 'er'}
+                    </p>
+                  </div>
+                  {isPending ? (
+                    <Badge variant="outline" className="shrink-0">
+                      Anfrage gesendet
+                    </Badge>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0"
+                      disabled={isSubmitting}
+                      onClick={() => handleRequest(group.id)}
+                    >
+                      <HiUserGroup className="size-4" />
+                      {wasDenied ? 'Erneut anfragen' : 'Beitritt anfragen'}
+                    </Button>
+                  )}
+                </div>
+              );
+            })}
+          </CardGrid>
+        )}
+      </div>
+    );
+  }
+);
+
+PublicGroupsSection.displayName = 'PublicGroupsSection';
+
+export default PublicGroupsSection;

--- a/apps/web/src/features/groups/hooks/useGroupRequests.ts
+++ b/apps/web/src/features/groups/hooks/useGroupRequests.ts
@@ -1,0 +1,121 @@
+/**
+ * Typed hooks for public-group discovery + admin-moderated join requests.
+ * Backed by the ts-rest groups contract via the shared contracts client.
+ */
+import { getContractsClient } from '@gruenerator/shared/api';
+import { GROUPS_QUERY_KEY, groupDetailsKey } from '@gruenerator/shared/groups';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useOptimizedAuth } from '../../../hooks/useAuth';
+
+import type {
+  GroupAudience,
+  JoinRequest,
+  PublicGroup,
+  SetGroupVisibilityBody,
+} from '@gruenerator/contracts';
+
+export const PUBLIC_GROUPS_QUERY_KEY = ['publicGroups'] as const;
+export const groupJoinRequestsKey = (groupId: string) => ['groupJoinRequests', groupId] as const;
+
+export type { JoinRequest, PublicGroup, GroupAudience };
+
+export function useDiscoverPublicGroups() {
+  const { user, isAuthenticated, loading } = useOptimizedAuth();
+  return useQuery<PublicGroup[]>({
+    queryKey: PUBLIC_GROUPS_QUERY_KEY,
+    queryFn: async () => {
+      const result = await getContractsClient().groups.discoverPublicGroups();
+      if (result.status !== 200) {
+        throw new Error('Öffentliche Gruppen konnten nicht geladen werden.');
+      }
+      return result.body;
+    },
+    enabled: !!user?.id && isAuthenticated && !loading,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useRequestToJoin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      const result = await getContractsClient().groups.requestToJoin({ params: { groupId } });
+      if (result.status !== 201) {
+        const message =
+          result.status === 409 ? result.body.message : 'Beitrittsanfrage fehlgeschlagen.';
+        throw new Error(message);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: PUBLIC_GROUPS_QUERY_KEY });
+    },
+  });
+}
+
+export function useGroupJoinRequests(groupId: string, enabled: boolean) {
+  return useQuery<JoinRequest[]>({
+    queryKey: groupJoinRequestsKey(groupId),
+    queryFn: async () => {
+      const result = await getContractsClient().groups.listJoinRequests({ params: { groupId } });
+      if (result.status !== 200) {
+        throw new Error('Beitrittsanfragen konnten nicht geladen werden.');
+      }
+      return result.body;
+    },
+    enabled: enabled && !!groupId,
+  });
+}
+
+export function useReviewJoinRequest(groupId: string) {
+  const queryClient = useQueryClient();
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: groupJoinRequestsKey(groupId) });
+    void queryClient.invalidateQueries({ queryKey: ['groupMembers', groupId] });
+    void queryClient.invalidateQueries({ queryKey: GROUPS_QUERY_KEY });
+  };
+
+  const approve = useMutation({
+    mutationFn: async (requestId: string) => {
+      const result = await getContractsClient().groups.approveJoinRequest({
+        params: { groupId, requestId },
+      });
+      if (result.status !== 200) throw new Error('Anfrage konnte nicht angenommen werden.');
+      return result.body;
+    },
+    onSuccess: invalidate,
+  });
+
+  const deny = useMutation({
+    mutationFn: async (requestId: string) => {
+      const result = await getContractsClient().groups.denyJoinRequest({
+        params: { groupId, requestId },
+      });
+      if (result.status !== 200) throw new Error('Anfrage konnte nicht abgelehnt werden.');
+      return result.body;
+    },
+    onSuccess: invalidate,
+  });
+
+  return { approve, deny };
+}
+
+export function useSetGroupVisibility(groupId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: SetGroupVisibilityBody) => {
+      const result = await getContractsClient().groups.setVisibility({
+        params: { groupId },
+        body,
+      });
+      if (result.status !== 200) throw new Error('Sichtbarkeit konnte nicht geändert werden.');
+      return result.body;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: groupDetailsKey(groupId) });
+      void queryClient.invalidateQueries({ queryKey: PUBLIC_GROUPS_QUERY_KEY });
+    },
+  });
+}

--- a/apps/web/src/features/groups/pages/GruppenPage.tsx
+++ b/apps/web/src/features/groups/pages/GruppenPage.tsx
@@ -8,6 +8,7 @@ import PageContainer from '../../../components/common/PageContainer';
 import ToolGrid from '../../../components/common/ToolGrid';
 import GroupDetailSection from '../components/GroupDetailSection';
 import GroupsCreateSection from '../components/GroupsCreateSection';
+import PublicGroupsSection from '../components/PublicGroupsSection';
 import { useGroups, type GroupSummary } from '../hooks/useGroups';
 
 import type { ToolEntry } from '../../../components/common/ToolGrid';
@@ -109,6 +110,7 @@ const GruppenPage = () => {
               columns={2}
             />
           )}
+          <PublicGroupsSection onSuccessMessage={showSuccess} onErrorMessage={showError} />
         </>
       )}
 

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -1,4 +1,12 @@
-import { FileText, Heart, LayoutDashboard, MessageSquare, Share2, Users } from 'lucide-react';
+import {
+  FileText,
+  Heart,
+  LayoutDashboard,
+  MessageSquare,
+  Share2,
+  UserPlus,
+  Users,
+} from 'lucide-react';
 
 import { openLinkAction, type NotificationTypeConfig } from '../notificationConfig';
 
@@ -71,6 +79,15 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
     description: 'Wenn eine Gruppe aufgelöst wird',
     icon: Users,
     group: 'groups',
+  },
+  group_join_requested: {
+    label: 'Beitrittsanfragen',
+    description:
+      'Wenn jemand einer öffentlichen Gruppe beitreten möchte oder deine Anfrage beantwortet wird',
+    icon: UserPlus,
+    group: 'groups',
+    subtypes: ['group_join_requested', 'group_join_approved', 'group_join_denied'],
+    actions: (ctx) => [openLinkAction('Gruppe öffnen')(ctx)],
   },
 
   notebook_liked: {

--- a/packages/contracts/src/contracts/groupsContract.ts
+++ b/packages/contracts/src/contracts/groupsContract.ts
@@ -1,0 +1,137 @@
+/**
+ * ts-rest contract for public-group discovery + admin-moderated join requests.
+ *
+ * Additive to the legacy raw group routes (apps/api/routes/auth/groups/*).
+ * These six endpoints are the new public-groups feature; the existing group
+ * CRUD / membership / content-sharing / avatar routes remain on the legacy
+ * router. All routes require auth — `requireAuth` is applied at the
+ * `/api/auth/groups` prefix in routes.ts.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  discoverGroupsResponseSchema,
+  groupErrorResponseSchema,
+  groupSuccessResponseSchema,
+  groupVisibilityResponseSchema,
+  joinRequestsResponseSchema,
+  requestToJoinResponseSchema,
+  setGroupVisibilityBodySchema,
+} from '../schemas/groups.js';
+
+const c = initContract();
+
+export const groupsContract = c.router({
+  /**
+   * GET /api/auth/groups/discover
+   * Public groups the caller can see (audience-filtered by locale), excluding
+   * groups they already belong to. Each is annotated with the caller's
+   * current request_status.
+   */
+  discoverPublicGroups: {
+    method: 'GET',
+    path: '/api/auth/groups/discover',
+    responses: {
+      200: discoverGroupsResponseSchema,
+      401: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'List discoverable public groups for the authenticated user',
+  },
+
+  /**
+   * PUT /api/auth/groups/:groupId/visibility
+   * Admin toggles discoverability + audience.
+   */
+  setVisibility: {
+    method: 'PUT',
+    path: '/api/auth/groups/:groupId/visibility',
+    pathParams: z.object({ groupId: z.string() }),
+    body: setGroupVisibilityBodySchema,
+    responses: {
+      200: groupVisibilityResponseSchema,
+      401: groupErrorResponseSchema,
+      403: groupErrorResponseSchema,
+      404: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'Set group public visibility and audience (admin)',
+  },
+
+  /**
+   * POST /api/auth/groups/:groupId/join-requests
+   * A user requests to join a public group. Idempotent on an existing pending
+   * request (409).
+   */
+  requestToJoin: {
+    method: 'POST',
+    path: '/api/auth/groups/:groupId/join-requests',
+    pathParams: z.object({ groupId: z.string() }),
+    body: c.noBody(),
+    responses: {
+      201: requestToJoinResponseSchema,
+      400: groupErrorResponseSchema,
+      401: groupErrorResponseSchema,
+      404: groupErrorResponseSchema,
+      409: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'Request to join a public group',
+  },
+
+  /**
+   * GET /api/auth/groups/:groupId/join-requests
+   * Admin lists pending join requests for a group.
+   */
+  listJoinRequests: {
+    method: 'GET',
+    path: '/api/auth/groups/:groupId/join-requests',
+    pathParams: z.object({ groupId: z.string() }),
+    responses: {
+      200: joinRequestsResponseSchema,
+      401: groupErrorResponseSchema,
+      403: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'List pending join requests for a group (admin)',
+  },
+
+  /**
+   * POST /api/auth/groups/:groupId/join-requests/:requestId/approve
+   * Admin approves a pending request → creates membership.
+   */
+  approveJoinRequest: {
+    method: 'POST',
+    path: '/api/auth/groups/:groupId/join-requests/:requestId/approve',
+    pathParams: z.object({ groupId: z.string(), requestId: z.string() }),
+    body: c.noBody(),
+    responses: {
+      200: groupSuccessResponseSchema,
+      401: groupErrorResponseSchema,
+      403: groupErrorResponseSchema,
+      404: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'Approve a join request (admin)',
+  },
+
+  /**
+   * POST /api/auth/groups/:groupId/join-requests/:requestId/deny
+   * Admin denies a pending request.
+   */
+  denyJoinRequest: {
+    method: 'POST',
+    path: '/api/auth/groups/:groupId/join-requests/:requestId/deny',
+    pathParams: z.object({ groupId: z.string(), requestId: z.string() }),
+    body: c.noBody(),
+    responses: {
+      200: groupSuccessResponseSchema,
+      401: groupErrorResponseSchema,
+      403: groupErrorResponseSchema,
+      404: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'Deny a join request (admin)',
+  },
+});

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -30,3 +30,4 @@ export { modelPreferencesContract } from './modelPreferencesContract.js';
 export { imageModelPreferenceContract } from './imageModelPreferenceContract.js';
 export { adminVorlagenContract } from './adminVorlagenContract.js';
 export { canvasAiContract } from './canvasAi.js';
+export { groupsContract } from './groupsContract.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -46,6 +46,7 @@ export {
   imageModelPreferenceContract,
   adminVorlagenContract,
   canvasAiContract,
+  groupsContract,
 } from './contracts/index.js';
 
 // ── Schemas (Zod) ───────────────────────────────────────────────────────────
@@ -78,3 +79,4 @@ export * from './schemas/imageModelPreference.js';
 export * from './schemas/adminVorlagen.js';
 export * from './schemas/canvasAi.js';
 export * from './schemas/skill.js';
+export * from './schemas/groups.js';

--- a/packages/contracts/src/schemas/groups.ts
+++ b/packages/contracts/src/schemas/groups.ts
@@ -1,0 +1,133 @@
+/**
+ * Zod schemas for public-group discovery and admin-moderated join requests.
+ *
+ * Single source of truth for the closed sets shared across the stack:
+ *   - group role      (admin | member)
+ *   - group audience  (de-DE | de-AT | all)  — Austria is a first-class locale
+ *   - join request status (pending | approved | denied)
+ *
+ * The Drizzle schema (apps/api/database/schema/groups.ts) imports the inferred
+ * types from here so the DB row types stay narrowed to these unions.
+ */
+import { z } from 'zod';
+
+// ── Closed sets ───────────────────────────────────────────────────────────────
+
+export const groupRoleSchema = z.enum(['admin', 'member']);
+export type GroupRole = z.infer<typeof groupRoleSchema>;
+
+export const groupAudienceSchema = z.enum(['de-DE', 'de-AT', 'all']);
+export type GroupAudience = z.infer<typeof groupAudienceSchema>;
+
+export const joinRequestStatusSchema = z.enum(['pending', 'approved', 'denied']);
+export type JoinRequestStatus = z.infer<typeof joinRequestStatusSchema>;
+
+export const ALLOWED_LINK_ICONS = [
+  'globe',
+  'link',
+  'mail',
+  'calendar',
+  'chat',
+  'folder',
+  'phone',
+  'video',
+  'document',
+  'map',
+  'signal',
+  'whatsapp',
+  'telegram',
+  'discord',
+  'slack',
+  'mattermost',
+  'canva',
+  'figma',
+  'miro',
+  'drive',
+  'nextcloud',
+  'notion',
+  'trello',
+  'github',
+  'zoom',
+  'googlemeet',
+  'youtube',
+  'instagram',
+  'mastodon',
+  'linkedin',
+  'x',
+] as const;
+export const groupLinkIconSchema = z.enum(ALLOWED_LINK_ICONS);
+
+export const groupLinkSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string(),
+  description: z.string().nullish(),
+  icon: z.string(),
+});
+export type GroupLink = z.infer<typeof groupLinkSchema>;
+
+// ── Response shapes ────────────────────────────────────────────────────────────
+
+/**
+ * A discoverable public group as shown on the /gruppen "Öffentliche Gruppen"
+ * section. `request_status` is the calling user's current request state for
+ * this group (null = never requested / can request).
+ */
+export const publicGroupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  avatar_url: z.string().nullable(),
+  member_count: z.number(),
+  audience: groupAudienceSchema,
+  request_status: joinRequestStatusSchema.nullable(),
+});
+export type PublicGroup = z.infer<typeof publicGroupSchema>;
+
+export const discoverGroupsResponseSchema = z.array(publicGroupSchema);
+
+/** A pending join request with the requester's profile fields joined in. */
+export const joinRequestSchema = z.object({
+  id: z.string(),
+  group_id: z.string(),
+  user_id: z.string(),
+  status: joinRequestStatusSchema,
+  requested_at: z.string(),
+  display_name: z.string().nullable(),
+  first_name: z.string().nullable(),
+  email: z.string().nullable(),
+  avatar_robot_id: z.number().nullable(),
+});
+export type JoinRequest = z.infer<typeof joinRequestSchema>;
+
+export const joinRequestsResponseSchema = z.array(joinRequestSchema);
+
+export const requestToJoinResponseSchema = z.object({
+  success: z.literal(true),
+  status: joinRequestStatusSchema,
+});
+
+export const groupVisibilityResponseSchema = z.object({
+  success: z.literal(true),
+  is_public: z.boolean(),
+  audience: groupAudienceSchema,
+});
+
+export const groupSuccessResponseSchema = z.object({
+  success: z.literal(true),
+  message: z.string(),
+});
+
+export const groupErrorResponseSchema = z.object({
+  success: z.literal(false),
+  message: z.string(),
+});
+export type GroupErrorResponse = z.infer<typeof groupErrorResponseSchema>;
+
+// ── Request bodies ─────────────────────────────────────────────────────────────
+
+export const setGroupVisibilityBodySchema = z.object({
+  is_public: z.boolean(),
+  audience: groupAudienceSchema,
+});
+export type SetGroupVisibilityBody = z.infer<typeof setGroupVisibilityBodySchema>;

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -31,6 +31,9 @@ export const notificationTypeSchema = z.enum([
   'group_role_changed',
   'group_content_shared',
   'group_deleted',
+  'group_join_requested',
+  'group_join_approved',
+  'group_join_denied',
   'transfer_downloaded',
   'notebook_liked',
 ]);

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -34,6 +34,7 @@ import {
   adminVorlagenContract,
   docsContract,
   documentsContract,
+  groupsContract,
 } from '@gruenerator/contracts';
 import { initClient } from '@ts-rest/core';
 
@@ -145,6 +146,7 @@ const _imageModelPreferenceClient = () => initClient(imageModelPreferenceContrac
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
 const _docsClient = () => initClient(docsContract, CLIENT_OPTS);
 const _documentsClient = () => initClient(documentsContract, CLIENT_OPTS);
+const _groupsClient = () => initClient(groupsContract, CLIENT_OPTS);
 
 export interface ContractsClient {
   threads: ReturnType<typeof _threadsClient>;
@@ -164,6 +166,7 @@ export interface ContractsClient {
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
   docs: ReturnType<typeof _docsClient>;
   documents: ReturnType<typeof _documentsClient>;
+  groups: ReturnType<typeof _groupsClient>;
 }
 
 // ── Lazy singleton ────────────────────────────────────────────────────────────
@@ -200,6 +203,7 @@ export function getContractsClient(): ContractsClient {
     adminVorlagen: _adminVorlagenClient(),
     docs: _docsClient(),
     documents: _documentsClient(),
+    groups: _groupsClient(),
   };
 
   return _client;


### PR DESCRIPTION
## Why

Groups were invite-only via a secret `join_token` link — there was no way to make a group discoverable, no pending-membership state, and no admin moderation. This adds public, discoverable groups with an admin-moderated join flow so people can find and request to join relevant groups instead of needing a link.

## What it does

- **Admins** can mark a group public via the group's admin menu, choosing an audience (`Deutschland` / `Österreich` / `Alle`). Toggling it back off makes the group private again and removes it from discovery.
- **Users** see public groups in a new "Öffentliche Gruppen" section on `/gruppen` (audience-filtered by their locale) and can send a join request.
- **Admins** see pending requests in the group detail view and approve/deny them. Each step fires a notification (request → admins; approval/denial → requester).

## Notes

- Austria is treated as a first-class locale: the public listing is audience-filtered (`de-DE` / `de-AT` / `all`), mirroring the notebook discovery pattern.
- New endpoints are fully ts-rest contracted end-to-end (Contract → Zod → Drizzle row types → ts-rest server → typed client). The feature is **additive** — existing raw group routes (CRUD, members, content-sharing, avatar) are untouched; migrating those to contracts is a possible follow-up.
- Schema change ships as an auto-run migration (`is_public` + `audience` on `groups`, new `group_join_requests` table with a partial-unique index allowing one pending request per user/group).

## Test plan

- [ ] Migration applies on backend start; `group_join_requests` exists.
- [ ] Admin A makes a group public → User B sees it under "Öffentliche Gruppen" and can request → A is notified.
- [ ] A approves → B becomes a member and is notified; A denies → B notified, no membership, can re-request.
- [ ] de-AT user does not see a `de-DE`-only public group; `all`/`de-AT` ones appear.
- [ ] Double-request returns a clean 409; non-admin hitting approve/list gets 403.
- [ ] Turning visibility back off removes the group from discovery.
- [ ] Regression: token-link join, role changes, content sharing, avatar upload still work.