### PR TITLE
refactor(mobile): route notification-settings through the typed contracts client

### DIFF
--- a/apps/mobile/app/(fullscreen)/notification-settings.tsx
+++ b/apps/mobile/app/(fullscreen)/notification-settings.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import { getGlobalApiClient } from '@gruenerator/shared/api';
+import { getContractsClient } from '@gruenerator/shared/api';
 import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -103,11 +103,10 @@ export default function NotificationSettingsScreen() {
   useEffect(() => {
     void (async () => {
       try {
-        const client = getGlobalApiClient();
-        const res = await client.get<{ preferences?: Record<string, ChannelPreferences> }>(
-          '/auth/profile/notification-preferences'
-        );
-        setPreferences(res.data?.preferences ?? {});
+        const res = await getContractsClient().notifications.getPreferences();
+        if (res.status === 200) {
+          setPreferences(res.body.preferences);
+        }
       } catch {
         // fall back to empty — toggles will default to on
       } finally {
@@ -123,11 +122,16 @@ export default function NotificationSettingsScreen() {
     }));
 
     try {
-      const client = getGlobalApiClient();
-      await client.patch('/auth/profile/notification-preferences', {
-        category,
-        channels: { [channel]: value },
+      const res = await getContractsClient().notifications.updatePreferences({
+        body: {
+          category,
+          // Computed key widens to `string`; cast to the typed partial channels shape.
+          channels: { [channel]: value } as Partial<Record<Channel, boolean>>,
+        },
       });
+      if (res.status !== 200) {
+        throw new Error(`Failed to update notification preferences (HTTP ${res.status})`);
+      }
     } catch {
       setPreferences((prev) => ({
         ...prev,


### PR DESCRIPTION
Phase 3 (final) of the profile-contract consolidation. The mobile notification-settings screen called `/auth/profile/notification-preferences` via raw axios. Route it through `getContractsClient().notifications` (`getPreferences` / `updatePreferences`) for end-to-end types.

No new infrastructure: the contracts client is already available via `@gruenerator/shared` and reuses the mobile axios instance's Bearer-token interceptors.

Post-#989 this path is served by `notificationsContract` (the legacy shadow router is gone). The PATCH response shape is `{success, preferences, defaults}` (no `message`) — the screen only reads `preferences`, so behavior is unchanged.

### Verification
- `@gruenerator/mobile` typechecks clean.
- GET hydrate + per-channel toggle (with optimistic rollback on failure) preserved.