### PR TITLE
feat: conversational agent creator (default entry to build a custom agent)

### DIFF
--- a/apps/api/routes/userAgents/userAgentsContractRouter.ts
+++ b/apps/api/routes/userAgents/userAgentsContractRouter.ts
@@ -18,6 +18,8 @@ import { userAgentsContract, type AgentFewShotExample } from '@gruenerator/contr
 import { isUserSelectableTool } from '@gruenerator/shared/agents';
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
+import { draftAgentSpec } from '../../services/userAgents/agentDraftService.js';
 import {
   createUserAgent,
   CUSTOM_GENERATOR_AGENT_PREFIX,
@@ -135,6 +137,57 @@ export const userAgentsContractRouter = s.router(userAgentsContract, {
         };
       }
       return { status: 500 as const, body: { success: false, message: err.message } };
+    }
+  },
+
+  draft: async (args) => {
+    try {
+      const userId = getAuthedUser(args.req).id;
+      const { threadId } = args.body;
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const threads = await postgres.query<{ user_id: string }>(
+        `SELECT user_id FROM chat_threads WHERE id = $1 LIMIT 1`,
+        [threadId]
+      );
+      if (threads.length === 0) {
+        return {
+          status: 404 as const,
+          body: { success: false, message: 'Thread nicht gefunden.' },
+        };
+      }
+      if (threads[0].user_id !== userId) {
+        return { status: 403 as const, body: { success: false, message: 'Keine Berechtigung.' } };
+      }
+
+      const rows = await postgres.query<{ role: string; content: unknown }>(
+        `SELECT role, content FROM chat_messages
+         WHERE thread_id = $1 AND role IN ('user', 'assistant')
+         ORDER BY created_at ASC
+         LIMIT 60`,
+        [threadId]
+      );
+      const messages = rows
+        .map((r) => ({ role: r.role, content: String(r.content ?? '').trim() }))
+        .filter((m) => m.content.length > 0);
+
+      if (messages.length === 0) {
+        return {
+          status: 400 as const,
+          body: { success: false, message: 'Noch keine Unterhaltung zum Auswerten vorhanden.' },
+        };
+      }
+
+      const spec = await draftAgentSpec(messages);
+      return { status: 200 as const, body: { success: true, spec } };
+    } catch (error) {
+      const err = error as Error;
+      log.error('[userAgentsContract.draft] Error:', err);
+      return {
+        status: 500 as const,
+        body: { success: false, message: 'Entwurf konnte nicht erstellt werden.' },
+      };
     }
   },
 

