### PR TITLE
fix(search): recover from Linkup timeouts + make swallowed search failures visible

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -24,6 +24,7 @@ import {
 import { expandQuery } from '../../../../services/search/QueryExpansionService.js';
 import { DEFAULT_RELEVANCE } from '../../../../services/search/rerankPipeline.js';
 import { createLogger } from '../../../../utils/logger.js';
+import { reportBackgroundError } from '../../../../utils/reportBackgroundError.js';
 import { type AIWorkerPool } from '../../../../workers/types.js';
 import {
   SOURCE_PREFIX,
@@ -1143,7 +1144,10 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
     };
   } catch (error: unknown) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    log.error(`[Search] Error during ${intent} search:`, errMsg);
+    // Search failure degrades silently to empty results, so surface it: the old
+    // `log.error(msg, errMsg)` passed a bare string as winston's 2nd arg, which
+    // got spread into `{"0":"T","1":"h",...}` and was invisible in Glitchtip.
+    reportBackgroundError(error, { job: 'chatgraph-search', intent });
 
     return {
       searchResults: [],

--- a/apps/api/services/search/searchRetryStrategy.ts
+++ b/apps/api/services/search/searchRetryStrategy.ts
@@ -24,8 +24,16 @@ export interface RetryOptions {
 export function isRecoverableError(error: Error): boolean {
   const msg = error.message.toLowerCase();
 
-  // Timeouts are always recoverable
-  if (msg.includes('timeout') || msg.includes('timed out') || msg.includes('etimedout')) {
+  // Timeouts are always recoverable. AbortError surfaces as "This operation
+  // was aborted" / "aborted due to timeout" (e.g. Linkup's deep-research
+  // deadline), so treat aborts as the timeouts they are — otherwise they fall
+  // through to the non-recoverable default and never retry or fall back.
+  if (
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('etimedout') ||
+    msg.includes('abort')
+  ) {
     return true;
   }
 

--- a/apps/api/services/search/searchRetryStrategy.vitest.ts
+++ b/apps/api/services/search/searchRetryStrategy.vitest.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+
+import { isRecoverableError } from './searchRetryStrategy.js';
+
+describe('isRecoverableError', () => {
+  it('treats AbortError ("operation was aborted") as recoverable', () => {
+    // Linkup's deep-research deadline surfaces as an AbortError; before this it
+    // fell through to the non-recoverable default and never retried/fell back.
+    expect(isRecoverableError(new Error('This operation was aborted'))).toBe(true);
+    expect(isRecoverableError(new Error('The operation was aborted due to timeout'))).toBe(true);
+  });
+
+  it('treats timeouts and connection resets as recoverable', () => {
+    expect(isRecoverableError(new Error('Request timed out'))).toBe(true);
+    expect(isRecoverableError(new Error('ETIMEDOUT'))).toBe(true);
+    expect(isRecoverableError(new Error('ECONNRESET'))).toBe(true);
+  });
+
+  it('treats 5xx as recoverable, 4xx as non-recoverable', () => {
+    expect(isRecoverableError(new Error('502 Bad Gateway'))).toBe(true);
+    expect(isRecoverableError(new Error('Request failed with status 401'))).toBe(false);
+  });
+
+  it('defaults unknown errors to non-recoverable', () => {
+    expect(isRecoverableError(new Error('something weird happened'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Production logs showed a research query degrade to no web results after Linkup's 60s deep-research deadline, with the error logged as unreadable garbage (`{"0":"T","1":"h",...}`) and nothing in Glitchtip.

Two independent bugs met at that symptom:

1. **Misclassified abort.** Linkup's deadline surfaces as an `AbortError` ("This operation was aborted"). `isRecoverableError` matched `timeout`/`timed out`/`etimedout` but **not `abort`**, so it fell through to the non-recoverable default — the retry → SearXNG → Mistral fallback chain never engaged and research silently returned empty.
2. **Garbage, unreported log.** The search node's catch logged `log.error(msg, errMsg)` — a bare string as winston's 2nd arg gets spread into `{"0":"T",...}` (the splat artifact), and was never sent to Sentry. Now routed through `reportBackgroundError`.

> **Stacked on #1004** (reuses the `reportBackgroundError` helper). Base will auto-retarget to `master` once #1004 merges.

Tested: new `searchRetryStrategy.vitest.ts` (abort/timeout/5xx/4xx classification); API typecheck clean.