### PR TITLE
fix(content-sync): send per-LV sync notifications to admin email

### DIFF
--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -19,6 +19,7 @@ import {
   type ContentPath,
   type LandesverbandSource,
 } from '../../../../config/landesverbaendeConfig.js';
+import { env } from '../../../../config/env.js';
 import { getQdrantInstance } from '../../../../database/services/QdrantService/index.js';
 import {
   scrollDocuments,
@@ -571,20 +572,24 @@ export class LandesverbandScraper extends BaseScraper {
       }
     }
 
-    // Send per-LV email notifications for sources with new articles
+    // Send per-LV email notifications for sources with new articles.
+    // Falls back to the admin CONTENT_SYNC_EMAIL when a source has no
+    // dedicated LV contact, so every Landesverband is covered until
+    // per-LV recipients are configured.
     const syncDate = new Date().toISOString();
     for (const outcome of outcomes) {
       if (!outcome.result || outcome.result.stored === 0) continue;
       const source = sources.find((s: { id: string }) => s.id === outcome.sourceId);
-      if (!source?.notificationEmail) continue;
+      const notificationEmail = source?.notificationEmail ?? env.CONTENT_SYNC_EMAIL;
+      if (!source || !notificationEmail) continue;
 
       try {
-        await sendLvSyncNotificationEmail(source.notificationEmail, {
+        await sendLvSyncNotificationEmail(notificationEmail, {
           lvName: source.name,
           newArticles: outcome.result.newArticles,
           syncDate,
         });
-        this.log(`Email sent to ${source.notificationEmail} for ${source.name}`);
+        this.log(`Email sent to ${notificationEmail} for ${source.name}`);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`[Landesverband] Email notification failed for ${source.name}: ${msg}`);


### PR DESCRIPTION
Per-LV "neue Artikel indexiert" notifications were never delivered: the send loop in `LandesverbandScraper` skips any source whose `notificationEmail` is unset — and it's unset on every source — so the email path has been dormant since it was added.

This falls the recipient back to the admin `CONTENT_SYNC_EMAIL` (already configured to moritz-waechter@outlook.de and already injected into the `sync-lv` CI job) whenever a source has no dedicated LV contact. Net effect: every Landesverband's per-sync notification now reaches the admin inbox on the next hourly run. The per-source `notificationEmail` field stays in place as an override for when real per-LV recipients are added later.

Note: the email only fires when a source actually indexed new articles (`stored > 0`), so a quiet hour still produces zero mail.