### PR TITLE
feat: guided agent builder wizard + user-agent notebook binding

### DIFF
--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -243,6 +243,10 @@ const standardRoutes: RouteConfig[] = [
     layoutMode: 'sidebarOnly',
   },
   {
+    path: '/agents/new/manual',
+    component: AgentBuilderPage,
+  },
+  {
     path: '/agents/:identifier/edit',
     component: AgentBuilderPage,
   },

--- a/apps/web/src/features/agents/AgentBuilderPage.tsx
+++ b/apps/web/src/features/agents/AgentBuilderPage.tsx
@@ -1,7 +1,16 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { type UpdateUserAgentBody } from '@gruenerator/contracts';
+import { SKILLS, USER_SELECTABLE_TOOLS } from '@gruenerator/shared/agents';
+import { generateSlugSuffix, slugifyName } from '@gruenerator/shared/utils';
+import { MultiStepForm } from '@gruenerator/ui';
+import { useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useCreateUserAgent, useUpdateUserAgent, useUserAgent, type UserAgentInput } from './api';
+
+import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
+import { SYSTEM_NOTEBOOKS } from '@/features/notebook/config/notebooksConfig';
+
+type Locale = 'de-DE' | 'de-AT';
 
 interface FormState {
   identifier: string;
@@ -10,9 +19,13 @@ interface FormState {
   systemRole: string;
   avatar: string;
   backgroundColor: string;
-  tags: string;
+  locale: Locale;
   openingMessage: string;
   openingQuestions: string;
+  enabledTools: string[];
+  skillMentions: string[];
+  defaultNotebookId: string; // '' = none
+  tags: string;
   model: string;
   provider: 'mistral' | 'anthropic' | 'litellm' | 'regolo';
   maxTokens: number;
@@ -26,16 +39,28 @@ const EMPTY: FormState = {
   systemRole: '',
   avatar: '✨',
   backgroundColor: '#316049',
-  tags: '',
+  locale: 'de-DE',
   openingMessage: '',
   openingQuestions: '',
+  enabledTools: ['search', 'web'],
+  skillMentions: [],
+  defaultNotebookId: '',
+  tags: '',
   model: 'mistral-large-latest',
   provider: 'mistral',
   maxTokens: 3000,
   temperature: 0.5,
 };
 
-export default function AgentBuilderPage() {
+const STEP_COUNT = 5;
+const inputCls =
+  'w-full rounded border border-grey-300 bg-background px-sm py-xs focus:border-primary-600 focus:outline-none dark:border-grey-700';
+
+function toggle(list: string[], value: string): string[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+function AgentBuilderPage() {
   const navigate = useNavigate();
   const { identifier } = useParams<{ identifier?: string }>();
   const isEdit = !!identifier;
@@ -44,76 +69,111 @@ export default function AgentBuilderPage() {
   const updateMut = useUpdateUserAgent(identifier ?? '');
 
   const [form, setForm] = useState<FormState>(EMPTY);
+  const [step, setStep] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  // Hydrate the form from the loaded agent once (edit mode). Setting state
+  // during render — React's sanctioned "reset on prop change" pattern — avoids
+  // a cascading-render effect.
+  const [hydratedFor, setHydratedFor] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (existing) {
-      setForm({
-        identifier: existing.identifier,
-        title: existing.title,
-        description: existing.description,
-        systemRole: existing.systemRole,
-        avatar: existing.avatar,
-        backgroundColor: existing.backgroundColor,
-        tags: existing.tags.join(', '),
-        openingMessage: existing.openingMessage,
-        openingQuestions: existing.openingQuestions.join('\n'),
-        model: existing.model,
-        provider: existing.provider,
-        maxTokens: existing.params.max_tokens,
-        temperature: existing.params.temperature,
-      });
-    }
-  }, [existing]);
+  useDocumentTitle(isEdit ? 'Agent*in bearbeiten' : 'Neue*r Agent*in');
+
+  if (existing && hydratedFor !== existing.identifier) {
+    setHydratedFor(existing.identifier);
+    setForm({
+      identifier: existing.identifier,
+      title: existing.title,
+      description: existing.description,
+      systemRole: existing.systemRole,
+      avatar: existing.avatar,
+      backgroundColor: existing.backgroundColor,
+      locale: existing.locale === 'de-AT' ? 'de-AT' : 'de-DE',
+      openingMessage: existing.openingMessage,
+      openingQuestions: existing.openingQuestions.join('\n'),
+      enabledTools: [...(existing.enabledTools ?? [])],
+      skillMentions: [...(existing.skillMentions ?? [])],
+      defaultNotebookId: existing.defaultNotebookId ?? '',
+      tags: existing.tags.join(', '),
+      model: existing.model,
+      provider: existing.provider,
+      maxTokens: existing.params.max_tokens,
+      temperature: existing.params.temperature,
+    });
+  }
 
   const set = <K extends keyof FormState>(k: K, v: FormState[K]) =>
     setForm((prev) => ({ ...prev, [k]: v }));
 
+  const skillOptions = useMemo(
+    () => SKILLS.map((s) => ({ mention: s.mention, title: s.title })),
+    []
+  );
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    const payload: UserAgentInput = {
-      identifier: form.identifier.trim(),
-      title: form.title.trim(),
-      description: form.description.trim(),
-      systemRole: form.systemRole.trim(),
-      avatar: form.avatar.trim(),
-      backgroundColor: form.backgroundColor,
-      tags: form.tags
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean),
-      model: form.model,
-      provider: form.provider,
-      params: { max_tokens: form.maxTokens, temperature: form.temperature },
-      openingMessage: form.openingMessage,
-      openingQuestions: form.openingQuestions
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean),
-      locale: 'de-DE',
-      author: 'Eigene*r Agent*in',
-    };
+    const openingQuestions = form.openingQuestions
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const tags = form.tags
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
 
     try {
       if (isEdit) {
-        const { identifier: _ignored, ...patch } = payload;
-        void _ignored;
+        const patch: UpdateUserAgentBody = {
+          title: form.title.trim(),
+          description: form.description.trim(),
+          systemRole: form.systemRole.trim(),
+          avatar: form.avatar.trim(),
+          backgroundColor: form.backgroundColor,
+          locale: form.locale,
+          openingMessage: form.openingMessage,
+          openingQuestions,
+          enabledTools: form.enabledTools,
+          skillMentions: form.skillMentions,
+          defaultNotebookId: form.defaultNotebookId || null,
+          tags,
+          model: form.model,
+          provider: form.provider,
+          params: { max_tokens: form.maxTokens, temperature: form.temperature },
+        };
         await updateMut.mutateAsync(patch);
+        void navigate(`/agents/${identifier}/edit`);
       } else {
-        await createMut.mutateAsync(payload);
+        const slug = slugifyName(form.title, 'agent');
+        const payload: UserAgentInput = {
+          identifier: `${slug}-${generateSlugSuffix()}`,
+          title: form.title.trim(),
+          description: form.description.trim(),
+          systemRole: form.systemRole.trim(),
+          avatar: form.avatar.trim(),
+          backgroundColor: form.backgroundColor,
+          tags,
+          model: form.model,
+          provider: form.provider,
+          params: { max_tokens: form.maxTokens, temperature: form.temperature },
+          openingMessage: form.openingMessage,
+          openingQuestions,
+          locale: form.locale,
+          author: 'Eigene*r Agent*in',
+          enabledTools: form.enabledTools,
+          skillMentions: form.skillMentions,
+          ...(form.defaultNotebookId ? { defaultNotebookId: form.defaultNotebookId } : {}),
+        };
+        const agent = await createMut.mutateAsync(payload);
+        void navigate(`/agents/${agent.identifier}/edit`);
       }
-      void navigate('/skills');
     } catch (err) {
-      const e2 = err as { response?: { data?: { message?: string; error?: string } } };
-      setError(
-        e2.response?.data?.message ?? e2.response?.data?.error ?? 'Speichern fehlgeschlagen.'
-      );
+      setError(err instanceof Error ? err.message : 'Speichern fehlgeschlagen.');
     }
   };
 
-  const inputCls =
-    'w-full rounded border border-grey-300 bg-background px-sm py-xs focus:border-primary-600 focus:outline-none dark:border-grey-700';
+  const canProceed = step < STEP_COUNT - 1;
+  const titleValid = form.title.trim().length > 0;
+  const roleValid = form.systemRole.trim().length >= 10;
 
   return (
     <div className="mx-auto max-w-3xl p-md">
@@ -121,187 +181,265 @@ export default function AgentBuilderPage() {
         {isEdit ? 'Agent*in bearbeiten' : 'Neue*r Agent*in'}
       </h1>
 
-      <form onSubmit={(e) => void handleSubmit(e)} className="flex flex-col gap-md">
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Bezeichner (Slug)</span>
-          <input
-            type="text"
-            className={inputCls}
-            value={form.identifier}
-            onChange={(e) => set('identifier', e.target.value)}
-            disabled={isEdit}
-            required
-            pattern="[a-z0-9-]+"
-            placeholder="mein-agent"
-          />
-          <span className="text-xs text-foreground-muted">
-            Nur Kleinbuchstaben, Ziffern, Bindestriche. Wird in URLs verwendet.
-          </span>
-        </label>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Titel</span>
-          <input
-            type="text"
-            className={inputCls}
-            value={form.title}
-            onChange={(e) => set('title', e.target.value)}
-            required
-            maxLength={100}
-          />
-        </label>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Beschreibung</span>
-          <input
-            type="text"
-            className={inputCls}
-            value={form.description}
-            onChange={(e) => set('description', e.target.value)}
-            required
-            maxLength={500}
-          />
-        </label>
-
-        <div className="flex gap-md">
-          <label className="flex flex-col gap-xs">
-            <span className="font-medium">Avatar (Emoji)</span>
-            <input
-              type="text"
-              className={`${inputCls} w-24 text-center text-2xl`}
-              value={form.avatar}
-              onChange={(e) => set('avatar', e.target.value)}
-              required
-              maxLength={8}
-            />
-          </label>
-
-          <label className="flex flex-col gap-xs">
-            <span className="font-medium">Hintergrundfarbe</span>
-            <input
-              type="color"
-              className="h-10 w-24 cursor-pointer rounded border border-grey-300 dark:border-grey-700"
-              value={form.backgroundColor}
-              onChange={(e) => set('backgroundColor', e.target.value)}
-            />
-          </label>
-        </div>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">System-Prompt</span>
-          <textarea
-            className={`${inputCls} min-h-[200px] font-mono text-sm`}
-            value={form.systemRole}
-            onChange={(e) => set('systemRole', e.target.value)}
-            required
-            rows={10}
-            placeholder="Du bist ein*e ..."
-          />
-        </label>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Begrüßungstext (optional)</span>
-          <textarea
-            className={`${inputCls} min-h-[80px]`}
-            value={form.openingMessage}
-            onChange={(e) => set('openingMessage', e.target.value)}
-            rows={3}
-          />
-        </label>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Beispielfragen (eine pro Zeile, optional)</span>
-          <textarea
-            className={`${inputCls} min-h-[80px]`}
-            value={form.openingQuestions}
-            onChange={(e) => set('openingQuestions', e.target.value)}
-            rows={4}
-          />
-        </label>
-
-        <label className="flex flex-col gap-xs">
-          <span className="font-medium">Tags (kommagetrennt)</span>
-          <input
-            type="text"
-            className={inputCls}
-            value={form.tags}
-            onChange={(e) => set('tags', e.target.value)}
-            placeholder="Klima, Verkehr"
-          />
-        </label>
-
-        <details className="rounded border border-grey-200 p-md dark:border-grey-700">
-          <summary className="cursor-pointer font-medium">Erweiterte Einstellungen</summary>
-          <div className="mt-md flex flex-col gap-md">
-            <label className="flex flex-col gap-xs">
-              <span className="font-medium">Modell</span>
-              <input
-                type="text"
-                className={inputCls}
-                value={form.model}
-                onChange={(e) => set('model', e.target.value)}
-              />
-            </label>
-            <label className="flex flex-col gap-xs">
-              <span className="font-medium">Provider</span>
-              <select
-                className={inputCls}
-                value={form.provider}
-                onChange={(e) => set('provider', e.target.value as FormState['provider'])}
-              >
-                <option value="mistral">Mistral</option>
-                <option value="anthropic">Anthropic</option>
-                <option value="litellm">LiteLLM</option>
-                <option value="regolo">Regolo</option>
-              </select>
-            </label>
-            <div className="flex gap-md">
-              <label className="flex flex-1 flex-col gap-xs">
-                <span className="font-medium">Max. Tokens</span>
+      <form onSubmit={(e) => void handleSubmit(e)}>
+        <MultiStepForm currentStep={step} onBack={() => setStep((s) => Math.max(0, s - 1))}>
+          <MultiStepForm.Step title="Grundlagen" subtitle="Name, Beschreibung, Aussehen">
+            <div className="flex flex-col gap-md">
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Titel</span>
                 <input
-                  type="number"
                   className={inputCls}
-                  value={form.maxTokens}
-                  min={100}
-                  max={8000}
-                  onChange={(e) => set('maxTokens', Number(e.target.value))}
+                  value={form.title}
+                  onChange={(e) => set('title', e.target.value)}
+                  maxLength={100}
+                  required
                 />
               </label>
-              <label className="flex flex-1 flex-col gap-xs">
-                <span className="font-medium">Temperatur</span>
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Beschreibung</span>
                 <input
-                  type="number"
-                  step="0.1"
                   className={inputCls}
-                  value={form.temperature}
-                  min={0}
-                  max={1}
-                  onChange={(e) => set('temperature', Number(e.target.value))}
+                  value={form.description}
+                  onChange={(e) => set('description', e.target.value)}
+                  maxLength={500}
                 />
+              </label>
+              <div className="flex gap-md">
+                <label className="flex flex-col gap-xs">
+                  <span className="font-medium">Avatar (Emoji)</span>
+                  <input
+                    className={`${inputCls} w-24 text-center text-2xl`}
+                    value={form.avatar}
+                    onChange={(e) => set('avatar', e.target.value)}
+                    maxLength={8}
+                  />
+                </label>
+                <label className="flex flex-col gap-xs">
+                  <span className="font-medium">Hintergrundfarbe</span>
+                  <input
+                    type="color"
+                    className="h-10 w-24 cursor-pointer rounded border border-grey-300 dark:border-grey-700"
+                    value={form.backgroundColor}
+                    onChange={(e) => set('backgroundColor', e.target.value)}
+                  />
+                </label>
+              </div>
+            </div>
+          </MultiStepForm.Step>
+
+          <MultiStepForm.Step title="Persönlichkeit" subtitle="Anweisungen, Begrüßung, Region">
+            <div className="flex flex-col gap-md">
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">System-Prompt</span>
+                <textarea
+                  className={`${inputCls} min-h-[200px] font-mono text-sm`}
+                  value={form.systemRole}
+                  onChange={(e) => set('systemRole', e.target.value)}
+                  rows={10}
+                  placeholder="Du bist ein*e ..."
+                />
+              </label>
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Begrüßungstext (optional)</span>
+                <textarea
+                  className={`${inputCls} min-h-[80px]`}
+                  value={form.openingMessage}
+                  onChange={(e) => set('openingMessage', e.target.value)}
+                  rows={3}
+                />
+              </label>
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Region</span>
+                <select
+                  className={inputCls}
+                  value={form.locale}
+                  onChange={(e) => set('locale', e.target.value as Locale)}
+                >
+                  <option value="de-DE">Deutschland (de-DE)</option>
+                  <option value="de-AT">Österreich (de-AT)</option>
+                </select>
               </label>
             </div>
-          </div>
-        </details>
+          </MultiStepForm.Step>
 
-        {error && <p className="text-red-600">{error}</p>}
+          <MultiStepForm.Step title="Fähigkeiten" subtitle="Tools und Skill-Schnellstarts">
+            <div className="flex flex-col gap-lg">
+              <fieldset className="flex flex-col gap-xs">
+                <legend className="mb-xs font-medium">Werkzeuge</legend>
+                <div className="grid grid-cols-1 gap-xs sm:grid-cols-2">
+                  {USER_SELECTABLE_TOOLS.map((t) => (
+                    <label
+                      key={t.key}
+                      className="flex cursor-pointer items-start gap-sm rounded border border-grey-200 p-sm dark:border-grey-700"
+                    >
+                      <input
+                        type="checkbox"
+                        className="mt-1"
+                        checked={form.enabledTools.includes(t.key)}
+                        onChange={() => set('enabledTools', toggle(form.enabledTools, t.key))}
+                      />
+                      <span>
+                        <span className="block text-sm font-medium">{t.label}</span>
+                        <span className="block text-xs text-foreground-muted">{t.description}</span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
 
-        <div className="flex gap-sm">
-          <button
-            type="submit"
-            className="rounded bg-primary-600 px-md py-sm text-white hover:bg-primary-700 disabled:opacity-50"
-            disabled={createMut.isPending || updateMut.isPending}
-          >
-            {isEdit ? 'Speichern' : 'Erstellen'}
-          </button>
+              <fieldset className="flex flex-col gap-xs">
+                <legend className="mb-xs font-medium">Skill-Schnellstarts (optional)</legend>
+                <div className="flex flex-wrap gap-xs">
+                  {skillOptions.map((s) => {
+                    const active = form.skillMentions.includes(s.mention);
+                    return (
+                      <button
+                        type="button"
+                        key={s.mention}
+                        onClick={() => set('skillMentions', toggle(form.skillMentions, s.mention))}
+                        className={`rounded-full border px-sm py-xs text-sm ${
+                          active
+                            ? 'border-primary-600 bg-primary-600/10 text-primary-700 dark:text-primary-300'
+                            : 'border-grey-300 hover:bg-hover-alt dark:border-grey-700'
+                        }`}
+                      >
+                        {s.title}
+                      </button>
+                    );
+                  })}
+                </div>
+              </fieldset>
+            </div>
+          </MultiStepForm.Step>
+
+          <MultiStepForm.Step title="Wissen" subtitle="Standard-Notizbuch (optional)">
+            <label className="flex flex-col gap-xs">
+              <span className="font-medium">Notizbuch</span>
+              <select
+                className={inputCls}
+                value={form.defaultNotebookId}
+                onChange={(e) => set('defaultNotebookId', e.target.value)}
+              >
+                <option value="">Kein Standard-Notizbuch</option>
+                {SYSTEM_NOTEBOOKS.map((nb) => (
+                  <option key={nb.id} value={nb.id}>
+                    {nb.title}
+                  </option>
+                ))}
+              </select>
+              <span className="text-xs text-foreground-muted">
+                Wird beim Öffnen der Agent*in automatisch als Wissensquelle ausgewählt.
+              </span>
+            </label>
+          </MultiStepForm.Step>
+
+          <MultiStepForm.Step title="Überblick" subtitle="Startfragen, Erweitertes, Speichern">
+            <div className="flex flex-col gap-md">
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Beispielfragen (eine pro Zeile, optional)</span>
+                <textarea
+                  className={`${inputCls} min-h-[80px]`}
+                  value={form.openingQuestions}
+                  onChange={(e) => set('openingQuestions', e.target.value)}
+                  rows={4}
+                />
+              </label>
+              <label className="flex flex-col gap-xs">
+                <span className="font-medium">Tags (kommagetrennt)</span>
+                <input
+                  className={inputCls}
+                  value={form.tags}
+                  onChange={(e) => set('tags', e.target.value)}
+                  placeholder="Klima, Verkehr"
+                />
+              </label>
+              <details className="rounded border border-grey-200 p-md dark:border-grey-700">
+                <summary className="cursor-pointer font-medium">Erweiterte Einstellungen</summary>
+                <div className="mt-md flex flex-col gap-md">
+                  <label className="flex flex-col gap-xs">
+                    <span className="font-medium">Modell</span>
+                    <input
+                      className={inputCls}
+                      value={form.model}
+                      onChange={(e) => set('model', e.target.value)}
+                    />
+                  </label>
+                  <label className="flex flex-col gap-xs">
+                    <span className="font-medium">Provider</span>
+                    <select
+                      className={inputCls}
+                      value={form.provider}
+                      onChange={(e) => set('provider', e.target.value as FormState['provider'])}
+                    >
+                      <option value="mistral">Mistral</option>
+                      <option value="anthropic">Anthropic</option>
+                      <option value="litellm">LiteLLM</option>
+                      <option value="regolo">Regolo</option>
+                    </select>
+                  </label>
+                  <div className="flex gap-md">
+                    <label className="flex flex-1 flex-col gap-xs">
+                      <span className="font-medium">Max. Tokens</span>
+                      <input
+                        type="number"
+                        className={inputCls}
+                        value={form.maxTokens}
+                        min={100}
+                        max={8000}
+                        onChange={(e) => set('maxTokens', Number(e.target.value))}
+                      />
+                    </label>
+                    <label className="flex flex-1 flex-col gap-xs">
+                      <span className="font-medium">Temperatur</span>
+                      <input
+                        type="number"
+                        step="0.1"
+                        className={inputCls}
+                        value={form.temperature}
+                        min={0}
+                        max={1}
+                        onChange={(e) => set('temperature', Number(e.target.value))}
+                      />
+                    </label>
+                  </div>
+                </div>
+              </details>
+            </div>
+          </MultiStepForm.Step>
+        </MultiStepForm>
+
+        {error && <p className="mt-md text-red-600">{error}</p>}
+
+        <div className="mt-lg flex items-center justify-between gap-sm">
           <button
             type="button"
-            className="rounded border border-grey-300 px-md py-sm hover:bg-hover-alt dark:border-grey-700"
-            onClick={() => void navigate('/skills')}
+            className="rounded border border-grey-300 px-md py-sm hover:bg-hover-alt disabled:opacity-50 dark:border-grey-700"
+            onClick={() => navigate('/skills')}
           >
             Abbrechen
           </button>
+          {canProceed ? (
+            <button
+              type="button"
+              className="rounded bg-primary-600 px-md py-sm text-white hover:bg-primary-700 disabled:opacity-50"
+              disabled={(step === 0 && !titleValid) || (step === 1 && !roleValid)}
+              onClick={() => setStep((s) => Math.min(STEP_COUNT - 1, s + 1))}
+            >
+              Weiter
+            </button>
+          ) : (
+            <button
+              type="submit"
+              className="rounded bg-primary-600 px-md py-sm text-white hover:bg-primary-700 disabled:opacity-50"
+              disabled={!titleValid || !roleValid || createMut.isPending || updateMut.isPending}
+            >
+              {isEdit ? 'Speichern' : 'Erstellen'}
+            </button>
+          )}
         </div>
       </form>
     </div>
   );
 }
+
+export default AgentBuilderPage;

--- a/apps/web/src/features/agents/AgentCreatorPage.tsx
+++ b/apps/web/src/features/agents/AgentCreatorPage.tsx
@@ -185,7 +185,14 @@ function AgentCreatorPage() {
         <div className="border-t border-grey-200 bg-background p-sm dark:border-grey-700">
           <div className="mx-auto flex max-w-2xl items-center justify-between gap-sm">
             <p className="text-xs text-foreground-muted">
-              Wenn ihr genug besprochen habt, erstelle ich daraus einen Entwurf.
+              Wenn ihr genug besprochen habt, erstelle ich daraus einen Entwurf.{' '}
+              <button
+                type="button"
+                onClick={() => void navigate('/agents/new/manual')}
+                className="text-primary-600 hover:underline dark:text-primary-300"
+              >
+                Lieber manuell?
+              </button>
             </p>
             <div className="flex flex-col items-end gap-1">
               <button

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired';
 import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
+import { useUserAgents } from '@/features/agents/api';
 import { SYSTEM_NOTEBOOKS } from '@/features/notebook/config/notebooksConfig';
 import { useFirstName } from '@/hooks/useFirstName';
 import { useAuthStore } from '@/stores/authStore';
@@ -38,6 +39,7 @@ function ChatPage() {
   const currentThreadTitle = useAgentStore((s) => s.currentThreadTitle);
   const firstName = useFirstName();
   const userLocale = useAuthStore((s) => s.locale) ?? 'de-DE';
+  const { data: userAgents } = useUserAgents();
   // Path-based /agents/:slug is the canonical form; ?agent= is legacy but
   // still wins when explicitly set so old deep links keep their behavior.
   const agentParam = searchParams.get('agent') ?? (slug ? resolveAgentSlug(slug) : null);
@@ -68,13 +70,16 @@ function ChatPage() {
       // a different notebook manually after the agent is selected is an
       // unusual flow we'd revisit only if users complain.
       const agentMeta = getSystemAgent(agentParam);
-      if (
-        agentMeta?.defaultNotebookId &&
-        store.selectedNotebookId !== agentMeta.defaultNotebookId
-      ) {
-        store.setSelectedNotebook(agentMeta.defaultNotebookId);
+      // User-created agents aren't in the system registry — resolve their
+      // notebook binding from the user-agents list (a system notebook id).
+      const userAgentNotebook = agentMeta
+        ? undefined
+        : userAgents?.find((a) => a.identifier === agentParam)?.defaultNotebookId;
+      const boundNotebookId = agentMeta?.defaultNotebookId ?? userAgentNotebook;
+      if (boundNotebookId && store.selectedNotebookId !== boundNotebookId) {
+        store.setSelectedNotebook(boundNotebookId);
       } else if (
-        !agentMeta?.defaultNotebookId &&
+        !boundNotebookId &&
         userLocale === 'de-AT' &&
         store.selectedNotebookId !== AT_DEFAULT_NOTEBOOK_ID
       ) {
@@ -93,7 +98,7 @@ function ChatPage() {
       store.setThreadMode(modeParam);
       store.setChatViewMode('thread');
     }
-  }, [agentParam, modeParam, userLocale]);
+  }, [agentParam, modeParam, userLocale, userAgents]);
 
   const handleNavigate = useCallback((path: string) => navigate(path), [navigate]);
 


### PR DESCRIPTION
Completes the manual authoring path alongside the conversational creator (#1051).

Why: the conversational creator's "Anpassen" needs a real editor, and users who prefer a form need one that exposes the full agent surface — not just the basics. Rewrites the agent builder as a 5-step MultiStepForm (Grundlagen → Persönlichkeit/Region → Fähigkeiten → Wissen → Überblick) covering tools, skill quick-starts, locale and a default system notebook, used for both manual create (`/agents/new/manual`, linked from the creator) and edit. ChatPage now also resolves a user agent's bound notebook (not just system agents') so it auto-selects on open.

Scoped deliberately: notebook binding offers **system** notebooks only — a user's own notebook (UUID) isn't scoped in chat search yet (`isKnownNotebook` rejects it), so offering it would silently no-op. Follow-ups: user-owned-notebook chat-time document scoping, and rendering an agent's skill quick-starts on the welcome screen.

Verification: typecheck green for web.