### PR TITLE
feat(mobile): native notebook sharing sheet

### DIFF
--- a/apps/mobile/app/(tabs)/(recherche)/index.tsx
+++ b/apps/mobile/app/(tabs)/(recherche)/index.tsx
@@ -16,6 +16,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { NotebookCreator } from '../../../components/notebook/NotebookCreator';
+import { NotebookShareSheet } from '../../../components/notebook/NotebookShareSheet';
 import {
   getMobileNotebooksByCategory,
   getVisibleNotebooks,
@@ -144,6 +145,7 @@ export default function NotebooksScreen() {
   const [searchOpen, setSearchOpen] = useState(false);
   const searchInputRef = useRef<TextInput>(null);
   const [creatorVisible, setCreatorVisible] = useState(false);
+  const [shareTarget, setShareTarget] = useState<{ id: string; name: string } | null>(null);
   const { user } = useAuth();
   const locale: 'de-DE' | 'de-AT' = user?.locale === 'de-AT' ? 'de-AT' : 'de-DE';
   const { collections, isLoading, processingIds, createCollection, deleteCollection } =
@@ -208,6 +210,17 @@ export default function NotebooksScreen() {
       ]);
     },
     [deleteCollection]
+  );
+
+  const handleCollectionLongPress = useCallback(
+    (id: string, name: string) => {
+      Alert.alert(name, undefined, [
+        { text: 'Teilen', onPress: () => setShareTarget({ id, name }) },
+        { text: 'Löschen', style: 'destructive', onPress: () => handleDeleteCollection(id, name) },
+        { text: 'Abbrechen', style: 'cancel' },
+      ]);
+    },
+    [handleDeleteCollection]
   );
 
   return (
@@ -325,7 +338,7 @@ export default function NotebooksScreen() {
                     icon="book"
                     title={c.name}
                     onPress={() => handleCollectionPress(c.id)}
-                    onLongPress={() => handleDeleteCollection(c.id, c.name)}
+                    onLongPress={() => handleCollectionLongPress(c.id, c.name)}
                     isProcessing={processingIds.has(c.id)}
                   />
                 ))