--- a/apps/api/services/userAgents/agentDraftService.ts
+++ b/apps/api/services/userAgents/agentDraftService.ts
@@ -1,0 +1,112 @@
+/**
+ * Agent-draft synthesis for the conversational creator.
+ *
+ * Turns the creator conversation into a validated agent spec via a single
+ * Mistral structured-generation call. The closed sets (tools, skills) are
+ * enforced here against the shared catalogs — the contract keeps them as free
+ * arrays since `@gruenerator/contracts` can't import shared.
+ */
+
+import { type DraftedAgentSpec } from '@gruenerator/contracts';
+import {
+  SKILLS,
+  USER_SELECTABLE_TOOLS,
+  DEFAULT_USER_AGENT_TOOLS,
+} from '@gruenerator/shared/agents';
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+import { createLogger } from '../../utils/logger.js';
+import { getModel } from '../ai/providers.js';
+
+const log = createLogger('AgentDraftService');
+
+const TOOL_KEYS = new Set<string>(USER_SELECTABLE_TOOLS.map((t) => t.key));
+const SKILL_MENTIONS = new Set<string>(SKILLS.map((s) => s.mention));
+const HEX_RE = /^#[0-9A-Fa-f]{6}$/;
+const DEFAULT_COLOR = '#316049';
+
+const TOOL_CATALOG = USER_SELECTABLE_TOOLS.map(
+  (t) => `- ${t.key}: ${t.label} — ${t.description}`
+).join('\n');
+const SKILL_CATALOG = SKILLS.map((s) => `- ${s.mention}: ${s.title}`).join('\n');
+
+// LLM output schema. `enabledTools`/`skillMentions` are free arrays here and
+// filtered against the catalogs after generation — strict enums would make the
+// call fail on a single near-miss value.
+const DraftSchema = z.object({
+  title: z.string().describe('Kurzer Anzeigename, z.B. "Pressestelle Kreisverband"'),
+  description: z.string().describe('Ein bis zwei Sätze: was der*die Agent*in tut'),
+  systemRole: z
+    .string()
+    .describe(
+      'Ausführlicher System-Prompt für den*die Agent*in: Rolle, Aufgabe, Ton, Arbeitsweise. Du-Form, Genderstern (*innen).'
+    ),
+  avatar: z.string().describe('Ein einzelnes passendes Emoji'),
+  backgroundColor: z.string().describe('Hex-Farbe wie #316049'),
+  enabledTools: z.array(z.string()).describe('Werkzeug-Schlüssel, ausschließlich aus dem Katalog'),
+  skillMentions: z
+    .array(z.string())
+    .describe('Optionale Skill-Mentions als Schnellstarts, ausschließlich aus dem Katalog'),
+  locale: z.enum(['de-DE', 'de-AT']).describe('Region: Deutschland oder Österreich'),
+  openingMessage: z.string().describe('Begrüßung, die der*die Agent*in beim Start zeigt'),
+  openingQuestions: z.array(z.string()).max(4).describe('Bis zu vier Beispiel-Startfragen'),
+});
+
+const SYSTEM_PROMPT = `Du bist der Spezifikations-Generator des Grünerator Agent-Creators. Aus dem folgenden Gespräch zwischen einer Nutzer*in und dem Creator erstellst du die finale Konfiguration für eine*n neue*n KI-Agent*in.
+
+Regeln:
+- Schreibe alle nutzersichtbaren Texte auf Deutsch, in Du-Form und mit Genderstern (*innen).
+- Der systemRole ist der wichtigste Teil: formuliere eine klare Rolle, Aufgabe, Tonalität und Arbeitsweise, passend zum besprochenen Zweck. Schreibe ihn so, als würdest du den*die Agent*in direkt instruieren ("Du bist ...").
+- enabledTools: Wähle NUR Schlüssel aus diesem Katalog, passend zum Zweck:
+${TOOL_CATALOG}
+- skillMentions: Optionale Schnellstart-Vorlagen, NUR aus diesem Katalog (leer lassen, wenn nichts passt):
+${SKILL_CATALOG}
+- locale: 'de-AT' nur, wenn explizit Österreich besprochen wurde, sonst 'de-DE'.
+- Erfinde keine Werte außerhalb der Kataloge.`;
+
+function buildTranscript(messages: ReadonlyArray<{ role: string; content: string }>): string {
+  return messages
+    .map((m) => `${m.role === 'user' ? 'Nutzer*in' : 'Creator'}: ${m.content}`)
+    .join('\n\n');
+}
+
+/** Synthesize a validated agent spec from the creator conversation. */
+export async function draftAgentSpec(
+  messages: ReadonlyArray<{ role: string; content: string }>
+): Promise<DraftedAgentSpec> {
+  const model = getModel('mistral');
+
+  const result = await generateObject({
+    model,
+    schema: DraftSchema,
+    system: SYSTEM_PROMPT,
+    prompt: `## Gespräch\n\n${buildTranscript(messages)}\n\nErstelle daraus die Agent*innen-Konfiguration.`,
+    maxOutputTokens: 1800,
+    temperature: 0.4,
+    abortSignal: AbortSignal.timeout(40000),
+  });
+
+  const draft = result.object;
+
+  const enabledTools = draft.enabledTools.filter((t) => TOOL_KEYS.has(t));
+  const skillMentions = draft.skillMentions.filter((m) => SKILL_MENTIONS.has(m));
+  const avatar = draft.avatar.trim().slice(0, 8) || '🤖';
+
+  log.info(
+    `[draftAgentSpec] "${draft.title}" tools=[${enabledTools.join(',')}] skills=[${skillMentions.join(',')}] locale=${draft.locale}`
+  );
+
+  return {
+    title: draft.title.trim().slice(0, 100),
+    description: draft.description.trim().slice(0, 500),
+    systemRole: draft.systemRole.trim(),
+    avatar,
+    backgroundColor: HEX_RE.test(draft.backgroundColor) ? draft.backgroundColor : DEFAULT_COLOR,
+    enabledTools: enabledTools.length > 0 ? enabledTools : [...DEFAULT_USER_AGENT_TOOLS],
+    skillMentions,
+    locale: draft.locale,
+    openingMessage: draft.openingMessage.trim(),
+    openingQuestions: draft.openingQuestions.slice(0, 4),
+  };
+}

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -581,25 +581,17 @@ const SidebarAgents = memo(function SidebarAgents({
             </li>
           )}
 
-          {/*
-            "Neue*r Agent*in" sidebar CTA — disabled until the agent-builder
-            feature ships. Route + SkillsPage CTA remain dev-only via Vite
-            (`devOnly` flag in routes.ts; `import.meta.env.DEV` in SkillsPage).
-          {showCreateAgentCta && (
-            <li>
-              <button
-                type="button"
-                onClick={() => onLinkClick('/agents/new', 'Neue*r Agent*in')}
-                className={cn(menuLinkClass(false), 'text-primary-600 dark:text-primary-300')}
-              >
-                <span className="shrink-0 w-6 h-6 flex items-center justify-center text-base">
-                  +
-                </span>
-                <span className={titleClass}>Neue*r Agent*in</span>
-              </button>
-            </li>
-          )}
-          */}
+          {/* Entry point to the conversational agent creator (/agents/new). */}
+          <li>
+            <button
+              type="button"
+              onClick={() => onLinkClick('/agents/new', 'Neue*r Agent*in')}
+              className={cn(menuLinkClass(false), 'text-primary-600 dark:text-primary-300')}
+            >
+              <span className="shrink-0 w-6 h-6 flex items-center justify-center text-base">+</span>
+              <span className={titleClass}>Neue*r Agent*in</span>
+            </button>
+          </li>
         </ul>
       )}
     </div>

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -195,6 +195,7 @@ const SitesLoginPage = lazy(() => import('../features/sites/SitesLoginPage'));
 const SitesDemoPage = lazy(() => import('../features/sites/SitesDemoPage'));
 const SitesEditPage = lazy(() => import('../features/sites/SitesEditPage'));
 const AgentBuilderPage = lazy(() => import('../features/agents/AgentBuilderPage'));
