### PR TITLE
docs: icon link tiles for Landesverband agents

### DIFF
--- a/documentation/docs/landesverbaende/index.md
+++ b/documentation/docs/landesverbaende/index.md
@@ -2,6 +2,8 @@
 sidebar_position: 1
 ---
 
+import AgentTiles from '@site/src/components/AgentTiles';
+
 # Landesverband-Agents
 
 Der Grünerator hat für mehrere Landesverbände **eigene, regional getunte KI-Agents**. Sie schreiben nicht generisch-grün, sondern im konkreten Stil des jeweiligen Landesverbands — mit den richtigen Sprecher\*innen, den lokalen Themen und der typischen Tonalität. Im Hintergrund recherchieren sie automatisch in der Wissensdatenbank des Landesverbands (Pressemitteilungen, Beschlüsse, Wahlprogramme) und im Web.
@@ -13,14 +15,9 @@ Es gibt zwei Sorten von Landesverband-Agents:
 
 ## Abgedeckte Landesverbände
 
-| Landesverband          | Öffentlichkeitsarbeit           | Bürger\*innenanfragen | Wissensdatenbank                            |
-| ---------------------- | ------------------------------- | --------------------- | ------------------------------------------- |
-| Berlin                 | ✅ `/agents/gruene-berlin`      | ✅                    | `/notebooks/berlin` · `@berlin`             |
-| Hamburg                | ✅ `/agents/gruene-hamburg`     | ✅                    | `/notebooks/hamburg` · `@hamburg`           |
-| Mecklenburg-Vorpommern | ✅ `/agents/gruene-mv`          | ✅                    | `/notebooks/mecklenburg-vorpommern` · `@mv` |
-| Thüringen              | ✅ `/agents/gruene-thueringen`  | ✅                    | `/notebooks/thueringen` · `@thüringen`      |
-| Brandenburg            | ✅ `/agents/gruene-brandenburg` | ✅                    | `/notebooks/brandenburg` · `@brandenburg`   |
-| Bayern                 | ✅ `/agents/gruene-bayern`      | ✅                    | `/notebooks/bayern` · `@bayern`             |
+<AgentTiles />
+
+Jede Kachel verlinkt auf den Öffentlichkeitsarbeit-Agent des Landesverbands; darunter stehen seine Skill-Abkürzungen und ein Link zur Wissensdatenbank (Notebook). Jeder Landesverband hat außerdem einen **Bürger\*innenanfragen**-Agent (siehe unten).
 
 :::note Österreich
 Die Grünen Österreich sind kein Landesverband, sondern die Bundespartei — sie haben aber dieselben beiden Agent-Typen (Agent `/agents/gruene-oesterreich`, Wissensdatenbank `/notebooks/oesterreich` · `@at`). Diese Agents verwenden österreichisches Vokabular (Nationalrat, Klubobfrau\*Klubobmann, Klimaticket) und erscheinen nur für Nutzer\*innen mit österreichischer Einstellung.

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -25,7 +25,8 @@
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "react-icons": "^5.6.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.10.1",

