### PR TITLE
feat(mobile): Von-der-Basis notebook discovery + likes

### DIFF
--- a/apps/mobile/app/(tabs)/(recherche)/index.tsx
+++ b/apps/mobile/app/(tabs)/(recherche)/index.tsx
@@ -16,6 +16,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { NotebookCreator } from '../../../components/notebook/NotebookCreator';
+import { VonDerBasisSection } from '../../../components/notebook/VonDerBasisSection';
 import {
   getMobileNotebooksByCategory,
   getVisibleNotebooks,
@@ -331,6 +332,8 @@ export default function NotebooksScreen() {
                 ))
               )}
             </View>
+
+            <VonDerBasisSection locale={locale} theme={theme} onOpen={handleCollectionPress} />
           </View>
         )}
 

--- a/apps/mobile/components/notebook/VonDerBasisSection.tsx
+++ b/apps/mobile/components/notebook/VonDerBasisSection.tsx
@@ -1,0 +1,126 @@
+import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+
+import { useNotebookDiscovery } from '../../hooks/notebook/useNotebookDiscovery';
+import { colors, spacing, typography, borderRadius } from '../../theme';
+
+import type { Theme } from '../../theme/colors';
+
+interface Props {
+  locale: 'de-DE' | 'de-AT';
+  theme: Theme;
+  onOpen: (id: string, name: string) => void;
+}
+
+export function VonDerBasisSection({ locale, theme, onOpen }: Props) {
+  const { collections, isLoading, likedIds, toggleLike } = useNotebookDiscovery(locale);
+
+  if (isLoading || collections.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: theme.text }]}>Von der Basis</Text>
+      {collections.map((c) => {
+        const liked = likedIds.has(c.id);
+        return (
+          <Pressable
+            key={c.id}
+            onPress={() => onOpen(c.id, c.name)}
+            style={({ pressed }) => [
+              styles.card,
+              {
+                backgroundColor: pressed ? theme.surface : theme.card,
+                borderColor: theme.cardBorder,
+              },
+            ]}
+          >
+            <View style={styles.cardBody}>
+              <Text style={[styles.cardTitle, { color: theme.text }]} numberOfLines={1}>
+                {c.name}
+              </Text>
+              {c.description && (
+                <Text
+                  style={[styles.cardDescription, { color: theme.textSecondary }]}
+                  numberOfLines={2}
+                >
+                  {c.description}
+                </Text>
+              )}
+              {c.creator_name && (
+                <Text
+                  style={[styles.cardCreator, { color: theme.textSecondary }]}
+                  numberOfLines={1}
+                >
+                  von {c.creator_name}
+                </Text>
+              )}
+            </View>
+            <Pressable
+              onPress={() => toggleLike(c.id)}
+              hitSlop={8}
+              style={styles.likeButton}
+              accessibilityLabel={liked ? 'Like entfernen' : 'Liken'}
+            >
+              <Ionicons
+                name={liked ? 'heart' : 'heart-outline'}
+                size={20}
+                color={liked ? colors.error[500] : theme.textSecondary}
+              />
+              {c.likes_count > 0 && (
+                <Text style={[styles.likeCount, { color: theme.textSecondary }]}>
+                  {c.likes_count}
+                </Text>
+              )}
+            </Pressable>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: spacing.large,
+  },
+  sectionTitle: {
+    ...typography.bodyBold,
+    fontSize: 17,
+    marginBottom: spacing.small,
+  },
+  card: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.small,
+    paddingHorizontal: spacing.small,
+    paddingVertical: spacing.small,
+    borderRadius: borderRadius.medium,
+    borderWidth: 1,
+    marginBottom: spacing.xsmall,
+  },
+  cardBody: {
+    flex: 1,
+    gap: 2,
+  },
+  cardTitle: {
+    ...typography.body,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  cardDescription: {
+    fontSize: 12,
+  },
+  cardCreator: {
+    fontSize: 11,
+  },
+  likeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: spacing.xsmall,
+  },
+  likeCount: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/hooks/notebook/useNotebookDiscovery.ts
+++ b/apps/mobile/hooks/notebook/useNotebookDiscovery.ts
@@ -1,0 +1,78 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export interface PublicCollection {
+  id: string;
+  name: string;
+  description: string | null;
+  likes_count: number;
+  creator_name: string | null;
+  audience: 'de-DE' | 'de-AT' | null;
+}
+
+/**
+ * "Von der Basis" discovery: the publicly published notebook collections plus the
+ * authenticated user's liked-ids, with like/unlike mutations. Mirrors web's
+ * VonDerBasisSection + usePublicNotebookCollections. The backend already applies the
+ * locale audience filter to the public listing; we additionally drop notebooks whose
+ * explicit audience differs from the viewer's locale as a belt-and-suspenders guard.
+ */
+export function useNotebookDiscovery(locale: 'de-DE' | 'de-AT') {
+  const client = getContractsClient().notebookCollections;
+  const qc = useQueryClient();
+  const likesKey = ['notebook', 'liked-ids'];
+
+  const publicCollections = useQuery({
+    queryKey: ['notebook', 'public-collections'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<PublicCollection[]> => {
+      const res = await client.listPublicCollections({});
+      if (res.status !== 200) return [];
+      return res.body.collections
+        .map((c) => ({
+          id: c.id,
+          name: c.name,
+          description: c.description ?? null,
+          likes_count: c.likes_count ?? 0,
+          creator_name: c.creator_name ?? null,
+          audience: c.audience ?? null,
+        }))
+        .filter((c) => !c.audience || c.audience === locale);
+    },
+  });
+
+  const likedIds = useQuery({
+    queryKey: likesKey,
+    staleTime: 60_000,
+    queryFn: async (): Promise<string[]> => {
+      const res = await client.listMyLikedCollections({});
+      return res.status === 200 ? res.body.liked_ids : [];
+    },
+  });
+
+  const like = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await client.likeCollection({ params: { id } });
+      if (res.status !== 200) throw new Error('Like fehlgeschlagen');
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: likesKey }),
+  });
+
+  const unlike = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await client.unlikeCollection({ params: { id } });
+      if (res.status !== 200) throw new Error('Like konnte nicht entfernt werden');
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: likesKey }),
+  });
+
+  const likedSet = new Set(likedIds.data ?? []);
+  const toggleLike = (id: string) => (likedSet.has(id) ? unlike.mutate(id) : like.mutate(id));
+
+  return {
+    collections: publicCollections.data ?? [],
+    isLoading: publicCollections.isLoading,
+    likedIds: likedSet,
+    toggleLike,
+  };
+}


### PR DESCRIPTION
Mobile's notebook gallery showed only system notebooks and the user's own — web's public **Von der Basis** discovery had no mobile equivalent. This adds a Von-der-Basis section listing publicly published notebooks (`notebookCollections.listPublicCollections`) with a native like/unlike heart (likes endpoints + liked-ids), filtered by the viewer's locale audience. Tapping a card opens the notebook in chat.

Third PR of the web↔mobile notebook parity plan (after #1037 detail+Recherche, #1038 sharing). Independent — based on master.