+const AgentCreatorPage = lazy(() => import('../features/agents/AgentCreatorPage'));
 const SkillsPage = lazy(() => import('../features/skills/SkillsPage'));
 
 /**
@@ -234,19 +235,16 @@ const standardRoutes: RouteConfig[] = [
   // Unified Text Generator route (wildcard for path-based tab navigation)
   { path: '/texte/*', component: GrueneratorenBundle.Texte, withForm: true },
   { path: '/workplace', component: WorkplacePage },
-  // Agent builder/editor. Dev-only until the feature ships — gated via the
-  // existing `devOnly` filter at the bottom of this file (Vite tree-shakes the
-  // routes in prod). The list/overview lives on the unified Library page at
-  // /skills.
+  // Conversational agent creator (default entry) + form editor. The list/
+  // overview lives on the unified Library page at /skills.
   {
     path: '/agents/new',
-    component: AgentBuilderPage,
-    devOnly: true,
+    component: AgentCreatorPage,
+    layoutMode: 'sidebarOnly',
   },
   {
     path: '/agents/:identifier/edit',
     component: AgentBuilderPage,
-    devOnly: true,
   },
   // Chat with a specific system agent at /agents/<slug>. Slug is the agent
   // identifier with the `gruenerator-` prefix stripped (see `getAgentSlug`

--- a/apps/web/src/features/agents/AgentCreatorPage.tsx
+++ b/apps/web/src/features/agents/AgentCreatorPage.tsx
@@ -1,0 +1,213 @@
+import { GrueneratorThread, useAgentStore } from '@gruenerator/chat';
+import { type DraftedAgentSpec } from '@gruenerator/contracts';
+import { getAgentSlug, USER_SELECTABLE_TOOLS } from '@gruenerator/shared/agents';
+import { slugifyName, generateSlugSuffix } from '@gruenerator/shared/utils';
+import { useCallback, useEffect, useState } from 'react';
+import { PiArrowRight, PiPencilSimple, PiSparkle, PiX } from 'react-icons/pi';
+import { useNavigate } from 'react-router-dom';
+
+import { useCreateUserAgent, useDraftAgent, type UserAgentInput } from './api';
+
+import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired';
+import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
+import { useFirstName } from '@/hooks/useFirstName';
+import { useAuthStore } from '@/stores/authStore';
+
+const CREATOR_AGENT_ID = 'gruenerator-agent-creator';
+
+const TOOL_LABELS = new Map(USER_SELECTABLE_TOOLS.map((t) => [t.key, t.label]));
+
+/** Map a synthesized draft into the create payload. Identifier, model/provider
+ *  defaults and the notebook binding are filled in here (the LLM doesn't pick
+ *  them); the notebook can be added later via the editor. */
+function specToInput(spec: DraftedAgentSpec): UserAgentInput {
+  return {
+    identifier: `${slugifyName(spec.title, 'agent')}-${generateSlugSuffix()}`,
+    title: spec.title,
+    description: spec.description,
+    systemRole: spec.systemRole,
+    avatar: spec.avatar,
+    backgroundColor: spec.backgroundColor,
+    tags: [],
+    model: 'mistral-large-latest',
+    provider: 'mistral',
+    params: { max_tokens: 3000, temperature: 0.6 },
+    openingMessage: spec.openingMessage,
+    openingQuestions: spec.openingQuestions,
+    locale: spec.locale,
+    author: 'Eigene*r Agent*in',
+    enabledTools: spec.enabledTools,
+    skillMentions: spec.skillMentions,
+  };
+}
+
+function DraftPanel({ spec, onDismiss }: { spec: DraftedAgentSpec; onDismiss: () => void }) {
+  const navigate = useNavigate();
+  const createMut = useCreateUserAgent();
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useCallback(
+    async (destination: 'chat' | 'edit') => {
+      setError(null);
+      try {
+        const agent = await createMut.mutateAsync(specToInput(spec));
+        if (destination === 'edit') {
+          void navigate(`/agents/${agent.identifier}/edit`);
+        } else {
+          void navigate(`/agents/${getAgentSlug(agent.identifier)}`);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Anlegen fehlgeschlagen.');
+      }
+    },
+    [createMut, navigate, spec]
+  );
+
+  const toolLabels = spec.enabledTools.map((k) => TOOL_LABELS.get(k) ?? k);
+
+  return (
+    <div className="border-t border-grey-200 bg-background-alt p-md dark:border-grey-700">
+      <div className="mx-auto flex max-w-2xl flex-col gap-sm">
+        <div className="flex items-start gap-sm">
+          <span
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl"
+            style={{ backgroundColor: spec.backgroundColor }}
+          >
+            {spec.avatar}
+          </span>
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-base font-semibold text-foreground-heading">
+              {spec.title}
+            </h2>
+            <p className="text-sm text-foreground-muted">{spec.description}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Entwurf verwerfen"
+            className="shrink-0 rounded-md p-1.5 text-grey-500 hover:bg-hover-alt"
+          >
+            <PiX className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-foreground-muted">
+          {toolLabels.length > 0 && (
+            <span>
+              Fähigkeiten: <span className="text-foreground">{toolLabels.join(', ')}</span>
+            </span>
+          )}
+          {spec.skillMentions.length > 0 && (
+            <span>
+              Skills:{' '}
+              <span className="text-foreground">
+                {spec.skillMentions.map((m) => `@${m}`).join(', ')}
+              </span>
+            </span>
+          )}
+          <span>
+            Region: <span className="text-foreground">{spec.locale}</span>
+          </span>
+        </div>
+
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        <div className="flex items-center gap-sm">
+          <button
+            type="button"
+            onClick={() => void create('chat')}
+            disabled={createMut.isPending}
+            className="inline-flex items-center gap-1.5 rounded-full bg-primary-600 px-md py-sm text-sm text-white hover:bg-primary-700 disabled:opacity-60"
+          >
+            <PiSparkle className="h-4 w-4" />
+            Agent*in erstellen
+            <PiArrowRight className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => void create('edit')}
+            disabled={createMut.isPending}
+            className="inline-flex items-center gap-1.5 rounded-full border border-grey-300 px-md py-sm text-sm hover:bg-hover-alt disabled:opacity-60 dark:border-grey-700"
+          >
+            <PiPencilSimple className="h-4 w-4" />
+            Anpassen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AgentCreatorPage() {
+  const navigate = useNavigate();
+  const firstName = useFirstName();
+  const userLocale = useAuthStore((s) => s.locale) ?? 'de-DE';
+  const currentThreadId = useAgentStore((s) => s.currentThreadId);
+  const draftMut = useDraftAgent();
+  const [draft, setDraft] = useState<DraftedAgentSpec | null>(null);
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  useDocumentTitle('Neue*r Agent*in');
+
+  useEffect(() => {
+    const store = useAgentStore.getState();
+    store.setSelectedAgent(CREATOR_AGENT_ID);
+    store.setChatViewMode('thread');
+  }, []);
+
+  const handleNavigate = useCallback((path: string) => navigate(path), [navigate]);
+
+  const handleDraft = useCallback(async () => {
+    if (!currentThreadId) return;
+    setDraftError(null);
+    try {
+      const spec = await draftMut.mutateAsync(currentThreadId);
+      setDraft(spec);
+    } catch (err) {
+      setDraftError(err instanceof Error ? err.message : 'Entwurf fehlgeschlagen.');
+    }
+  }, [currentThreadId, draftMut]);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <main className="flex min-h-0 flex-1 flex-col">
+        <GrueneratorThread
+          onNavigate={handleNavigate}
+          firstName={firstName}
+          requireProfileHydration
+          userLocale={userLocale}
+        />
+      </main>
+
+      {draft ? (
+        <DraftPanel spec={draft} onDismiss={() => setDraft(null)} />
+      ) : (
+        <div className="border-t border-grey-200 bg-background p-sm dark:border-grey-700">
+          <div className="mx-auto flex max-w-2xl items-center justify-between gap-sm">
+            <p className="text-xs text-foreground-muted">
+              Wenn ihr genug besprochen habt, erstelle ich daraus einen Entwurf.
+            </p>
+            <div className="flex flex-col items-end gap-1">
+              <button
+                type="button"
+                onClick={() => void handleDraft()}
+                disabled={!currentThreadId || draftMut.isPending}
+                className="inline-flex items-center gap-1.5 rounded-full bg-primary-600 px-md py-sm text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+                title={!currentThreadId ? 'Starte zuerst die Unterhaltung' : undefined}
+              >
+                <PiSparkle className="h-4 w-4" />
+                {draftMut.isPending ? 'Erstelle Entwurf…' : 'Entwurf erstellen'}
+              </button>
+              {draftError && <span className="text-xs text-red-600">{draftError}</span>}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default withAuthRequired(AgentCreatorPage, {
+  title: 'Neue*r Agent*in',
+  fallback: <div className="flex min-h-0 flex-1 bg-background" />,
+});

--- a/apps/web/src/features/agents/api.ts
+++ b/apps/web/src/features/agents/api.ts
@@ -1,4 +1,8 @@
-import { type CreateUserAgentBody, type UpdateUserAgentBody } from '@gruenerator/contracts';
+import {
+  type CreateUserAgentBody,
+  type UpdateUserAgentBody,
+  type DraftedAgentSpec,
+} from '@gruenerator/contracts';
 import { SYSTEM_AGENTS, type Agent } from '@gruenerator/shared/agents';
 import { getContractsClient } from '@gruenerator/shared/api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -63,6 +67,21 @@ export function useCreateUserAgent() {
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: KEY });
+    },
+  });
+}
+
+/**
+ * Synthesize an agent spec from the creator conversation (the thread the user
+ * is chatting in). The backend loads the thread's messages and runs a Mistral
+ * structured-generation pass; we return the validated spec for the draft panel.
+ */
+export function useDraftAgent() {
+  return useMutation({
+    mutationFn: async (threadId: string): Promise<DraftedAgentSpec> => {
+      const res = await getContractsClient().userAgents.draft({ body: { threadId } });
+      if (res.status === 200) return res.body.spec;
+      throw new Error(readError(res.body).message);
     },
   });
 }