--- a/documentation/src/components/AgentTiles/index.tsx
+++ b/documentation/src/components/AgentTiles/index.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { PiAnchor, PiBuildings, PiFlowerLight, PiMountains, PiTree, PiWaves } from 'react-icons/pi';
+import type { IconType } from 'react-icons';
+
+import styles from './styles.module.css';
+
+const APP = 'https://gruenerator.eu';
+
+type Landesverband = {
+  name: string;
+  Icon: IconType;
+  agentSlug: string;
+  notebookSlug: string;
+  mention: string;
+  presse: string;
+  insta: string;
+};
+
+const LANDESVERBAENDE: Landesverband[] = [
+  {
+    name: 'Berlin',
+    Icon: PiBuildings,
+    agentSlug: 'gruene-berlin',
+    notebookSlug: 'berlin',
+    mention: '@berlin',
+    presse: '/presse-berlin',
+    insta: '/insta-berlin',
+  },
+  {
+    name: 'Hamburg',
+    Icon: PiAnchor,
+    agentSlug: 'gruene-hamburg',
+    notebookSlug: 'hamburg',
+    mention: '@hamburg',
+    presse: '/presse-hamburg',
+    insta: '/insta-hamburg',
+  },
+  {
+    name: 'Mecklenburg-Vorpommern',
+    Icon: PiWaves,
+    agentSlug: 'gruene-mv',
+    notebookSlug: 'mecklenburg-vorpommern',
+    mention: '@mv',
+    presse: '/presse-mv',
+    insta: '/insta-mv',
+  },
+  {
+    name: 'Thüringen',
+    Icon: PiTree,
+    agentSlug: 'gruene-thueringen',
+    notebookSlug: 'thueringen',
+    mention: '@thüringen',
+    presse: '/presse-thueringen',
+    insta: '/insta-thueringen',
+  },
+  {
+    name: 'Brandenburg',
+    Icon: PiFlowerLight,
+    agentSlug: 'gruene-brandenburg',
+    notebookSlug: 'brandenburg',
+    mention: '@brandenburg',
+    presse: '/presse-brandenburg',
+    insta: '/insta-brandenburg',
+  },
+  {
+    name: 'Bayern',
+    Icon: PiMountains,
+    agentSlug: 'gruene-bayern',
+    notebookSlug: 'bayern',
+    mention: '@bayern',
+    presse: '/presse-bayern',
+    insta: '/insta-bayern',
+  },
+];
+
+export default function AgentTiles(): React.JSX.Element {
+  return (
+    <div className={styles.grid}>
+      {LANDESVERBAENDE.map((lv) => {
+        const Icon = lv.Icon;
+        return (
+          <div key={lv.agentSlug} className={styles.tile}>
+            <div className={styles.head}>
+              <span className={styles.icon} aria-hidden="true">
+                <Icon />
+              </span>
+              <a className={styles.name} href={`${APP}/agents/${lv.agentSlug}`}>
+                {lv.name}
+              </a>
+            </div>
+            <p className={styles.kinds}>Öffentlichkeitsarbeit · Bürger*innenanfragen</p>
+            <div className={styles.chips}>
+              <span className={styles.chip}>{lv.presse}</span>
+              <span className={styles.chip}>{lv.insta}</span>
+            </div>
+            <a className={styles.notebook} href={`${APP}/notebooks/${lv.notebookSlug}`}>
+              Notebook {lv.mention}
+            </a>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/documentation/src/components/AgentTiles/styles.module.css
+++ b/documentation/src/components/AgentTiles/styles.module.css
@@ -1,0 +1,86 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.1rem 1.15rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+}
+
+.tile:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: var(--ifm-color-primary-lightest);
+  color: var(--ifm-color-primary);
+  font-size: 1.2rem;
+}
+
+.name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--ifm-heading-color);
+  text-decoration: none;
+}
+
+.name:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.kinds {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  padding: 0.12rem 0.5rem;
+  border-radius: 999px;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+  white-space: nowrap;
+}
+
+.notebook {
+  margin-top: auto;
+  font-size: 0.82rem;
+  font-weight: 500;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1041,6 +1041,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-icons:
+        specifier: ^5.6.0
+        version: 5.6.0(react@19.2.4)
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.10.1
@@ -45299,6 +45302,10 @@ snapshots:
   react-hook-form@7.75.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  react-icons@5.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-icons@5.6.0(react@19.2.6):
     dependencies:


### PR DESCRIPTION
Follow-up to #1040 and #1041. Turns the flat coverage table on the Landesverband-Agents page into icon-based link tiles — one per LV, using the same Phosphor icons (react-icons) the app's skill picker uses, each linking to its Öffentlichkeitsarbeit agent on gruenerator.eu with skill chips and a notebook link.

Adds `react-icons@^5.6.0` to the docs workspace (already used elsewhere in the monorepo; lockfile updated). The component follows the existing `SignalMessage` MDX-in-docs pattern and uses Docusaurus theme tokens for light/dark.