### PR TITLE
fix(web): filter DuckDuckGo runtime.sendMessage noise from error tracking

### DIFF
--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -30,6 +30,7 @@ if (sentryDsn) {
       'Thread not found', // @assistant-ui race condition on thread delete/switch — handled gracefully
       /feature named `.+` was not found/, // DuckDuckGo browser internal privacy feature errors
       'invalid origin', // DuckDuckGo iOS WKWebView internal error
+      'Invalid call to runtime.sendMessage', // DuckDuckGo iOS content-script messaging — no extension tab in WKWebView
     ],
   });
 } else {


### PR DESCRIPTION
GlitchTip issue GRUENERATOR-C5 ("Invalid call to runtime.sendMessage(). Tab not found.") is not an app bug — it's thrown by DuckDuckGo's iOS browser (`Ddg/26.5`), whose privacy content-script tries to message an extension background context that doesn't exist inside a WKWebView. We don't call `runtime.sendMessage` anywhere; the script is injected into our page from outside.

Added it to the existing `ignoreErrors` allowlist next to the two other DuckDuckGo iOS errors already filtered there. Matched on the stable substring (not the full ". Tab not found." suffix) so sibling variants are caught too.