### PR TITLE
feat(wolke): surface connected accounts in production

### DIFF
--- a/apps/web/src/features/auth/components/profile/tabs/WolkeManagement/WolkeManagementView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/WolkeManagement/WolkeManagementView.tsx
@@ -232,9 +232,7 @@ const WolkeManagementView = memo(
           </div>
         </CloudCard>
         {import.meta.env.DEV && <WordPressSection />}
-        {import.meta.env.DEV && (
-          <ConnectedAccountsSection onSuccess={onSuccessMessage} onError={onErrorMessage} />
-        )}
+        <ConnectedAccountsSection onSuccess={onSuccessMessage} onError={onErrorMessage} />
       </motion.div>
     );
   }


### PR DESCRIPTION
The Nango OAuth middleware is now deployed and reachable in production (verified end-to-end in Salt: `nango` container, Postgres DB, Passbolt secrets, nginx `nango.<domain>` vhost, and TLS cert all present). Until now the connected-accounts connectors — Google, Microsoft, Jira, Confluence — were hidden behind an `import.meta.env.DEV` gate, so they only ever rendered in local builds.

This drops that gate so the section ships to production. It keeps its existing experimental banner and 'Experimentell' badge for a cautious rollout. WordPress stays dev-gated (still in progress).

The backend (`/api/connections`) and graceful-degradation UI (empty list + 'Nango-Server nicht erreichbar' fallback) were already in place, so this is a single-line exposure change.