### PR TITLE
chore(mobile): bump version to 1.2.0 for SDK 56 release

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Grünerator",
     "slug": "gruenerator",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -24,6 +24,10 @@
         "serviceAccountKeyPath": "./google-service-account.json",
         "track": "internal",
         "releaseStatus": "completed"
+      },
+      "ios": {
+        "ascAppId": "6740809955",
+        "appleTeamId": "P74W7SGX8R"
       }
     }
   }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -66,7 +66,7 @@
     "expo-router": "~56.2.5",
     "expo-secure-store": "~56.0.4",
     "expo-sharing": "~56.0.12",
-    "expo-speech-recognition": "^3.1.3",
+    "expo-speech-recognition": "~56.0.0",
     "expo-splash-screen": "^56.0.9",
     "expo-status-bar": "~56.0.4",
     "expo-system-ui": "~56.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,8 +577,8 @@ importers:
         specifier: ~56.0.12
         version: 56.0.12(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-speech-recognition:
-        specifier: ^3.1.3
-        version: 3.1.3(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        specifier: ~56.0.0
+        version: 56.0.0(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       expo-splash-screen:
         specifier: ^56.0.9
         version: 56.0.9(expo@56.0.3)(typescript@6.0.3)
@@ -13663,8 +13663,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-speech-recognition@3.1.3:
-    resolution: {integrity: sha512-vluXqggfY2AJcazYITvnV6YSE2rVe5SId5TpdjMC/m6JPUgHCOODrcHJtAQF6OUYl4f2T7oZSceGw6fJCC86Xw==}
+  expo-speech-recognition@56.0.0:
+    resolution: {integrity: sha512-spA6HqnA/rgwMNS5YmFktmzly7f46kGOv3tXZ2f0Xfh7x9pAsmXyG3YtPtB9sHGbW7RmUSjbMGEzsvCak2Q4sA==}
     peerDependencies:
       expo: '*'
       react: '*'
@@ -38690,7 +38690,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-speech-recognition@3.1.3(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  expo-speech-recognition@56.0.0(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       expo: 56.0.3(@babel/core@7.29.0)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.11)(expo-router@56.2.5)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3


### PR DESCRIPTION
Marks the first SDK 56 production release of the mobile app. All prior store builds (Android versionCode 23, iOS build 3) were SDK 55 on marketing version 1.1.0; this bump distinguishes the SDK 56 + latest mobile feature work (chat tool-UI, image-studio UX, gallery/share fixes from #1047) now going to Play internal + TestFlight.

EAS still auto-increments build numbers (appVersionSource: remote); only the marketing version changes here.