### PR TITLE
refactor(groups): dedupe error handling + fix masked 500s in contract router

### DIFF
--- a/apps/api/routes/auth/groups/groupsContractRouter.ts
+++ b/apps/api/routes/auth/groups/groupsContractRouter.ts
@@ -117,6 +117,26 @@ function isPermissionError(err: unknown): boolean {
   return msg.includes('Mitglied') || msg.includes('Berechtigung') || msg.includes('Admin');
 }
 
+/**
+ * Shared error tail for membership-gated handlers: a permission throw becomes a
+ * 403 (with the thrown message), anything else is logged and becomes a 500.
+ * Every gated route declares both 403 and 500 with `groupErrorResponseSchema`,
+ * so this union is assignable in each handler.
+ */
+function groupErrorResponse(
+  handler: string,
+  message500: string,
+  error: unknown
+):
+  | { status: 403; body: { success: false; message: string } }
+  | { status: 500; body: { success: false; message: string } } {
+  if (isPermissionError(error)) {
+    return { status: 403, body: { success: false, message: (error as Error).message } };
+  }
+  log.error(`[groupsContract.${handler}] Error:`, error);
+  return { status: 500, body: { success: false, message: message500 } };
+}
+
 function toIsoOrNull(value: unknown): string | null {
   if (value == null) return null;
   if (value instanceof Date) return value.toISOString();
@@ -241,11 +261,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, is_public: updated.is_public, audience: updated.audience },
       };
     } catch (error) {
-      log.warn('[groupsContract.setVisibility] Denied/failed:', (error as Error).message);
-      return {
-        status: 403 as const,
-        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
-      };
+      return groupErrorResponse('setVisibility', 'Interner Fehler.', error);
     }
   },
 
@@ -357,11 +373,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         })),
       };
     } catch (error) {
-      log.warn('[groupsContract.listJoinRequests] Denied/failed:', (error as Error).message);
-      return {
-        status: 403 as const,
-        body: { success: false as const, message: 'Keine Berechtigung für diese Aktion.' },
-      };
+      return groupErrorResponse('listJoinRequests', 'Interner Fehler.', error);
     }
   },
 
@@ -908,17 +920,11 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, message: 'Gruppenname erfolgreich aktualisiert.' },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.updateName] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Aktualisieren des Gruppennamens.' },
-      };
+      return groupErrorResponse(
+        'updateName',
+        'Fehler beim Aktualisieren des Gruppennamens.',
+        error
+      );
     }
   },
 
@@ -1145,17 +1151,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.listMembers] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Laden der Gruppenmitglieder.' },
-      };
+      return groupErrorResponse('listMembers', 'Fehler beim Laden der Gruppenmitglieder.', error);
     }
   },
 
@@ -1221,17 +1217,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, message: 'Rolle erfolgreich aktualisiert.' },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.updateMemberRole] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Aktualisieren der Rolle.' },
-      };
+      return groupErrorResponse('updateMemberRole', 'Fehler beim Aktualisieren der Rolle.', error);
     }
   },
 
@@ -1271,17 +1257,7 @@ export const groupsContractRouter = s.router(groupsContract, {
 
       return { status: 200 as const, body: { success: true as const, link: newLink } };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.addLink] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Hinzufügen des Links.' },
-      };
+      return groupErrorResponse('addLink', 'Fehler beim Hinzufügen des Links.', error);
     }
   },
 
@@ -1321,17 +1297,7 @@ export const groupsContractRouter = s.router(groupsContract, {
 
       return { status: 200 as const, body: { success: true as const, link: links[idx] } };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.updateLink] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Aktualisieren des Links.' },
-      };
+      return groupErrorResponse('updateLink', 'Fehler beim Aktualisieren des Links.', error);
     }
   },
 
@@ -1354,17 +1320,7 @@ export const groupsContractRouter = s.router(groupsContract, {
 
       return { status: 200 as const, body: { success: true as const } };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.deleteLink] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Löschen des Links.' },
-      };
+      return groupErrorResponse('deleteLink', 'Fehler beim Löschen des Links.', error);
     }
   },
 
