### PR TITLE
feat(chat): add @connect mention for connected-account files

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -48,6 +48,7 @@ import type {
   DocumentSource,
   SynthesisMode,
   WolkeFileRef,
+  ConnectFileRef,
 } from './types.js';
 import type { SubcategoryFilters } from '../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../routes/chat/agents/types.js';
@@ -128,6 +129,10 @@ const ChatStateAnnotation = Annotation.Root({
   }),
   // Wolke (Nextcloud) file refs selected via @wolke mentionable.
   wolkeFiles: Annotation<WolkeFileRef[]>({
+    reducer: (x, y) => y ?? x ?? [],
+  }),
+  // Connected-account (Nango) file refs selected via @connect mentionable.
+  connectFiles: Annotation<ConnectFileRef[]>({
     reducer: (x, y) => y ?? x ?? [],
   }),
   // Current open document in the docs editor (primary context for docs surface)
@@ -673,6 +678,9 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
 
     // Wolke (Nextcloud) file refs (from @wolke mentionable, validated by controller)
     wolkeFiles: input.wolkeFiles || [],
+
+    // Connected-account (Nango) file refs (from @connect mentionable)
+    connectFiles: input.connectFiles || [],
 
     // Current open document (docs editor surface)
     currentDocument: input.currentDocument || null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/buildDocumentSources.ts
@@ -19,6 +19,7 @@ import type {
   SearchIntent,
   SynthesisMode,
   WolkeFileRef,
+  ConnectFileRef,
 } from '../types.js';
 
 const COMPARE_VERB_PATTERN =
@@ -55,6 +56,7 @@ interface BuildOpts {
   docMentionIds: string[];
   notebookIds: string[];
   wolkeFiles: WolkeFileRef[];
+  connectFiles: ConnectFileRef[];
   threadAttachments: ChatGraphState['threadAttachments'];
   currentDocument: ChatGraphState['currentDocument'];
 }
@@ -102,6 +104,15 @@ export function buildDocumentSources(opts: BuildOpts): DocumentSource[] {
       id: `wolke:${ref.shareLinkId}:${ref.path}`,
       label: ref.name,
       wolke: ref,
+    });
+  }
+
+  for (const ref of opts.connectFiles) {
+    sources.push({
+      kind: 'connect',
+      id: `connect:${ref.provider}:${ref.fileId}`,
+      label: ref.name,
+      connect: ref,
     });
   }
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/citableSources.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/citableSources.ts
@@ -105,6 +105,10 @@ export function docKindToCitableKind(kind: DocumentSourceKind): CitableSourceKin
       return 'attachment';
     case 'current_doc':
       return 'document';
+    case 'connect':
+      // Connect (Nango) file sources have no public URL; group as 'other',
+      // matching inferSourceKind's fallback for the `connect:` source prefix.
+      return 'other';
     default:
       return 'other';
   }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -73,6 +73,7 @@ export async function classifierNode(state: ChatGraphState): Promise<Partial<Cha
     docMentionIds: state.docMentionIds ?? [],
     notebookIds: state.notebookIds ?? [],
     wolkeFiles: state.wolkeFiles ?? [],
+    connectFiles: state.connectFiles ?? [],
     threadAttachments: state.threadAttachments ?? [],
     currentDocument: state.currentDocument ?? null,
   });
@@ -139,6 +140,7 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
     const hasDocuments = state.documentIds && state.documentIds.length > 0;
     const hasDocumentChat = state.documentChatIds && state.documentChatIds.length > 0;
     const hasWolkeFiles = state.wolkeFiles && state.wolkeFiles.length > 0;
+    const hasConnectFiles = state.connectFiles && state.connectFiles.length > 0;
     const hasBoards = state.boardIds && state.boardIds.length > 0;
     // Open document in the docs-editor is primary context, not retrieval scope.
     // Distinct from documentChatIds — we do NOT force-route to search for it.
