### PR TITLE
fix(boards): column rename works + board rename in settings menu

### DIFF
--- a/apps/web/src/features/boards/components/BoardDropdown.tsx
+++ b/apps/web/src/features/boards/components/BoardDropdown.tsx
@@ -19,6 +19,7 @@ import {
   FiShare2,
   FiSliders,
   FiCheck,
+  FiEdit2,
 } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
@@ -31,6 +32,7 @@ interface BoardDropdownProps {
   onDelete: () => void;
   onArchiveToggle: () => void;
   onExpertModeToggle: () => void;
+  onRequestRename: () => void;
 }
 
 export const BoardDropdown = memo(function BoardDropdown({
@@ -40,6 +42,7 @@ export const BoardDropdown = memo(function BoardDropdown({
   onDelete,
   onArchiveToggle,
   onExpertModeToggle,
+  onRequestRename,
 }: BoardDropdownProps) {
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
@@ -55,7 +58,11 @@ export const BoardDropdown = memo(function BoardDropdown({
             <FiMoreHorizontal size={16} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+          <DropdownMenuItem onClick={onRequestRename}>
+            <FiEdit2 className="mr-2" size={14} />
+            Umbenennen
+          </DropdownMenuItem>
           <DropdownMenuItem onClick={onExpertModeToggle}>
             <FiSliders className="mr-2" size={14} />
             Expert*innenmodus

--- a/apps/web/src/features/boards/components/BoardInlineHeader.tsx
+++ b/apps/web/src/features/boards/components/BoardInlineHeader.tsx
@@ -1,6 +1,9 @@
 import { useCollaborators } from '@gruenerator/collab';
-import { EditableTitle } from '@gruenerator/shared/components/EditableTitle';
-import { memo } from 'react';
+import {
+  EditableTitle,
+  type EditableTitleHandle,
+} from '@gruenerator/shared/components/EditableTitle';
+import { memo, useRef } from 'react';
 import { FiArrowLeft } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
@@ -40,6 +43,7 @@ export const BoardInlineHeader = memo(function BoardInlineHeader({
 }: BoardInlineHeaderProps) {
   const navigate = useNavigate();
   const collaborators = useCollaborators(provider);
+  const titleRef = useRef<EditableTitleHandle>(null);
 
   const showStatusDot = !isConnected || !isSynced;
   const statusClass = !isConnected ? 'bg-red-500' : 'bg-yellow-500';
@@ -57,6 +61,7 @@ export const BoardInlineHeader = memo(function BoardInlineHeader({
           <FiArrowLeft size={compact ? 16 : 18} />
         </button>
         <EditableTitle
+          ref={titleRef}
           as="h1"
           title={title}
           editable
@@ -80,6 +85,7 @@ export const BoardInlineHeader = memo(function BoardInlineHeader({
           onDelete={onDelete}
           onArchiveToggle={onArchiveToggle}
           onExpertModeToggle={onExpertModeToggle}
+          onRequestRename={() => titleRef.current?.startEdit()}
         />
       </div>
     </div>

--- a/apps/web/src/features/boards/components/ColumnHeader.tsx
+++ b/apps/web/src/features/boards/components/ColumnHeader.tsx
@@ -1,10 +1,14 @@
 import {
+  EditableTitle,
+  type EditableTitleHandle,
+} from '@gruenerator/shared/components/EditableTitle';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@gruenerator/ui';
-import { memo, useState } from 'react';
+import { memo, useRef } from 'react';
 import { FiMoreVertical, FiTrash2, FiEdit2, FiEyeOff } from 'react-icons/fi';
 
 import { useColumnActivity } from '../context/BoardAwarenessContext';
@@ -36,16 +40,7 @@ export const ColumnHeader = memo(function ColumnHeader({
   onColorChange,
 }: ColumnHeaderProps) {
   const columnActivity = useColumnActivity(columnId);
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState(column.name);
-
-  const handleSubmit = () => {
-    const trimmed = editValue.trim();
-    if (trimmed && trimmed !== column.name) {
-      onRename(trimmed);
-    }
-    setIsEditing(false);
-  };
+  const titleRef = useRef<EditableTitleHandle>(null);
 
   return (
     <div className="flex items-center gap-xs px-3 py-2">
@@ -56,21 +51,17 @@ export const ColumnHeader = memo(function ColumnHeader({
         />
       )}
 
-      {isEditing ? (
-        <input
-          value={editValue}
-          onChange={(e) => setEditValue(e.target.value)}
-          onBlur={handleSubmit}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') handleSubmit();
-            if (e.key === 'Escape') setIsEditing(false);
-          }}
-          autoFocus
-          className="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-foreground"
-        />
-      ) : (
-        <span className="flex-1 text-sm font-semibold text-foreground truncate">{column.name}</span>
-      )}
+      <EditableTitle
+        ref={titleRef}
+        as="span"
+        title={column.name}
+        editable
+        activateOn="doubleClick"
+        onTitleChange={onRename}
+        className="flex-1 text-sm font-semibold text-foreground truncate"
+        inputClassName="flex-1 text-sm font-semibold bg-transparent border-none outline-none text-foreground"
+        editableClassName="cursor-pointer"
+      />
 
       <span className="text-xs text-grey-400 tabular-nums">{cardCount}</span>
 
@@ -93,13 +84,8 @@ export const ColumnHeader = memo(function ColumnHeader({
             <FiMoreVertical size={14} />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onClick={() => {
-              setEditValue(column.name);
-              setIsEditing(true);
-            }}
-          >
+        <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+          <DropdownMenuItem onClick={() => titleRef.current?.startEdit()}>
             <FiEdit2 className="mr-2" size={14} />
             Umbenennen
           </DropdownMenuItem>

--- a/packages/shared/src/components/EditableTitle/EditableTitle.tsx
+++ b/packages/shared/src/components/EditableTitle/EditableTitle.tsx
@@ -1,4 +1,16 @@
-import { type ElementType, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type ElementType,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+export interface EditableTitleHandle {
+  startEdit: () => void;
+}
 
 interface EditableTitleProps {
   title: string;
@@ -13,122 +25,129 @@ interface EditableTitleProps {
   activateOn?: 'click' | 'doubleClick';
 }
 
-export const EditableTitle = ({
-  title,
-  editable = false,
-  onTitleChange,
-  className,
-  inputClassName,
-  editableClassName,
-  ariaLabel = 'Titel bearbeiten',
-  placeholder = 'Unbenannt',
-  as = 'h1',
-  activateOn = 'click',
-}: EditableTitleProps) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState(title);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const committedRef = useRef(false);
-
-  useEffect(() => {
-    setEditValue(title);
-  }, [title]);
-
-  useEffect(() => {
-    if (isEditing) {
-      inputRef.current?.focus();
-      inputRef.current?.select();
-    }
-  }, [isEditing]);
-
-  const commitEdit = useCallback(() => {
-    if (committedRef.current) return;
-    committedRef.current = true;
-    setIsEditing(false);
-    const trimmed = editValue.trim();
-    const newTitle = trimmed || placeholder;
-    const currentTitle = title || placeholder;
-    if (newTitle !== currentTitle) {
-      onTitleChange?.(newTitle);
-    }
-  }, [editValue, title, onTitleChange, placeholder]);
-
-  const cancelEdit = useCallback(() => {
-    setEditValue(title);
-    setIsEditing(false);
-  }, [title]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        commitEdit();
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        cancelEdit();
-      }
+export const EditableTitle = forwardRef<EditableTitleHandle, EditableTitleProps>(
+  function EditableTitle(
+    {
+      title,
+      editable = false,
+      onTitleChange,
+      className,
+      inputClassName,
+      editableClassName,
+      ariaLabel = 'Titel bearbeiten',
+      placeholder = 'Unbenannt',
+      as = 'h1',
+      activateOn = 'click',
     },
-    [commitEdit, cancelEdit]
-  );
+    ref
+  ) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editValue, setEditValue] = useState(title);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const committedRef = useRef(false);
 
-  const canEditTitle = editable && !!onTitleChange;
+    useEffect(() => {
+      setEditValue(title);
+    }, [title]);
 
-  const startEdit = useCallback(() => {
-    committedRef.current = false;
-    setIsEditing(true);
-  }, []);
+    useEffect(() => {
+      if (isEditing) {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }
+    }, [isEditing]);
 
-  if (isEditing) {
+    const commitEdit = useCallback(() => {
+      if (committedRef.current) return;
+      committedRef.current = true;
+      setIsEditing(false);
+      const trimmed = editValue.trim();
+      const newTitle = trimmed || placeholder;
+      const currentTitle = title || placeholder;
+      if (newTitle !== currentTitle) {
+        onTitleChange?.(newTitle);
+      }
+    }, [editValue, title, onTitleChange, placeholder]);
+
+    const cancelEdit = useCallback(() => {
+      setEditValue(title);
+      setIsEditing(false);
+    }, [title]);
+
+    const handleKeyDown = useCallback(
+      (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          commitEdit();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          cancelEdit();
+        }
+      },
+      [commitEdit, cancelEdit]
+    );
+
+    const canEditTitle = editable && !!onTitleChange;
+
+    const startEdit = useCallback(() => {
+      committedRef.current = false;
+      setIsEditing(true);
+    }, []);
+
+    useImperativeHandle(ref, () => ({ startEdit }), [startEdit]);
+
+    if (isEditing) {
+      return (
+        <input
+          ref={inputRef}
+          className={inputClassName}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          // Stop the input's own pointer events from reaching a parent drag handler
+          // (e.g. a dnd-kit kanban card) so text can be selected while editing.
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={ariaLabel}
+        />
+      );
+    }
+
+    const Tag: ElementType = as;
+    const idleClassName =
+      canEditTitle && editableClassName
+        ? `${className ?? ''} ${editableClassName}`.trim()
+        : className;
+
+    // In doubleClick mode the title owns its clicks: a single click is swallowed
+    // so it never reaches a parent handler (e.g. a card's open-detail onClick),
+    // and a double click enters edit mode.
+    const activationHandlers = !canEditTitle
+      ? {}
+      : activateOn === 'doubleClick'
+        ? {
+            onClick: (e: React.MouseEvent) => e.stopPropagation(),
+            onDoubleClick: (e: React.MouseEvent) => {
+              e.stopPropagation();
+              startEdit();
+            },
+          }
+        : { onClick: startEdit };
+
     return (
-      <input
-        ref={inputRef}
-        className={inputClassName}
-        value={editValue}
-        onChange={(e) => setEditValue(e.target.value)}
-        onBlur={commitEdit}
-        onKeyDown={handleKeyDown}
-        // Stop the input's own pointer events from reaching a parent drag handler
-        // (e.g. a dnd-kit kanban card) so text can be selected while editing.
-        onPointerDown={(e) => e.stopPropagation()}
-        aria-label={ariaLabel}
-      />
+      <Tag
+        className={idleClassName}
+        {...activationHandlers}
+        title={
+          canEditTitle
+            ? activateOn === 'doubleClick'
+              ? 'Doppelklicken zum Umbenennen'
+              : 'Klicken zum Umbenennen'
+            : undefined
+        }
+      >
+        {title || placeholder}
+      </Tag>
     );
   }
-
-  const Tag: ElementType = as;
-  const idleClassName =
-    canEditTitle && editableClassName
-      ? `${className ?? ''} ${editableClassName}`.trim()
-      : className;
-
-  // In doubleClick mode the title owns its clicks: a single click is swallowed
-  // so it never reaches a parent handler (e.g. a card's open-detail onClick),
-  // and a double click enters edit mode.
-  const activationHandlers = !canEditTitle
-    ? {}
-    : activateOn === 'doubleClick'
-      ? {
-          onClick: (e: React.MouseEvent) => e.stopPropagation(),
-          onDoubleClick: (e: React.MouseEvent) => {
-            e.stopPropagation();
-            startEdit();
-          },
-        }
-      : { onClick: startEdit };
-
-  return (
-    <Tag
-      className={idleClassName}
-      {...activationHandlers}
-      title={
-        canEditTitle
-          ? activateOn === 'doubleClick'
-            ? 'Doppelklicken zum Umbenennen'
-            : 'Klicken zum Umbenennen'
-          : undefined
-      }
-    >
-      {title || placeholder}
-    </Tag>
-  );
-};
+);

--- a/packages/shared/src/components/EditableTitle/index.ts
+++ b/packages/shared/src/components/EditableTitle/index.ts
@@ -1,1 +1,1 @@
-export { EditableTitle } from './EditableTitle';
+export { EditableTitle, type EditableTitleHandle } from './EditableTitle';


### PR DESCRIPTION
Two rename interactions in Boards were broken or undiscoverable.

The column **Umbenennen** dropdown item did nothing: the inline edit input opened from inside a Radix `DropdownMenu`, and the menu's close restored focus to its trigger button — blurring the input before the user could type, so it committed an unchanged value and exited. Renaming the board was only possible by double-clicking the title, with no entry in the settings (⋮) menu, which is where users actually looked.

The fix is one shared mechanism: `EditableTitle` now exposes an imperative `startEdit()`, both dropdowns trigger it, and `onCloseAutoFocus` is prevented on the menu content so closing no longer steals focus from the edit input. Columns additionally get double-click-to-rename, matching the board title and cards.

Backend (`PUT /api/boards/:id`), `handleRenameGroup`, and `renameMutation` were already correct and are untouched — the bug was purely the edit-input focus flow plus a missing menu entry.