### PR TITLE
chore(mobile): declare react-native-drawer-layout + post-SDK56 on-device QA

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -75,6 +75,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.85.3",
+    "react-native-drawer-layout": "^4.2.2",
     "react-native-gesture-handler": "^2.31.2",
     "react-native-keyboard-controller": "1.21.6",
     "react-native-markdown-display": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -603,6 +603,9 @@ importers:
       react-native:
         specifier: 0.85.3
         version: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+      react-native-drawer-layout:
+        specifier: ^4.2.2
+        version: 4.2.2(react-native-gesture-handler@2.31.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-gesture-handler:
         specifier: ^2.31.2
         version: 2.31.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
Follow-ups to the mobile sidebar / SDK 56 work merged in #1031.

**Why:** `AppDrawer.tsx` (the global chat-sidebar drawer host) imports `react-native-drawer-layout` directly, but it was only present transitively through the react-navigation / expo-router stack. A strict prod install can prune undeclared transitive deps, so the import is declared explicitly here. Pinned to the already-resolved `4.2.2`, so the lockfile gains only the `apps/mobile` importer entry (no graph churn).

### On-device QA checklist (carried over from #1031 — verify before/after this merges)
- [ ] Global drawer opens from the **main page** menu button and via **edge-swipe** on every tab.
- [ ] Schnellstart agents (pinned, locale-aware) start a chat; horizontal scroll works; ghost eucalyptus icons render.
- [ ] "Mehr" bottom sheet shows ghost eucalyptus icons (no emoji), agents/tools/notebooks.
- [ ] Thread long-press deletes; active-thread dot tracks the open thread; empty state shows with no threads.
- [ ] `@expo/ui/community/bottom-sheet` sheets (EditorModal, CitationDetailSheet, NativeColorPicker) render + dismiss correctly (native presentation).
- [ ] Reel download shows the live `%`.