### PR TITLE
feat(mobile): native notebook detail page with Recherche

### DIFF
--- a/apps/mobile/app/(focused)/notebook-detail.tsx
+++ b/apps/mobile/app/(focused)/notebook-detail.tsx
@@ -1,0 +1,125 @@
+import { Ionicons, type IoniconsIconName } from '@react-native-vector-icons/ionicons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useState } from 'react';
+import { View, Text, Pressable, StyleSheet, useColorScheme } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { NotebookResearchPanel } from '../../components/notebook/NotebookResearchPanel';
+import { MOBILE_SYSTEM_NOTEBOOKS } from '../../config/notebooksConfig';
+import { colors, spacing, typography, borderRadius, lightTheme, darkTheme } from '../../theme';
+import { routeWithParams } from '../../types/routes';
+
+type Tab = 'recherche' | 'chat';
+
+export default function NotebookDetailScreen() {
+  const { notebookId, title, kind } = useLocalSearchParams<{
+    notebookId: string;
+    title?: string;
+    kind: 'system' | 'user';
+  }>();
+  const colorScheme = useColorScheme();
+  const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>('recherche');
+
+  const notebookKind: 'system' | 'user' = kind === 'user' ? 'user' : 'system';
+  const icon: IoniconsIconName =
+    MOBILE_SYSTEM_NOTEBOOKS.find((nb) => nb.id === notebookId)?.icon ?? 'book';
+  const displayTitle = title || 'Notebook';
+
+  const openChat = () => {
+    setTab('chat');
+    router.push(routeWithParams('/(focused)/chat-conversation', { threadId: 'new', notebookId }));
+    // Restore the Recherche segment so returning here doesn't show Chat as active.
+    setTimeout(() => setTab('recherche'), 400);
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]} edges={['top']}>
+      <View style={[styles.header, { borderBottomColor: theme.cardBorder }]}>
+        <Pressable onPress={() => router.back()} hitSlop={8} style={styles.backButton}>
+          <Ionicons name="chevron-back" size={24} color={theme.text} />
+        </Pressable>
+        <Ionicons name={icon} size={20} color={colors.primary[600]} />
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={1}>
+          {displayTitle}
+        </Text>
+      </View>
+
+      <View style={styles.segmentRow}>
+        <Pressable
+          onPress={() => setTab('recherche')}
+          style={[
+            styles.segment,
+            {
+              backgroundColor: tab === 'recherche' ? colors.primary[600] : theme.surface,
+              borderColor: tab === 'recherche' ? colors.primary[600] : theme.border,
+            },
+          ]}
+        >
+          <Ionicons
+            name="search-outline"
+            size={16}
+            color={tab === 'recherche' ? colors.white : theme.textSecondary}
+          />
+          <Text
+            style={[styles.segmentText, { color: tab === 'recherche' ? colors.white : theme.text }]}
+          >
+            Recherche
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={openChat}
+          style={[styles.segment, { backgroundColor: theme.surface, borderColor: theme.border }]}
+        >
+          <Ionicons name="chatbubbles-outline" size={16} color={theme.textSecondary} />
+          <Text style={[styles.segmentText, { color: theme.text }]}>Chat</Text>
+        </Pressable>
+      </View>
+
+      <NotebookResearchPanel notebookId={notebookId} kind={notebookKind} theme={theme} />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xsmall,
+    paddingHorizontal: spacing.small,
+    paddingVertical: spacing.small,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  backButton: {
+    padding: 2,
+  },
+  title: {
+    ...typography.bodyBold,
+    fontSize: 17,
+    flex: 1,
+  },
+  segmentRow: {
+    flexDirection: 'row',
+    gap: spacing.xsmall,
+    paddingHorizontal: spacing.medium,
+    paddingTop: spacing.small,
+  },
+  segment: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xsmall,
+    paddingVertical: spacing.small,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  segmentText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/app/(tabs)/(recherche)/index.tsx
+++ b/apps/mobile/app/(tabs)/(recherche)/index.tsx
@@ -170,18 +170,20 @@ export default function NotebooksScreen() {
 
   const handleNotebookPress = (notebook: MobileNotebookEntry) => {
     router.push(
-      routeWithParams('/(focused)/chat-conversation', {
-        threadId: 'new',
+      routeWithParams('/(focused)/notebook-detail', {
         notebookId: notebook.id,
+        title: notebook.title,
+        kind: 'system',
       })
     );
   };
 
-  const handleCollectionPress = (collectionId: string) => {
+  const handleCollectionPress = (collectionId: string, name: string) => {
     router.push(
-      routeWithParams('/(focused)/chat-conversation', {
-        threadId: 'new',
+      routeWithParams('/(focused)/notebook-detail', {
         notebookId: collectionId,
+        title: name,
+        kind: 'user',
       })
     );
   };
@@ -256,7 +258,7 @@ export default function NotebooksScreen() {
                     key={c.id}
                     icon="book"
                     title={c.name}
-                    onPress={() => handleCollectionPress(c.id)}
+                    onPress={() => handleCollectionPress(c.id, c.name)}
                     isProcessing={processingIds.has(c.id)}
                   />
                 ))}
@@ -324,7 +326,7 @@ export default function NotebooksScreen() {
                     key={c.id}
                     icon="book"
                     title={c.name}
-                    onPress={() => handleCollectionPress(c.id)}
+                    onPress={() => handleCollectionPress(c.id, c.name)}
                     onLongPress={() => handleDeleteCollection(c.id, c.name)}
                     isProcessing={processingIds.has(c.id)}
                   />

--- a/apps/mobile/components/notebook/NotebookResearchPanel.tsx
+++ b/apps/mobile/components/notebook/NotebookResearchPanel.tsx
@@ -1,0 +1,480 @@
+import { Ionicons, type IoniconsIconName } from '@react-native-vector-icons/ionicons';
+import { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  Pressable,
+  ActivityIndicator,
+  Keyboard,
+} from 'react-native';
+
+import { useNotebookFilters } from '../../hooks/notebook/useNotebookFilters';
+import {
+  useNotebookResearch,
+  type ResearchResult,
+  type SearchMode,
+  type SortOption,
+} from '../../hooks/notebook/useNotebookResearch';
+import { colors, spacing, typography, borderRadius } from '../../theme';
+import { CitationDetailSheet } from '../chat/CitationDetailSheet';
+import { BottomSheet } from '../common/BottomSheet';
+
+import { ResearchResultCard } from './ResearchResultCard';
+
+import type { Theme } from '../../theme/colors';
+import type { Citation } from '@gruenerator/chat';
+
+interface Props {
+  notebookId: string;
+  kind: 'system' | 'user';
+  theme: Theme;
+}
+
+const MODE_LABELS: Record<SearchMode, string> = {
+  hybrid: 'Hybrid',
+  vector: 'Semantisch',
+  text: 'Volltext',
+};
+const SORT_LABELS: Record<SortOption, string> = {
+  relevance: 'Relevanz',
+  date_desc: 'Neueste',
+  date_asc: 'Älteste',
+};
+const MODE_CYCLE: SearchMode[] = ['hybrid', 'vector', 'text'];
+const SORT_CYCLE: SortOption[] = ['relevance', 'date_desc', 'date_asc'];
+
+const KEYWORD_FILTER_LABELS: Record<string, string> = {
+  content_type: 'Inhaltstyp',
+  primary_category: 'Kategorie',
+  subcategories: 'Unterkategorien',
+  country: 'Land',
+  source_type: 'Organ',
+};
+
+/** Map a chunk-level research result onto the shared Citation shape the detail sheet renders. */
+const toCitation = (r: ResearchResult): Citation => ({
+  id: r.top_chunks?.[0]?.chunk_index ?? 0,
+  title: r.title,
+  url: r.source_url ?? '',
+  snippet: r.relevant_content,
+  citedText: r.top_chunks?.[0]?.preview ?? r.relevant_content,
+  source: r.collection_name ?? r.source_url ?? '',
+  collectionName: r.collection_name ?? undefined,
+  collectionId: r.collection_id ?? undefined,
+  documentId: r.document_id,
+  similarityScore: r.similarity_score,
+  chunkIndex: r.top_chunks?.[0]?.chunk_index,
+});
+
+function FilterChip({
+  label,
+  active,
+  onPress,
+  icon,
+  theme,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  icon: IoniconsIconName;
+  theme: Theme;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        {
+          backgroundColor: active ? colors.primary[600] : theme.surface,
+          borderColor: active ? colors.primary[600] : theme.border,
+        },
+      ]}
+    >
+      <Ionicons name={icon} size={14} color={active ? colors.white : theme.textSecondary} />
+      <Text style={[styles.chipText, { color: active ? colors.white : theme.text }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+export function NotebookResearchPanel({ notebookId, kind, theme }: Props) {
+  const [query, setQuery] = useState('');
+  const [mode, setMode] = useState<SearchMode>('hybrid');
+  const [sortBy, setSortBy] = useState<SortOption>('relevance');
+  const [keywordFilters, setKeywordFilters] = useState<Record<string, string[]>>({});
+  const [selected, setSelected] = useState<ResearchResult | null>(null);
+  const [filtersSheetVisible, setFiltersSheetVisible] = useState(false);
+
+  const { search, results, metadata, isLoading, hasSearched, error } = useNotebookResearch(
+    notebookId,
+    kind
+  );
+  const { filterFields } = useNotebookFilters(notebookId, kind);
+  const keywordFields = filterFields.filter(
+    (f) => f.type === 'keyword' && f.values && f.values.length > 0
+  );
+  const keywordFilterCount = Object.values(keywordFilters).reduce((s, a) => s + a.length, 0);
+
+  const runSearch = useCallback(
+    (overrides?: {
+      mode?: SearchMode;
+      sortBy?: SortOption;
+      filters?: Record<string, string[]>;
+    }) => {
+      const trimmed = query.trim();
+      if (trimmed.length < 2) return;
+      Keyboard.dismiss();
+      search({
+        query: trimmed,
+        mode: overrides?.mode ?? mode,
+        sortBy: overrides?.sortBy ?? sortBy,
+        filters: overrides?.filters ?? keywordFilters,
+      });
+    },
+    [query, mode, sortBy, keywordFilters, search]
+  );
+
+  const cycleMode = () => {
+    const next = MODE_CYCLE[(MODE_CYCLE.indexOf(mode) + 1) % MODE_CYCLE.length];
+    setMode(next);
+    if (hasSearched) runSearch({ mode: next });
+  };
+  const cycleSort = () => {
+    const next = SORT_CYCLE[(SORT_CYCLE.indexOf(sortBy) + 1) % SORT_CYCLE.length];
+    setSortBy(next);
+    if (hasSearched) runSearch({ sortBy: next });
+  };
+
+  const toggleFilterValue = (field: string, value: string) => {
+    setKeywordFilters((prev) => {
+      const current = prev[field] ?? [];
+      const updated = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value];
+      if (updated.length === 0) {
+        const { [field]: _drop, ...rest } = prev;
+        return rest;
+      }
+      return { ...prev, [field]: updated };
+    });
+  };
+
+  const showFilterChip = kind === 'system' && keywordFields.length > 0;
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={[styles.searchBar, { backgroundColor: theme.surface, borderColor: theme.border }]}
+      >
+        <Ionicons name="search" size={20} color={theme.textSecondary} />
+        <TextInput
+          style={[styles.searchInput, { color: theme.text }]}
+          placeholder="In diesem Notebook recherchieren…"
+          placeholderTextColor={theme.textSecondary}
+          value={query}
+          onChangeText={setQuery}
+          onSubmitEditing={() => runSearch()}
+          returnKeyType="search"
+          autoCorrect={false}
+        />
+        {query.length > 0 && (
+          <Pressable onPress={() => setQuery('')} hitSlop={8}>
+            <Ionicons name="close-circle" size={20} color={theme.textSecondary} />
+          </Pressable>
+        )}
+        <Pressable
+          onPress={() => runSearch()}
+          style={[styles.searchButton, { backgroundColor: colors.primary[600] }]}
+          disabled={query.trim().length < 2}
+        >
+          <Ionicons name="arrow-forward" size={18} color={colors.white} />
+        </Pressable>
+      </View>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipBar}
+      >
+        <FilterChip
+          label={MODE_LABELS[mode]}
+          active={mode !== 'hybrid'}
+          onPress={cycleMode}
+          icon="options-outline"
+          theme={theme}
+        />
+        <FilterChip
+          label={SORT_LABELS[sortBy]}
+          active={sortBy !== 'relevance'}
+          onPress={cycleSort}
+          icon="swap-vertical-outline"
+          theme={theme}
+        />
+        {showFilterChip && (
+          <FilterChip
+            label={keywordFilterCount > 0 ? `Filter (${keywordFilterCount})` : 'Filter'}
+            active={keywordFilterCount > 0}
+            onPress={() => setFiltersSheetVisible(true)}
+            icon="funnel-outline"
+            theme={theme}
+          />
+        )}
+      </ScrollView>
+
+      <ScrollView contentContainerStyle={styles.resultsContent} keyboardShouldPersistTaps="handled">
+        {isLoading && (
+          <View style={styles.centerState}>
+            <ActivityIndicator size="large" color={colors.primary[600]} />
+            <Text style={[styles.stateText, { color: theme.textSecondary }]}>Suche läuft…</Text>
+          </View>
+        )}
+
+        {error && !isLoading && (
+          <View style={[styles.errorBox, { backgroundColor: colors.error[500] + '15' }]}>
+            <Ionicons name="alert-circle" size={20} color={colors.error[500]} />
+            <Text style={[styles.errorText, { color: colors.error[500] }]}>{error}</Text>
+          </View>
+        )}
+
+        {metadata && !isLoading && (
+          <Text style={[styles.metaText, { color: theme.textSecondary }]}>
+            {metadata.totalResults} Ergebnisse in {metadata.timeMs} ms
+          </Text>
+        )}
+
+        {!isLoading &&
+          results.map((result) => (
+            <ResearchResultCard
+              key={result.document_id}
+              result={result}
+              theme={theme}
+              onPress={setSelected}
+            />
+          ))}
+
+        {!hasSearched && !isLoading && (
+          <View style={styles.centerState}>
+            <Ionicons name="search-outline" size={44} color={theme.textSecondary} />
+            <Text style={[styles.stateText, { color: theme.textSecondary }]}>
+              Durchsuche die Dokumente dieses Notebooks.
+            </Text>
+          </View>
+        )}
+
+        {hasSearched && !isLoading && results.length === 0 && !error && (
+          <View style={styles.centerState}>
+            <Ionicons name="document-outline" size={44} color={theme.textSecondary} />
+            <Text style={[styles.stateText, { color: theme.textSecondary }]}>
+              Keine Ergebnisse gefunden.
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {showFilterChip && (
+        <BottomSheet visible={filtersSheetVisible} onClose={() => setFiltersSheetVisible(false)}>
+          <View style={styles.sheetHeader}>
+            <Text style={[styles.sheetTitle, { color: theme.text }]}>Filter</Text>
+            <Pressable onPress={() => setFiltersSheetVisible(false)} hitSlop={8}>
+              <Ionicons name="close" size={24} color={theme.text} />
+            </Pressable>
+          </View>
+          <ScrollView style={styles.sheetScroll}>
+            {keywordFields.map((field) => (
+              <View key={field.field} style={styles.filterSection}>
+                <Text style={[styles.filterSectionTitle, { color: theme.text }]}>
+                  {KEYWORD_FILTER_LABELS[field.field] ?? field.label}
+                </Text>
+                <View style={styles.filterValues}>
+                  {field.values!.map((v) => {
+                    const isActive = (keywordFilters[field.field] ?? []).includes(v.value);
+                    return (
+                      <Pressable
+                        key={v.value}
+                        onPress={() => toggleFilterValue(field.field, v.value)}
+                        style={[
+                          styles.valueChip,
+                          {
+                            backgroundColor: isActive ? colors.primary[600] : theme.surface,
+                            borderColor: isActive ? colors.primary[600] : theme.border,
+                          },
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.valueText,
+                            { color: isActive ? colors.white : theme.text },
+                          ]}
+                          numberOfLines={1}
+                        >
+                          {v.value}
+                        </Text>
+                        <Text
+                          style={[
+                            styles.valueCount,
+                            { color: isActive ? colors.primary[200] : theme.textSecondary },
+                          ]}
+                        >
+                          {v.count}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+            ))}
+          </ScrollView>
+          <Pressable
+            onPress={() => {
+              setFiltersSheetVisible(false);
+              runSearch();
+            }}
+            style={[styles.applyButton, { backgroundColor: colors.primary[600] }]}
+          >
+            <Text style={styles.applyButtonText}>
+              {keywordFilterCount > 0
+                ? `${keywordFilterCount} Filter anwenden`
+                : 'Ohne Filter suchen'}
+            </Text>
+          </Pressable>
+        </BottomSheet>
+      )}
+
+      <CitationDetailSheet
+        citation={selected ? toCitation(selected) : null}
+        theme={theme}
+        onClose={() => setSelected(null)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.small,
+    paddingVertical: spacing.xsmall,
+    borderRadius: borderRadius.large,
+    borderWidth: 1,
+    gap: spacing.xsmall,
+    marginHorizontal: spacing.medium,
+    marginTop: spacing.small,
+  },
+  searchInput: {
+    ...typography.body,
+    flex: 1,
+    paddingVertical: spacing.xsmall,
+  },
+  searchButton: {
+    width: 32,
+    height: 32,
+    borderRadius: borderRadius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  chipBar: {
+    gap: spacing.xsmall,
+    paddingHorizontal: spacing.medium,
+    paddingVertical: spacing.small,
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.small,
+    paddingVertical: 6,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  resultsContent: {
+    padding: spacing.medium,
+    paddingTop: 0,
+    gap: spacing.small,
+  },
+  centerState: {
+    alignItems: 'center',
+    padding: spacing.xlarge,
+    gap: spacing.medium,
+  },
+  stateText: {
+    ...typography.body,
+    textAlign: 'center',
+  },
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    padding: spacing.medium,
+    borderRadius: borderRadius.medium,
+  },
+  errorText: {
+    ...typography.body,
+    flex: 1,
+  },
+  metaText: {
+    ...typography.caption,
+    textAlign: 'right',
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.small,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  sheetScroll: {
+    maxHeight: 360,
+  },
+  filterSection: {
+    marginTop: spacing.medium,
+  },
+  filterSectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: spacing.xsmall,
+  },
+  filterValues: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xsmall,
+  },
+  valueChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.small,
+    paddingVertical: 6,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+  },
+  valueText: {
+    fontSize: 13,
+  },
+  valueCount: {
+    fontSize: 11,
+  },
+  applyButton: {
+    marginTop: spacing.medium,
+    paddingVertical: 14,
+    borderRadius: borderRadius.large,
+    alignItems: 'center',
+  },
+  applyButtonText: {
+    color: colors.white,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/components/notebook/ResearchResultCard.tsx
+++ b/apps/mobile/components/notebook/ResearchResultCard.tsx
@@ -1,0 +1,135 @@
+import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { memo } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+
+import { colors, spacing, typography, borderRadius } from '../../theme';
+
+import type { ResearchResult } from '../../hooks/notebook/useNotebookResearch';
+import type { Theme } from '../../theme/colors';
+
+interface Props {
+  result: ResearchResult;
+  theme: Theme;
+  onPress: (result: ResearchResult) => void;
+}
+
+const scorePercent = (score: number) => `${Math.round(score * 100)}%`;
+
+const formatDate = (iso: string | null | undefined): string | null => {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  } catch {
+    return null;
+  }
+};
+
+export const ResearchResultCard = memo(function ResearchResultCard({
+  result,
+  theme,
+  onPress,
+}: Props) {
+  const date = formatDate(result.published_at);
+
+  return (
+    <Pressable
+      onPress={() => onPress(result)}
+      style={({ pressed }) => [
+        styles.card,
+        { backgroundColor: pressed ? theme.surface : theme.card, borderColor: theme.cardBorder },
+      ]}
+    >
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={2}>
+          {result.title}
+        </Text>
+        <View style={[styles.scoreBadge, { backgroundColor: colors.primary[600] + '20' }]}>
+          <Text style={[styles.scoreText, { color: colors.primary[600] }]}>
+            {scorePercent(result.similarity_score)}
+          </Text>
+        </View>
+      </View>
+
+      <View style={styles.metaRow}>
+        {result.collection_name && (
+          <View style={[styles.badge, { backgroundColor: theme.surface }]}>
+            <Ionicons name="library-outline" size={12} color={theme.textSecondary} />
+            <Text style={[styles.badgeText, { color: theme.textSecondary }]} numberOfLines={1}>
+              {result.collection_name}
+            </Text>
+          </View>
+        )}
+        {date && (
+          <View style={[styles.badge, { backgroundColor: theme.surface }]}>
+            <Ionicons name="calendar-outline" size={12} color={theme.textSecondary} />
+            <Text style={[styles.badgeText, { color: theme.textSecondary }]}>{date}</Text>
+          </View>
+        )}
+        {result.chunk_count != null && result.chunk_count > 1 && (
+          <View style={[styles.badge, { backgroundColor: theme.surface }]}>
+            <Text style={[styles.badgeText, { color: theme.textSecondary }]}>
+              {result.chunk_count} Abschnitte
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <Text style={[styles.content, { color: theme.textSecondary }]} numberOfLines={4}>
+        {result.relevant_content}
+      </Text>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    padding: spacing.medium,
+    borderRadius: borderRadius.large,
+    borderWidth: 1,
+    gap: spacing.xsmall,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: spacing.small,
+  },
+  title: {
+    ...typography.bodyBold,
+    flex: 1,
+  },
+  scoreBadge: {
+    paddingHorizontal: spacing.xsmall,
+    paddingVertical: spacing.xxsmall,
+    borderRadius: borderRadius.small,
+  },
+  scoreText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.xsmall,
+    paddingVertical: 2,
+    borderRadius: borderRadius.small,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '500',
+  },
+  content: {
+    ...typography.bodySmall,
+    lineHeight: 20,
+  },
+});

--- a/apps/mobile/config/notebooksConfig.ts
+++ b/apps/mobile/config/notebooksConfig.ts
@@ -81,6 +81,47 @@ export const MOBILE_SYSTEM_NOTEBOOKS: MobileNotebookEntry[] = NOTEBOOK_REGISTRY.
 
 export const HIDDEN_NOTEBOOK_IDS = ['gruenerator-notebook', 'gruenblog-notebook'];
 
+/**
+ * Maps each gallery notebook to the `*-system` collection id(s) the research backend
+ * (`/research/search`, `/research/filters`) expects. The backend keeps the canonical
+ * `notebook → collection` map (`apps/api/config/notebookCollectionMap.ts`) but in a
+ * different id namespace (`bayern` vs `bayern-system`) and never ships it to the client,
+ * so the notebook-detail Recherche needs this small client-side table to scope a search.
+ *
+ * `satisfies Record<NotebookId, …>` forces an entry for every notebook in the shared
+ * registry — adding one there fails the mobile build until its research collection is
+ * supplied, the same safety the `NOTEBOOK_IONICONS` map relies on.
+ */
+const NOTEBOOK_RESEARCH_COLLECTIONS = {
+  'gruenerator-notebook': [
+    'grundsatz-system',
+    'bundestagsfraktion-system',
+    'gruene-de-system',
+    'kommunalwiki-system',
+    'gruenblog-system',
+  ],
+  'gruene-notebook': ['grundsatz-system'],
+  'bundestagsfraktion-notebook': ['bundestagsfraktion-system'],
+  'hamburg-notebook': ['hamburg-system'],
+  'schleswig-holstein-notebook': ['schleswig-holstein-system'],
+  'thueringen-notebook': ['thueringen-system'],
+  'berlin-notebook': ['berlin-system'],
+  'mecklenburg-vorpommern-notebook': ['mecklenburg-vorpommern-system'],
+  'brandenburg-notebook': ['brandenburg-system'],
+  'bayern-notebook': ['bayern-system'],
+  'oesterreich-notebook': ['oesterreich-gruene-system'],
+  'kommunalwiki-notebook': ['kommunalwiki-system'],
+  'gruenblog-notebook': ['gruenblog-system'],
+  'boell-stiftung-notebook': ['boell-stiftung-system'],
+} satisfies Record<NotebookId, string[]>;
+
+/**
+ * Research collection ids for a system notebook, or `[]` for user notebooks (UUIDs) which
+ * scope research through the per-notebook contract endpoint instead.
+ */
+export const getResearchCollectionIds = (notebookId: string): string[] =>
+  (NOTEBOOK_RESEARCH_COLLECTIONS as Record<string, string[]>)[notebookId] ?? [];
+
 const audienceOf = (id: string): 'de-DE' | 'de-AT' | 'all' =>
   NOTEBOOK_REGISTRY.find((nb) => nb.id === id)?.audience ?? 'all';
 

--- a/apps/mobile/hooks/notebook/useNotebookFilters.ts
+++ b/apps/mobile/hooks/notebook/useNotebookFilters.ts
@@ -1,0 +1,53 @@
+import { getGlobalApiClient } from '@gruenerator/shared/api';
+import { useQuery } from '@tanstack/react-query';
+
+import { getResearchCollectionIds } from '../../config/notebooksConfig';
+
+export interface FilterFieldValues {
+  field: string;
+  label: string;
+  type: 'keyword' | 'date_range';
+  values?: Array<{ value: string; count: number }>;
+}
+
+interface FilterEntryRaw {
+  label?: string;
+  type?: string;
+  values?: Array<{ value: string; count: number }>;
+}
+
+interface FiltersApiResponse {
+  filters?: Record<string, FilterEntryRaw>;
+}
+
+/**
+ * Keyword/date facets for a system notebook, merged across its `*-system` collections.
+ * Disabled for user notebooks (the per-notebook research endpoint has no facets).
+ */
+export function useNotebookFilters(notebookId: string, kind: 'system' | 'user') {
+  const collectionIds = getResearchCollectionIds(notebookId);
+  const ids = collectionIds.join(',');
+
+  const query = useQuery({
+    queryKey: ['notebook', notebookId, 'research-filters', ids],
+    enabled: kind === 'system' && collectionIds.length > 0,
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<FilterFieldValues[]> => {
+      const res = await getGlobalApiClient().get<FiltersApiResponse>(
+        `/research/filters?collectionIds=${ids}`
+      );
+      const filtersObj = res.data.filters ?? {};
+      return Object.entries(filtersObj).map(([field, e]) => ({
+        field,
+        label: e.label ?? field,
+        type: (e.type ?? 'keyword') as 'keyword' | 'date_range',
+        values: e.values,
+      }));
+    },
+  });
+
+  return {
+    filterFields: query.data ?? [],
+    isLoading: query.isLoading,
+  };
+}

--- a/apps/mobile/hooks/notebook/useNotebookResearch.ts
+++ b/apps/mobile/hooks/notebook/useNotebookResearch.ts
@@ -1,0 +1,85 @@
+import { getContractsClient, getGlobalApiClient } from '@gruenerator/shared/api';
+import { useMutation } from '@tanstack/react-query';
+
+import { getResearchCollectionIds } from '../../config/notebooksConfig';
+
+export type SearchMode = 'hybrid' | 'vector' | 'text';
+export type SortOption = 'relevance' | 'date_desc' | 'date_asc';
+
+export interface ResearchResult {
+  document_id: string;
+  title: string;
+  source_url: string | null;
+  relevant_content: string;
+  similarity_score: number;
+  chunk_count?: number;
+  top_chunks?: Array<{ preview: string; chunk_index: number; page_number: number | null }>;
+  collection_id?: string | null;
+  collection_name?: string | null;
+  published_at?: string | null;
+}
+
+export interface ResearchMetadata {
+  totalResults: number;
+  collections: string[];
+  timeMs: number;
+}
+
+export interface NotebookSearchInput {
+  query: string;
+  mode: SearchMode;
+  sortBy: SortOption;
+  /** Keyword/date facets, system notebooks only. */
+  filters?: Record<string, unknown>;
+}
+
+interface ResearchResponse {
+  results: ResearchResult[];
+  metadata: ResearchMetadata | null;
+}
+
+/**
+ * Per-notebook manual research. The backend keeps two disjoint research paths
+ * (see notebooksConfig `NOTEBOOK_RESEARCH_COLLECTIONS`):
+ *  - system notebooks → `/research/search`, scoped to the notebook's `*-system`
+ *    collection ids, with full keyword/date facets (raw client; no contract exists).
+ *  - user notebooks (UUIDs) → the contracted per-notebook endpoint, which accepts
+ *    only query/mode/sortBy (no facets) and rejects system ids.
+ */
+export function useNotebookResearch(notebookId: string, kind: 'system' | 'user') {
+  const mutation = useMutation<ResearchResponse, Error, NotebookSearchInput>({
+    mutationKey: ['notebook', notebookId, 'research'],
+    mutationFn: async (input) => {
+      const query = input.query.trim();
+      if (query.length < 2) return { results: [], metadata: null };
+
+      if (kind === 'user') {
+        const result = await getContractsClient().notebook.researchSearch({
+          params: { id: notebookId },
+          body: { query, mode: input.mode, sortBy: input.sortBy, limit: 30 },
+        });
+        if (result.status !== 200) {
+          throw new Error('Suche fehlgeschlagen. Bitte erneut versuchen.');
+        }
+        return { results: result.body.results as ResearchResult[], metadata: result.body.metadata };
+      }
+
+      const body: Record<string, unknown> = { query, mode: input.mode, sortBy: input.sortBy };
+      const collectionIds = getResearchCollectionIds(notebookId);
+      if (collectionIds.length > 0) body.collectionIds = collectionIds;
+      if (input.filters && Object.keys(input.filters).length > 0) body.filters = input.filters;
+
+      const response = await getGlobalApiClient().post<ResearchResponse>('/research/search', body);
+      return { results: response.data.results ?? [], metadata: response.data.metadata ?? null };
+    },
+  });
+
+  return {
+    search: mutation.mutate,
+    results: mutation.data?.results ?? [],
+    metadata: mutation.data?.metadata ?? null,
+    isLoading: mutation.isPending,
+    hasSearched: mutation.isSuccess || mutation.isError,
+    error: mutation.error?.message ?? null,
+  };
+}

--- a/apps/mobile/types/routes.ts
+++ b/apps/mobile/types/routes.ts
@@ -31,6 +31,7 @@ export type AppRoute =
   | '/auth/callback'
   // Focused routes
   | '/(focused)/chat-conversation'
+  | '/(focused)/notebook-detail'
   | '/(focused)/image-studio-create/image'
   | '/(focused)/image-studio-create/ki-input'
   | '/(focused)/image-studio-create/template-input'
@@ -50,6 +51,11 @@ export interface ModalRouteParams {
     notebookId?: string;
     agentId?: string;
     initialComposerText?: string;
+  };
+  '/(focused)/notebook-detail': {
+    notebookId: string;
+    title?: string;
+    kind: 'system' | 'user';
   };
   '/(fullscreen)/subtitle-editor': {
     projectId: string;


### PR DESCRIPTION
Mobile previously jumped straight from the notebook gallery into chat, with no equivalent of web's notebook landing page. The biggest gap was **Recherche** — web lets you run a faceted manual search scoped to a single notebook, mobile had only the global cross-collection research screen.

This adds a native notebook detail screen between the gallery and chat (gallery → detail → chat). Its primary surface is per-notebook Recherche; a Chat segment still opens the existing Q&A path.

The two backend research paths are reconciled client-side: system notebooks scope `/research/search` through a build-checked `NotebookId → '*-system'` collection map (the backend's own map is in a different id namespace and never ships to the client), with full keyword facets; user notebooks use the contracted per-notebook `researchSearch` endpoint (no facets — hidden accordingly). Result cards reuse the existing `CitationDetailSheet`.

First milestone of the web↔mobile notebook parity plan; sharing UI and public discovery follow as separate PRs.