### PR TITLE
fix(subtitler): sanitize degenerate word timings so Reel transcription stops crashing

### DIFF
--- a/apps/api/routes/subtitler/processingController.ts
+++ b/apps/api/routes/subtitler/processingController.ts
@@ -59,6 +59,7 @@ import { getVideoMetadata } from '../../services/subtitler/videoUploadService.js
 import { setContentDisposition } from '../../utils/http/contentDisposition.js';
 import { createLogger } from '../../utils/logger.js';
 import { redisClient } from '../../utils/redis/index.js';
+import { reportBackgroundError } from '../../utils/reportBackgroundError.js';
 
 import type { AuthenticatedRequest } from '../../middleware/types.js';
 import type { ParamsDictionary } from 'express-serve-static-core';
@@ -154,6 +155,7 @@ router.post(
           });
         })
         .catch(async (error: Error) => {
+          reportBackgroundError(error, { job: 'subtitler-transcription', uploadId });
           void scheduleImmediateCleanup(uploadId, 'transcription error');
           await redisClient.set(jobKey, JSON.stringify({ status: 'error', data: error.message }), {
             EX: 86400,
@@ -576,7 +578,9 @@ router.post(
         projectId,
         userId,
         textOverlays: toAssTextOverlays(textOverlays),
-      }).catch((e: Error) => log.error(`Background export failed: ${e.message}`));
+      }).catch((e: Error) =>
+        reportBackgroundError(e, { job: 'subtitler-export', exportToken, uploadId: uploadId || '' })
+      );
     } catch (e: unknown) {
       if (!res.headersSent)
         res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
@@ -722,7 +726,7 @@ router.post(
             { EX: 3600 }
           );
         })
