### PR TITLE
fix(chat): derive message agent badge/avatar from provenance, not selection

### DIFF
--- a/packages/chat/src/components/thread/AssistantMessage.tsx
+++ b/packages/chat/src/components/thread/AssistantMessage.tsx
@@ -2,7 +2,6 @@
 
 import { memo, useMemo } from 'react';
 import { MessagePrimitive, useMessage } from '@assistant-ui/react';
-import { useScopedAgentId } from '../../lib/useScopedAgentState';
 import { agentsList, getDefaultAgent } from '../../lib/agents';
 import { GrueneratorHomeIconLoading } from '../icons';
 import { CitationMarkdownText } from '../message-parts/CitationMarkdownText';
@@ -44,15 +43,19 @@ export const AssistantMessage = memo(function AssistantMessage() {
   const message = useMessage();
   const density = useChatDensity();
   const isCompact = density === 'compact';
-  const selectedAgentId = useScopedAgentId();
   const custom = message.metadata?.custom as ChatMessageMetadata | undefined;
 
+  // Resolve the agent that PRODUCED this message from its own metadata only.
+  // The chat adapter sets `custom.agentId`/`agentMention` on every frame when an
+  // agent is active, so this covers normal agent chats. Surfaces with no agent
+  // (notebook QA, eigener chat) leave it unset → no agent avatar/badge. We do
+  // NOT fall back to the currently-selected agent: selection is ambient UI state,
+  // not message provenance, and leaks the wrong agent into notebook answers.
   const messageAgent = useMemo(() => {
     if (custom?.agentMention) return agentsList.find((a) => a.mention === custom.agentMention);
     if (custom?.agentId) return agentsList.find((a) => a.identifier === custom.agentId);
-    if (selectedAgentId) return agentsList.find((a) => a.identifier === selectedAgentId);
     return undefined;
-  }, [custom?.agentMention, custom?.agentId, selectedAgentId]);
+  }, [custom?.agentMention, custom?.agentId]);
 
   const isNonDefaultAgent = messageAgent != null && messageAgent.identifier !== getDefaultAgent();
   const fetchFullText = useFetchFullText();


### PR DESCRIPTION
Notebook QA answers (e.g. in the LV Bayern notebook) were rendered with the **press agent's avatar and a "Pressemitteilung" skill badge**, even though those answers come from the document-QA endpoint and are not produced by any agent.

Root cause: `AssistantMessage` resolved the message's agent from `custom.agentMention` → `custom.agentId` → **the currently-selected agent** (`useScopedAgentId`). The selected agent is ambient UI state, not message provenance. The notebook surface has no `ChatSurfaceContext`, so that fallback read the *global* selected agent (the LV notebook also preselects its PR agent), which resolved to the base `gruenerator-oeffentlichkeitsarbeit` skill titled "Pressemitteilung" — leaking the wrong agent's identity into notebook answers.

Fix: resolve the producing agent from message metadata only. The chat adapter sets `custom.agentId`/`agentMention` on every frame when an agent is active, so normal agent chats are unchanged; surfaces without an agent (notebook QA, eigener chat) now correctly show the neutral Grünerator avatar and no badge. This drops a fallback rather than adding an abstraction.

Verify in-app: notebook answer shows no agent badge/avatar; `/chat` with a selected agent still shows both; sanity-check eigener chat (the other surface where `custom.agentId` is unset).