### PR TITLE
fix(groups): read ts-rest error body defensively in group hooks

### DIFF
--- a/apps/web/src/features/groups/hooks/useGroups.ts
+++ b/apps/web/src/features/groups/hooks/useGroups.ts
@@ -32,6 +32,16 @@ export { getGroupInitials, type GroupLink, type GroupMember, type GroupSummary }
 
 export const useGroupDetails = useGroupDetailsShared;
 
+// ts-rest widens the body to `unknown` for non-2xx statuses; read `message`
+// defensively rather than asserting the error-schema shape.
+function errMessage(body: unknown, fallback = 'Aktion fehlgeschlagen.'): string {
+  if (body && typeof body === 'object' && 'message' in body) {
+    const m = (body as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return fallback;
+}
+
 interface MutationOptions<T = unknown> {
   onSuccess?: (result: T) => void;
   onError?: (error: Error) => void;
@@ -67,7 +77,7 @@ export const useGroups = ({ isActive }: UseGroupsOptions = {}) => {
     mutationFn: async (input: { groupId: string; name?: string; description?: string }) => {
       const { groupId, ...body } = input;
       const res = await getContractsClient().groups.updateInfo({ params: { groupId }, body });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return { groupId, data: res.body };
     },
     onSuccess: ({ groupId }) => {
@@ -82,7 +92,7 @@ export const useGroups = ({ isActive }: UseGroupsOptions = {}) => {
         params: { groupId: input.groupId },
         body: { name: input.name },
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return { groupId: input.groupId, data: res.body };
     },
     onSuccess: ({ groupId }) => {
@@ -305,7 +315,7 @@ export const useUpdateGroupSettings = (groupId: string | null) => {
         params: { groupId },
         body: { settings },
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return res.body;
     },
     onSuccess: () => {

--- a/apps/web/src/features/groups/pages/JoinGroupPage.tsx
+++ b/apps/web/src/features/groups/pages/JoinGroupPage.tsx
@@ -31,7 +31,7 @@ const JoinGroupPage = () => {
         params: { joinToken: joinToken ?? '' },
       });
       if (res.status !== 200) {
-        throw new Error(res.body.message ?? 'Ungültiger Einladungslink');
+        throw new Error('Ungültiger Einladungslink');
       }
       return { group: { name: res.body.group.name }, alreadyMember: res.body.alreadyMember };
     },

--- a/packages/shared/src/groups/useGroups.ts
+++ b/packages/shared/src/groups/useGroups.ts
@@ -14,6 +14,19 @@ import {
   type VerifyTokenResult,
 } from './types.js';
 
+/**
+ * Safely read a `message` off a ts-rest error body. The client response type
+ * widens the body to `unknown` for non-2xx (undeclared) statuses, so we extract
+ * defensively rather than asserting the error-schema shape.
+ */
+function errMessage(body: unknown, fallback = 'Aktion fehlgeschlagen.'): string {
+  if (body && typeof body === 'object' && 'message' in body) {
+    const m = (body as { message?: unknown }).message;
+    if (typeof m === 'string') return m;
+  }
+  return fallback;
+}
+
 export const useUserGroups = (options: { enabled?: boolean } = {}) =>
   useQuery({
     queryKey: GROUPS_QUERY_KEY,
@@ -79,7 +92,7 @@ export const useDeleteGroup = () => {
   return useMutation({
     mutationFn: async (groupId: string) => {
       const res = await getContractsClient().groups.deleteGroup({ params: { groupId } });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return groupId;
     },
     onSuccess: (groupId) => {
@@ -102,7 +115,7 @@ export const useUpdateGroupInfo = (groupId: string) => {
         params: { groupId },
         body: input,
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: GROUPS_QUERY_KEY });
@@ -119,7 +132,7 @@ export const useUpdateGroupName = (groupId: string) => {
         params: { groupId },
         body: { name },
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: GROUPS_QUERY_KEY });
@@ -135,7 +148,7 @@ export const useVerifyJoinToken = (joinToken: string | null | undefined) =>
       const res = await getContractsClient().groups.verifyToken({
         params: { joinToken: joinToken ?? '' },
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return { group: res.body.group, alreadyMember: res.body.alreadyMember };
     },
     enabled: !!joinToken,
@@ -149,7 +162,7 @@ export const useJoinGroup = () => {
   return useMutation({
     mutationFn: async (joinToken: string) => {
       const res = await getContractsClient().groups.joinByToken({ body: { joinToken } });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return { group: res.body.group, alreadyMember: res.body.alreadyMember ?? false };
     },
     onSuccess: () => {
@@ -163,7 +176,7 @@ export const useLeaveGroup = () => {
   return useMutation({
     mutationFn: async (groupId: string) => {
       const res = await getContractsClient().groups.leaveGroup({ params: { groupId } });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return groupId;
     },
     onSuccess: (groupId) => {
@@ -182,7 +195,7 @@ export const useUpdateMemberRole = (groupId: string) => {
         params: { groupId, memberId: input.memberId },
         body: { role: input.role },
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: groupMembersKey(groupId) });
@@ -195,7 +208,7 @@ export const useAddGroupLink = (groupId: string) => {
   return useMutation({
     mutationFn: async (link: Omit<GroupLink, 'id'>) => {
       const res = await getContractsClient().groups.addLink({ params: { groupId }, body: link });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return res.body.link as GroupLink;
     },
     onSuccess: () => {
@@ -213,7 +226,7 @@ export const useUpdateGroupLink = (groupId: string) => {
         params: { groupId, linkId },
         body: link,
       });
-      if (res.status !== 200) throw new Error(res.body.message);
+      if (res.status !== 200) throw new Error(errMessage(res.body));
       return res.body.link as GroupLink;
     },
     onSuccess: () => {


### PR DESCRIPTION
## Why

Follow-up to #983 (group core → ts-rest migration), which was merged before this typecheck fix landed. The ts-rest client types the response `body` as `unknown` for non-2xx (undeclared) statuses, so accessing `res.body.message` in the error branch of the migrated group hooks fails `tsc` (`error TS18046: 'res.body' is of type 'unknown'`) in `@gruenerator/shared` and `@gruenerator/web`.

This extracts the error message through a small runtime guard (`errMessage`) instead of asserting the error-schema shape — matching the existing `useNotificationsTyped` pattern of not trusting `res.body` in the error branch.

## Changes

- `packages/shared/src/groups/useGroups.ts` — `errMessage` helper; 9 error-branch throws.
- `apps/web/src/features/groups/hooks/useGroups.ts` — same helper; 3 facade mutations.
- `apps/web/src/features/groups/pages/JoinGroupPage.tsx` — static invite-link error message.

## Test plan

- [x] `pnpm --filter @gruenerator/shared typecheck` — 0 errors
- [x] `pnpm --filter @gruenerator/web typecheck` — 0 errors
- [ ] Group create/delete/leave/role error toasts still show a sensible message.