@@ -1491,17 +1447,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, message: 'Inhalt erfolgreich mit der Gruppe geteilt.' },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.shareContent] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Teilen des Inhalts.' },
-      };
+      return groupErrorResponse('shareContent', 'Fehler beim Teilen des Inhalts.', error);
     }
   },
 
@@ -1547,20 +1493,11 @@ export const groupsContractRouter = s.router(groupsContract, {
         },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.unshareContent] Error:', error);
-      return {
-        status: 500 as const,
-        body: {
-          success: false as const,
-          message: 'Fehler beim Entfernen des Inhalts aus der Gruppe.',
-        },
-      };
+      return groupErrorResponse(
+        'unshareContent',
+        'Fehler beim Entfernen des Inhalts aus der Gruppe.',
+        error
+      );
     }
   },
 
@@ -1828,17 +1765,7 @@ export const groupsContractRouter = s.router(groupsContract, {
 
       return { status: 200 as const, body: { success: true as const, content: groupContent } };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.listGroupContent] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Laden der Gruppeninhalte.' },
-      };
+      return groupErrorResponse('listGroupContent', 'Fehler beim Laden der Gruppeninhalte.', error);
     }
   },
 
@@ -1884,17 +1811,11 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, message: 'Berechtigungen erfolgreich aktualisiert.' },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.updateContentPermissions] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Aktualisieren der Berechtigungen.' },
-      };
+      return groupErrorResponse(
+        'updateContentPermissions',
+        'Fehler beim Aktualisieren der Berechtigungen.',
+        error
+      );
     }
   },
 
@@ -1938,17 +1859,11 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, message: 'Inhalt erfolgreich aus der Gruppe entfernt.' },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.removeGroupContent] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Entfernen des geteilten Inhalts.' },
-      };
+      return groupErrorResponse(
+        'removeGroupContent',
+        'Fehler beim Entfernen des geteilten Inhalts.',
+        error
+      );
     }
   },
 
@@ -2027,17 +1942,7 @@ export const groupsContractRouter = s.router(groupsContract, {
         body: { success: true as const, vorlagen, tags: templateTags },
       };
     } catch (error) {
-      if (isPermissionError(error)) {
-        return {
-          status: 403 as const,
-          body: { success: false as const, message: (error as Error).message },
-        };
-      }
-      log.error('[groupsContract.listGroupVorlagen] Error:', error);
-      return {
-        status: 500 as const,
-        body: { success: false as const, message: 'Fehler beim Laden der Vorlagen.' },
-      };
+      return groupErrorResponse('listGroupVorlagen', 'Fehler beim Laden der Vorlagen.', error);
     }
   },
 });

--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -38,7 +38,6 @@ import {
 import { PiSquaresFour } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 
-
 import { type GroupAudience } from '../hooks/useGroupRequests';
 import {
   useCloneCanvasTemplate,

--- a/apps/web/src/features/groups/hooks/useGroups.ts
+++ b/apps/web/src/features/groups/hooks/useGroups.ts
@@ -1,6 +1,7 @@
 import { type GroupContentType } from '@gruenerator/contracts';
 import { getContractsClient } from '@gruenerator/shared/api';
 import {
+  errMessage,
   useAddGroupLink,
   useCreateGroup,
   useDeleteGroup,
@@ -32,16 +33,6 @@ import { useAuthStore } from '../../../stores/authStore';
 export { getGroupInitials, type GroupLink, type GroupMember, type GroupSummary };
 
 export const useGroupDetails = useGroupDetailsShared;
-
-// ts-rest widens the body to `unknown` for non-2xx statuses; read `message`
-// defensively rather than asserting the error-schema shape.
-function errMessage(body: unknown, fallback = 'Aktion fehlgeschlagen.'): string {
-  if (body && typeof body === 'object' && 'message' in body) {
-    const m = (body as { message?: unknown }).message;
-    if (typeof m === 'string') return m;
-  }
-  return fallback;
-}
 
 interface MutationOptions<T = unknown> {
   onSuccess?: (result: T) => void;
@@ -320,7 +311,7 @@ export const useUpdateGroupSettings = (groupId: string | null) => {
       return res.body;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['groupDetails'] });
+      void queryClient.invalidateQueries({ queryKey: groupDetailsKey(groupId ?? '') });
       void queryClient.invalidateQueries({ queryKey: ['groupVorlagen', groupId] });
     },
   });