--- a/packages/chat/src/lib/resolveAutoModel.ts
+++ b/packages/chat/src/lib/resolveAutoModel.ts
@@ -25,6 +25,9 @@ export interface AutoResolverContext {
 
 export function resolveAutoModel(ctx: AutoResolverContext): TextModelId {
   if (ctx.threadMode === 'notebook') return 'mistral-medium-3.5';
+  // Mistral for instruction-heavy agents (e.g. the agent creator) so "auto"
+  // lands on a strong instruction-follower rather than the GPT-OSS default.
+  if (ctx.agent?.autoRoutingHint === 'precise') return 'mistral-medium-3.5';
   if (ctx.agent?.autoRoutingHint === 'creative') return 'gemma-litellm';
   return 'litellm';
 }

--- a/packages/contracts/src/contracts/userAgentsContract.ts
+++ b/packages/contracts/src/contracts/userAgentsContract.ts
@@ -15,9 +15,11 @@ import { z } from 'zod';
 import {
   createUserAgentBodySchema,
   updateUserAgentBodySchema,
+  draftAgentBodySchema,
   userAgentsListResponseSchema,
   userAgentItemResponseSchema,
   userAgentDeleteResponseSchema,
+  userAgentDraftResponseSchema,
   userAgentErrorResponseSchema,
 } from '../schemas/userAgents.js';
 
@@ -50,6 +52,22 @@ export const userAgentsContract = c.router(
         500: userAgentErrorResponseSchema,
       },
       summary: 'Create a user agent',
+    },
+
+    /** POST /api/user-agents/draft — synthesize an agent spec from a creator conversation. */
+    draft: {
+      method: 'POST',
+      path: '/api/user-agents/draft',
+      body: draftAgentBodySchema,
+      responses: {
+        200: userAgentDraftResponseSchema,
+        400: userAgentErrorResponseSchema,
+        401: userAgentErrorResponseSchema,
+        403: userAgentErrorResponseSchema,
+        404: userAgentErrorResponseSchema,
+        500: userAgentErrorResponseSchema,
+      },
+      summary: 'Draft an agent spec from the creator conversation',
     },
 
     /** POST /api/user-agents/convert-cg/:slug — persist a virtualized custom generator. */

