### PR TITLE
feat(offboarding): add dry-run mode and default the daily cron to it

### DIFF
--- a/.github/workflows/offboarding-daily.yml
+++ b/.github/workflows/offboarding-daily.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Preview without processing'
+        description: 'Preview without processing (uncheck to run a real offboarding)'
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -45,18 +45,27 @@ jobs:
         id: offboard
         continue-on-error: true
         run: |
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "Running dry-run..."
-            RESULT=$(curl -sf -X POST "$API_URL/api/internal/offboarding/dry-run" \
-              -H "x-admin-token: ${{ secrets.ADMIN_TOKEN }}" \
-              -H "Content-Type: application/json" \
-              -d '{"limit": 50}')
+          # Scheduled runs are dry-run "for now": report how many users would be
+          # processed without deleting/anonymizing anything. A real run requires a
+          # manual dispatch with the dry_run input unchecked.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            DRY=true
           else
-            echo "Running offboarding..."
-            RESULT=$(curl -sf -X POST "$API_URL/api/internal/offboarding/run-sync" \
-              -H "x-admin-token: ${{ secrets.ADMIN_TOKEN }}" \
-              --max-time 1800)
+            DRY="${{ inputs.dry_run }}"
           fi
+          echo "dry=$DRY" >> "$GITHUB_OUTPUT"
+
+          if [ "$DRY" = "true" ]; then
+            echo "Running offboarding dry run (no changes will be made)..."
+          else
+            echo "Running LIVE offboarding (will delete/anonymize users)..."
+          fi
+
+          RESULT=$(curl -sf -X POST "$API_URL/api/internal/offboarding/run-sync" \
+            -H "x-admin-token: ${{ secrets.ADMIN_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"dryRun\": $DRY}" \
+            --max-time 1800)
 
           echo "$RESULT" | jq .
           echo "result<<EOF" >> "$GITHUB_OUTPUT"
