### PR TITLE
fix(logger): make metadata serialization circular-safe

### DIFF
--- a/apps/api/utils/logger.ts
+++ b/apps/api/utils/logger.ts
@@ -18,11 +18,20 @@ const logger = winston.createLogger({
       // Serialize structured metadata so log.error('msg', { error }) actually
       // surfaces the error in stdout. Without this, second-arg objects are
       // silently dropped by the formatter and failures look mysterious in CI.
+      // The WeakSet drops circular refs: Axios errors carry a ClientRequest
+      // whose req/res close a cycle, and an unguarded JSON.stringify would
+      // throw mid-log and surface as an unhandled 500 instead of the error.
+      const seen = new WeakSet<object>();
       const meta = Object.keys(rest).length
         ? ' ' +
-          JSON.stringify(rest, (_k: string, v: unknown) =>
-            v instanceof Error ? { name: v.name, message: v.message, stack: v.stack } : v
-          )
+          JSON.stringify(rest, (_k: string, v: unknown) => {
+            if (v instanceof Error) return { name: v.name, message: v.message, stack: v.stack };
+            if (typeof v === 'object' && v !== null) {
+              if (seen.has(v)) return '[Circular]';
+              seen.add(v);
+            }
+            return v;
+          })
         : '';
       return `${timestamp} ${level.toUpperCase().padEnd(5)} ${svc} ${message}${meta}`;
     })


### PR DESCRIPTION
The Winston logger's `printf` formatter serializes second-arg metadata with `JSON.stringify`, but its replacer only special-cased `Error` values — it never guarded against circular *non-Error* objects.

An Axios error carries a `ClientRequest` whose `req`/`res` form a reference cycle. When such an error was logged, `JSON.stringify` threw `TypeError: Converting circular structure to JSON` *inside the log call itself*, and that throw bubbled up as an unhandled HTTP 500. This was observed in production on `GET /api/connections/status` once the Nango connectors went live.

Because the bug lives in the shared logger, it is systemic: *any* API client that logs an Axios (or otherwise circular) error could crash the request it was trying to diagnose — not just Nango. A `WeakSet`-based replacer now drops already-seen objects as `'[Circular]'`, so logging can never crash the request regardless of what's passed in. Error special-casing is preserved.