### PR TITLE
fix(notebook): hide owner-only actions on shared notebooks in "Eigene"

### DIFF
--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -165,8 +165,11 @@ NotebookSection.displayName = 'NotebookSection';
 
 const COLLAPSE_THRESHOLD = 3;
 
+const isOwnedCollection = (c: NotebookCollection): boolean =>
+  c.access_source == null || c.access_source === 'owned';
+
 interface EigeneNotebooksProps {
-  qaCollections: { id: string; name: string }[];
+  qaCollections: NotebookCollection[];
   onView: (id: string) => void;
   onEdit: (id: string) => void;
   onDelete: (id: string) => Promise<void>;
@@ -191,14 +194,19 @@ const EigeneNotebooks = memo(
     const [deletingId, setDeletingId] = useState<string | null>(null);
     const [sharedInfo, setSharedInfo] = useState<string | null>(null);
     const [shareError, setShareError] = useState<string | null>(null);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
 
     const { userGroups = [] } = useGroups({ isActive: qaCollections.length > 0 });
 
     const handleDelete = async (id: string, name: string) => {
       if (window.confirm(`Notebook "${name}" wirklich löschen?`)) {
         setDeletingId(id);
+        setDeleteError(null);
         try {
           await onDelete(id);
+        } catch {
+          setDeleteError(id);
+          setTimeout(() => setDeleteError(null), 2000);
         } finally {
           setDeletingId(null);
         }
@@ -299,7 +307,7 @@ const EigeneNotebooks = memo(
                               <HiShare />
                               {copiedId === c.id ? 'Link kopiert!' : 'Link kopieren'}
                             </DropdownMenuItem>
-                            {userGroups.length > 0 && (
+                            {isOwnedCollection(c) && userGroups.length > 0 && (
                               <>
                                 <DropdownMenuSeparator />
                                 {(userGroups as { id: string; name: string }[]).map((group) => (
@@ -315,14 +323,22 @@ const EigeneNotebooks = memo(
                             )}
                           </DropdownMenuSubContent>
                         </DropdownMenuSub>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          variant="destructive"
-                          onClick={() => handleDelete(c.id, c.name)}
-                        >
-                          <HiOutlineTrash />
-                          {deletingId === c.id ? 'Wird gelöscht…' : 'Löschen'}
-                        </DropdownMenuItem>
+                        {isOwnedCollection(c) && (
+                          <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              variant="destructive"
+                              onClick={() => handleDelete(c.id, c.name)}
+                            >
+                              <HiOutlineTrash />
+                              {deleteError === c.id
+                                ? 'Fehler!'
+                                : deletingId === c.id
+                                  ? 'Wird gelöscht…'
+                                  : 'Löschen'}
+                            </DropdownMenuItem>
+                          </>
+                        )}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </div>

--- a/packages/contracts/src/contracts/notebookCollectionsContract.ts
+++ b/packages/contracts/src/contracts/notebookCollectionsContract.ts
@@ -178,6 +178,7 @@ export const notebookCollectionsContract = c.router(
       responses: {
         200: simpleSuccessMessageSchema,
         401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
         404: notebookErrorResponseSchema,
         500: notebookErrorResponseSchema,
       },


### PR DESCRIPTION
Fixes GlitchTip **GRUENERATOR-C3**: an uncaught `AxiosError: 403` reached Sentry when a user clicked **Löschen** on a notebook in the "Eigene" list.

The user wasn't actually the owner — the "Eigene" list also surfaces group-shared and publicly-shared notebooks (`access_source: 'shared' | 'authenticated'`), but it rendered the full owner menu on every row. Deleting a non-owned collection is owner-only server-side, so it 403s, and nothing caught the error.

Now owner-only actions (Löschen, group-share targets) are gated behind `access_source` ownership, and `handleDelete` catches errors inline ("Fehler!") as defense-in-depth so an edge-case 403 can't escape to Sentry. Delete policy stays owner-only by design. The `403` response is also declared on the `deleteCollection` ts-rest contract to match the handler and its sibling mutations.