-        .catch((e: Error) => log.error(`Auto-process failed: ${e.message}`));
+        .catch((e: Error) => reportBackgroundError(e, { job: 'subtitler-auto-process', uploadId }));
     } catch (e: unknown) {
       if (!res.headersSent)
         res.status(500).json({ error: e instanceof Error ? e.message : String(e) });

--- a/apps/api/services/subtitler/__tests__/manualSubtitleGenerator.vitest.ts
+++ b/apps/api/services/subtitler/__tests__/manualSubtitleGenerator.vitest.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  generateManualSubtitles,
+  sanitizeWordTimestamps,
+  type WordTimestamp,
+} from '../manualSubtitleGeneratorService.js';
+
+describe('sanitizeWordTimestamps', () => {
+  it('repairs a leading zero-duration cue (the start=0,end=0 provider artifact)', () => {
+    const words: WordTimestamp[] = [
+      { word: 'Hallo', start: 0, end: 0 },
+      { word: 'Welt', start: 0.5, end: 1.0 },
+    ];
+    const cleaned = sanitizeWordTimestamps(words);
+    expect(cleaned).toHaveLength(2);
+    expect(cleaned[0].start).toBe(0);
+    expect(cleaned[0].end).toBeGreaterThan(cleaned[0].start);
+  });
+
+  it('clamps negative starts to 0', () => {
+    const cleaned = sanitizeWordTimestamps([{ word: 'a', start: -1, end: 0.5 }]);
+    expect(cleaned[0].start).toBe(0);
+    expect(cleaned[0].end).toBe(0.5);
+  });
+
+  it('enforces monotonically non-decreasing starts', () => {
+    const cleaned = sanitizeWordTimestamps([
+      { word: 'a', start: 2.0, end: 2.5 },
+      { word: 'b', start: 1.0, end: 1.5 },
+    ]);
+    expect(cleaned[1].start).toBeGreaterThanOrEqual(cleaned[0].start);
+  });
+
+  it('drops structurally invalid entries (non-finite timing)', () => {
+    const cleaned = sanitizeWordTimestamps([
+      { word: 'a', start: NaN, end: 1 },
+      { word: 'b', start: 0.5, end: 1.0 },
+    ]);
+    expect(cleaned).toHaveLength(1);
+    expect(cleaned[0].word).toBe('b');
+  });
+
+  it('throws only when nothing usable remains (silent/empty audio)', () => {
+    expect(() => sanitizeWordTimestamps([])).toThrow(/No usable word timestamps/);
+    expect(() => sanitizeWordTimestamps([{ word: 'x', start: Infinity, end: Infinity }])).toThrow(
+      /No usable word timestamps/
+    );
+  });
+});
+
+describe('generateManualSubtitles', () => {
+  it('produces subtitles for input whose first word has start=0,end=0 (no longer aborts)', async () => {
+    const words: WordTimestamp[] = [
+      { word: 'Hallo', start: 0, end: 0 },
+      { word: 'liebe', start: 0.4, end: 0.8 },
+      { word: 'Welt.', start: 0.9, end: 1.4 },
+    ];
+    const result = await generateManualSubtitles('Hallo liebe Welt.', words);
+    expect(result).toBeTruthy();
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
+++ b/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
@@ -117,32 +117,52 @@ function formatTime(timeInSeconds: number): string {
   return `${minutes}:${wholeSeconds.toString().padStart(2, '0')}.${fractionalSecond}`;
 }
 
-function validateWordTimestamps(words: WordTimestamp[]): void {
+const MIN_CUE_DURATION = 0.05;
+
+/**
+ * Repair degenerate word timings from transcription providers instead of
+ * aborting. faster-whisper / Voxtral routinely emit a leading cue with
+ * start=0,end=0 (a zero-duration token at audio onset), which the old strict
+ * validation rejected — killing the whole job even though the grouping below
+ * already clamps each cue to minDuration and to the next word's start.
+ *
+ * Drops only structurally unusable entries (non-string word, non-finite
+ * timing); throws only when nothing usable remains (genuinely silent/empty
+ * audio).
+ */
+function sanitizeWordTimestamps(words: WordTimestamp[]): WordTimestamp[] {
   if (!Array.isArray(words)) {
     throw new Error('Word timestamps must be an array');
   }
 
-  if (words.length === 0) {
-    throw new Error('Word timestamps array cannot be empty');
-  }
+  const cleaned: WordTimestamp[] = [];
+  let prevStart = 0;
 
-  for (let i = 0; i < Math.min(3, words.length); i++) {
-    const word = words[i];
+  for (const word of words) {
     if (
       !word ||
       typeof word.word !== 'string' ||
-      typeof word.start !== 'number' ||
-      typeof word.end !== 'number'
+      !Number.isFinite(word.start) ||
+      !Number.isFinite(word.end)
     ) {
-      throw new Error(
-        `Invalid word timestamp structure at index ${i}. Expected: {word: string, start: number, end: number}`
-      );
+      continue;
     }
 
-    if (word.start < 0 || word.end < 0 || word.start >= word.end) {
-      throw new Error(`Invalid timing at index ${i}: start=${word.start}, end=${word.end}`);
-    }
+    // Clamp negatives and keep starts monotonically non-decreasing.
+    const start = Math.max(0, word.start, prevStart);
+    // Repair zero/negative-duration cues with a small floor; the grouping step
+    // re-clamps the end to the next word's start, so the exact value is moot.
+    const end = word.end > start ? word.end : start + MIN_CUE_DURATION;
+
+    cleaned.push({ word: word.word, start, end });
+    prevStart = start;
   }
+
+  if (cleaned.length === 0) {
+    throw new Error('No usable word timestamps after sanitization (empty or silent audio?)');
+  }
+
+  return cleaned;
 }
 
 function findSmartBreakPoint(
@@ -227,10 +247,10 @@ function applyElasticTiming(segments: ManualSegmentCandidate[]): ManualSegmentCa
 }
 
 function groupWordsIntoSegments(
-  words: WordTimestamp[],
+  rawWords: WordTimestamp[],
   fullText: string
 ): ManualSegmentCandidate[] {
-  validateWordTimestamps(words);
+  const words = sanitizeWordTimestamps(rawWords);
 
   const segments: ManualSegmentCandidate[] = [];
   let currentSegment: CurrentSegment = {
@@ -457,7 +477,7 @@ export {
   formatTime,
   groupWordsIntoSegments,
   formatSegmentsToSubtitleText,
-  validateWordTimestamps,
+  sanitizeWordTimestamps,
   findSmartBreakPoint,
   applyElasticTiming,
 };

--- a/apps/api/utils/reportBackgroundError.ts
+++ b/apps/api/utils/reportBackgroundError.ts
@@ -1,0 +1,33 @@
+import { Sentry } from '../lib/sentry.js';
+
+import { createLogger } from './logger.js';
+
+const log = createLogger('background');
+
+interface BackgroundErrorContext {
+  /** Short stable identifier for the job, e.g. 'subtitler-transcription'. */
+  job: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Report a swallowed background-job failure: log it readably AND surface it to
+ * Sentry/Glitchtip.
+ *
+ * Fire-and-forget jobs (transcription, exports, document OCR, chat
+ * post-response work) catch their own errors and write a status to Redis/DB so
+ * the request can return early. Without this, the failure only ever lands in a
+ * status string the user sees — it never reaches monitoring, so the same bug
+ * can fail thousands of times invisibly. Pass the original error plus a `job`
+ * tag and any context worth grouping on.
+ */
+export function reportBackgroundError(error: unknown, ctx: BackgroundErrorContext): void {
+  const { job, ...extra } = ctx;
+  const message = error instanceof Error ? error.message : String(error);
+
+  // Single interpolated message + structured meta; the logger serializes Error
+  // objects (name/message/stack) but mangles a bare string passed as a 2nd arg.
+  log.error(`[${job}] background job failed: ${message}`, { error, ...extra });
+
+  Sentry.captureException(error, { tags: { background_job: job }, extra });
+}


### PR DESCRIPTION
A user hit **"Manual subtitle generation failed: Invalid timing at index 0: start=0, end=0"** on `/reel`. Production logs show it firing on *every* auto-processed video — not an edge case.

The transcription providers (faster-whisper/Regolo, Voxtral) consistently emit a leading cue with `start=0, end=0` (a zero-duration token at audio onset). The strict `validateWordTimestamps` gate threw on it and aborted the whole job — even though the grouping step already clamps every cue to `minDuration` and to the next word's start, so the degenerate cue is harmless downstream. The validation was the bug, not the data.

`sanitizeWordTimestamps` now repairs instead of rejecting (clamp negatives, keep starts monotonic, floor zero-duration cues) and throws only when no usable words remain (genuinely silent/empty audio).

Separately, these failures never reached Glitchtip because the fire-and-forget job catches wrote a Redis status string and never called `captureException`. A small `reportBackgroundError` helper closes that blind spot for the three subtitler catches; follow-up PRs extend it elsewhere.

Tested: new `manualSubtitleGenerator.vitest.ts` (6 cases — repair paths + genuine-failure path); API typecheck clean.