### PR TITLE
chore(mobile): declare iOS export compliance exemption

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -11,7 +11,8 @@
       "supportsTablet": true,
       "bundleIdentifier": "de.gruenerator.app",
       "infoPlist": {
-        "CFBundleAllowMixedLocalizations": true
+        "CFBundleAllowMixedLocalizations": true,
+        "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {


### PR DESCRIPTION
iOS TestFlight builds upload fine but never trigger the "ready to test" email because `ITSAppUsesNonExemptEncryption` is unset — Apple holds each build at "Missing Compliance" until the export-compliance question is answered by hand.

The app uses only standard/exempt encryption (HTTPS + OS crypto + auth), so declaring the exemption in Info.plist lets future builds auto-clear compliance and notify. Does not affect already-uploaded build 5 (answer that one's prompt once in App Store Connect).