### PR TITLE
fix(offboarding): surface Grüne API fetch failures instead of reporting zero users

### DIFF
--- a/apps/api/services/admin/OffboardingService.ts
+++ b/apps/api/services/admin/OffboardingService.ts
@@ -47,24 +47,20 @@ export class OffboardingService {
   async *fetchOffboardingUsers(): AsyncGenerator<OffboardingUser> {
     let after: string | null = null;
 
+    // A fetch failure must NOT be swallowed: silently breaking here makes a failed
+    // Grüne API call indistinguishable from an empty offboarding queue, so the run
+    // reports success with zero users processed. Let the error propagate (the client
+    // already logs it) so runOffboarding/dryRunOffboarding fail loudly instead.
     while (true) {
-      try {
-        const response = await this.apiClient.findUsersToOffboard(this.config.REQUEST_LIMIT, after);
-        const users = response.data || [];
+      const response = await this.apiClient.findUsersToOffboard(this.config.REQUEST_LIMIT, after);
+      const users = response.data || [];
 
-        for (const user of users) {
-          yield user;
-        }
+      for (const user of users) {
+        yield user;
+      }
 
-        after = response.meta?.cursorNext || null;
-        if (!after) {
-          break;
-        }
-      } catch (error: unknown) {
-        log.error(
-          'Failed to fetch users from API:',
-          error instanceof Error ? error.message : String(error)
-        );
+      after = response.meta?.cursorNext || null;
+      if (!after) {
         break;
       }
     }


### PR DESCRIPTION
When the daily offboarding cron ran a dry-run against prod (after `ADMIN_TOKEN` was finally provisioned), it returned `wouldProcess: 0, notFound: 0, failed: 0, success: true` in 123ms — far too fast and too clean to be real.

Root cause: `fetchOffboardingUsers()` wrapped the Grüne API call in a try/catch that logged and `break`ed on any error, yielding zero users. A failed fetch (expired API key, 401/403, network) was therefore **indistinguishable from a genuinely empty offboarding queue** — both produce a clean `success: true` with zero counts. For a GDPR offboarding job, silently doing nothing on an auth failure is the dangerous failure mode.

The API client (`GrueneApiClient.findUsersToOffboard`) already logs and rethrows, so the swallow was redundant on top of harmful. Letting the error propagate makes the run fail loudly: the controller returns HTTP 500 and the workflow goes red, instead of a false green with 0 users.

Does not change behavior for a real empty queue (still 0, still success). Only changes the failure case.