### PR TITLE
feat(notebook): hourly Wolke folder watcher (detect → notify → add)

### DIFF
--- a/.github/workflows/wolke-watch-hourly.yml
+++ b/.github/workflows/wolke-watch-hourly.yml
@@ -1,0 +1,72 @@
+name: Hourly Wolke Watch
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Hourly, on the hour (UTC)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wolke-watch
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: Run Wolke Watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      API_URL: ${{ vars.WOLKE_WATCH_API_URL || 'https://gruenerator.eu' }}
+    steps:
+      - name: Run wolke watch
+        id: watch
+        continue-on-error: true
+        run: |
+          echo "Scanning auto_sync notebooks for new Wolke files at $API_URL..."
+          RESULT=$(curl -sf -X POST "$API_URL/api/internal/wolke-watch/run" \
+            -H "x-admin-token: ${{ secrets.ADMIN_TOKEN }}" \
+            --max-time 600)
+          echo "$RESULT" | jq .
+          echo "result<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$RESULT" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Generate summary
+        if: always()
+        run: |
+          RESULT='${{ steps.watch.outputs.result }}'
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ -z "$RESULT" ]; then
+            {
+              echo "## :x: Wolke Watch — No Result"
+              echo ""
+              echo "The wolke-watch endpoint returned nothing. Check the [workflow logs]($RUN_URL)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          SCANNED=$(echo "$RESULT" | jq -r '.scannedCollections // "?"')
+          WITH_NEW=$(echo "$RESULT" | jq -r '.collectionsWithNewFiles // "?"')
+          NEW_FILES=$(echo "$RESULT" | jq -r '.totalNewFiles // "?"')
+          NOTIFIED=$(echo "$RESULT" | jq -r '.notificationsSent // "?"')
+
+          {
+            echo "## :cloud: Wolke Watch"
+            echo ""
+            echo "**Date:** $(date -u '+%d.%m.%Y %H:%M UTC')"
+            echo "**Run:** [${{ github.run_id }}]($RUN_URL)"
+            echo ""
+            echo "| Metric | Count |"
+            echo "|--------|------:|"
+            echo "| Notebooks scanned | $SCANNED |"
+            echo "| With new files | $WITH_NEW |"
+            echo "| New files detected | $NEW_FILES |"
+            echo "| Notifications sent | $NOTIFIED |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if watch run errored
+        if: steps.watch.outcome == 'failure'
+        run: exit 1

--- a/apps/api/database/postgres/migrations/create_wolke_pending_files.sql
+++ b/apps/api/database/postgres/migrations/create_wolke_pending_files.sql
@@ -1,0 +1,27 @@
+-- Wolke folder watcher: files detected in an auto_sync notebook's Wolke folders
+-- that are not yet imported, awaiting the user's "Hinzufügen" click.
+-- The unique (collection_id, file_path) index makes hourly detection idempotent.
+-- No BEGIN/COMMIT — the migration runner wraps each file in its own transaction.
+
+CREATE TABLE IF NOT EXISTS wolke_pending_files (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  collection_id UUID NOT NULL,
+  user_id       UUID NOT NULL,
+  share_link_id TEXT NOT NULL,
+  folder_path   TEXT NOT NULL DEFAULT '',
+  file_path     TEXT NOT NULL,
+  file_name     TEXT NOT NULL,
+  etag          TEXT,
+  size          BIGINT,
+  mime_type     TEXT,
+  status        TEXT NOT NULL DEFAULT 'pending',
+  detected_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at   TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_wolke_pending_collection_file
+  ON wolke_pending_files (collection_id, file_path);
+CREATE INDEX IF NOT EXISTS idx_wolke_pending_collection_status
+  ON wolke_pending_files (collection_id, status);
+CREATE INDEX IF NOT EXISTS idx_wolke_pending_user_status
+  ON wolke_pending_files (user_id, status);

--- a/apps/api/database/schema/system.ts
+++ b/apps/api/database/schema/system.ts
@@ -33,6 +33,38 @@ export const wolkeSyncStatus = pgTable(
   ]
 );
 
+/**
+ * Wolke folder watcher: files detected in an `auto_sync` notebook's Wolke
+ * folders that are not yet imported, awaiting the user's "Hinzufügen" click.
+ * The unique (collection_id, file_path) index makes hourly detection
+ * idempotent — re-runs insert with ON CONFLICT DO NOTHING.
+ */
+export const wolkePendingFiles = pgTable(
+  'wolke_pending_files',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    collectionId: uuid('collection_id').notNull(),
+    userId: uuid('user_id').notNull(),
+    shareLinkId: text('share_link_id').notNull(),
+    folderPath: text('folder_path').notNull().default(''),
+    filePath: text('file_path').notNull(),
+    fileName: text('file_name').notNull(),
+    etag: text('etag'),
+    size: bigint('size', { mode: 'number' }),
+    mimeType: text('mime_type'),
+    status: text('status').notNull().default('pending'),
+    detectedAt: timestamp('detected_at', { withTimezone: true }).notNull().defaultNow(),
+    resolvedAt: timestamp('resolved_at', { withTimezone: true }),
+  },
+  (t) => [
+    unique('uq_wolke_pending_collection_file').on(t.collectionId, t.filePath),
+    index('idx_wolke_pending_collection_status').on(t.collectionId, t.status),
+    index('idx_wolke_pending_user_status').on(t.userId, t.status),
+  ]
+);
+export type WolkePendingFileRow = typeof wolkePendingFiles.$inferSelect;
+export type WolkePendingFileInsert = typeof wolkePendingFiles.$inferInsert;
+
 export const routeUsageStats = pgTable(
   'route_usage_stats',
   {

--- a/apps/api/database/services/NotebookQdrantHelper.ts
+++ b/apps/api/database/services/NotebookQdrantHelper.ts
@@ -507,6 +507,41 @@ class NotebookQdrantHelper {
   }
 
   /**
+   * List every collection with `auto_sync=true`, across all users. Used by the
+   * hourly Wolke folder watcher (WolkeWatchService) to find notebooks to scan.
+   *
+   * Deliberately skips the per-collection document-association lookup that
+   * getUserNotebookCollections does — the watcher only needs the share-link IDs,
+   * and the hourly scan should stay cheap. `document_count` is left as the
+   * stored payload value (unused by the watcher).
+   */
+  async getNotebookCollectionsByAutoSync(
+    options: GetCollectionsOptions = {}
+  ): Promise<NotebookCollection[]> {
+    await this.ensureInitialized();
+
+    try {
+      const { limit = 1000, offset = 0 } = options;
+
+      const filter: QdrantFilter = {
+        must: [{ key: 'auto_sync', match: { value: true } }],
+      };
+
+      const results = await this.qdrantOps!.scrollDocuments(
+        this.qdrant.collections.notebook_collections,
+        filter,
+        { limit, offset, withPayload: true }
+      );
+
+      return results.map((result: ScrollPoint) => this.formatCollectionFromPayload(result.payload));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`Error getting auto_sync Notebook collections: ${message}`);
+      throw new Error(`Failed to get auto_sync Notebook collections: ${message}`);
+    }
+  }
+
+  /**
    * Update Notebook collection
    */
   async updateNotebookCollection(

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -40,12 +40,14 @@ import {
   rateLimitRouter,
   grueneApiTestRouter,
   contentSyncRouter,
+  wolkeWatchRouter,
 } from './routes/internal/index.js';
 import { markdownController as markdownRouter } from './routes/markdown/index.js';
 import { monitorRouter, monitorInternalRouter } from './routes/monitor/index.js';
 import { mountNotebookCollectionsContractRouter } from './routes/notebook/notebookCollectionsContractRouter.js';
 import { mountNotebookContractRouter } from './routes/notebook/notebookContractRouter.js';
 import { mountNotebookSharingContractRouter } from './routes/notebook/notebookSharingContractRouter.js';
+import { mountWolkePendingContractRouter } from './routes/notebook/wolkePendingContractRouter.js';
 import notificationsRouter from './routes/notifications/index.js';
 import { mountNotificationsContractRouter } from './routes/notifications/notificationsContractRouter.js';
 import protokollRouter from './routes/protokoll/index.js';
@@ -324,6 +326,9 @@ export async function setupRoutes(app: Application): Promise<void> {
   // Sharing endpoints (share mode, edit policy, group shares) — mounted BEFORE
   // the CRUD router so :id/share doesn't fall through to the legacy router.
   mountNotebookSharingContractRouter(app);
+  // Wolke pending-files endpoints (:id/pending-files/...) — mounted BEFORE the
+  // CRUD router so they don't fall through to the legacy collectionsController.
+  mountWolkePendingContractRouter(app);
   mountNotebookCollectionsContractRouter(app);
   app.use('/api/auth/notebook-collections', authenticatedReadLimiter, notebookCollectionsRouter);
   // Mixed-auth contract: `optionalAuth` populates req.user without rejecting,
@@ -635,6 +640,7 @@ export async function setupRoutes(app: Application): Promise<void> {
     app.use('/api/internal', snapshottingRouter);
   }
   app.use('/api/internal/offboarding', offboardingRouter);
+  app.use('/api/internal/wolke-watch', wolkeWatchRouter);
   app.use('/api/internal/gruene-api', grueneApiTestRouter);
   app.use('/api/internal/monitor', monitorInternalRouter);
   app.use('/api/internal/notebook', internalNotebookRouter);

--- a/apps/api/routes/internal/index.ts
+++ b/apps/api/routes/internal/index.ts
@@ -4,3 +4,4 @@ export { default as rateLimitRouter } from './rateLimitController.js';
 export { default as offboardingRouter } from './offboardingController.js';
 export { default as grueneApiTestRouter } from './grueneApiTestController.js';
 export { contentSyncRouter } from './contentSyncController.js';
+export { default as wolkeWatchRouter } from './wolkeWatchController.js';

--- a/apps/api/routes/internal/wolkeWatchController.ts
+++ b/apps/api/routes/internal/wolkeWatchController.ts
@@ -1,0 +1,50 @@
+import { Router, type Request, type Response, type NextFunction } from 'express';
+
+import { env } from '../../config/env.js';
+import { getWolkeWatchService } from '../../services/sync/WolkeWatchService.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('wolke-watch');
+const router: Router = Router();
+
+interface AdminRequest extends Request {
+  headers: Request['headers'] & {
+    'x-admin-token'?: string;
+  };
+}
+
+const requireAdmin = (req: AdminRequest, res: Response, next: NextFunction): void => {
+  const adminToken = req.headers['x-admin-token'];
+
+  if (!adminToken || adminToken !== env.ADMIN_TOKEN) {
+    res.status(403).json({
+      error: 'Admin authentication required',
+      message: 'This endpoint requires admin privileges',
+    });
+    return;
+  }
+
+  next();
+};
+
+/**
+ * POST /internal/wolke-watch/run
+ * Scan every auto_sync notebook for new Wolke files, record them as pending,
+ * and notify owners. Triggered hourly by .github/workflows/wolke-watch-hourly.yml.
+ * Runs synchronously so the workflow can report the result.
+ */
+router.post('/run', requireAdmin, async (_req: AdminRequest, res: Response): Promise<void> => {
+  try {
+    const result = await getWolkeWatchService().runAll();
+    log.info(
+      `Wolke watch run complete: ${result.totalNewFiles} new across ${result.collectionsWithNewFiles} notebooks (${result.durationMs}ms)`
+    );
+    res.json({ success: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error(`Wolke watch run failed: ${message}`);
+    res.status(500).json({ success: false, error: message });
+  }
+});
+
+export default router;

--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -736,7 +736,11 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         if (typeof remove_missing_on_sync === 'boolean')
           updateData.remove_missing_on_sync = remove_missing_on_sync;
       } else {
-        updateData.auto_sync = false;
+        // wolke_folders model: auto_sync is the hourly-watch toggle, set via the
+        // dedicated /auto-sync endpoint. Only honour an explicit value here and
+        // otherwise leave it untouched — don't clobber the watch flag on an
+        // unrelated edit (rename, label change, etc.).
+        if (typeof auto_sync === 'boolean') updateData.auto_sync = auto_sync;
         updateData.remove_missing_on_sync = false;
       }
 

--- a/apps/api/routes/notebook/wolkePendingContractRouter.ts
+++ b/apps/api/routes/notebook/wolkePendingContractRouter.ts
@@ -1,0 +1,237 @@
+/**
+ * ts-rest contract router for the Wolke folder watcher's pending-files endpoints.
+ *
+ * Hangs off /api/auth/notebook-collections/:id/pending-files. Mount alongside
+ * notebookCollectionsContractRouter in routes.ts (requireAuth applied at the
+ * prefix, so req.user is always present).
+ *
+ * The actual file import reuses WolkeSyncService.processFile — no download/OCR/
+ * embed logic is reimplemented here. Pending rows store the OWNER's userId
+ * (the Wolke share link belongs to them), so import runs as the owner while the
+ * access guard checks the calling user's edit rights.
+ */
+import {
+  wolkePendingContract,
+  type WolkePendingFileDto,
+  type WolkePendingStatus,
+} from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+import { and, eq } from 'drizzle-orm';
+
+import {
+  documents,
+  wolkePendingFiles,
+  type WolkePendingFileRow,
+} from '../../database/schema/index.js';
+import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
+import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import { getWolkeSyncService } from '../../services/sync/WolkeSyncService.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { createLogger } from '../../utils/logger.js';
+
+import { requireNotebookEdit } from './notebookAccess.js';
+
+import type { NextcloudFile } from '../../services/sync/types.js';
+import type { UserProfile } from '../../services/user/types.js';
+import type { Application, Request } from 'express';
+
+const log = createLogger('wolkePendingContractRouter');
+const notebookHelper = new NotebookQdrantHelper();
+const sync = getWolkeSyncService();
+
+/** Safety guard — requireAuth at the prefix guarantees req.user is set. */
+function getUserId(req: Request): string {
+  const user = req.user as UserProfile | undefined;
+  if (!user?.id) throw new Error('Authentication required');
+  return user.id;
+}
+
+/** Map a Drizzle row to the snake_case contract DTO. */
+function toDto(row: WolkePendingFileRow): WolkePendingFileDto {
+  return {
+    id: row.id,
+    collection_id: row.collectionId,
+    share_link_id: row.shareLinkId,
+    folder_path: row.folderPath,
+    file_path: row.filePath,
+    file_name: row.fileName,
+    etag: row.etag,
+    size: row.size,
+    mime_type: row.mimeType,
+    // `status` is a TEXT column; the closed set is enforced everywhere it is
+    // written. Boundary cast from the DB string to the contract enum.
+    status: row.status as WolkePendingStatus,
+    detected_at: row.detectedAt.toISOString(),
+    resolved_at: row.resolvedAt ? row.resolvedAt.toISOString() : null,
+  };
+}
+
+const s = initServer();
+
+export const wolkePendingContractRouter = s.router(wolkePendingContract, {
+  listPendingFiles: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collectionId = args.params.id;
+
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
+
+      const db = getDrizzleInstance();
+      const rows = await db
+        .select()
+        .from(wolkePendingFiles)
+        .where(
+          and(
+            eq(wolkePendingFiles.collectionId, collectionId),
+            eq(wolkePendingFiles.status, 'pending')
+          )
+        );
+
+      return { status: 200 as const, body: { pending: rows.map(toDto) } };
+    } catch (error) {
+      log.error('[wolkePendingContract.listPendingFiles] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  addPendingFile: async (args) => {
+    try {
+      const callingUserId = getUserId(args.req);
+      const collectionId = args.params.id;
+
+      const guard = await requireNotebookEdit(collectionId, callingUserId);
+      if (guard) return guard;
+
+      const db = getDrizzleInstance();
+      const [row] = await db
+        .select()
+        .from(wolkePendingFiles)
+        .where(
+          and(
+            eq(wolkePendingFiles.id, args.params.pendingId),
+            eq(wolkePendingFiles.collectionId, collectionId)
+          )
+        )
+        .limit(1);
+
+      if (!row) {
+        return { status: 404 as const, body: { error: 'Datei nicht gefunden' } };
+      }
+      if (row.status !== 'pending') {
+        return { status: 409 as const, body: { error: 'Datei wurde bereits verarbeitet' } };
+      }
+
+      // Import runs as the OWNER (row.userId) — the share link is theirs.
+      const shareLink = await sync.getShareLink(row.userId, row.shareLinkId);
+      const file: NextcloudFile = {
+        name: row.fileName,
+        href: row.filePath,
+        size: row.size ?? 0,
+        ...(row.etag ? { etag: row.etag } : {}),
+      };
+      const result = await sync.processFile(row.userId, row.shareLinkId, file, shareLink);
+
+      let documentId = result.documentId ?? null;
+      // Race: the file was imported (e.g. by a manual sync) between detection
+      // and this click — processFile skips with 'up_to_date' and returns no id.
+      // Resolve the existing document so we can still attach it.
+      if (!documentId && result.skipped && result.reason === 'up_to_date') {
+        const [existing] = await db
+          .select({ id: documents.id })
+          .from(documents)
+          .where(
+            and(
+              eq(documents.user_id, row.userId),
+              eq(documents.wolke_share_link_id, row.shareLinkId),
+              eq(documents.wolke_file_path, row.filePath)
+            )
+          )
+          .limit(1);
+        documentId = existing ? String(existing.id) : null;
+      }
+
+      if (!documentId) {
+        log.error(
+          `[wolkePendingContract.addPendingFile] Import produced no document (reason=${result.reason ?? 'unknown'}) for ${row.filePath}`
+        );
+        return { status: 500 as const, body: { error: 'Import fehlgeschlagen' } };
+      }
+
+      await notebookHelper.addDocumentsToCollection(collectionId, [documentId], callingUserId);
+
+      const [updated] = await db
+        .update(wolkePendingFiles)
+        .set({ status: 'added', resolvedAt: new Date() })
+        .where(eq(wolkePendingFiles.id, row.id))
+        .returning();
+
+      return {
+        status: 200 as const,
+        body: { success: true, document_id: documentId, pending: toDto(updated) },
+      };
+    } catch (error) {
+      log.error('[wolkePendingContract.addPendingFile] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  dismissPendingFile: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collectionId = args.params.id;
+
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
+
+      const db = getDrizzleInstance();
+      const [updated] = await db
+        .update(wolkePendingFiles)
+        .set({ status: 'dismissed', resolvedAt: new Date() })
+        .where(
+          and(
+            eq(wolkePendingFiles.id, args.params.pendingId),
+            eq(wolkePendingFiles.collectionId, collectionId)
+          )
+        )
+        .returning();
+
+      if (!updated) {
+        return { status: 404 as const, body: { error: 'Datei nicht gefunden' } };
+      }
+
+      return { status: 200 as const, body: { success: true, pending: toDto(updated) } };
+    } catch (error) {
+      log.error('[wolkePendingContract.dismissPendingFile] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+
+  setNotebookAutoSync: async (args) => {
+    try {
+      const userId = getUserId(args.req);
+      const collectionId = args.params.id;
+
+      const guard = await requireNotebookEdit(collectionId, userId);
+      if (guard) return guard;
+
+      const enabled = args.body.enabled;
+      await notebookHelper.updateNotebookCollection(collectionId, { auto_sync: enabled });
+
+      return { status: 200 as const, body: { success: true, auto_sync: enabled } };
+    } catch (error) {
+      log.error('[wolkePendingContract.setNotebookAutoSync] Error:', error);
+      return { status: 500 as const, body: { error: 'Internal server error' } };
+    }
+  },
+});
+
+/**
+ * Mount the ts-rest Wolke-pending contract router. requireAuth must be applied
+ * at the path prefix in routes.ts before calling this.
+ */
+export function mountWolkePendingContractRouter(app: Application): void {
+  createExpressEndpoints(wolkePendingContract, wolkePendingContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'wolkePendingContract'),
+  });
+}

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -40,6 +40,7 @@ const DEFAULT_CHANNEL_PREFERENCES: Record<NotificationType, ChannelPreferences> 
   group_join_denied: { email: false, push: true, in_app: true },
   transfer_downloaded: { email: false, push: true, in_app: true },
   notebook_liked: { email: false, push: false, in_app: true },
+  wolke_new_files: { email: true, push: true, in_app: true },
 };
 
 /**

--- a/apps/api/services/sync/WolkeSyncService.ts
+++ b/apps/api/services/sync/WolkeSyncService.ts
@@ -248,6 +248,25 @@ export class WolkeSyncService {
   }
 
   /**
+   * List the supported files in a SPECIFIC folder of a share (honours
+   * folderPath, unlike listFolderContents which only sees the share root).
+   * Uses the same `client.listFolder(folderPath)` the manual import path uses,
+   * so `file.href` — the dedup key stored as documents.wolke_file_path — is
+   * identical between detection and import. Reuses the shared supportedFileTypes
+   * filter (no duplicated extension list).
+   */
+  async listSupportedFilesInFolder(
+    shareLink: NextcloudShareLink,
+    folderPath: string = ''
+  ): Promise<NextcloudFile[]> {
+    const client = await NextcloudApiClient.create(shareLink.share_link);
+    const files = await client.listFolder(folderPath || undefined);
+    return files.filter((file) =>
+      this.supportedFileTypes.includes(path.extname(file.name.toLowerCase()))
+    ) as NextcloudFile[];
+  }
+
+  /**
    * Multi-tier change detection for files
    * Uses ETags (primary), lastModified dates (secondary), and always sync if no existing data
    */

--- a/apps/api/services/sync/WolkeWatchService.ts
+++ b/apps/api/services/sync/WolkeWatchService.ts
@@ -1,0 +1,187 @@
+/**
+ * WolkeWatchService — hourly detection of NEW files in the Wolke folders of
+ * notebooks the user opted into (auto_sync=true).
+ *
+ * Detection is cheap: it only LISTS each share (no download) and diffs against
+ * the files already imported (`documents.wolke_file_path`) and already-recorded
+ * pending rows. New files are recorded in `wolke_pending_files` and the owner
+ * gets ONE aggregated notification per notebook. The actual import (download →
+ * OCR → embed → attach) happens on demand when the user clicks "Hinzufügen",
+ * via WolkePendingContractRouter reusing WolkeSyncService.processFile.
+ *
+ * Idempotency + anti-spam: the unique (collection_id, file_path) index plus
+ * onConflictDoNothing means re-runs never create duplicate pending rows, and
+ * `newCount` (rows actually inserted) only counts genuinely-new files — so a
+ * notebook is never re-notified about files it already flagged.
+ */
+import { type WolkeFolderRef } from '@gruenerator/contracts';
+import { and, eq } from 'drizzle-orm';
+
+import { documents, wolkePendingFiles } from '../../database/schema/index.js';
+import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
+import { NotebookQdrantHelper } from '../../database/services/NotebookQdrantHelper.js';
+import { createLogger } from '../../utils/logger.js';
+import { createNotification } from '../notifications/NotificationService.js';
+
+import { getWolkeSyncService } from './WolkeSyncService.js';
+
+const log = createLogger('wolke-watch');
+
+/** Minimal shape the watcher needs from a notebook collection. */
+interface WatchableCollection {
+  id: string;
+  user_id: string;
+  name: string;
+  wolke_folders: WolkeFolderRef[];
+}
+
+/** Read the persisted Wolke folder refs out of a collection's settings JSONB. */
+function readWolkeFolders(settings: Record<string, unknown>): WolkeFolderRef[] {
+  const raw = settings.wolke_folders;
+  return Array.isArray(raw) ? (raw as WolkeFolderRef[]) : [];
+}
+
+export interface DetectResult {
+  collectionId: string;
+  newCount: number;
+}
+
+export interface WatchRunResult {
+  scannedCollections: number;
+  collectionsWithNewFiles: number;
+  totalNewFiles: number;
+  notificationsSent: number;
+  durationMs: number;
+}
+
+export class WolkeWatchService {
+  private sync = getWolkeSyncService();
+  private notebookHelper = new NotebookQdrantHelper();
+
+  /**
+   * Detect new files for ONE collection across all its Wolke share links.
+   * Idempotent: inserts pending rows with ON CONFLICT DO NOTHING and returns
+   * only the count of genuinely-new rows.
+   */
+  async detectForCollection(collection: WatchableCollection): Promise<DetectResult> {
+    const db = getDrizzleInstance();
+    let newCount = 0;
+
+    // Files already recorded as pending (any status) for this notebook — skip them.
+    const existingPending = await db
+      .select({ path: wolkePendingFiles.filePath })
+      .from(wolkePendingFiles)
+      .where(eq(wolkePendingFiles.collectionId, collection.id));
+    const pendingPaths = new Set(existingPending.map((p) => p.path));
+
+    for (const folder of collection.wolke_folders) {
+      const shareLink = await this.sync.getShareLink(collection.user_id, folder.shareLinkId);
+      const files = await this.sync.listSupportedFilesInFolder(shareLink, folder.folderPath);
+
+      // Files already imported into `documents` for this (user, share link).
+      const importedRows = await db
+        .select({ path: documents.wolke_file_path })
+        .from(documents)
+        .where(
+          and(
+            eq(documents.user_id, collection.user_id),
+            eq(documents.wolke_share_link_id, folder.shareLinkId)
+          )
+        );
+      const importedPaths = new Set(importedRows.map((d) => d.path));
+
+      const newFiles = files.filter((f) => !importedPaths.has(f.href) && !pendingPaths.has(f.href));
+      if (newFiles.length === 0) continue;
+
+      const inserted = await db
+        .insert(wolkePendingFiles)
+        .values(
+          newFiles.map((f) => ({
+            collectionId: collection.id,
+            userId: collection.user_id,
+            shareLinkId: folder.shareLinkId,
+            folderPath: folder.folderPath,
+            filePath: f.href,
+            fileName: f.name,
+            etag: f.etag ?? null,
+            size: f.size ?? null,
+            mimeType: null,
+            status: 'pending',
+          }))
+        )
+        .onConflictDoNothing({
+          target: [wolkePendingFiles.collectionId, wolkePendingFiles.filePath],
+        })
+        .returning({ id: wolkePendingFiles.id });
+
+      newCount += inserted.length;
+      for (const f of newFiles) pendingPaths.add(f.href);
+    }
+
+    return { collectionId: collection.id, newCount };
+  }
+
+  /**
+   * Top-level hourly runner: scan every auto_sync notebook with Wolke sources,
+   * and fire ONE aggregated notification per notebook that gained new files.
+   * A per-collection failure (e.g. a dead share link) is logged and skipped so
+   * one bad notebook never aborts the whole run.
+   */
+  async runAll(): Promise<WatchRunResult> {
+    const start = Date.now();
+    const collections = await this.notebookHelper.getNotebookCollectionsByAutoSync();
+    const eligible: WatchableCollection[] = collections
+      .map((c) => ({
+        id: c.id,
+        user_id: c.user_id,
+        name: c.name,
+        wolke_folders: readWolkeFolders(c.settings),
+      }))
+      .filter((c) => c.wolke_folders.length > 0);
+
+    let collectionsWithNewFiles = 0;
+    let totalNewFiles = 0;
+    let notificationsSent = 0;
+
+    for (const collection of eligible) {
+      try {
+        const { newCount } = await this.detectForCollection(collection);
+        if (newCount === 0) continue;
+
+        collectionsWithNewFiles += 1;
+        totalNewFiles += newCount;
+
+        const plural = newCount === 1 ? 'eine neue Datei' : `${newCount} neue Dateien`;
+        await createNotification({
+          userId: collection.user_id,
+          type: 'wolke_new_files',
+          title: `${plural} in „${collection.name}“`,
+          body: `In deinem Notebook „${collection.name}“ wurde${
+            newCount === 1 ? '' : 'n'
+          } ${plural} aus der Wolke gefunden. Du kannst sie mit einem Klick hinzufügen.`,
+          metadata: { collectionId: collection.id, newCount },
+          actionUrl: `/notebooks/${collection.id}/bearbeiten`,
+          groupKey: `wolke_new_files:${collection.id}`,
+        });
+        notificationsSent += 1;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log.error(`Wolke watch failed for collection ${collection.id}: ${message}`);
+      }
+    }
+
+    return {
+      scannedCollections: eligible.length,
+      collectionsWithNewFiles,
+      totalNewFiles,
+      notificationsSent,
+      durationMs: Date.now() - start,
+    };
+  }
+}
+
+let instance: WolkeWatchService | null = null;
+export function getWolkeWatchService(): WolkeWatchService {
+  if (!instance) instance = new WolkeWatchService();
+  return instance;
+}

--- a/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookEditorPage.tsx
@@ -1,5 +1,6 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
 import { DocsProvider } from '@gruenerator/docs';
+import { buildNotebookSlug, extractSlugSuffix } from '@gruenerator/shared/utils';
 import {
   Button,
   Empty,
@@ -9,7 +10,6 @@ import {
   EmptyTitle,
   toast,
 } from '@gruenerator/ui';
-import { buildNotebookSlug, extractSlugSuffix } from '@gruenerator/shared/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { HiArrowLeft, HiRefresh, HiShare } from 'react-icons/hi';
@@ -21,11 +21,12 @@ import ErrorBoundary from '../../../components/ErrorBoundary';
 import { useAuthStore } from '../../../stores/authStore';
 import { useDocumentsStore } from '../../../stores/documentsStore';
 import { cn } from '../../../utils/cn';
-import { webAppDocsAdapter } from '../../docs/docsAdapter';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
+import { webAppDocsAdapter } from '../../docs/docsAdapter';
 
 import NotebookEditor from './NotebookEditor';
 import { NotebookFullSyncModal } from './NotebookFullSyncModal';
+import NotebookPendingFilesPanel from './NotebookPendingFilesPanel';
 import { NotebookShareModal } from './NotebookShareModal';
 
 import type { NotebookCollection } from '../../../types/notebook';
@@ -275,6 +276,19 @@ function NotebookEditorPageInner({ mode }: NotebookEditorPageProps) {
                   </p>
                 </button>
               )}
+            </div>
+          ) : null}
+
+          {mode === 'edit' &&
+          editingCollection &&
+          currentUserId &&
+          editingCollection.user_id === currentUserId ? (
+            <div className="mb-xl">
+              <NotebookPendingFilesPanel
+                collectionId={editingCollection.id}
+                wolkeFolders={editingCollection.wolke_folders ?? []}
+                autoSync={editingCollection.auto_sync ?? false}
+              />
             </div>
           ) : null}
 

--- a/apps/web/src/features/notebook/components/NotebookPendingFilesPanel.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPendingFilesPanel.tsx
@@ -1,0 +1,157 @@
+import { type WolkeFolderRef } from '@gruenerator/contracts';
+import { Badge, Button, SectionHeader, Switch } from '@gruenerator/ui';
+import { useState } from 'react';
+import { HiCheck, HiCloud, HiX } from 'react-icons/hi';
+
+import {
+  usePendingWolkeFiles,
+  useAddPendingFile,
+  useDismissPendingFile,
+  useSetNotebookAutoSync,
+} from '../hooks/usePendingWolkeFiles';
+
+interface Props {
+  collectionId: string;
+  wolkeFolders: WolkeFolderRef[];
+  autoSync: boolean;
+}
+
+const ExperimentalBadge = (
+  <Badge
+    variant="outline"
+    className="border-amber-300 bg-amber-50 text-[10px] uppercase text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+  >
+    Experimentell
+  </Badge>
+);
+
+/**
+ * Shows files the hourly watcher detected in this notebook's Wolke folders but
+ * that haven't been imported yet, with a one-click "Hinzufügen", plus the
+ * toggle that turns hourly watching on/off. Only renders for notebooks that
+ * actually have Wolke folders attached.
+ */
+const NotebookPendingFilesPanel = ({ collectionId, wolkeFolders, autoSync }: Props) => {
+  const [watching, setWatching] = useState(autoSync);
+  const [addingId, setAddingId] = useState<string | null>(null);
+
+  const pendingQuery = usePendingWolkeFiles(collectionId, wolkeFolders.length > 0 && watching);
+  const addMutation = useAddPendingFile(collectionId);
+  const dismissMutation = useDismissPendingFile(collectionId);
+  const autoSyncMutation = useSetNotebookAutoSync(collectionId);
+
+  if (wolkeFolders.length === 0) return null;
+
+  const pending = pendingQuery.data ?? [];
+
+  const handleToggle = (next: boolean) => {
+    setWatching(next);
+    autoSyncMutation.mutate(next, {
+      onError: () => setWatching(!next), // revert on failure
+    });
+  };
+
+  const handleAdd = (pendingId: string) => {
+    setAddingId(pendingId);
+    addMutation.mutate(pendingId, { onSettled: () => setAddingId(null) });
+  };
+
+  return (
+    <section>
+      <SectionHeader
+        title="Neue Dateien aus der Wolke"
+        actions={
+          <div className="flex items-center gap-sm">
+            {ExperimentalBadge}
+            {watching && pending.length > 0 && (
+              <span className="text-sm text-grey-500">{pending.length}</span>
+            )}
+          </div>
+        }
+      />
+
+      <div className="mb-md flex items-center justify-between gap-md rounded-xl border border-grey-200 bg-background px-md py-sm dark:border-grey-800">
+        <div className="min-w-0">
+          <p className="m-0 text-sm font-medium text-foreground">
+            Stündlich auf neue Dateien prüfen
+          </p>
+          <p className="m-0 text-xs text-grey-500">
+            Wir benachrichtigen dich, wenn in deinen Wolke-Ordnern neue Dateien auftauchen.
+          </p>
+        </div>
+        <Switch
+          checked={watching}
+          onCheckedChange={handleToggle}
+          disabled={autoSyncMutation.isPending}
+          aria-label="Stündliche Überwachung umschalten"
+        />
+      </div>
+
+      {watching && pending.length > 0 && (
+        <div className="grid grid-cols-1 gap-md sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+          {pending.map((file) => {
+            const isAdding = addingId === file.id;
+            const isDismissing = dismissMutation.isPending && dismissMutation.variables === file.id;
+            return (
+              <div
+                key={file.id}
+                className="group relative flex min-h-[112px] min-w-0 flex-col gap-xs overflow-hidden rounded-xl border border-grey-200 bg-background p-md dark:border-grey-800"
+                aria-label={`Neue Datei: ${file.file_name}`}
+              >
+                <div className="flex items-start gap-xs pr-6">
+                  <HiCloud
+                    size={14}
+                    className="mt-[2px] shrink-0 text-secondary-600 dark:text-secondary-400"
+                    aria-hidden
+                  />
+                  <div
+                    className="line-clamp-2 break-words text-sm font-medium leading-snug text-foreground"
+                    title={file.file_name}
+                  >
+                    {file.file_name}
+                  </div>
+                </div>
+                <div className="mt-auto flex items-center justify-end gap-xs">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={isAdding || isDismissing}
+                    onClick={() => dismissMutation.mutate(file.id)}
+                    aria-label={`${file.file_name} verwerfen`}
+                  >
+                    <HiX size={12} />
+                    Verwerfen
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={isAdding || isDismissing}
+                    onClick={() => handleAdd(file.id)}
+                    aria-label={`${file.file_name} hinzufügen`}
+                  >
+                    {isAdding ? (
+                      <span className="size-3 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                    ) : (
+                      <HiCheck size={12} />
+                    )}
+                    Hinzufügen
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {watching && pending.length === 0 && !pendingQuery.isLoading && (
+        <p className="m-0 rounded-xl border border-dashed border-grey-300 bg-background p-md text-sm text-grey-500 dark:border-grey-700">
+          Keine neuen Dateien. Du wirst benachrichtigt, sobald welche auftauchen.
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default NotebookPendingFilesPanel;

--- a/apps/web/src/features/notebook/hooks/usePendingWolkeFiles.ts
+++ b/apps/web/src/features/notebook/hooks/usePendingWolkeFiles.ts
@@ -1,0 +1,89 @@
+/**
+ * React Query hooks for the Wolke folder watcher's pending-files UI.
+ *
+ * Backed by the typed `wolkePending` contract client. The hourly watcher
+ * records new Wolke files as "pending"; these hooks let the owner list them,
+ * import one on demand ("Hinzufügen"), dismiss one, and toggle hourly watching.
+ */
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+const pendingKey = (collectionId: string) => ['wolkePending', collectionId] as const;
+
+export function usePendingWolkeFiles(collectionId: string, enabled = true) {
+  return useQuery({
+    queryKey: pendingKey(collectionId),
+    queryFn: async () => {
+      const client = getContractsClient();
+      const result = await client.wolkePending.listPendingFiles({ params: { id: collectionId } });
+      if (result.status !== 200) {
+        throw new Error(`Failed to load pending files (HTTP ${result.status})`);
+      }
+      return result.body.pending;
+    },
+    enabled: enabled && collectionId.length > 0,
+    staleTime: 60_000,
+  });
+}
+
+export function useAddPendingFile(collectionId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (pendingId: string) => {
+      const client = getContractsClient();
+      const result = await client.wolkePending.addPendingFile({
+        params: { id: collectionId, pendingId },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to add file (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: pendingKey(collectionId) });
+      // The notebook gained a document — refresh its detail + listings.
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
+      void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+    },
+  });
+}
+
+export function useDismissPendingFile(collectionId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (pendingId: string) => {
+      const client = getContractsClient();
+      const result = await client.wolkePending.dismissPendingFile({
+        params: { id: collectionId, pendingId },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to dismiss file (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: pendingKey(collectionId) });
+    },
+  });
+}
+
+export function useSetNotebookAutoSync(collectionId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (enabled: boolean) => {
+      const client = getContractsClient();
+      const result = await client.wolkePending.setNotebookAutoSync({
+        params: { id: collectionId },
+        body: { enabled },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to update watch setting (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['notebook', 'collection'] });
+      void queryClient.invalidateQueries({ queryKey: ['notebookCollections'] });
+    },
+  });
+}

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -1,4 +1,5 @@
 import {
+  CloudDownload,
   FileText,
   Heart,
   LayoutDashboard,
@@ -94,6 +95,13 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
     label: 'Notizbuch-Likes',
     description: 'Wenn andere dein öffentliches Notizbuch mögen',
     icon: Heart,
+    group: 'system',
+    actions: (ctx) => [openLinkAction('Notizbuch öffnen')(ctx)],
+  },
+  wolke_new_files: {
+    label: 'Neue Wolke-Dateien',
+    description: 'Wenn in den Wolke-Ordnern deiner Notizbücher neue Dateien gefunden werden',
+    icon: CloudDownload,
     group: 'system',
     actions: (ctx) => [openLinkAction('Notizbuch öffnen')(ctx)],
   },

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -12,6 +12,7 @@ export { sharesContract } from './sharesContract.js';
 export { userProfileContract } from './userProfileContract.js';
 export { notebookContract } from './notebookContract.js';
 export { notebookCollectionsContract } from './notebookCollectionsContract.js';
+export { wolkePendingContract } from './wolkePendingContract.js';
 export { notebookSharingContract } from './notebookSharingContract.js';
 export { docsContract } from './docsContract.js';
 export { documentsContract } from './documentsContract.js';

--- a/packages/contracts/src/contracts/wolkePendingContract.ts
+++ b/packages/contracts/src/contracts/wolkePendingContract.ts
@@ -1,0 +1,103 @@
+/**
+ * ts-rest contract for the Wolke folder watcher's pending-files endpoints.
+ *
+ * These hang off the notebook-collections prefix (`/:id/pending-files/...`) and
+ * are owner-scoped — auth is enforced by `requireAuth` at the prefix in routes.ts
+ * before the contract is mounted. The extra `/pending-files` segment keeps these
+ * routes from colliding with the `/:slugOrId` catch-all on notebookCollectionsContract.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import { notebookErrorResponseSchema } from '../schemas/notebook.js';
+import {
+  listPendingFilesResponseSchema,
+  addPendingFileResponseSchema,
+  dismissPendingFileResponseSchema,
+  setNotebookAutoSyncBodySchema,
+  setNotebookAutoSyncResponseSchema,
+} from '../schemas/wolkePending.js';
+
+const c = initContract();
+
+export const wolkePendingContract = c.router(
+  {
+    /**
+     * GET /api/auth/notebook-collections/:id/pending-files
+     * List files detected in the notebook's Wolke folders that are still pending.
+     */
+    listPendingFiles: {
+      method: 'GET',
+      path: '/api/auth/notebook-collections/:id/pending-files',
+      pathParams: z.object({ id: z.string() }),
+      responses: {
+        200: listPendingFilesResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'List pending Wolke files detected for a notebook',
+    },
+
+    /**
+     * POST /api/auth/notebook-collections/:id/pending-files/:pendingId/add
+     * Import a pending file (download → OCR → embed) and attach it to the notebook.
+     */
+    addPendingFile: {
+      method: 'POST',
+      path: '/api/auth/notebook-collections/:id/pending-files/:pendingId/add',
+      pathParams: z.object({ id: z.string(), pendingId: z.string() }),
+      body: c.noBody(),
+      responses: {
+        200: addPendingFileResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        409: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Import a pending Wolke file and attach it to the notebook',
+    },
+
+    /**
+     * POST /api/auth/notebook-collections/:id/pending-files/:pendingId/dismiss
+     * Dismiss a pending file so it is no longer offered (and not re-detected).
+     */
+    dismissPendingFile: {
+      method: 'POST',
+      path: '/api/auth/notebook-collections/:id/pending-files/:pendingId/dismiss',
+      pathParams: z.object({ id: z.string(), pendingId: z.string() }),
+      body: c.noBody(),
+      responses: {
+        200: dismissPendingFileResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Dismiss a pending Wolke file',
+    },
+
+    /**
+     * POST /api/auth/notebook-collections/:id/auto-sync
+     * Toggle hourly watching for a notebook's Wolke folders. Sets the
+     * collection's `auto_sync` flag, which the hourly watcher enumerates.
+     */
+    setNotebookAutoSync: {
+      method: 'POST',
+      path: '/api/auth/notebook-collections/:id/auto-sync',
+      pathParams: z.object({ id: z.string() }),
+      body: setNotebookAutoSyncBodySchema,
+      responses: {
+        200: setNotebookAutoSyncResponseSchema,
+        401: notebookErrorResponseSchema,
+        403: notebookErrorResponseSchema,
+        404: notebookErrorResponseSchema,
+        500: notebookErrorResponseSchema,
+      },
+      summary: 'Toggle hourly Wolke watching for a notebook',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,6 +28,7 @@ export {
   userProfileContract,
   notebookContract,
   notebookCollectionsContract,
+  wolkePendingContract,
   notebookSharingContract,
   docsContract,
   documentsContract,
@@ -60,6 +61,7 @@ export * from './schemas/shares.js';
 export * from './schemas/userProfile.js';
 export * from './schemas/notebook.js';
 export * from './schemas/notebookCollections.js';
+export * from './schemas/wolkePending.js';
 export * from './schemas/notebookSharing.js';
 export * from './schemas/docs.js';
 export * from './schemas/documents.js';

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -36,6 +36,7 @@ export const notificationTypeSchema = z.enum([
   'group_join_denied',
   'transfer_downloaded',
   'notebook_liked',
+  'wolke_new_files',
 ]);
 export type NotificationType = z.infer<typeof notificationTypeSchema>;
 

--- a/packages/contracts/src/schemas/wolkePending.ts
+++ b/packages/contracts/src/schemas/wolkePending.ts
@@ -1,0 +1,59 @@
+/**
+ * Zod schemas for the Wolke folder watcher's pending-files endpoints.
+ * Mirrors apps/api/routes/notebook/wolkePendingContractRouter.ts and the
+ * `wolke_pending_files` Drizzle table (apps/api/database/schema/system.ts).
+ *
+ * The DTO is snake_case to match the rest of the notebook-collections contract;
+ * the server router maps the camelCase Drizzle row to this shape.
+ */
+import { z } from 'zod';
+
+/** Lifecycle of a detected file. Closed set → enum (no free strings). */
+export const wolkePendingStatusSchema = z.enum(['pending', 'added', 'dismissed']);
+export type WolkePendingStatus = z.infer<typeof wolkePendingStatusSchema>;
+
+export const wolkePendingFileSchema = z.object({
+  id: z.string(),
+  collection_id: z.string(),
+  share_link_id: z.string(),
+  folder_path: z.string(),
+  file_path: z.string(),
+  file_name: z.string(),
+  etag: z.string().nullable(),
+  size: z.number().nullable(),
+  mime_type: z.string().nullable(),
+  status: wolkePendingStatusSchema,
+  detected_at: z.string(),
+  resolved_at: z.string().nullable(),
+});
+export type WolkePendingFileDto = z.infer<typeof wolkePendingFileSchema>;
+
+export const listPendingFilesResponseSchema = z.object({
+  pending: z.array(wolkePendingFileSchema),
+});
+export type ListPendingFilesResponse = z.infer<typeof listPendingFilesResponseSchema>;
+
+export const addPendingFileResponseSchema = z.object({
+  success: z.boolean(),
+  document_id: z.string(),
+  pending: wolkePendingFileSchema,
+});
+export type AddPendingFileResponse = z.infer<typeof addPendingFileResponseSchema>;
+
+export const dismissPendingFileResponseSchema = z.object({
+  success: z.boolean(),
+  pending: wolkePendingFileSchema,
+});
+export type DismissPendingFileResponse = z.infer<typeof dismissPendingFileResponseSchema>;
+
+/** Toggle hourly watching for a notebook (sets the collection's auto_sync flag). */
+export const setNotebookAutoSyncBodySchema = z.object({
+  enabled: z.boolean(),
+});
+export type SetNotebookAutoSyncBody = z.infer<typeof setNotebookAutoSyncBodySchema>;
+
+export const setNotebookAutoSyncResponseSchema = z.object({
+  success: z.boolean(),
+  auto_sync: z.boolean(),
+});
+export type SetNotebookAutoSyncResponse = z.infer<typeof setNotebookAutoSyncResponseSchema>;

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -24,6 +24,7 @@ import {
   boardsContract,
   notebookContract,
   notebookCollectionsContract,
+  wolkePendingContract,
   notebookSharingContract,
   wordpressContract,
   transferContract,
@@ -137,6 +138,7 @@ const _searchClient = () => initClient(searchContract, CLIENT_OPTS);
 const _boardsClient = () => initClient(boardsContract, CLIENT_OPTS);
 const _notebookClient = () => initClient(notebookContract, CLIENT_OPTS);
 const _notebookCollectionsClient = () => initClient(notebookCollectionsContract, CLIENT_OPTS);
+const _wolkePendingClient = () => initClient(wolkePendingContract, CLIENT_OPTS);
 const _notebookSharingClient = () => initClient(notebookSharingContract, CLIENT_OPTS);
 const _wordpressClient = () => initClient(wordpressContract, CLIENT_OPTS);
 const _transferClient = () => initClient(transferContract, CLIENT_OPTS);
@@ -158,6 +160,7 @@ export interface ContractsClient {
   boards: ReturnType<typeof _boardsClient>;
   notebook: ReturnType<typeof _notebookClient>;
   notebookCollections: ReturnType<typeof _notebookCollectionsClient>;
+  wolkePending: ReturnType<typeof _wolkePendingClient>;
   notebookSharing: ReturnType<typeof _notebookSharingClient>;
   wordpress: ReturnType<typeof _wordpressClient>;
   transfer: ReturnType<typeof _transferClient>;
@@ -196,6 +199,7 @@ export function getContractsClient(): ContractsClient {
     boards: _boardsClient(),
     notebook: _notebookClient(),
     notebookCollections: _notebookCollectionsClient(),
+    wolkePending: _wolkePendingClient(),
     notebookSharing: _notebookSharingClient(),
     wordpress: _wordpressClient(),
     transfer: _transferClient(),


### PR DESCRIPTION
## Why

Notebooks with Wolke (Nextcloud) folders only stay current if the owner remembers to open them and run a wholesale sync — and that sync silently imports *every* new file. There was no signal when new files appear, and no user control over what gets added.

This adds an **opt-in hourly watcher**: it cheaply lists each watched notebook's Wolke folders, detects genuinely new files, records them as *pending*, and notifies the owner (email + push + in-app, via the existing `createNotification` fan-out). The owner reviews them in a new "Neue Dateien aus der Wolke" panel on the notebook editor and adds each file with one click — the expensive download → OCR → embed runs on demand, reusing `WolkeSyncService.processFile`.

## How it fits together

- **Opt-in** reuses the collection's existing `auto_sync` flag, toggled from the panel via a dedicated `/auto-sync` endpoint (the editor save no longer clobbers it).
- **Detection** keys off the notebook's `wolke_folders` and lists each with the *same* `client.listFolder(folderPath)` the manual import uses, so the `href`/`wolke_file_path` dedup key is identical. A unique `(collection_id, file_path)` index + `ON CONFLICT DO NOTHING` makes the hourly run idempotent and self-deduplicating — only genuinely new files trigger a notification, so no hourly re-spam.
- **Cron** is a GitHub Actions workflow hitting a new admin-token-protected `/api/internal/wolke-watch/run`, mirroring `offboarding-daily.yml`. ⚠️ Depends on `ADMIN_TOKEN`, which is currently unprovisioned in Salt (already affects other workflows) — needs provisioning for the schedule to authenticate.

100% typesafe across all 4 layers (Zod schema, ts-rest contract, Drizzle table with `$inferSelect`, ts-rest server router); typecheck + lint clean on contracts/shared/api/web.

## Follow-up (separate PR)

Delete the dead `WolkeSyncService.downloadFileToTemp` stub (zero callers, returns a phantom path) — tracked separately per plan.

## Verification

1. Restart backend → `wolke_pending_files` table auto-migrates.
2. Enable the toggle on a notebook with a Wolke folder; drop a new file in the folder.
3. `curl -X POST .../api/internal/wolke-watch/run -H "x-admin-token: $ADMIN_TOKEN"` → `totalNewFiles>=1`, one pending row, notification delivered. Re-run → 0 new, no second notification.
4. Open the notebook editor → "Hinzufügen" imports + attaches the file (no duplicate document); "Verwerfen" dismisses it.