### PR TITLE
fix(notebook): audience-filter the public 'Von der Basis' listing

### DIFF
--- a/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
+++ b/apps/api/routes/notebook/notebookCollectionsContractRouter.ts
@@ -337,7 +337,7 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
     }
   },
 
-  listPublicCollections: async () => {
+  listPublicCollections: async (args) => {
     try {
       type NotebookCollectionFromQdrantRaw = {
         id: string;
@@ -355,11 +355,17 @@ export const notebookCollectionsContractRouter = s.router(notebookCollectionsCon
         notebook_collection_documents?: Array<{ document_id: string }>;
         is_public?: boolean;
         public_ownership?: 'owner' | 'public_data' | null;
+        audience?: 'de-DE' | 'de-AT';
       };
 
       const postgres = getPostgresInstance();
-      const collections =
-        (await notebookHelper.getPublicNotebookCollections()) as NotebookCollectionFromQdrantRaw[];
+      // Audience-filter the public listing so a DE-targeted notebook never
+      // surfaces in an AT viewer's "Von der Basis" (and vice versa) — same
+      // exact-match rule the authenticated-share listing uses above.
+      const viewerLocale = getUserLocale(args.req);
+      const collections = (
+        (await notebookHelper.getPublicNotebookCollections()) as NotebookCollectionFromQdrantRaw[]
+      ).filter((c) => c.audience === viewerLocale);
 
       const likeCounts = await getLikeCountsForEntities(
         'notebook',


### PR DESCRIPTION
A notebook created on a DE (`de-DE`) account was showing up in an Austrian (`de-AT`) viewer's **Von der Basis** community section, even though notebooks carry an `audience` field precisely to keep cross-locale notebooks out of the wrong audience's listings.

The authenticated-share listing (`listCollections`) already enforces `audience === viewerLocale`, but the public discovery listing (`listPublicCollections`, which powers Von der Basis) never received the same filter — the handler didn't even accept the request object, so it couldn't know the viewer's locale. This applies the same exact-match rule there.

The `audience` value is already stored and read (`formatCollectionFromPayload`), so no schema, Qdrant, or frontend changes are needed. Filtering happens before the like-count fetch, so we only look up likes for collections the viewer will actually see.