### PR TITLE
fix(mobile): repair Dateien/Einstellungen profile-menu navigation

### DIFF
--- a/apps/mobile/components/navigation/ProfileMenu.tsx
+++ b/apps/mobile/components/navigation/ProfileMenu.tsx
@@ -27,18 +27,8 @@ interface MenuItem {
 
 const MENU_ITEMS: MenuItem[] = [
   { key: 'gruppen', label: 'Gruppen', icon: 'people-outline', href: '/(focused)/gruppen' },
-  {
-    key: 'inhalte',
-    label: 'Dateien',
-    icon: 'folder-outline',
-    href: { pathname: '/profile', params: { section: 'inhalte' } },
-  },
-  {
-    key: 'einstellungen',
-    label: 'Einstellungen',
-    icon: 'settings-outline',
-    href: { pathname: '/profile', params: { section: 'einstellungen' } },
-  },
+  { key: 'inhalte', label: 'Dateien', icon: 'folder-outline', href: '/(tabs)/(docs)' },
+  { key: 'einstellungen', label: 'Einstellungen', icon: 'settings-outline', href: '/profile' },
 ];
 
 const getPossessiveForm = (name: string | undefined): string => {


### PR DESCRIPTION
The profile dropdown's **Dateien** and **Einstellungen** rows did nothing on iOS while **Gruppen** worked.

All three rows call the same `router.push(href)`. Gruppen passes a plain-string href to a `(focused)` root-stack route, so it navigates cleanly. The other two passed an *object* href — `{ pathname: '/profile', params: { section: '…' } }` — where the `section` param is read by no screen in the app, and the param-bearing href to the **hidden** `profile` native tab fails to navigate on iOS.

Fix: drop the dead `section` param and give both rows plain-string hrefs to real destinations, matching the known-good drawer/avatar navigation — Dateien → the Docs tab (the app's own vocabulary maps documents to "Dateien"), Einstellungen → the profile screen, which is where the app settings actually live.

JS-only routing change — no native rebuild required.