### PR TITLE
refactor(groups): type AddContentToGroupModal content fetches via contracts client

### DIFF
--- a/apps/web/src/features/groups/components/AddContentToGroupModal.tsx
+++ b/apps/web/src/features/groups/components/AddContentToGroupModal.tsx
@@ -1,3 +1,4 @@
+import { getContractsClient } from '@gruenerator/shared/api';
 import {
   Badge,
   Button,
@@ -23,7 +24,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HiDocumentText, HiCollection, HiLink } from 'react-icons/hi';
 import { PiSquaresFour } from 'react-icons/pi';
 
-import apiClient from '../../../components/utils/apiClient';
 import { ICONS } from '../../../config/icons';
 import { profileApiService } from '../../auth/services/profileApiService';
 import { SYSTEM_NOTEBOOKS } from '../../notebook/config/notebooksConfig';
@@ -171,16 +171,16 @@ const AddContentToGroupModal: React.FC<AddContentToGroupModalProps> = ({
       {
         queryKey: ['add-to-group', 'collabDocs'],
         queryFn: async (): Promise<ContentItem[]> => {
-          const r = await apiClient.get<ContentItem[]>('/docs');
-          return Array.isArray(r.data) ? r.data : [];
+          const result = await getContractsClient().docs.listDocuments({ query: {} });
+          return result.status === 200 ? result.body : [];
         },
         enabled: isOpen,
       },
       {
         queryKey: ['add-to-group', 'boards'],
         queryFn: async (): Promise<ContentItem[]> => {
-          const r = await apiClient.get<ContentItem[]>('/boards');
-          return Array.isArray(r.data) ? r.data : [];
+          const result = await getContractsClient().boards.listBoards();
+          return result.status === 200 ? result.body : [];
         },
         enabled: isOpen,
       },


### PR DESCRIPTION
Follow-up to the boards ts-rest migration (#1018), which deliberately left the cross-feature board call in the groups content picker out of scope.

The group-content picker (`AddContentToGroupModal`) fetched boards and docs through raw `apiClient` with a hand-cast `ContentItem[]` response — the last untyped cross-feature board call. Both endpoints are already contracted, so this swaps them to `getContractsClient().boards.listBoards()` / `.docs.listDocuments()` and drops the now-unused `apiClient` import.

Exploring the rest of the groups feature confirmed it's otherwise already on the typed client (`useGroups`, `GroupDetailSection`, `GroupInfoSection`, `JoinGroupPage` all use `client.groups.*`, and the group-share POST is already `groups.shareContent()`). The only remaining raw call in the feature is an unrelated `POST /canvas/:id/clone` in `useGroups.ts` — a canvas-feature concern, left for a canvas pass.

Verification: web `typecheck` + `lint` green.