### PR TITLE
refactor(profile): route web profile writes through the typed contracts client

### DIFF
--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/RolesSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/RolesSection.tsx
@@ -1,4 +1,5 @@
 import { type UserRole } from '@gruenerator/chat';
+import { getContractsClient } from '@gruenerator/shared/api';
 import {
   Button,
   SelectCard,
@@ -14,7 +15,6 @@ import {
 import { useState, useCallback, useEffect, useMemo, useRef, memo } from 'react';
 import { HiOutlineArrowLeft, HiOutlineTrash, HiPlus } from 'react-icons/hi2';
 
-import apiClient from '../../../../../../components/utils/apiClient';
 import { searchMdBs } from '../../../../../../features/chat/grueneMdBs';
 import {
   useSetUserDefault,
@@ -379,7 +379,14 @@ export default function RolesSection() {
           value: nextRoles,
         });
         const prompt = generateProfilePrompt(nextRoles, isAustrian);
-        await apiClient.put('/auth/profile', { custom_prompt: prompt || null });
+        // Empty prompt clears the field: the backend converts '' -> null. The
+        // contract body types custom_prompt as string, so send '' (not null).
+        const res = await getContractsClient().userProfile.updateProfile({
+          body: { custom_prompt: prompt || '' },
+        });
+        if (res.status !== 200) {
+          throw new Error(`Profil-Update fehlgeschlagen (HTTP ${res.status})`);
+        }
         return { ok: true };
       } catch (error) {
         const detail = error instanceof Error ? error.message : 'Unbekannter Fehler';

--- a/apps/web/src/features/auth/services/profileApiService.ts
+++ b/apps/web/src/features/auth/services/profileApiService.ts
@@ -1,3 +1,4 @@
+import { getContractsClient } from '@gruenerator/shared/api';
 import {
   getRobotAvatarPath,
   validateRobotId,
@@ -246,12 +247,6 @@ interface BundleResponse {
   memories?: Memory[] | null;
 }
 
-interface ProfileMutationResponse {
-  success: boolean;
-  message?: string;
-  profile: Profile;
-}
-
 interface AnweisungenResponse {
   presseabbinder?: string;
   knowledge?: KnowledgeEntry[];
@@ -384,32 +379,40 @@ export const profileApiService = {
   },
 
   async updateProfile(profileData: ProfileUpdateData): Promise<Profile> {
-    const response = await apiClient.put<ProfileMutationResponse>('/auth/profile', profileData);
-    const result = response.data;
+    // The contract body types clearable fields as string|undefined, but
+    // ProfileUpdateData uses `null` to clear. Map null -> '' (the backend
+    // converts '' -> null), preserving clear semantics under the contract.
+    const body: {
+      display_name?: string;
+      username?: string;
+      email?: string;
+      custom_prompt?: string;
+    } = {};
+    if (profileData.display_name !== undefined) body.display_name = profileData.display_name;
+    if (profileData.username !== undefined) body.username = profileData.username ?? '';
+    if (profileData.email !== undefined) body.email = profileData.email ?? '';
+    if (profileData.custom_prompt !== undefined)
+      body.custom_prompt = profileData.custom_prompt ?? '';
 
-    if (!result.success) {
-      throw new Error(result.message ?? 'Profil-Update fehlgeschlagen');
+    const res = await getContractsClient().userProfile.updateProfile({ body });
+    if (res.status !== 200) {
+      throw new Error(`Profil-Update fehlgeschlagen (HTTP ${res.status})`);
     }
 
-    return result.profile;
+    return res.body.profile;
   },
 
   async updateAvatar(avatarRobotId: string | number): Promise<Profile> {
     try {
-      const response = await apiClient.patch<ProfileMutationResponse>('/auth/profile/avatar', {
-        avatar_robot_id: avatarRobotId,
+      const res = await getContractsClient().userProfile.updateAvatar({
+        body: { avatar_robot_id: Number(avatarRobotId) },
       });
-      const result = response.data;
 
-      if (!result.success) {
-        throw new Error(result.message ?? 'Avatar-Update fehlgeschlagen');
+      if (res.status !== 200) {
+        throw new Error(`Avatar-Update fehlgeschlagen (HTTP ${res.status})`);
       }
 
-      if (!result.profile) {
-        throw new Error('Server returned success but no profile data');
-      }
-
-      return result.profile;
+      return res.body.profile;
     } catch (error) {
       console.error(`[ProfileAPI] Avatar update failed for robot ID ${avatarRobotId}:`, error);
       throw error;

--- a/apps/web/src/features/user-defaults/userDefaultsQueries.ts
+++ b/apps/web/src/features/user-defaults/userDefaultsQueries.ts
@@ -1,3 +1,4 @@
+import { getContractsClient } from '@gruenerator/shared/api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import apiClient from '../../components/utils/apiClient';
@@ -61,7 +62,12 @@ export function useSetUserDefault<G extends UserDefaultsGenerator, K extends Use
 
   return useMutation({
     mutationFn: async ({ generator, key, value }: SetUserDefaultVariables<G, K>) => {
-      await apiClient.patch('/auth/profile/user-defaults', { generator, key, value });
+      const res = await getContractsClient().userProfile.updateUserDefaults({
+        body: { generator, key, value },
+      });
+      if (res.status !== 200) {
+        throw new Error(`Failed to save user default (HTTP ${res.status})`);
+      }
     },
     onMutate: async ({ generator, key, value }) => {
       await queryClient.cancelQueries({ queryKey: USER_DEFAULTS_QUERY_KEY });

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { useUserProfileStore } from '@gruenerator/chat';
 import { type UserProfile } from '@gruenerator/contracts';
+import { getContractsClient } from '@gruenerator/shared/api';
 import { create } from 'zustand';
 
 import apiClient, { setLoggingOutFlag } from '../components/utils/apiClient';
@@ -38,14 +39,6 @@ export interface DeleteAccountConfirmation {
   confirm?: string;
   password?: string;
   confirmation?: string;
-}
-
-export interface ApiResponse<T = unknown> {
-  success: boolean;
-  message?: string;
-  error?: string;
-  data?: T;
-  [key: string]: unknown;
 }
 
 export interface AuthStore {
@@ -226,56 +219,64 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     });
   },
 
-  // Profile management via Backend API
+  // Profile management via typed contracts client
   updateProfile: async (profileData: ProfileData): Promise<ProfileData> => {
-    const response = await apiClient.put('/auth/profile', profileData);
-    const result = response.data as ApiResponse<ProfileData> & { profile?: ProfileData };
+    // ProfileData is loosely typed (index signature); pick the fields the
+    // contract body declares, guarding the `unknown`-typed values.
+    const body: {
+      display_name?: string;
+      username?: string;
+      email?: string;
+      custom_prompt?: string;
+    } = {};
+    if (typeof profileData.display_name === 'string') body.display_name = profileData.display_name;
+    if (typeof profileData.username === 'string') body.username = profileData.username;
+    if (typeof profileData.email === 'string') body.email = profileData.email;
+    if (typeof profileData.custom_prompt === 'string')
+      body.custom_prompt = profileData.custom_prompt;
 
-    if (!result.success) {
-      throw new Error(result.message || 'Profil-Update fehlgeschlagen');
+    const res = await getContractsClient().userProfile.updateProfile({ body });
+    if (res.status !== 200) {
+      throw new Error(`Profil-Update fehlgeschlagen (HTTP ${res.status})`);
     }
 
     // Update user in store with new profile data
     set((state) => ({
-      user: state.user ? { ...state.user, ...result.profile } : null,
+      user: state.user ? { ...state.user, ...res.body.profile } : null,
     }));
 
-    return result.profile as ProfileData;
+    return res.body.profile;
   },
 
-  // Avatar update via Backend API
+  // Avatar update via typed contracts client
   updateAvatar: async (avatarRobotId: string): Promise<ProfileData> => {
-    const response = await apiClient.patch('/auth/profile/avatar', {
-      avatar_robot_id: avatarRobotId,
+    const res = await getContractsClient().userProfile.updateAvatar({
+      body: { avatar_robot_id: Number(avatarRobotId) },
     });
-    const result = response.data as ApiResponse<ProfileData> & { profile?: ProfileData };
-
-    if (!result.success) {
-      throw new Error(result.message || 'Avatar-Update fehlgeschlagen');
+    if (res.status !== 200) {
+      throw new Error(`Avatar-Update fehlgeschlagen (HTTP ${res.status})`);
     }
 
     // Update user in store with new avatar
     set((state) => ({
-      user: state.user ? { ...state.user, ...result.profile } : null,
+      user: state.user ? { ...state.user, ...res.body.profile } : null,
     }));
 
-    return result.profile as ProfileData;
+    return res.body.profile;
   },
 
-  // Message color management via Backend API
+  // Message color management via typed contracts client
   updateMessageColor: async (color: string): Promise<string> => {
     // Optimistic update
     set({ selectedMessageColor: color });
 
     try {
-      const response = await apiClient.patch('/auth/profile/message-color', { color });
-      const result = response.data as ApiResponse & { messageColor?: string };
-
-      if (!result.success) {
-        throw new Error(result.message || 'Message Color Update fehlgeschlagen');
+      const res = await getContractsClient().userProfile.updateMessageColor({ body: { color } });
+      if (res.status !== 200) {
+        throw new Error(`Message Color Update fehlgeschlagen (HTTP ${res.status})`);
       }
 
-      return result.messageColor as string;
+      return res.body.messageColor;
     } catch (error: unknown) {
       // Revert optimistic update on failure
       const state = get();
@@ -446,22 +447,21 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
     confirmationData?: DeleteAccountConfirmation
   ): Promise<{ success: boolean; message: string }> => {
     try {
-      // Primary attempt: JSON body
-      const response = await apiClient.delete('/auth/delete-account', {
-        data: confirmationData || {},
-        headers: {
-          Accept: 'application/json',
-        },
+      // Primary attempt: JSON body via typed contracts client
+      const res = await getContractsClient().userProfile.deleteAccount({
+        body: confirmationData || {},
       });
 
-      const data = response.data as { message?: string } | undefined;
+      if (res.status !== 200) {
+        throw new Error(`Konto-Löschung fehlgeschlagen (HTTP ${res.status})`);
+      }
 
       // Clear local auth state
       get().clearAuth();
 
       return {
         success: true,
-        message: data?.message || 'Konto erfolgreich gelöscht',
+        message: res.body.message || 'Konto erfolgreich gelöscht',
       };
     } catch (error: unknown) {
       // Try fallback with query param if the first attempt failed

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -35,6 +35,7 @@ import {
   docsContract,
   documentsContract,
   groupsContract,
+  userProfileContract,
 } from '@gruenerator/contracts';
 import { initClient } from '@ts-rest/core';
 
@@ -147,6 +148,7 @@ const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS
 const _docsClient = () => initClient(docsContract, CLIENT_OPTS);
 const _documentsClient = () => initClient(documentsContract, CLIENT_OPTS);
 const _groupsClient = () => initClient(groupsContract, CLIENT_OPTS);
+const _userProfileClient = () => initClient(userProfileContract, CLIENT_OPTS);
 
 export interface ContractsClient {
   threads: ReturnType<typeof _threadsClient>;
@@ -167,6 +169,7 @@ export interface ContractsClient {
   docs: ReturnType<typeof _docsClient>;
   documents: ReturnType<typeof _documentsClient>;
   groups: ReturnType<typeof _groupsClient>;
+  userProfile: ReturnType<typeof _userProfileClient>;
 }
 
 // ── Lazy singleton ────────────────────────────────────────────────────────────
@@ -204,6 +207,7 @@ export function getContractsClient(): ContractsClient {
     docs: _docsClient(),
     documents: _documentsClient(),
     groups: _groupsClient(),
+    userProfile: _userProfileClient(),
   };
 
   return _client;


### PR DESCRIPTION
Phase 2 of the profile-contract consolidation (phase 1 = #989, merged). After #989 the ts-rest `userProfileContract` is the single backend handler, but the web frontend still reached it through raw axios — so the contract types stopped at the network boundary. That gap is exactly what let the avatar `max(9)` drift ship.

This routes the profile **write** paths through `getContractsClient().userProfile`, so a schema change propagates into the caller's types at compile time. The avatar update — where the bug lived — is now type-checked against the contract end to end.

Registers `userProfile` in the shared contracts client (it was unregistered), then swaps: `authStore` (updateProfile / updateAvatar / updateMessageColor + the deleteAccount primary attempt), `profileApiService` (updateProfile / updateAvatar), `userDefaultsQueries` (the PATCH), and `RolesSection`'s inline profile PUT.

The migration surfaced a **latent post-#989 bug**: the `custom_prompt: x || null` clear-idiom (RolesSection, profileApiService) would 400 against the contract body (`z.string()`, no null). Fixed by mapping `null → ''` (the backend converts `'' → null`), preserving clear-on-empty behavior — the type checker flushed out a request the backend can no longer accept.

### Left on raw axios by design (documented exceptions, not oversights)
- `getProfile`, the user-defaults **GET**, and `betaFeaturesStore` all pass `skipAuthRedirect: true` (guards the 401 redirect/refresh storm), which the shared ts-rest fetcher has no channel to forward.
- `deleteAccount` keeps its query-param fallback as a safety net; only the primary attempt is typed.

### Verification
- `@gruenerator/shared` and `@gruenerator/web` typecheck clean.
- Behavior preserved: Zustand `set()` state updates, React Query cache writes, optimistic-rollback in `updateMessageColor`, and the deleteAccount fallback are all intact.

Phase 3 (mobile notification-settings) follows in a separate PR.