--- a/packages/contracts/src/schemas/userAgents.ts
+++ b/packages/contracts/src/schemas/userAgents.ts
@@ -135,3 +135,40 @@ export const userAgentErrorResponseSchema = z.object({
   message: z.string(),
   agent: userAgentSchema.optional(),
 });
+
+// ── Conversational draft (creator) ────────────────────────────────────────────
+
+/**
+ * POST /api/user-agents/draft — synthesize a spec from a creator conversation.
+ * The server loads the thread's messages (ownership-checked) rather than
+ * trusting a client-supplied transcript.
+ */
+export const draftAgentBodySchema = z.object({
+  threadId: z.string().min(1),
+});
+
+/**
+ * The agent spec the creator synthesizes from the conversation. A subset of the
+ * create body — `identifier`, `model`/`provider`/`params`, and the notebook
+ * binding are filled in by the frontend (slug derivation, defaults, the
+ * notebook picker), not the LLM.
+ */
+export const draftedAgentSpecSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  systemRole: z.string(),
+  avatar: z.string(),
+  backgroundColor: z.string(),
+  enabledTools: z.array(z.string()),
+  skillMentions: z.array(z.string()),
+  locale: z.string(),
+  openingMessage: z.string(),
+  openingQuestions: z.array(z.string()),
+});
+
+export type DraftedAgentSpec = z.infer<typeof draftedAgentSpecSchema>;
+
+export const userAgentDraftResponseSchema = z.object({
+  success: z.boolean(),
+  spec: draftedAgentSpecSchema,
+});

