### PR TITLE
feat(api): plain-binary subtitler upload endpoint for non-tus clients

### DIFF
--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -33,7 +33,7 @@ import { createAIService, type AIService } from './services/ai/aiService.js';
 import { startUploadsCleanup } from './services/cleanup/uploadsCleanupService.js';
 import { startNotificationCleanup } from './services/notifications/notificationCleanupService.js';
 import { startCleanupScheduler as startExportCleanup } from './services/subtitler/exportCleanupService.js';
-import { tusServer } from './services/subtitler/tusService.js';
+import { tusServer, handleBinaryUpload } from './services/subtitler/tusService.js';
 import { getCorsOrigins, PRIMARY_DOMAIN } from './utils/domainUtils.js';
 import { createLogger } from './utils/logger.js';
 import redisClient, { ensureConnected, checkRedisHealth } from './utils/redis/client.js';
@@ -287,6 +287,13 @@ async function startWorker(): Promise<void> {
   });
   app.all(audioUploadPath + '/*splat', (req: Request, res: Response) => {
     void tusServer.handle(req, res);
+  });
+
+  // Plain binary upload for non-TUS clients (mobile uses expo-file-system's
+  // native uploader). Registered here — before compression and the body
+  // parsers — so `req` stays the raw byte stream and writes straight to disk.
+  app.post('/api/subtitler/upload-binary', (req: Request, res: Response) => {
+    void handleBinaryUpload(req, res);
   });
 
   // Compression middleware

--- a/apps/api/services/subtitler/tusService.ts
+++ b/apps/api/services/subtitler/tusService.ts
@@ -4,12 +4,17 @@
  * Resumable file uploads using TUS protocol with intelligent cleanup.
  */
 
+import { randomBytes } from 'crypto';
+import { createWriteStream } from 'fs';
 import fs from 'fs/promises';
 import path, { dirname } from 'path';
+import { Transform } from 'stream';
+import { pipeline } from 'stream/promises';
 import { fileURLToPath } from 'url';
 
 import { FileStore } from '@tus/file-store';
 import { Server } from '@tus/server';
+import { type Request, type Response } from 'express';
 
 import { createLogger } from '../../utils/logger.js';
 
@@ -354,6 +359,80 @@ async function getOriginalFilename(uploadId: string): Promise<string> {
   return status.metadata?.metadata?.filename || `video_${uploadId}.mp4`;
 }
 
+const MAX_UPLOAD_SIZE = 500 * 1024 * 1024;
+
+/**
+ * Plain binary upload endpoint for clients that can't speak the TUS protocol.
+ * The mobile app streams the picked video natively via expo-file-system, which
+ * only supports binary/multipart uploads — not TUS's create + PATCH-offset loop.
+ * The bytes land at the same `tus-temp/<uploadId>` path the rest of the subtitler
+ * pipeline (process-auto / projects / export) already reads, alongside a
+ * TUS-compatible `.json` sidecar so `getUploadStatus` and cleanup treat it like
+ * any other upload (it reads `offset`/`size`/`metadata.filename`, and considers
+ * `offset >= size` complete). Mounted before the body parsers so `req` is the
+ * raw byte stream; the file streams straight to disk (no full-file buffering).
+ */
+async function handleBinaryUpload(req: Request, res: Response): Promise<void> {
+  const declaredSize = Number(req.headers['content-length'] ?? 0);
+  if (declaredSize > MAX_UPLOAD_SIZE) {
+    res.status(413).json({ error: 'Video ist zu groß. Maximal 500MB erlaubt.' });
+    return;
+  }
+
+  const uploadId = randomBytes(16).toString('hex');
+  const filenameHeader = req.headers['x-filename'];
+  const filename =
+    typeof filenameHeader === 'string' && filenameHeader.length > 0
+      ? filenameHeader
+      : `video_${uploadId}.mp4`;
+  const videoPath = getFilePathFromUploadId(uploadId);
+
+  let bytesWritten = 0;
+  const counter = new Transform({
+    transform(chunk: Buffer, _encoding, callback) {
+      bytesWritten += chunk.length;
+      if (bytesWritten > MAX_UPLOAD_SIZE) {
+        callback(new Error('UPLOAD_TOO_LARGE'));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+
+  try {
+    await pipeline(req, counter, createWriteStream(videoPath));
+  } catch (err: unknown) {
+    await fs.unlink(videoPath).catch(() => {});
+    if (err instanceof Error && err.message === 'UPLOAD_TOO_LARGE') {
+      if (!res.headersSent) {
+        res.status(413).json({ error: 'Video ist zu groß. Maximal 500MB erlaubt.' });
+      }
+      return;
+    }
+    log.error(
+      `Binary upload failed for ${uploadId}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Upload fehlgeschlagen' });
+    }
+    return;
+  }
+
+  const sidecar = {
+    id: uploadId,
+    size: bytesWritten,
+    offset: bytesWritten,
+    metadata: { filename, filetype: 'video/mp4' },
+    creation_date: new Date().toISOString(),
+    storage: { type: 'file', path: uploadId },
+  };
+  await fs.writeFile(`${videoPath}.json`, JSON.stringify(sidecar), 'utf8');
+
+  activeUploads.add(uploadId);
+  log.debug(`Binary upload complete: ${uploadId} (${bytesWritten} bytes)`);
+  res.status(201).json({ uploadId });
+}
+
 if (!isInitialized) {
   void intelligentCleanup();
 
@@ -382,6 +461,7 @@ if (!isInitialized) {
 
 export {
   tusServer,
+  handleBinaryUpload,
   getFilePathFromUploadId,
   checkFileExists,
   cleanupTusUploads,


### PR DESCRIPTION
## Why

The mobile reel uploader is being migrated off the JS `tus-js-client` to expo-file-system's **native** uploader. Under Expo SDK 56 the tus client is no longer viable in React Native — reading a `file://` URI via `XMLHttpRequest` crashes on the new architecture, and every workaround either OOMs (`File.slice()` loads the whole file into the JS heap) or crawls (quadratic stream buffering). The native uploader streams straight from disk, but only speaks plain **binary/multipart** — not the TUS protocol (Creation `POST` + offset `PATCH` loop) that `/api/subtitler/upload` requires.

This adds an **additive** `POST /api/subtitler/upload-binary` so non-tus clients can upload. It streams the raw request body straight to the same `tus-temp/<uploadId>` store the rest of the subtitler pipeline (`process-auto` / `projects` / `export`) already reads — the pipeline is path-keyed, not protocol-keyed — and writes a tus-compatible `.json` sidecar so `getUploadStatus` and cleanup treat it like any other upload.

The web tus flow is **untouched** (different route, same temp store), so this can't regress existing uploads.

Needed on prod before the mobile native-upload change can be tested on-device (mobile points at the production API).