@@ -344,6 +346,23 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
       return classifyWithForcedSearch({
         reason: 'Wolke',
         docCount: state.wolkeFiles.length,
+        aiWorkerPool,
+        userContent,
+        conversationContext,
+        topicalContext,
+        temporal,
+        complexity,
+        startTime,
+      });
+    }
+
+    // @connect selections force search intent — the connected-account file content
+    // must reach respondNode via perSourceResults, and that only happens inside the
+    // search path. Mirrors the @wolke forced-search branch above.
+    if (hasConnectFiles && userContent.length > 0) {
+      return classifyWithForcedSearch({
+        reason: 'Connect',
+        docCount: state.connectFiles.length,
         aiWorkerPool,
         userContent,
         conversationContext,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/connectRetrieval.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/connectRetrieval.ts
@@ -58,9 +58,11 @@ function htmlToText(html: string): string {
   return html
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    // Decode &amp; last so an escaped entity like &amp;lt; survives intact
+    // instead of being double-unescaped into '<'.
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/apps/api/agents/langgraph/ChatGraph/nodes/connectRetrieval.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/connectRetrieval.ts
@@ -1,0 +1,169 @@
+/**
+ * Connected-account (Nango) file retrieval for the multi-doc fan-out.
+ *
+ * Resolves a single user-selected file from a Nango-connected provider
+ * (Microsoft / Google / Jira / Confluence) at chat-send time, extracts its
+ * text via the shared OCR / text-extraction pipeline (binary payloads) or
+ * directly (string payloads), and returns SearchResult chunks the respondNode
+ * can quote.
+ *
+ * No DB writes, no Qdrant indexing — purely inline-at-send-time. Stale tokens,
+ * revoked connections, or unsupported files yield an empty result set so the
+ * rest of the turn still succeeds. Mirrors wolkeRetrieval.ts (Nextcloud).
+ */
+
+import * as atlassianClient from '../../../../services/api-clients/atlassianClient.js';
+import * as googleDriveClient from '../../../../services/api-clients/googleDriveClient.js';
+import * as microsoftGraphClient from '../../../../services/api-clients/microsoftGraphClient.js';
+import { ConnectionService } from '../../../../services/connections/ConnectionService.js';
+import { extractTextFromFile } from '../../../../services/document-services/DocumentProcessingService/textExtraction.js';
+import { createLogger } from '../../../../utils/logger.js';
+import { SOURCE_PREFIX, type DocumentSource, type SearchResult } from '../types.js';
+
+import type { NangoProviderKey } from '../../../../config/nango.js';
+
+const log = createLogger('ConnectRetrieval');
+
+const CHUNK_SIZE = 1500;
+const CHUNK_OVERLAP = 100;
+
+function chunkText(text: string, perSourceLimit: number): string[] {
+  const cleaned = text.trim();
+  if (!cleaned) return [];
+  if (cleaned.length <= CHUNK_SIZE) return [cleaned];
+  const chunks: string[] = [];
+  let pos = 0;
+  const stride = CHUNK_SIZE - CHUNK_OVERLAP;
+  while (pos < cleaned.length && chunks.length < perSourceLimit) {
+    chunks.push(cleaned.slice(pos, pos + CHUNK_SIZE));
+    pos += stride;
+  }
+  return chunks;
+}
+
+function mimeTypeFromName(name: string, fallback?: string | null): string {
+  if (fallback) return fallback;
+  const lower = name.toLowerCase();
+  if (lower.endsWith('.pdf')) return 'application/pdf';
+  if (lower.endsWith('.docx'))
+    return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+  if (lower.endsWith('.pptx'))
+    return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+  if (lower.endsWith('.txt') || lower.endsWith('.md')) return 'text/plain';
+  return 'application/octet-stream';
+}
+
+/** Strip HTML tags + collapse whitespace for Confluence storage/view bodies. */
+function htmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Acquire the text content of a connected-account file.
+ * Returns null when the provider/file is unsupported or the fetch failed.
+ */
+async function acquireText(
+  provider: NangoProviderKey,
+  accessToken: string,
+  fileId: string,
+  name: string,
+  mimeType?: string | null
+): Promise<string | null> {
+  switch (provider) {
+    case 'microsoft': {
+      const buffer = await microsoftGraphClient.downloadDriveItem(accessToken, fileId);
+      return extractTextFromFile({
+        buffer,
+        mimetype: mimeTypeFromName(name, mimeType),
+        originalname: name,
+        size: buffer.length,
+      });
+    }
+    case 'google': {
+      // Google-native docs/sheets can't be downloaded raw — export to text.
+      if (mimeType?.startsWith('application/vnd.google-apps')) {
+        if (mimeType === 'application/vnd.google-apps.spreadsheet') {
+          const sheet = await googleDriveClient.getSheetContent(accessToken, fileId);
+          return JSON.stringify(sheet);
+        }
+        return googleDriveClient.exportDoc(accessToken, fileId, 'text/plain');
+      }
+      const buffer = await googleDriveClient.downloadFile(accessToken, fileId);
+      return extractTextFromFile({
+        buffer,
+        mimetype: mimeTypeFromName(name, mimeType),
+        originalname: name,
+        size: buffer.length,
+      });
+    }
+    case 'jira': {
+      const sites = await atlassianClient.getAccessibleResources(accessToken);
+      if (sites.length === 0) return null;
+      const issue = await atlassianClient.getJiraIssue(accessToken, sites[0].id, fileId);
+      const description =
+        typeof issue.fields.description === 'string'
+          ? issue.fields.description
+          : JSON.stringify(issue.fields.description ?? '');
+      return [
+        `${issue.key}: ${issue.fields.summary}`,
+        `Status: ${issue.fields.status.name}`,
+        `Typ: ${issue.fields.issuetype.name}`,
+        description,
+      ].join('\n');
+    }
+    case 'confluence': {
+      const sites = await atlassianClient.getAccessibleResources(accessToken);
+      if (sites.length === 0) return null;
+      const page = await atlassianClient.getConfluencePageContent(accessToken, sites[0].id, fileId);
+      const body = page.body.view?.value ?? page.body.storage?.value ?? '';
+      return `${page.title}\n\n${htmlToText(body)}`;
+    }
+    default:
+      return null;
+  }
+}
+
+export async function retrieveConnectFile(
+  src: DocumentSource,
+  perSourceLimit: number,
+  userId: string
+): Promise<SearchResult[]> {
+  if (src.kind !== 'connect' || !src.connect) return [];
+  const { provider, fileId, name, mimeType } = src.connect;
+
+  let accessToken: string;
+  try {
+    const connection = await ConnectionService.getConnection(userId, provider as NangoProviderKey);
+    accessToken = connection.accessToken;
+  } catch (err) {
+    log.warn(`[Connect] Connection lookup failed for ${provider} (${name})`, err);
+    return [];
+  }
+
+  let text: string | null;
+  try {
+    text = await acquireText(provider as NangoProviderKey, accessToken, fileId, name, mimeType);
+  } catch (err) {
+    log.warn(`[Connect] content retrieval skipped for ${name} (${provider})`, err);
+    return [];
+  }
+
+  if (!text) return [];
+
+  const chunks = chunkText(text, perSourceLimit);
+  return chunks.map<SearchResult>((content, idx) => ({
+    source: `${SOURCE_PREFIX.CONNECT}${provider}:${fileId}`,
+    title: name,
+    content,
+    relevance: 0.7,
+    documentSourceId: src.id,
+    chunkIndex: idx,
+  }));
+}

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -197,6 +197,7 @@ async function testExpandedContextWindow() {
     docMentionIds: [],
     documentMentionContext: null,
     wolkeFiles: [],
+    connectFiles: [],
     currentDocument: null,
     searchSources: [],
     intent: 'search',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -238,6 +238,7 @@ async function evaluateBudgetAllocation() {
     docMentionIds: [],
     documentMentionContext: null,
     wolkeFiles: [],
+    connectFiles: [],
     currentDocument: null,
     searchSources: [],
     intent: 'search',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -44,6 +44,7 @@ import {
   resolveCollectionName,
 } from './citationUtils.js';
 import { retrieveWolkeFile } from './wolkeRetrieval.js';
+import { retrieveConnectFile } from './connectRetrieval.js';
 
 import type { SubcategoryFilters } from '../../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../../routes/chat/agents/types.js';
@@ -365,6 +366,16 @@ export async function executeMultiDocFanout(
         return [src.id, results];
       }
 
+      if (src.kind === 'connect') {
+        collections.add(`connect:${src.connect?.provider ?? '?'}`);
+        if (!agentConfig.userId) {
+          log.warn(`[Search] Skipping connect source ${src.id}: no userId on agentConfig`);
+          return [src.id, []];
+        }
+        const results = await retrieveConnectFile(src, perSourceLimit, agentConfig.userId);
+        return [src.id, results];
+      }
+
       if (src.kind === 'notebook' && src.collectionIds && src.collectionIds.length > 0) {
         const collectionPromises = src.collectionIds.map((collection) => {
           collections.add(collection);
@@ -467,16 +478,19 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         s.kind === 'document_chat' ||
         s.kind === 'doc_mention' ||
         s.kind === 'notebook' ||
-        s.kind === 'wolke'
+        s.kind === 'wolke' ||
+        s.kind === 'connect'
     );
     const hasWolke = retrievableDocSources.some((s) => s.kind === 'wolke');
+    const hasConnect = retrievableDocSources.some((s) => s.kind === 'connect');
 
     // Multi-document fan-out: when the user references ≥2 retrievable doc sources,
     // run a doc-scoped retrieval per source so each gets its own evidence budget.
     // Prevents one denser/better-embedded doc from starving the others at rerank time.
     // Wolke sources always fan out (single or multiple) because they have no single-source
     // retrieval path in the `case 'search'` block — they're only fetched via retrieveWolkeFile.
-    if (retrievableDocSources.length >= 2 || hasWolke) {
+    // Connect (Nango) sources behave identically — fetched only via retrieveConnectFile.
+    if (retrievableDocSources.length >= 2 || hasWolke || hasConnect) {
       const query = truncateQuery(searchQuery || '');
       log.info(
         `[Search] Multi-doc fan-out across ${retrievableDocSources.length} sources: ${retrievableDocSources.map((s) => `${s.kind}:${s.id.slice(0, 8)}`).join(', ')}`

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -13,17 +13,23 @@
 import type { SubcategoryFilters } from '../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../routes/chat/agents/types.js';
 import type { AIWorkerPool } from '../../../workers/types.js';
-import type { WolkeFileRef } from '@gruenerator/contracts';
+import type { WolkeFileRef, ConnectFileRef } from '@gruenerator/contracts';
 import type { ModelMessage } from 'ai';
 
-export type { WolkeFileRef };
+export type { WolkeFileRef, ConnectFileRef };
 
 /**
  * Search source backends that can be queried in parallel.
  * When multiple sources are specified, the search node runs them concurrently
  * and merges/deduplicates the results before reranking.
  */
-export type SearchSource = 'documents' | 'web' | 'examples' | 'chat_history' | 'wolke';
+export type SearchSource =
+  | 'documents'
+  | 'web'
+  | 'examples'
+  | 'chat_history'
+  | 'wolke'
+  | 'connect';
 
 /**
  * Supported user locales for locale-aware collection routing.
@@ -112,6 +118,7 @@ export const SOURCE_PREFIX = {
   DOCUMENT: 'document',
   DOCUMENT_CHAT: 'documentchat:',
   WOLKE: 'wolke:',
+  CONNECT: 'connect:',
 } as const;
 
 /**
@@ -166,7 +173,8 @@ export type DocumentSourceKind =
   | 'notebook' // notebookIds (collection scope)
   | 'attachment' // threadAttachments (uploaded file context)
   | 'current_doc' // currentDocument (open in docs editor)
-  | 'wolke'; // wolkeFiles (@wolke mentionable — Nextcloud file picker)
+  | 'wolke' // wolkeFiles (@wolke mentionable — Nextcloud file picker)
+  | 'connect'; // connectFiles (@connect mentionable — Nango-connected provider file picker)
 
 /**
  * Normalized reference to a single document the user is working with this turn.
@@ -184,6 +192,9 @@ export interface DocumentSource {
   // For `wolke` kind: the original share-link + path so searchNode can fetch
   // the file content via WebDAV at retrieval time.
   wolke?: WolkeFileRef | undefined;
+  // For `connect` kind: the provider + fileId so searchNode can fetch the file
+  // content via the matching Nango provider API client at retrieval time.
+  connect?: ConnectFileRef | undefined;
 }
 
 /**
@@ -301,6 +312,7 @@ export interface ChatGraphInput {
   boardIds?: string[] | undefined;
   docMentionIds?: string[] | undefined;
   wolkeFiles?: WolkeFileRef[] | undefined;
+  connectFiles?: ConnectFileRef[] | undefined;
   currentDocument?: CurrentDocument | undefined;
   userLocale?: UserLocale | undefined;
   customSystemPrompt?: string | undefined;
@@ -365,6 +377,10 @@ export interface ChatGraphState {
   // Wolke (Nextcloud) file refs selected via @wolke mentionable.
   // Downloaded + parsed inline at searchNode time; never persisted.
   wolkeFiles: WolkeFileRef[];
+
+  // Connected-account (Nango) file refs selected via @connect mentionable.
+  // Downloaded + parsed inline at searchNode time; never persisted.
+  connectFiles: ConnectFileRef[];
 
   // Current open document in the docs editor (primary context, not retrieval scope).
   // Set when chat is embedded in a document editor surface.

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -116,6 +116,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         boardIds: rawBoardIds,
         docMentionIds: rawDocMentionIds,
         wolkeFiles: rawWolkeFiles,
+        connectFiles: rawConnectFiles,
         currentDocument: rawCurrentDocument,
         customSystemPrompt: rawCustomSystemPrompt,
         roleName: rawRoleName,
@@ -177,6 +178,20 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           wolkeFiles = undefined;
         }
       }
+
+      // @connect file refs need no per-ref ownership pre-check: the Nango
+      // connection (resolved per-file at retrieval time via
+      // ConnectionService.getConnection(userId, provider)) IS the ownership
+      // boundary, and a revoked/expired token fails safe to an empty result.
+      // Normalize null mimeType → omit so downstream types stay clean.
+      const connectFiles = rawConnectFiles?.length
+        ? rawConnectFiles.map((f) => ({
+            provider: f.provider,
+            fileId: f.fileId,
+            name: f.name,
+            ...(f.mimeType ? { mimeType: f.mimeType } : {}),
+          }))
+        : undefined;
 
       log.info(`[ChatGraph] Processing request for user ${userId}, agent ${agentId ?? 'default'}`);
       if (notebookIds.length > 0) {
@@ -378,6 +393,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
             : undefined,
         boardIds: rawBoardIds?.length ? rawBoardIds : undefined,
         wolkeFiles,
+        connectFiles,
         // When the docs editor sends a currentDocument, also surface its id as a
         // doc-mention so the existing modify_doc / summary intent paths activate
         // (they key off `hasDocMentions`). Explicit @doc mentions always take

--- a/packages/chat/src/components/assistant-ui/attachment.tsx
+++ b/packages/chat/src/components/assistant-ui/attachment.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { PropsWithChildren, useEffect, useState, type FC } from 'react';
-import { XIcon, PlusIcon, FileText, FileSearch, Cloud } from 'lucide-react';
+import { XIcon, PlusIcon, FileText, FileSearch, Cloud, Plug } from 'lucide-react';
 import {
   AttachmentPrimitive,
   ComposerPrimitive,
@@ -133,12 +133,15 @@ const GruenAttachmentChip: FC = () => {
 
   const isCollab = contentType === 'application/x-gruenerator-collab-doc';
   const isWolke = contentType === 'application/x-gruenerator-wolke';
-  const Icon = isWolke ? Cloud : isCollab ? FileText : FileSearch;
-  const variant = isWolke
-    ? 'bg-sky-500/10 text-sky-900 border-sky-500/30 dark:text-sky-100'
-    : isCollab
-      ? 'bg-cyan-500/10 text-cyan-900 border-cyan-500/30 dark:text-cyan-100'
-      : 'bg-primary/5 text-foreground border-primary/20';
+  const isConnect = contentType === 'application/x-gruenerator-connect';
+  const Icon = isConnect ? Plug : isWolke ? Cloud : isCollab ? FileText : FileSearch;
+  const variant = isConnect
+    ? 'bg-violet-500/10 text-violet-900 border-violet-500/30 dark:text-violet-100'
+    : isWolke
+      ? 'bg-sky-500/10 text-sky-900 border-sky-500/30 dark:text-sky-100'
+      : isCollab
+        ? 'bg-cyan-500/10 text-cyan-900 border-cyan-500/30 dark:text-cyan-100'
+        : 'bg-primary/5 text-foreground border-primary/20';
 
   return (
     <AttachmentPrimitive.Root

--- a/packages/chat/src/components/thread/ConnectMentionPopover.tsx
+++ b/packages/chat/src/components/thread/ConnectMentionPopover.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  useConnectProvidersQuery,
+  useConnectBrowseQuery,
+  type ChatConnectFile,
+} from '../../hooks/useMentionablesQuery';
+import { type ConnectFileToken } from '../../lib/mentionables';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
+
+interface ConnectMentionPopoverProps {
+  visible: boolean;
+  onSelect: (files: ConnectFileToken[]) => void;
+  onDismiss: () => void;
+}
+
+interface SelectedFile {
+  provider: string;
+  fileId: string;
+  name: string;
+  mimeType?: string;
+}
+
+export function ConnectMentionPopover({
+  visible,
+  onSelect,
+  onDismiss,
+}: ConnectMentionPopoverProps) {
+  const { data: providers, isLoading: providersLoading } = useConnectProvidersQuery(visible);
+
+  const [activeProvider, setActiveProvider] = useState<string | null>(null);
+  const [folderId, setFolderId] = useState<string | null>(null);
+  const [filter, setFilter] = useState<string>('');
+  const [selection, setSelection] = useState<Map<string, SelectedFile>>(new Map());
+
+  useEffect(() => {
+    if (!visible) {
+      setSelection(new Map());
+      setActiveProvider(null);
+      setFolderId(null);
+      setFilter('');
+    }
+  }, [visible]);
+
+  const browse = useConnectBrowseQuery(activeProvider, folderId, visible && !!activeProvider);
+
+  const filteredFiles = useMemo(() => {
+    const files = browse.data ?? [];
+    if (!filter) return files;
+    const q = filter.toLowerCase();
+    return files.filter((f) => f.name.toLowerCase().includes(q));
+  }, [browse.data, filter]);
+
+  const hasNoProviders = !providersLoading && (!providers || providers.length === 0);
+  const selectionList = [...selection.values()];
+
+  const toggleFile = (file: ChatConnectFile) => {
+    if (file.isDirectory || !activeProvider) return;
+    const key = `${activeProvider}:${file.id}`;
+    setSelection((prev) => {
+      const next = new Map(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.set(key, {
+          provider: activeProvider,
+          fileId: file.id,
+          name: file.name,
+          ...(file.mimeType ? { mimeType: file.mimeType } : {}),
+        });
+      }
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    if (selectionList.length === 0) return;
+    onSelect(
+      selectionList.map((f) => ({
+        provider: f.provider,
+        fileId: f.fileId,
+        name: f.name,
+        ...(f.mimeType ? { mimeType: f.mimeType } : {}),
+      }))
+    );
+  };
+
+  return (
+    <MentionFloatingPanel
+      open={visible}
+      onDismiss={onDismiss}
+      width="w-[360px]"
+      role="dialog"
+      ariaLabel="Dateien aus verbundenen Accounts auswählen"
+    >
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onDismiss();
+          }
+        }}
+      >
+        <div className="border-b border-border px-3 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted/70">
+              Verbundene Accounts
+            </span>
+            {activeProvider && (
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  setActiveProvider(null);
+                  setFolderId(null);
+                  setFilter('');
+                }}
+                className="text-xs text-foreground-muted hover:text-foreground"
+              >
+                ← Dienste
+              </button>
+            )}
+          </div>
+          {activeProvider && !hasNoProviders && (
+            <div className="mt-2 flex items-center gap-2">
+              <input
+                type="text"
+                autoFocus
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Dateien filtern…"
+                className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary/40"
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {hasNoProviders ? (
+            <div className="flex flex-col items-start gap-2 px-3 py-4">
+              <p className="text-sm font-medium text-foreground">Keine Accounts verbunden</p>
+              <p className="text-xs text-foreground-muted">
+                Verbinde zuerst einen Dienst (Microsoft, Google, Jira, Confluence) unter Einstellungen,
+                damit du Dateien per @connect einfügen kannst.
+              </p>
+            </div>
+          ) : !activeProvider ? (
+            providersLoading ? (
+              <div className="px-3 py-4 text-sm text-foreground-muted">Lade Dienste…</div>
+            ) : (
+              (providers ?? []).map((p) => (
+                <button
+                  key={p.provider}
+                  type="button"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    setActiveProvider(p.provider);
+                    setFolderId(null);
+                    setFilter('');
+                  }}
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-foreground-muted transition-colors hover:bg-primary/5"
+                >
+                  <span aria-hidden className="text-base">
+                    🔌
+                  </span>
+                  <span className="flex-1 truncate">{p.label}</span>
+                </button>
+              ))
+            )
+          ) : browse.isLoading ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">Lade Dateien…</div>
+          ) : browse.isError ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">
+              Fehler beim Laden der Dateien.
+            </div>
+          ) : filteredFiles.length === 0 ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">
+              {filter ? 'Keine Treffer.' : 'Keine Dateien.'}
+            </div>
+          ) : (
+            filteredFiles.map((file) => {
+              const key = `${activeProvider}:${file.id}`;
+              const isSelected = selection.has(key);
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    if (file.isDirectory) {
+                      setFolderId(file.id);
+                      setFilter('');
+                    } else {
+                      toggleFile(file);
+                    }
+                  }}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                    isSelected
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-foreground-muted hover:bg-primary/5'
+                  }`}
+                >
+                  <span aria-hidden className="text-base">
+                    {file.isDirectory ? '📁' : isSelected ? '☑️' : '📄'}
+                  </span>
+                  <span className="flex-1 truncate">{file.name}</span>
+                  {!file.isDirectory && file.sizeFormatted && (
+                    <span className="text-xs text-foreground-muted/70">{file.sizeFormatted}</span>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-border px-3 py-2">
+          <span className="text-xs text-foreground-muted">{selectionList.length} ausgewählt</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onDismiss();
+              }}
+              className="rounded-md px-2 py-1 text-xs text-foreground-muted hover:bg-primary/5"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="button"
+              disabled={selectionList.length === 0 || hasNoProviders}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleConfirm();
+              }}
+              className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              Hinzufügen
+            </button>
+          </div>
+        </div>
+      </div>
+    </MentionFloatingPanel>
+  );
+}

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -25,8 +25,9 @@ import { getFilteredForMode } from '../../lib/mentionDetection';
 import { computeMentionInsertion } from '../../lib/mentionInsertion';
 import { FileMentionPopover } from './FileMentionPopover';
 import { WolkeMentionPopover } from './WolkeMentionPopover';
+import { ConnectMentionPopover } from './ConnectMentionPopover';
 import type { CollabDocSelection } from '../../lib/documentMentionables';
-import type { WolkeFileToken } from '../../lib/mentionables';
+import type { WolkeFileToken, ConnectFileToken } from '../../lib/mentionables';
 import { PlusMenu } from './PlusMenu';
 import { ModelPicker } from './ModelPicker';
 import { getCaretCoords } from '../../lib/caretPosition';
@@ -196,7 +197,7 @@ function ComposerButtons({
 
 interface MentionState {
   visible: boolean;
-  mode: 'functions' | 'skills' | 'datei' | 'wolke';
+  mode: 'functions' | 'skills' | 'datei' | 'wolke' | 'connect';
   query: string;
   selectedIndex: number;
   anchorRect: { x: number; y: number } | null;
@@ -282,6 +283,24 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
           });
         }
         setMention((prev) => ({ ...prev, mode: 'wolke', visible: true, mentionStart: -1 }));
+        return;
+      }
+
+      // When user selects the @connect trigger, swap to the connected-account picker
+      if (mentionable.type === 'connect') {
+        // Strip the in-progress "@conn…" trigger from the textarea — the picker
+        // inserts one @connect:<token> per chosen file via handleConnectSelect.
+        if (mention.mentionStart >= 0) {
+          const currentText = composerRuntime.getState().text;
+          const before = currentText.slice(0, mention.mentionStart);
+          const after = currentText.slice(textarea.selectionStart);
+          composerRuntime.setText(`${before}${after}`);
+          requestAnimationFrame(() => {
+            const pos = before.length;
+            textarea.setSelectionRange(pos, pos);
+          });
+        }
+        setMention((prev) => ({ ...prev, mode: 'connect', visible: true, mentionStart: -1 }));
         return;
       }
 
@@ -406,10 +425,41 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
     [composerRuntime, dismissPopover]
   );
 
+  const handleConnectSelect = useCallback(
+    (files: ConnectFileToken[]) => {
+      if (files.length === 0) return;
+      for (const f of files) {
+        void composerRuntime.addAttachment({
+          id: `gruenerator-connect-${f.provider}:${f.fileId}`,
+          type: 'document',
+          name: f.name,
+          contentType: 'application/x-gruenerator-connect',
+          content: [
+            {
+              type: 'data',
+              name: 'gruenerator-mention',
+              data: {
+                kind: 'connect',
+                provider: f.provider,
+                fileId: f.fileId,
+                name: f.name,
+                ...(f.mimeType ? { mimeType: f.mimeType } : {}),
+              },
+            },
+          ],
+        });
+      }
+      dismissPopover();
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    },
+    [composerRuntime, dismissPopover]
+  );
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // Don't interfere when file/doc browser or wolke picker is open
-      if (mention.mode === 'datei' || mention.mode === 'wolke') return;
+      // Don't interfere when file/doc browser, wolke, or connect picker is open
+      if (mention.mode === 'datei' || mention.mode === 'wolke' || mention.mode === 'connect')
+        return;
 
       const textarea = e.target;
       const text = textarea.value;
@@ -441,7 +491,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
       // In datei/docs mode, only handle Escape (cmdk handles arrow keys internally).
       // Enter is swallowed so the textarea doesn't submit the form while the picker
       // is open — the user must select via the picker or dismiss with Escape first.
-      if (mention.mode === 'datei' || mention.mode === 'wolke') {
+      if (mention.mode === 'datei' || mention.mode === 'wolke' || mention.mode === 'connect') {
         if (e.key === 'Escape') {
           e.preventDefault();
           dismissPopover();
@@ -537,6 +587,12 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
             <WolkeMentionPopover
               visible={mention.visible}
               onSelect={handleWolkeSelect}
+              onDismiss={dismissPopover}
+            />
+          ) : mention.mode === 'connect' ? (
+            <ConnectMentionPopover
+              visible={mention.visible}
+              onSelect={handleConnectSelect}
               onDismiss={dismissPopover}
             />
           ) : mention.mode === 'skills' ? (

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -29,7 +29,7 @@ export function MentionPopover({
   anchorRect,
 }: MentionPopoverProps) {
   const listRef = useRef<HTMLDivElement>(null);
-  const { notebooks, userNotebooks, tools, boards, docs, documents, wolke } =
+  const { notebooks, userNotebooks, tools, boards, docs, documents, wolke, connect } =
     filterMentionables(query);
 
   const sections: MentionSection[] = useMemo(() => {
@@ -47,6 +47,7 @@ export function MentionPopover({
       { kind: 'flat', label: 'Dokumente', items: docs },
       { kind: 'flat', label: 'Dateien', items: documents },
       { kind: 'flat', label: 'Wolke', items: wolke },
+      { kind: 'flat', label: 'Verbundene Accounts', items: connect },
       ...(notebookGroups.length > 0
         ? [{ kind: 'grouped' as const, label: 'Notizbücher', groups: notebookGroups }]
         : []),
@@ -55,7 +56,7 @@ export function MentionPopover({
     return all.filter((s) =>
       s.kind === 'flat' ? s.items.length > 0 : s.groups.some((g) => g.items.length > 0)
     );
-  }, [tools, boards, docs, documents, wolke, notebooks, userNotebooks]);
+  }, [tools, boards, docs, documents, wolke, connect, notebooks, userNotebooks]);
 
   const totalItems = sections.reduce(
     (sum, s) =>

--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -208,6 +208,103 @@ export function useWolkeBrowseQuery(shareLinkId: string | null, path: string, en
   });
 }
 
+// ── @connect (Nango-connected provider files) ────────────────────────────────
+//
+// Mirrors the @wolke hooks above, but talks to /api/connections/* instead of
+// the Nextcloud share-link endpoints. Used by the @connect picker to (1) list
+// which providers the user has actually connected and (2) browse their files.
+
+export interface ChatConnectProvider {
+  provider: string;
+  label: string;
+  services: readonly string[];
+  connected: boolean;
+}
+
+export interface ChatConnectFile {
+  id: string;
+  name: string;
+  mimeType?: string;
+  isDirectory?: boolean;
+  sizeFormatted?: string;
+}
+
+/**
+ * The user's Nango connection status, filtered to connected providers. Used by
+ * the @connect picker to render the provider list and an empty-state when the
+ * user hasn't connected anything yet. Re-fetches on open (users connect/
+ * disconnect via /profile between sessions).
+ */
+export function useConnectProvidersQuery(enabled = true) {
+  const apiClient = useApiClient();
+  return useQuery<ChatConnectProvider[]>({
+    queryKey: ['mention-connect-providers'],
+    queryFn: async () => {
+      const res = await apiClient.get<{ providers?: ChatConnectProvider[] }>(
+        '/api/connections/status'
+      );
+      return (res?.providers ?? []).filter((p) => p.connected);
+    },
+    staleTime: 0,
+    refetchOnMount: 'always',
+    enabled,
+    retry: 1,
+  });
+}
+
+/**
+ * File/folder listing for a single connected provider. The /files endpoint
+ * returns a provider-specific shape (Google `{files}`, Microsoft `{items}`,
+ * Jira `{projects}`, Confluence `{spaces}`) — normalize each into a flat
+ * ChatConnectFile[] so the picker stays provider-agnostic. Disabled until both
+ * `provider` and `enabled` are truthy.
+ */
+export function useConnectBrowseQuery(
+  provider: string | null,
+  folderId: string | null,
+  enabled = true
+) {
+  const apiClient = useApiClient();
+  return useQuery<ChatConnectFile[]>({
+    queryKey: ['mention-connect-browse', provider, folderId],
+    queryFn: async () => {
+      const qs = folderId ? `?folderId=${encodeURIComponent(folderId)}` : '';
+      const res = await apiClient.get<{
+        files?: Array<{ id: string; name: string; mimeType?: string }>;
+        items?: Array<{ id: string; name: string; size?: number; file?: unknown; folder?: unknown }>;
+        projects?: Array<{ id: string; key: string; name: string }>;
+        spaces?: Array<{ id: string; key: string; name: string }>;
+      }>(`/api/connections/${provider}/files${qs}`);
+
+      if (Array.isArray(res?.files)) {
+        return res.files.map((f) => ({
+          id: f.id,
+          name: f.name,
+          ...(f.mimeType ? { mimeType: f.mimeType } : {}),
+          isDirectory: f.mimeType === 'application/vnd.google-apps.folder',
+        }));
+      }
+      if (Array.isArray(res?.items)) {
+        return res.items.map((i) => ({
+          id: i.id,
+          name: i.name,
+          isDirectory: !!i.folder,
+        }));
+      }
+      if (Array.isArray(res?.projects)) {
+        return res.projects.map((p) => ({ id: p.key, name: p.name }));
+      }
+      if (Array.isArray(res?.spaces)) {
+        return res.spaces.map((s) => ({ id: s.id, name: s.name }));
+      }
+      return [];
+    },
+    enabled: !!provider && enabled,
+    staleTime: 15_000,
+    retry: 1,
+  });
+}
+
 /**
  * Convenience hook that triggers all dynamic-mentionable queries — call from
  * the chat composer so dynamic mentionables are warm by the time @-popovers

--- a/packages/chat/src/lib/mentionDetection.ts
+++ b/packages/chat/src/lib/mentionDetection.ts
@@ -51,8 +51,8 @@ export function detectMention(text: string, caretPosition: number): MentionDetec
 }
 
 export function getFilteredFunctions(query: string): Mentionable[] {
-  const { notebooks, tools, boards, docs, documents, wolke } = filterMentionables(query);
-  return [...tools, ...boards, ...docs, ...documents, ...wolke, ...notebooks];
+  const { notebooks, tools, boards, docs, documents, wolke, connect } = filterMentionables(query);
+  return [...tools, ...boards, ...docs, ...documents, ...wolke, ...connect, ...notebooks];
 }
 
 export function getFilteredSkills(query: string): Mentionable[] {

--- a/packages/chat/src/lib/mentionParser.ts
+++ b/packages/chat/src/lib/mentionParser.ts
@@ -1,6 +1,12 @@
 import { getDefaultAgent } from './agents';
 import { resolveDocumentSlug } from './documentMentionables';
-import { decodeWolkeToken, resolveMentionable, type WolkeFileToken } from './mentionables';
+import {
+  decodeWolkeToken,
+  decodeConnectToken,
+  resolveMentionable,
+  type WolkeFileToken,
+  type ConnectFileToken,
+} from './mentionables';
 
 export interface MentionResult {
   agentId: string;
@@ -19,6 +25,7 @@ export interface ParsedMentions {
   boardIds: string[];
   docMentionIds: string[];
   wolkeFiles: WolkeFileToken[];
+  connectFiles: ConnectFileToken[];
   unresolvedMentions: string[];
   cleanText: string;
 }
@@ -56,6 +63,7 @@ export function parseAllMentions(text: string): ParsedMentions {
   const boardIds: string[] = [];
   const docMentionIds: string[] = [];
   const wolkeFiles: WolkeFileToken[] = [];
+  const connectFiles: ConnectFileToken[] = [];
   const seenNotebooks = new Set<string>();
   const seenTools = new Set<string>();
   const seenDocuments = new Set<string>();
@@ -63,6 +71,7 @@ export function parseAllMentions(text: string): ParsedMentions {
   const seenBoards = new Set<string>();
   const seenDocMentions = new Set<string>();
   const seenWolke = new Set<string>();
+  const seenConnect = new Set<string>();
   const unresolvedMentions: string[] = [];
   const mentionSpans: [number, number][] = [];
 
@@ -122,6 +131,29 @@ export function parseAllMentions(text: string): ParsedMentions {
 
     // Handle bare @wolke trigger (popover hint — strip, no payload)
     if (trigger === '@' && alias === 'wolke') {
+      const triggerIndex = match.index + match[0].indexOf('@');
+      mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
+      continue;
+    }
+
+    // Handle @connect:<base64-token> — decoded into connectFiles
+    if (trigger === '@' && alias.startsWith('connect:')) {
+      const token = alias.slice(8);
+      const ref = decodeConnectToken(token);
+      if (ref) {
+        const key = `${ref.provider}:${ref.fileId}`;
+        if (!seenConnect.has(key)) {
+          seenConnect.add(key);
+          connectFiles.push(ref);
+        }
+      }
+      const triggerIndex = match.index + match[0].indexOf('@');
+      mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
+      continue;
+    }
+
+    // Handle bare @connect trigger (popover hint — strip, no payload)
+    if (trigger === '@' && alias === 'connect') {
       const triggerIndex = match.index + match[0].indexOf('@');
       mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
       continue;
@@ -192,6 +224,7 @@ export function parseAllMentions(text: string): ParsedMentions {
     boardIds,
     docMentionIds,
     wolkeFiles,
+    connectFiles,
     unresolvedMentions,
     cleanText,
   };
@@ -205,6 +238,7 @@ export type MentionPreviewKind =
   | 'notebook'
   | 'board'
   | 'wolke'
+  | 'connect'
   | 'unresolved';
 
 export interface MentionPreview {
@@ -238,7 +272,34 @@ export function extractMentionPreviews(text: string): MentionPreview[] {
     // types and shouldn't render chips (especially red unresolved ones).
     if (end === text.length) continue;
 
-    if (trigger === '@' && (alias === 'datei' || alias === 'dokumentchat' || alias === 'wolke')) {
+    if (
+      trigger === '@' &&
+      (alias === 'datei' || alias === 'dokumentchat' || alias === 'wolke' || alias === 'connect')
+    ) {
+      continue;
+    }
+
+    if (trigger === '@' && alias.startsWith('connect:')) {
+      const token = alias.slice(8);
+      const ref = decodeConnectToken(token);
+      if (ref) {
+        previews.push({
+          kind: 'connect',
+          match: literal,
+          start: triggerIndex,
+          end,
+          title: ref.name,
+          avatar: '🔌',
+        });
+      } else {
+        previews.push({
+          kind: 'unresolved',
+          match: literal,
+          start: triggerIndex,
+          end,
+          title: alias,
+        });
+      }
       continue;
     }
 

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -15,6 +15,7 @@ import {
   PiSparkle,
   PiCloud,
   PiNotePencil,
+  PiPlugsConnected,
 } from 'react-icons/pi';
 import { agentsList, type AgentListItem } from './agents';
 
@@ -25,7 +26,8 @@ export type MentionableType =
   | 'document'
   | 'board'
   | 'doc'
-  | 'wolke';
+  | 'wolke'
+  | 'connect';
 export type MentionableCategory = 'skill' | 'function';
 
 export interface Mentionable {
@@ -618,6 +620,55 @@ export function decodeWolkeToken(token: string): WolkeFileToken | null {
   }
 }
 
+// @connect opens a sub-popover that lets the user pick files from their
+// Nango-connected provider accounts (Microsoft / Google / Jira / Confluence).
+// Selected files are inserted into the text as opaque `@connect:<base64>`
+// tokens which the parser decodes back into {provider, fileId, name, mimeType}
+// refs sent in the request body. Mirrors the @wolke pipeline (Nextcloud).
+export const connectMentionables: Mentionable[] = [
+  {
+    type: 'connect',
+    category: 'function',
+    trigger: '@',
+    identifier: 'connect-trigger',
+    title: 'Verbundene Accounts',
+    description: 'Dateien aus verbundenen Diensten einfügen',
+    avatar: '🔌',
+    icon: PiPlugsConnected,
+    backgroundColor: '#7C3AED',
+    mention: 'connect',
+  },
+];
+
+export interface ConnectFileToken {
+  provider: string;
+  fileId: string;
+  name: string;
+  mimeType?: string;
+}
+
+export function encodeConnectToken(ref: ConnectFileToken): string {
+  return `@connect:${toBase64Url(JSON.stringify(ref))}`;
+}
+
+export function decodeConnectToken(token: string): ConnectFileToken | null {
+  try {
+    const parsed = JSON.parse(fromBase64Url(token)) as unknown;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      typeof (parsed as Record<string, unknown>).provider === 'string' &&
+      typeof (parsed as Record<string, unknown>).fileId === 'string' &&
+      typeof (parsed as Record<string, unknown>).name === 'string'
+    ) {
+      return parsed as ConnectFileToken;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 export function getAllMentionables(): Mentionable[] {
   return [
     ...agentMentionables,
@@ -631,6 +682,7 @@ export function getAllMentionables(): Mentionable[] {
     ...dynamicDocMentionables,
     ...documentMentionables,
     ...wolkeMentionables,
+    ...connectMentionables,
   ];
 }
 
@@ -650,6 +702,7 @@ function rebuildMentionableMap(): void {
     dynamicDocMentionables,
     documentMentionables,
     wolkeMentionables,
+    connectMentionables,
   ];
   for (const source of orderedSources) {
     for (const m of source) {
@@ -678,6 +731,7 @@ export function filterMentionables(query: string): {
   docs: Mentionable[];
   documents: Mentionable[];
   wolke: Mentionable[];
+  connect: Mentionable[];
 } {
   const allBoards = [...boardToolMentionables, ...dynamicBoardMentionables];
   const allDocs = [...docToolMentionables, ...dynamicDocMentionables];
@@ -692,6 +746,7 @@ export function filterMentionables(query: string): {
       docs: allDocs,
       documents: documentMentionables,
       wolke: wolkeMentionables,
+      connect: connectMentionables,
     };
   }
   const q = query.toLowerCase();
@@ -722,6 +777,7 @@ export function filterMentionables(query: string): {
     docs: 'dok'.startsWith(q) || q.startsWith('dok') ? allDocs : allDocs.filter(matchFn),
     documents: documentMentionables.filter(matchFn),
     wolke: wolkeMentionables.filter(matchFn),
+    connect: connectMentionables.filter(matchFn),
   };
 }
 
@@ -739,6 +795,7 @@ export function filterMentionablesByCategory(
     ...all.docs,
     ...all.documents,
     ...all.wolke,
+    ...all.connect,
     ...all.userNotebooks,
     ...all.notebooks,
   ];

--- a/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
@@ -22,6 +22,7 @@ const SYNTHETIC_MENTION_TYPES = [
   'application/x-gruenerator-datei-document',
   'application/x-gruenerator-datei-text',
   'application/x-gruenerator-wolke',
+  'application/x-gruenerator-connect',
 ];
 
 export class GrueneratorAttachmentAdapter implements AttachmentAdapter {

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -1010,6 +1010,7 @@ export function createGrueneratorModelAdapter(
       let boardIds: string[] = [];
       let docMentionIds: string[] = [];
       let wolkeFiles: ReturnType<typeof parseAllMentions>['wolkeFiles'] = [];
+      let connectFiles: ReturnType<typeof parseAllMentions>['connectFiles'] = [];
       let hasDocumentChat = false;
       if (isChatMode)
         for (let i = formattedMessages.length - 1; i >= 0; i--) {
@@ -1035,6 +1036,7 @@ export function createGrueneratorModelAdapter(
             boardIds = parsed.boardIds;
             docMentionIds = parsed.docMentionIds;
             wolkeFiles = parsed.wolkeFiles;
+            connectFiles = parsed.connectFiles;
             hasDocumentChat = parsed.hasDocumentChat;
             textPart.text = parsed.cleanText;
 
@@ -1063,6 +1065,7 @@ export function createGrueneratorModelAdapter(
         const seenTexts = new Set(textIds);
         const seenCollab = new Set(docMentionIds);
         const seenWolke = new Set(wolkeFiles.map((f) => `${f.shareLinkId}:${f.path}`));
+        const seenConnect = new Set(connectFiles.map((f) => `${f.provider}:${f.fileId}`));
         type GruenMentionData =
           | { kind: 'collab'; id: string; slug: string; title: string }
           | {
@@ -1070,7 +1073,8 @@ export function createGrueneratorModelAdapter(
               documentId: string;
               sourceType: 'notebook' | 'document' | 'text';
             }
-          | { kind: 'wolke'; shareLinkId: string; path: string; name: string };
+          | { kind: 'wolke'; shareLinkId: string; path: string; name: string }
+          | { kind: 'connect'; provider: string; fileId: string; name: string; mimeType?: string };
         const attachments = (lastUserMsg as { attachments: readonly CompleteAttachment[] })
           .attachments;
         for (const att of attachments) {
@@ -1105,6 +1109,17 @@ export function createGrueneratorModelAdapter(
                   shareLinkId: data.shareLinkId,
                   path: data.path,
                   name: data.name,
+                });
+              }
+            } else if (data.kind === 'connect') {
+              const key = `${data.provider}:${data.fileId}`;
+              if (!seenConnect.has(key)) {
+                seenConnect.add(key);
+                connectFiles.push({
+                  provider: data.provider,
+                  fileId: data.fileId,
+                  name: data.name,
+                  ...(data.mimeType ? { mimeType: data.mimeType } : {}),
                 });
               }
             }
@@ -1227,6 +1242,7 @@ export function createGrueneratorModelAdapter(
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
           wolkeFiles: wolkeFiles.length > 0 ? wolkeFiles : undefined,
+          connectFiles: connectFiles.length > 0 ? connectFiles : undefined,
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,
@@ -1255,6 +1271,7 @@ export function createGrueneratorModelAdapter(
           boardIds: boardIds.length > 0 ? boardIds : undefined,
           docMentionIds: docMentionIds.length > 0 ? docMentionIds : undefined,
           wolkeFiles: wolkeFiles.length > 0 ? wolkeFiles : undefined,
+          connectFiles: connectFiles.length > 0 ? connectFiles : undefined,
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,

--- a/packages/contracts/src/schemas/chatGraph.ts
+++ b/packages/contracts/src/schemas/chatGraph.ts
@@ -23,6 +23,21 @@ export const wolkeFileRefSchema = z.object({
 });
 export type WolkeFileRef = z.infer<typeof wolkeFileRefSchema>;
 
+/**
+ * Reference to a single file inside a user's Nango-connected provider account
+ * (Microsoft / Google / Jira / Confluence). Selected via the @connect
+ * mentionable in chat; resolved server-side at send-time by downloading the
+ * file content via the matching provider API client. No DB / Qdrant
+ * persistence — transient per-turn context, mirroring wolkeFileRefSchema.
+ */
+export const connectFileRefSchema = z.object({
+  provider: z.string(),
+  fileId: z.string(),
+  name: z.string(),
+  mimeType: z.string().nullish(),
+});
+export type ConnectFileRef = z.infer<typeof connectFileRefSchema>;
+
 // ── Request bodies ──────────────────────────────────────────────────────────
 //
 // All optional fields use `.nullish()` (= `.optional().nullable()`) so they
@@ -50,6 +65,7 @@ export const chatStreamBodySchema = z.object({
   boardIds: z.array(z.string()).nullish(),
   docMentionIds: z.array(z.string()).nullish(),
   wolkeFiles: z.array(wolkeFileRefSchema).nullish(),
+  connectFiles: z.array(connectFileRefSchema).nullish(),
   currentDocument: z
     .object({
       id: z.string(),


### PR DESCRIPTION
Connecting a Nango account (Microsoft / Google / Jira / Confluence) was inert inside chat — there was no way to actually pull a connected file's content into a conversation. This adds the `@connect` mention so a user can pick files from a connected provider and have their content injected as **transient context for that single chat turn**, exactly mirroring how `@wolke` works for Nextcloud files.

Why this shape: it deliberately clones the `@wolke` pipeline end to end (mentionable → picker → encoded token → parsed request field → DocumentSource → per-source retrieval → respondNode quoting) so it inherits the same fan-out, budgeting, and citation behaviour rather than introducing a parallel mechanism. Content is fetched at send-time via the matching provider API client and text-extracted; there is **no Qdrant indexing and no DB persistence** — it's per-turn only.

Ownership/security: unlike `@wolke` (which pre-filters refs against the user's share-link table), the Nango connection itself is the ownership boundary. Each file is resolved via `ConnectionService.getConnection(userId, provider)` at retrieval time, so a revoked or expired token simply fails safe to an empty result — no separate pre-check needed.

All four providers are wired: Microsoft/Google Drive binaries go through the shared text-extraction pipeline; Google-native docs/sheets export to text; Jira issues and Confluence pages are formatted to text directly.