### PR TITLE
docs(notebook): re-ground create guide to current /notebooks index

### DIFF
--- a/documentation/docs/notebooks/eigenes-notebook-erstellen.md
+++ b/documentation/docs/notebooks/eigenes-notebook-erstellen.md
@@ -15,7 +15,7 @@ Ein angemeldetes Grünerator-Konto und ein paar Dokumente, die du zusammenfassen
 
 ### Schritt 1: Zur Notebook-Übersicht
 
-Öffne in der Navigation **Notebooks → Meine Notebooks** (`/notebooks/meine`). Dort siehst du eine Liste deiner eigenen Notebooks — beim ersten Mal ist sie leer, mit einem Hinweis und einem grünen Button **„Eigenes Notebook erstellen"**. Klicke auf den Button, oder oben rechts auf **„Neues Notebook"**.
+Öffne in der Navigation **Notebooks** (`/notebooks`). Auf dieser Seite sind alle Notebooks an einem Ort gebündelt; deine eigenen findest du im Abschnitt **„Eigene"**. Beim ersten Mal ist er leer, mit dem Hinweis **„Noch keine eigenen Notebooks."**. Klicke neben der Überschrift **„Eigene"** auf das **Plus-Symbol** (➕), um den Editor zu öffnen.
 
 ### Schritt 2: Dateien hochladen
 
@@ -61,17 +61,11 @@ Klicke unten rechts auf **„Erstellen"**. Der Button bleibt deaktiviert, solang
 
 ## Dein Notebook nach der Erstellung
 
-Auf **Meine Notebooks** findest du jede deiner Sammlungen als Karte. Dort hast du folgende Möglichkeiten:
+Im Abschnitt **„Eigene"** erscheint jedes deiner Notebooks als Eintrag in einer Liste. Ein **Klick** auf den Eintrag öffnet die Notebook-Detailseite, von der aus du chatten und durchsuchen kannst. Über das **Drei-Punkte-Menü** (erscheint, wenn du mit der Maus über den Eintrag fährst) erreichst du weitere Aktionen:
 
-- **Öffnen** — bringt dich zur Notebook-Detailseite, von der aus du chatten und durchsuchen kannst.
-- **Umbenennen** — schnelle Namens- und Beschreibungsänderung im Dialog.
 - **Bearbeiten** — öffnet wieder den Editor mit allen Optionen (Dokumente, Labels, Wolke, öffentlich).
 - **Link kopieren** — kopiert die URL des Notebooks in die Zwischenablage.
 - **Löschen** — entfernt das Notebook unwiderruflich. **Wichtig:** Die enthaltenen Dokumente bleiben in deiner persönlichen Bibliothek erhalten und können in andere Notebooks aufgenommen werden.
-
-### Dateien per Drag &amp; Drop hinzufügen
-
-Du kannst Dateien direkt aus deinem Dateibrowser auf eine Notebook-Karte ziehen, ohne den Editor zu öffnen. Während des Ziehens hebt sich die Karte hervor, und ein Hinweis bestätigt, in welches Notebook die Datei fließt. Ist das Notebook voll (100 Dokumente erreicht), erscheint stattdessen ein roter Hinweis und der Drop wird abgelehnt.
 
 ## Häufige Fragen
 


### PR DESCRIPTION
The notebook surfaces were consolidated into the single `/notebooks` index page (`/notebooks/meine` is now only a legacy redirect), but `eigenes-notebook-erstellen.md` still walked users through the old layout.

Re-grounded against the shipped UI (`NotebooksIndexPage.tsx`, `SectionHeader`):
- Navigation now points at `/notebooks` → the **Eigene** section, created via the **+ icon** (the "Notebook erstellen" string is the icon's `aria-label`, not visible text).
- Post-creation actions match the real dropdown (Bearbeiten / Link kopieren / Löschen) — the **Umbenennen** action no longer exists (its dialog is orphaned dead code).
- Removed the **drag-drop onto a card** subsection; the index has no drag handlers.

Behavioural content (formats, limits, public toggle, delete-keeps-files, FAQ) was verified against code and left unchanged.

Note: `apps/web/src/features/notebook/components/RenameNotebookDialog.tsx` is now unimported dead code — flagging for a separate cleanup, not touched here.