### PR TITLE
fix(connections): look up Nango connections by end-user id

### DIFF
--- a/apps/api/services/connections/ConnectionService.ts
+++ b/apps/api/services/connections/ConnectionService.ts
@@ -17,7 +17,10 @@ export interface ConnectionDetail {
 
 export class ConnectionService {
   static async listConnections(userId: string): Promise<ConnectionStatus[]> {
-    const result = await getNango().listConnections({ connectionId: userId });
+    // Connections are created via createConnectSession with end_user.id = userId, so Nango
+    // files them under that end-user id and assigns its own random connection_id. Filter by
+    // userId (→ ?endUserId=), NOT connectionId (which never equals userId).
+    const result = await getNango().listConnections({ userId });
 
     return Object.entries(NANGO_PROVIDERS).map(([key, config]) => {
       const connection = result.connections.find((c) => c.provider_config_key === key);
@@ -32,11 +35,26 @@ export class ConnectionService {
     });
   }
 
+  // getConnection/deleteConnection need Nango's real connection_id, not the end-user id —
+  // resolve it from the end-user id first.
+  private static async resolveConnectionId(
+    userId: string,
+    providerKey: NangoProviderKey
+  ): Promise<string | null> {
+    const result = await getNango().listConnections({ userId, integrationId: providerKey });
+    const connection = result.connections.find((c) => c.provider_config_key === providerKey);
+    return connection ? connection.connection_id : null;
+  }
+
   static async getConnection(
     userId: string,
     providerKey: NangoProviderKey
   ): Promise<ConnectionDetail> {
-    const connection = await getNango().getConnection(providerKey, userId);
+    const connectionId = await this.resolveConnectionId(userId, providerKey);
+    if (!connectionId) {
+      throw new Error(`No ${providerKey} connection found for user`);
+    }
+    const connection = await getNango().getConnection(providerKey, connectionId);
     const credentials = connection.credentials as { access_token?: string };
     if (!credentials.access_token) {
       throw new Error(`No access token available for ${providerKey}`);
@@ -44,12 +62,16 @@ export class ConnectionService {
     return {
       provider: providerKey,
       accessToken: credentials.access_token,
-      connectionId: userId,
+      connectionId,
     };
   }
 
   static async deleteConnection(userId: string, providerKey: NangoProviderKey): Promise<void> {
-    await getNango().deleteConnection(providerKey, userId);
+    const connectionId = await this.resolveConnectionId(userId, providerKey);
+    if (!connectionId) {
+      return;
+    }
+    await getNango().deleteConnection(providerKey, connectionId);
   }
 
   static async createSessionToken(userId: string): Promise<string> {


### PR DESCRIPTION
## Why

A Microsoft account connected successfully (Nango stored the tokens) but the `/profile/wolke` card stayed on **Verbinden** instead of flipping to **Verbunden**.

Root cause: `ConnectionService.createSessionToken` creates the connection via `createConnectSession({ end_user: { id: userId } })`, so Nango files it under that **end-user id** and assigns its own random `connection_id`. But `listConnections` queried `{ connectionId: userId }` (SDK → `?connectionId=`), which never equals `userId` — so the status lookup always missed. `getConnection`/`deleteConnection` had the same latent bug (they passed `userId` as the `connection_id` positional arg → would 404 once the file-import features start using them).

Fix: query by **end-user id** (`{ userId }` → `?endUserId=`, the pattern the SDK itself uses internally) and resolve the real `connection_id` before any per-connection call.

Verified the param shapes against `@nangohq/node` 0.69.50 types; CI runs the typecheck.