### PR TITLE
fix(api): report swallowed background-job failures to Sentry

### DIFF
--- a/apps/api/routes/chat/services/attachmentPersistenceService.ts
+++ b/apps/api/routes/chat/services/attachmentPersistenceService.ts
@@ -15,6 +15,7 @@ import { generateText } from 'ai';
 
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import { createLogger } from '../../../utils/logger.js';
+import { reportBackgroundError } from '../../../utils/reportBackgroundError.js';
 import { getIntermediateModel } from '../agents/providers.js';
 
 const log = createLogger('AttachmentPersistenceService');
@@ -65,7 +66,7 @@ export async function saveThreadAttachment(params: SaveAttachmentParams): Promis
 
   if (extractedText && extractedText.length > 100 && !isImage) {
     generateAttachmentSummary(attachmentId, extractedText).catch((err) => {
-      log.error(`[AttachmentPersistence] Failed to generate summary for ${attachmentId}:`, err);
+      reportBackgroundError(err, { job: 'attachment-summary', attachmentId });
     });
   }
 

--- a/apps/api/routes/chat/services/contextPruningService.ts
+++ b/apps/api/routes/chat/services/contextPruningService.ts
@@ -11,6 +11,7 @@ import {
   getTokenStats,
 } from '../../../services/counters/TokenCounter.js';
 import { createLogger } from '../../../utils/logger.js';
+import { reportBackgroundError } from '../../../utils/reportBackgroundError.js';
 
 import {
   getCompactionState,
@@ -98,7 +99,7 @@ export async function applyCompaction(
       const threadMessages = await getThreadMessages(threadId);
       generateCompactionSummary(threadId, threadMessages, contextWindowTokens)
         .then(() => lastCompactionTime.set(threadId, Date.now()))
-        .catch((err) => log.error('[Compaction] Background compaction failed:', err))
+        .catch((err) => reportBackgroundError(err, { job: 'context-compaction', threadId }))
         .finally(() => compactionInProgress.delete(threadId));
     }
 

--- a/apps/api/routes/chat/services/postResponseService.ts
+++ b/apps/api/routes/chat/services/postResponseService.ts
@@ -14,6 +14,7 @@ import { shouldExtractMemories } from '../../../services/mem0/gatekeeperService.
 import { getMem0Instance } from '../../../services/mem0/index.js';
 import { maybeRecompilePersona } from '../../../services/mem0/personaService.js';
 import { createLogger } from '../../../utils/logger.js';
+import { reportBackgroundError } from '../../../utils/reportBackgroundError.js';
 import { type AIWorkerPool } from '../../../workers/types.js';
 
 import { saveThreadAttachment } from './attachmentPersistenceService.js';
@@ -310,7 +311,7 @@ export async function persistAssistantResponse(params: PersistParams): Promise<v
             });
         })
         .catch((memError) => {
-          log.warn(`[${requestId}] Async memory save failed:`, memError);
+          reportBackgroundError(memError, { job: 'chat-memory-save', requestId, userId });
         });
     }
   } catch (error) {

--- a/apps/api/services/document-services/DocumentProcessingService/triggerPendingDocProcessing.ts
+++ b/apps/api/services/document-services/DocumentProcessingService/triggerPendingDocProcessing.ts
@@ -1,7 +1,8 @@
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import { createLogger } from '../../../utils/logger.js';
-import { getPostgresDocumentService } from '../PostgresDocumentService/index.js';
+import { reportBackgroundError } from '../../../utils/reportBackgroundError.js';
 import { getQdrantDocumentService } from '../DocumentSearchService/index.js';
+import { getPostgresDocumentService } from '../PostgresDocumentService/index.js';
 
 import { processUploadedDocument } from './fileProcessing.js';
 
@@ -46,10 +47,9 @@ export async function triggerPendingDocProcessing({
   const qdrantDocService = getQdrantDocumentService();
   for (const doc of pendingDocs) {
     processUploadedDocument(pgDocService, qdrantDocService, doc.id, userId).catch((err) => {
-      log.error(
-        `[${logScope}] Background processing failed for doc ${doc.id}${collectionSuffix}:`,
-        err
-      );
+      // Without reporting, a failed upload sits in "pending" forever and the
+      // user never learns why — surface it.
+      reportBackgroundError(err, { job: 'document-processing', docId: doc.id, logScope, userId });
     });
   }
 


### PR DESCRIPTION
Follow-up to #1004 / #1005. The subtitler crash was invisible in Glitchtip because the fire-and-forget job caught its error, wrote a status, and never called `captureException`. The same swallow-pattern exists in other user-triggered background jobs — when they fail, the user sees a stuck/missing result but devs see nothing.

Routes the remaining confirmed user-visible swallow sites through the `reportBackgroundError` helper (added in #1004): document processing (otherwise a doc sits "pending" forever), chat attachment summaries, context compaction, and async memory saves.

Deliberately left alone: sites already wrapped with fallbacks, by-design fail-fast throws, and intentional best-effort `.catch(() => {})` (push/email delivery, font copy). Internal cron loops were skipped as non-user-visible.

API typecheck clean.