--- a/packages/shared/src/groups/index.ts
+++ b/packages/shared/src/groups/index.ts
@@ -15,6 +15,7 @@ export {
 } from './types.js';
 
 export {
+  errMessage,
   useAddGroupLink,
   useCreateGroup,
   useDeleteGroup,

--- a/packages/shared/src/groups/useGroups.ts
+++ b/packages/shared/src/groups/useGroups.ts
@@ -19,7 +19,7 @@ import {
  * widens the body to `unknown` for non-2xx (undeclared) statuses, so we extract
  * defensively rather than asserting the error-schema shape.
  */
-function errMessage(body: unknown, fallback = 'Aktion fehlgeschlagen.'): string {
+export function errMessage(body: unknown, fallback = 'Aktion fehlgeschlagen.'): string {
   if (body && typeof body === 'object' && 'message' in body) {
     const m = (body as { message?: unknown }).message;
     if (typeof m === 'string') return m;
@@ -240,7 +240,8 @@ export const useDeleteGroupLink = (groupId: string) => {
   return useMutation({
     mutationFn: async (linkId: string) => {
       const res = await getContractsClient().groups.deleteLink({ params: { groupId, linkId } });
-      if (res.status !== 200) throw new Error('Fehler beim Löschen des Links.');
+      if (res.status !== 200)
+        throw new Error(errMessage(res.body, 'Fehler beim Löschen des Links.'));
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: groupDetailsKey(groupId) });


### PR DESCRIPTION
## Why

A `/simplify` review of the now-fully-migrated group contract surface (3-agent reuse/quality/efficiency pass) surfaced two real bugs and a large block of duplicated error-handling boilerplate. This is the cleanup before the planned file-split of `groupsContractRouter.ts`.

## What it does

- **Bug fix — masked 500s:** `setVisibility` and `listJoinRequests` previously mapped *every* thrown error to `403 "Keine Berechtigung"`, so genuine DB failures were reported as permission errors and the contract's declared `500` was unreachable. They now use the same permission-vs-server error mapping as every other handler.
- **DRY:** the 14 identical `isPermissionError(error) ? 403 : (log + 500)` catch-tails collapse into one `groupErrorResponse(handler, msg, error)` helper. This removes ~150 lines and — more importantly — centralizes the error policy so it changes in one place. The per-route success/4xx returns stay inline (that explicitness is the ts-rest value).
- **Dedupe:** `errMessage` was defined identically in `packages/shared/.../useGroups.ts` and the web facade; now a single exported source from `@gruenerator/shared/groups`.
- **Cache correctness:** `useUpdateGroupSettings` invalidates the specific group's detail key instead of the entire `['groupDetails']` prefix (was refetching details for all cached groups). `useDeleteGroupLink` now surfaces the server message via `errMessage` like its sibling mutations.

## Notes

Two review findings were intentionally **not** acted on (false positives): `deleteGroup`'s notification must run *before* the delete transaction (it reads memberships that the txn removes, and `notifyGroupMembers` never throws), and `toIso` can't fold into `toIsoOrNull` because `joinRequestSchema.requested_at` is non-nullable `z.string()`.

Deferred to follow-up PRs (correctly scoped separately): the `useShareWithGroup` consolidation across 8 call sites, the `shareContent` ownership lookup table, and the `groupsContractRouter.ts` **file split** — the split will fold in the ownership table so handlers aren't edited twice.

## Test plan

- [x] `eslint`, contracts build, and api/shared/web typechecks all pass (0 errors).
- [ ] Group create/delete/leave/role/links + content share/unshare still work; error toasts show sensible messages.
- [ ] A forced DB error in setVisibility/listJoinRequests now returns 500, not a misleading 403.