--- a/packages/shared/src/agents/coreAgents.ts
+++ b/packages/shared/src/agents/coreAgents.ts
@@ -50,6 +50,36 @@ export const CORE_AGENTS = [
     ],
   },
   {
+    identifier: 'gruenerator-agent-creator',
+    title: 'Agent-Creator',
+    // Reached via the dedicated /agents/new route, not the agent pickers.
+    hiddenFromInventory: true,
+    iconKey: 'sparkle',
+    description:
+      'Baut im Dialog eigene Grünerator-Agent*innen: klärt Zweck, Ton, Fähigkeiten, Skills und Wissensquelle — daraus entsteht ein Entwurf zum Anlegen.',
+    systemRole:
+      'Du bist der Agent-Creator des Grünerator. Du hilfst Nutzer*innen, im Gespräch eine*n eigene*n KI-Agent*in zu entwerfen. Du sprichst die Nutzer*in mit **Du** an und verwendest durchgehend Genderstern (z.B. Bürger*innen).\n\nDeine Aufgabe ist NICHT, selbst Texte zu schreiben, sondern die Anforderungen an eine*n neue*n Agent*in herauszuarbeiten. Stelle gezielte, freundliche Rückfragen — immer nur wenige auf einmal — bis du genug weißt für:\n\n1. **Zweck & Aufgabe**: Wofür ist der*die Agent*in da? (z.B. Pressemitteilungen, Recherche, Bürger*innenanfragen, Social Media)\n2. **Zielgruppe & Ton**: Für wen schreibt der*die Agent*in, in welchem Stil?\n3. **Fähigkeiten (Tools)**: Welche der folgenden Werkzeuge braucht der*die Agent*in?\n   - Grünerator-Wissen durchsuchen (Programme, Beschlüsse, KommunalWiki)\n   - Websuche (aktuelle Infos)\n   - Tiefenrecherche (mehrstufig, mit Quellen)\n   - Social-Media-Beispiele\n   - Bildgenerierung / Bildbearbeitung / Bildanalyse\n   - Webseiten auslesen\n   - Umfragewerte\n   - Eigene gespeicherte Inhalte durchsuchen\n4. **Skills**: Sollen vorhandene Schnellstart-Vorlagen (z.B. Antrag, Pressemitteilung, Rede, Social-Media-Posts) als Schnellstarts verknüpft werden?\n5. **Wissensquelle**: Soll der*die Agent*in standardmäßig an ein Notizbuch (Wissensdatenbank) gebunden sein?\n6. **Region**: Deutschland (de-DE) oder Österreich (de-AT)? Das beeinflusst Begriffe und politischen Kontext.\n\n**Wichtig:**\n- Schlage proaktiv sinnvolle Fähigkeiten und einen Systemprompt-Charakter vor, statt alles abzufragen. Halte das Gespräch kurz und konkret.\n- Erfinde KEINE Notizbuch-IDs. Die konkrete Wissensquelle wählt die Nutzer*in später selbst aus.\n- Wenn ihr genug besprochen habt, weise die Nutzer*in darauf hin, dass sie über den Button **„Entwurf erstellen"** aus eurem Gespräch einen fertigen Agent*innen-Entwurf generieren kann, den sie dann prüfen, anpassen und anlegen kann.\n\nBleib hilfsbereit, konkret und ermutigend.',
+    avatar: '🤖',
+    backgroundColor: '#316049',
+    tags: ['Agent', 'Setup', 'Konfiguration'],
+    model: 'mistral-large-latest',
+    defaultModel: 'mistral-medium-3.5',
+    provider: 'mistral',
+    autoRoutingHint: 'precise',
+    params: { max_tokens: 2000, temperature: 0.5 },
+    openingMessage:
+      'Hi! Ich helfe dir, eine*n eigene*n Agent*in für den Grünerator zu bauen. 🤖\n\nErzähl mir einfach, was dein*e Agent*in können soll — zum Beispiel Pressemitteilungen für deinen Kreisverband schreiben, Anfragen recherchieren oder Social-Media-Posts entwerfen. Ich frage dann nach, welche Fähigkeiten, Skills und welche Wissensquelle sinnvoll sind.\n\nWenn wir genug besprochen haben, klickst du auf **„Entwurf erstellen"** — daraus baue ich dir einen fertigen Vorschlag zum Anpassen und Anlegen.',
+    welcomeQuestion: 'Was für eine*n Agent*in möchtest du bauen?',
+    openingQuestions: [
+      'Ein*e Agent*in für Pressemitteilungen meines Kreisverbands',
+      'Ein Recherche-Bot für Verkehrs- und Mobilitätsthemen',
+      'Ein*e Agent*in, die Bürger*innenanfragen freundlich beantwortet',
+      'Ein*e Social-Media-Agent*in für Instagram-Posts',
+    ],
+    locale: 'de-DE',
+    author: 'Grünerator',
+  },
+  {
     identifier: 'gruenerator-antrag',
     title: 'Kommunalpolitik',
     iconKey: 'buildings',

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -134,9 +134,10 @@ export interface Agent {
    * Routing hint for the "Automatisch" model picker. Read by the frontend
    * resolver (`resolveAutoModel`) to map this agent to a context-appropriate
    * model without hand-curating ID lists. `'creative'` → Gemma 4 today;
-   * `'research'` is reserved for a future bucket.
+   * `'precise'` → Mistral (strong instruction-following, e.g. the agent
+   * creator); `'research'` is reserved for a future bucket.
    */
-  autoRoutingHint?: 'creative' | 'research';
+  autoRoutingHint?: 'creative' | 'precise' | 'research';
   /**
    * System skill `mention` strings (e.g. `'presse'`, `'antrag'`) surfaced as
    * clickable quick-starts on this agent's chat landing. Each resolves via


### PR DESCRIPTION
Builds on the user-agents foundation (#1049) to deliver the default way users create their own agent: a conversation, not a form.

Why this shape: the live chat path classifies an intent and streams a text response — it doesn't function-call tools — so an in-stream "tool card" isn't viable without touching the hot path. Instead the creator agent (`gruenerator-agent-creator`) drives the conversation in the existing composer, and an explicit "Entwurf erstellen" action calls a dedicated Mistral structured-generation endpoint (`POST /api/user-agents/draft`) that turns the thread's messages into a validated spec, shown in a page-level panel. This keeps the chat hot path untouched.

- Auto-routing gains a `precise` hint so the creator runs on Mistral (the "auto" default is GPT-OSS, not Mistral).
- The draft endpoint constrains tools/skills to the shared catalogs server-side (the contract package stays dependency-light).
- From the panel: create directly (opens the new agent's chat) or "Anpassen" (opens the editor). Routes ungated; sidebar "Neue*r Agent*in" CTA wired.

Follow-up (next PR): the guided multi-step manual wizard, notebook binding at chat open, skill quick-starts on the welcome screen, and a "Meine Agent*innen" management surface.

Verification: typecheck green for contracts, shared, chat, api, web.