@@ -361,6 +374,16 @@ export default function NotebooksScreen() {
           onClose={() => setCreatorVisible(false)}
           createCollection={createCollection}
         />
+
+        {shareTarget && (
+          <NotebookShareSheet
+            notebookId={shareTarget.id}
+            notebookName={shareTarget.name}
+            visible={!!shareTarget}
+            onClose={() => setShareTarget(null)}
+            theme={theme}
+          />
+        )}
       </ScrollView>
       {!searchOpen && (
         <Pressable

--- a/apps/mobile/components/notebook/NotebookShareSheet.tsx
+++ b/apps/mobile/components/notebook/NotebookShareSheet.tsx
@@ -1,0 +1,292 @@
+import { Ionicons } from '@react-native-vector-icons/ionicons';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ScrollView,
+  Switch,
+  ActivityIndicator,
+} from 'react-native';
+
+import {
+  useNotebookSharing,
+  type Audience,
+  type EditPolicy,
+  type ShareMode,
+} from '../../hooks/notebook/useNotebookSharing';
+import { colors, spacing, typography } from '../../theme';
+import { BottomSheet } from '../common/BottomSheet';
+
+import type { Theme } from '../../theme/colors';
+
+interface Props {
+  notebookId: string;
+  notebookName: string;
+  visible: boolean;
+  onClose: () => void;
+  theme: Theme;
+}
+
+const SHARE_MODE_OPTIONS: Array<{ value: ShareMode; label: string; description: string }> = [
+  { value: 'private', label: 'Privat', description: 'Nur du hast Zugriff.' },
+  { value: 'groups', label: 'Mit Gruppen', description: 'Ausgewählte Gruppen können lesen.' },
+  {
+    value: 'authenticated',
+    label: 'Alle Angemeldeten',
+    description: 'Alle angemeldeten Nutzer*innen können lesen.',
+  },
+];
+
+const EDIT_POLICY_OPTIONS: Array<{ value: EditPolicy; label: string }> = [
+  { value: 'owner_only', label: 'Nur ich' },
+  { value: 'group_admins', label: 'Gruppen-Admins' },
+  { value: 'all_members', label: 'Alle Mitglieder' },
+];
+
+const AUDIENCE_OPTIONS: Array<{ value: Audience; label: string }> = [
+  { value: 'de-DE', label: 'Deutschland' },
+  { value: 'de-AT', label: 'Österreich' },
+];
+
+function OptionRow({
+  label,
+  description,
+  selected,
+  onPress,
+  theme,
+}: {
+  label: string;
+  description?: string;
+  selected: boolean;
+  onPress: () => void;
+  theme: Theme;
+}) {
+  return (
+    <Pressable onPress={onPress} style={styles.optionRow}>
+      <Ionicons
+        name={selected ? 'radio-button-on' : 'radio-button-off'}
+        size={20}
+        color={selected ? colors.primary[600] : theme.textSecondary}
+      />
+      <View style={styles.optionTextWrap}>
+        <Text style={[styles.optionLabel, { color: theme.text }]}>{label}</Text>
+        {description && (
+          <Text style={[styles.optionDescription, { color: theme.textSecondary }]}>
+            {description}
+          </Text>
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+export function NotebookShareSheet({ notebookId, notebookName, visible, onClose, theme }: Props) {
+  const {
+    settings,
+    isLoading,
+    error,
+    myGroups,
+    groupShares,
+    setShareMode,
+    setEditPolicy,
+    setAudience,
+    setIsPublic,
+    addGroupShare,
+    removeGroupShare,
+  } = useNotebookSharing(notebookId, visible);
+
+  const sharedGroupIds = new Set(groupShares.map((g) => g.group_id));
+  const addableGroups = myGroups.filter((g) => !sharedGroupIds.has(g.id));
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose}>
+      <View style={styles.header}>
+        <Text style={[styles.title, { color: theme.text }]} numberOfLines={1}>
+          „{notebookName}“ teilen
+        </Text>
+        <Pressable onPress={onClose} hitSlop={8}>
+          <Ionicons name="close" size={24} color={theme.text} />
+        </Pressable>
+      </View>
+
+      {isLoading && (
+        <View style={styles.center}>
+          <ActivityIndicator color={colors.primary[600]} />
+        </View>
+      )}
+
+      {error && !isLoading && (
+        <Text style={[styles.errorText, { color: colors.error[500] }]}>{error}</Text>
+      )}
+
+      {settings && (
+        <ScrollView style={styles.scroll}>
+          <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Wer kann lesen?</Text>
+          {SHARE_MODE_OPTIONS.map((opt) => (
+            <OptionRow
+              key={opt.value}
+              label={opt.label}
+              description={opt.description}
+              selected={settings.share_mode === opt.value}
+              onPress={() => setShareMode(opt.value)}
+              theme={theme}
+            />
+          ))}
+
+          {settings.share_mode !== 'private' && (
+            <>
+              <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>
+                Wer kann bearbeiten?
+              </Text>
+              {EDIT_POLICY_OPTIONS.map((opt) => (
+                <OptionRow
+                  key={opt.value}
+                  label={opt.label}
+                  selected={settings.edit_policy === opt.value}
+                  onPress={() => setEditPolicy(opt.value)}
+                  theme={theme}
+                />
+              ))}
+            </>
+          )}
+
+          {settings.share_mode === 'groups' && (
+            <>
+              <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Gruppen</Text>
+              {groupShares.map((g) => (
+                <View key={g.group_id} style={styles.groupRow}>
+                  <Ionicons name="people" size={18} color={colors.primary[600]} />
+                  <Text style={[styles.groupName, { color: theme.text }]} numberOfLines={1}>
+                    {g.group_name}
+                  </Text>
+                  <Pressable onPress={() => removeGroupShare(g.group_id)} hitSlop={8}>
+                    <Ionicons name="close-circle" size={20} color={theme.textSecondary} />
+                  </Pressable>
+                </View>
+              ))}
+              {addableGroups.map((g) => (
+                <Pressable key={g.id} onPress={() => addGroupShare(g.id)} style={styles.groupRow}>
+                  <Ionicons name="add-circle-outline" size={18} color={theme.textSecondary} />
+                  <Text
+                    style={[styles.groupName, { color: theme.textSecondary }]}
+                    numberOfLines={1}
+                  >
+                    {g.name}
+                  </Text>
+                </Pressable>
+              ))}
+              {groupShares.length === 0 && addableGroups.length === 0 && (
+                <Text style={[styles.emptyText, { color: theme.textSecondary }]}>
+                  Du bist in keinen Gruppen.
+                </Text>
+              )}
+            </>
+          )}
+
+          {settings.share_mode === 'authenticated' && (
+            <>
+              <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>Zielgruppe</Text>
+              {AUDIENCE_OPTIONS.map((opt) => (
+                <OptionRow
+                  key={opt.value}
+                  label={opt.label}
+                  selected={settings.audience === opt.value}
+                  onPress={() => setAudience(opt.value)}
+                  theme={theme}
+                />
+              ))}
+              <View style={styles.switchRow}>
+                <View style={styles.switchTextWrap}>
+                  <Text style={[styles.optionLabel, { color: theme.text }]}>Von der Basis</Text>
+                  <Text style={[styles.optionDescription, { color: theme.textSecondary }]}>
+                    In der öffentlichen Notebook-Galerie zeigen.
+                  </Text>
+                </View>
+                <Switch
+                  value={settings.is_public}
+                  onValueChange={(v) => setIsPublic(v)}
+                  trackColor={{ true: colors.primary[600] }}
+                />
+              </View>
+            </>
+          )}
+        </ScrollView>
+      )}
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.small,
+  },
+  title: {
+    ...typography.bodyBold,
+    fontSize: 17,
+    flex: 1,
+  },
+  scroll: {
+    maxHeight: 420,
+  },
+  center: {
+    padding: spacing.large,
+    alignItems: 'center',
+  },
+  errorText: {
+    ...typography.bodySmall,
+    paddingVertical: spacing.small,
+  },
+  sectionTitle: {
+    ...typography.caption,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: spacing.medium,
+    marginBottom: spacing.xsmall,
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingVertical: spacing.small,
+  },
+  optionTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+  optionLabel: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  optionDescription: {
+    fontSize: 12,
+  },
+  groupRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingVertical: spacing.small,
+  },
+  groupName: {
+    fontSize: 15,
+    flex: 1,
+  },
+  emptyText: {
+    ...typography.bodySmall,
+    paddingVertical: spacing.small,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingVertical: spacing.small,
+  },
+  switchTextWrap: {
+    flex: 1,
+    gap: 2,
+  },
+});

--- a/apps/mobile/hooks/notebook/useNotebookSharing.ts
+++ b/apps/mobile/hooks/notebook/useNotebookSharing.ts
@@ -1,0 +1,143 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export type ShareMode = 'private' | 'groups' | 'authenticated';
+export type EditPolicy = 'owner_only' | 'group_admins' | 'all_members';
+export type Audience = 'de-DE' | 'de-AT';
+
+export interface ShareSettings {
+  share_mode: ShareMode;
+  edit_policy: EditPolicy;
+  audience: Audience;
+  is_public: boolean;
+  public_ownership: 'owner' | 'public_data' | null;
+}
+
+export interface UserGroup {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export interface GroupShare {
+  group_id: string;
+  group_name: string;
+  shared_at: string;
+}
+
+/**
+ * Read + mutate a user notebook's share settings via the `notebookSharing` contract.
+ * Mirrors web's `useNotebookSharing`: the two axes are `share_mode` (who can read) and
+ * `edit_policy` (who can write); group shares live in the polymorphic shares table; the
+ * Von-der-Basis toggle (`is_public`) sits on top of `share_mode='authenticated'`.
+ */
+export function useNotebookSharing(notebookId: string, enabled: boolean) {
+  const client = getContractsClient().notebookSharing;
+  const qc = useQueryClient();
+  const settingsKey = ['notebook', notebookId, 'share-settings'];
+  const groupSharesKey = ['notebook', notebookId, 'group-shares'];
+
+  const settings = useQuery({
+    queryKey: settingsKey,
+    enabled,
+    queryFn: async (): Promise<ShareSettings> => {
+      const res = await client.getShareSettings({ params: { id: notebookId } });
+      if (res.status !== 200) throw new Error('Freigabe-Einstellungen nicht verfügbar');
+      return res.body;
+    },
+  });
+
+  const myGroups = useQuery({
+    queryKey: ['notebook', 'my-groups'],
+    enabled,
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<UserGroup[]> => {
+      const res = await client.listMyGroups({});
+      return res.status === 200 ? res.body : [];
+    },
+  });
+
+  const groupShares = useQuery({
+    queryKey: groupSharesKey,
+    enabled: enabled && settings.data?.share_mode === 'groups',
+    queryFn: async (): Promise<GroupShare[]> => {
+      const res = await client.listGroupShares({ params: { id: notebookId } });
+      return res.status === 200 ? res.body : [];
+    },
+  });
+
+  const invalidate = () => {
+    void qc.invalidateQueries({ queryKey: settingsKey });
+    void qc.invalidateQueries({ queryKey: groupSharesKey });
+  };
+
+  const setShareMode = useMutation({
+    mutationFn: async (mode: ShareMode) => {
+      const res = await client.setShareMode({ params: { id: notebookId }, body: { mode } });
+      if (res.status !== 200) throw new Error('Freigabe konnte nicht geändert werden');
+    },
+    onSuccess: invalidate,
+  });
+
+  const setEditPolicy = useMutation({
+    mutationFn: async (policy: EditPolicy) => {
+      const res = await client.setEditPolicy({ params: { id: notebookId }, body: { policy } });
+      if (res.status !== 200) throw new Error('Bearbeitungsrechte konnten nicht geändert werden');
+    },
+    onSuccess: invalidate,
+  });
+
+  const setAudience = useMutation({
+    mutationFn: async (audience: Audience) => {
+      const res = await client.setAudience({ params: { id: notebookId }, body: { audience } });
+      if (res.status !== 200) throw new Error('Zielgruppe konnte nicht geändert werden');
+    },
+    onSuccess: invalidate,
+  });
+
+  const setIsPublic = useMutation({
+    mutationFn: async (isPublic: boolean) => {
+      const res = await client.setIsPublic({
+        params: { id: notebookId },
+        body: { is_public: isPublic, public_ownership: isPublic ? 'owner' : null },
+      });
+      if (res.status !== 200) throw new Error('Von-der-Basis-Freigabe fehlgeschlagen');
+    },
+    onSuccess: invalidate,
+  });
+
+  const addGroupShare = useMutation({
+    mutationFn: async (groupId: string) => {
+      const res = await client.addGroupShare({
+        params: { id: notebookId },
+        body: { group_id: groupId },
+      });
+      if (res.status !== 201) throw new Error('Gruppe konnte nicht hinzugefügt werden');
+    },
+    onSuccess: invalidate,
+  });
+
+  const removeGroupShare = useMutation({
+    mutationFn: async (groupId: string) => {
+      const res = await client.deleteGroupShare({
+        params: { id: notebookId, groupId },
+      });
+      if (res.status !== 200) throw new Error('Gruppe konnte nicht entfernt werden');
+    },
+    onSuccess: invalidate,
+  });
+
+  return {
+    settings: settings.data ?? null,
+    isLoading: settings.isLoading,
+    error: settings.error?.message ?? null,
+    myGroups: myGroups.data ?? [],
+    groupShares: groupShares.data ?? [],
+    setShareMode: setShareMode.mutate,
+    setEditPolicy: setEditPolicy.mutate,
+    setAudience: setAudience.mutate,
+    setIsPublic: setIsPublic.mutate,
+    addGroupShare: addGroupShare.mutate,
+    removeGroupShare: removeGroupShare.mutate,
+  };
+}


### PR DESCRIPTION
User-created notebooks could be created on mobile but never shared — sharing was web-only. This adds a native share sheet, opened by long-pressing a notebook in "Meine Notebooks" → **Teilen**, mirroring web's `NotebookShareModal` via the `notebookSharing` contract: read access (`share_mode`), edit policy, locale audience, group add/remove, and the **Von der Basis** (`is_public`) discovery toggle.

Second PR of the web↔mobile notebook parity plan (after #1037, notebook detail + Recherche). Independent of #1037 — based on master.