@@ -78,22 +87,25 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            COUNT=$(echo "$RESULT" | jq -r '.results | length')
-            WOULD_PROCESS=$(echo "$RESULT" | jq -r '[.results[] | select(.action == "would_be_processed")] | length')
-            NOT_FOUND=$(echo "$RESULT" | jq -r '[.results[] | select(.action == "not_found")] | length')
+          if [ "${{ steps.offboard.outputs.dry }}" = "true" ]; then
+            WOULD_PROCESS=$(echo "$RESULT" | jq -r '.wouldProcess')
+            NOT_FOUND=$(echo "$RESULT" | jq -r '.notFound')
+            FAILED=$(echo "$RESULT" | jq -r '.failed')
+            DURATION=$(echo "$RESULT" | jq -r '.durationMs')
+            DURATION_S=$(( DURATION / 1000 ))
 
             {
-              echo "## :mag: Offboarding Dry Run"
+              echo "## :mag: Offboarding Dry Run (no changes made)"
               echo ""
               echo "**Date:** $(date -u '+%d.%m.%Y %H:%M UTC')"
+              echo "**Duration:** ${DURATION_S}s"
               echo "**Run:** [${{ github.run_id }}]($RUN_URL)"
               echo ""
               echo "| Metric | Count |"
               echo "|--------|------:|"
-              echo "| Users checked | $COUNT |"
               echo "| Would be processed | $WOULD_PROCESS |"
               echo "| Not found in DB | $NOT_FOUND |"
+              echo "| Lookup errors | $FAILED |"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             SUCCESS=$(echo "$RESULT" | jq -r '.success')

--- a/apps/api/routes/internal/offboardingController.ts
+++ b/apps/api/routes/internal/offboardingController.ts
@@ -69,13 +69,15 @@ router.post('/run', requireAdmin, async (req: AdminRequest, res: Response): Prom
  * POST /internal/offboarding/run-sync
  * Trigger offboarding and wait for completion. Returns anonymized counts only.
  * Used by GitHub Actions daily cron for protocol/summary.
+ * Pass { dryRun: true } to count how many users would be processed without changing anything.
  */
 router.post('/run-sync', requireAdmin, async (req: AdminRequest, res: Response): Promise<void> => {
   try {
     OffboardingService.validateConfig();
 
+    const { dryRun = false } = (req.body ?? {}) as { dryRun?: boolean };
     const service = new OffboardingService();
-    const result = await service.runOffboarding();
+    const result = await service.runOffboarding({ dryRun });
 
     res.json(result);
   } catch (error) {

--- a/apps/api/services/admin/OffboardingService.ts
+++ b/apps/api/services/admin/OffboardingService.ts
@@ -112,9 +112,16 @@ export class OffboardingService {
 
   /**
    * Run the complete offboarding process
-   * @returns True if successful, false otherwise
+   * @param options.dryRun - When true, no users are deleted/anonymized and nothing is
+   *   reported upstream; the result reports how many users *would* be processed.
    */
-  async runOffboarding(): Promise<OffboardingResult> {
+  async runOffboarding(options: { dryRun?: boolean } = {}): Promise<OffboardingResult> {
+    const { dryRun = false } = options;
+
+    if (dryRun) {
+      return this.dryRunOffboarding();
+    }
+
     const startTime = Date.now();
     const counts = { deleted: 0, anonymized: 0, not_found: 0, failed: 0 };
     let retriesProcessed = 0;
@@ -159,7 +166,9 @@ export class OffboardingService {
 
     const result: OffboardingResult = {
       success,
+      dryRun: false,
       processed: counts.deleted + counts.anonymized + counts.not_found + counts.failed,
+      wouldProcess: 0,
       deleted: counts.deleted,
       anonymized: counts.anonymized,
       notFound: counts.not_found,
@@ -172,6 +181,58 @@ export class OffboardingService {
     log.info(
       `Offboarding completed in ${result.durationMs}ms: ${result.processed} processed ` +
         `(${result.deleted} deleted, ${result.anonymized} anonymized, ${result.notFound} not found, ${result.failed} failed)`
+    );
+
+    return result;
+  }
+
+  /**
+   * Walk the full offboarding set without mutating anything, counting how many users
+   * would be processed. Delete-vs-anonymize cannot be predicted (deletion is attempted
+   * first with anonymization as fallback), so we only distinguish found vs not-found.
+   */
+  private async dryRunOffboarding(): Promise<OffboardingResult> {
+    const startTime = Date.now();
+    let wouldProcess = 0;
+    let notFound = 0;
+    let failed = 0;
+
+    log.info('Starting Grünerator offboarding DRY RUN (no changes will be made)');
+
+    for await (const user of this.fetchOffboardingUsers()) {
+      try {
+        const grueneratorUser = await this.grueneratorOffboarding.findUserInGruenerator(user);
+        if (grueneratorUser) {
+          wouldProcess += 1;
+        } else {
+          notFound += 1;
+        }
+      } catch (error: unknown) {
+        failed += 1;
+        log.warn(
+          `Dry-run lookup failed for ${user.username}:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+
+    const result: OffboardingResult = {
+      success: true,
+      dryRun: true,
+      processed: wouldProcess + notFound + failed,
+      wouldProcess,
+      deleted: 0,
+      anonymized: 0,
+      notFound,
+      failed,
+      retriesProcessed: 0,
+      durationMs: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    };
+
+    log.info(
+      `Offboarding dry run completed in ${result.durationMs}ms: ${wouldProcess} would be processed, ` +
+        `${notFound} not found in DB, ${failed} lookup errors`
     );
 
     return result;

--- a/apps/api/services/admin/types.ts
+++ b/apps/api/services/admin/types.ts
@@ -79,7 +79,11 @@ export interface UserProfile {
  */
 export interface OffboardingResult {
   success: boolean;
+  /** True when no changes were made — counts reflect what *would* happen. */
+  dryRun: boolean;
   processed: number;
+  /** Dry-run only: users found in Grünerator that would be deleted/anonymized. 0 on real runs. */
+  wouldProcess: number;
   deleted: number;
   anonymized: number;
   notFound: number;


### PR DESCRIPTION
The daily offboarding job deletes/anonymizes Grünerator accounts. It has been silently failing with HTTP 403 because `ADMIN_TOKEN` was never provisioned — that's being fixed in Salt now, which means the job is about to start performing real deletions again.

Before letting it delete anything, we want to see **how many accounts it would touch** — especially on the first run, where a backlog accumulated during the outage could be large. So this defaults the scheduled job to a non-destructive dry run that reports the would-process count, and gates real deletions behind an explicit manual dispatch.

- `runOffboarding({ dryRun })` walks the full offboarding set via `findUserInGruenerator` without mutating anything (delete-vs-anonymize can't be predicted, so it only distinguishes found vs not-found).
- `/run-sync` accepts `{ dryRun: true }`; the existing capped `/dry-run` preview endpoint is left untouched for manual spot-checks.
- Scheduled runs are dry-run "for now"; a real run requires a `workflow_dispatch` with `dry_run` unchecked.

Flip back to live by removing the `schedule → dry` branch in the workflow once the count looks right.