### PR TITLE
feat: bind user-owned notebooks to agents (chat-time document scoping)

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -107,6 +107,10 @@ const ChatStateAnnotation = Annotation.Root({
   defaultNotebookCollectionIds: Annotation<string[]>({
     reducer: (x, y) => y ?? x ?? [],
   }),
+  // Default-notebook document scope when the agent binds a user-owned notebook.
+  defaultNotebookDocumentIds: Annotation<string[]>({
+    reducer: (x, y) => y ?? x ?? [],
+  }),
   documentIds: Annotation<string[]>({
     reducer: (x, y) => y ?? x ?? [],
   }),
@@ -661,6 +665,7 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     defaultNotebookCollectionIds: input.defaultNotebookId
       ? resolveNotebookCollections([input.defaultNotebookId])
       : [],
+    defaultNotebookDocumentIds: input.defaultNotebookDocumentIds ?? [],
 
     // Document scoping (from @datei mentions)
     documentIds: input.documentIds || [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -190,6 +190,7 @@ async function testExpandedContextWindow() {
     notebookCollectionIds: [],
     notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
+    defaultNotebookDocumentIds: [],
     documentIds: [],
     documentChatIds: [],
     boardIds: [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -231,6 +231,7 @@ async function evaluateBudgetAllocation() {
     notebookCollectionIds: [],
     notebookDocumentIds: [],
     defaultNotebookCollectionIds: [],
+    defaultNotebookDocumentIds: [],
     documentIds: [],
     documentChatIds: [],
     boardIds: [],

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -43,8 +43,8 @@ import {
   extractDomain,
   resolveCollectionName,
 } from './citationUtils.js';
-import { retrieveWolkeFile } from './wolkeRetrieval.js';
 import { retrieveConnectFile } from './connectRetrieval.js';
+import { retrieveWolkeFile } from './wolkeRetrieval.js';
 
 import type { SubcategoryFilters } from '../../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../../routes/chat/agents/types.js';
@@ -771,10 +771,22 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         // set of @datei picks.
         const explicitDocIds = state.documentIds ?? [];
         const userNotebookDocIds = state.notebookDocumentIds ?? [];
-        const scopeDocIds = [...new Set([...explicitDocIds, ...userNotebookDocIds])];
+        // The agent's bound user-notebook docs apply only when the user hasn't
+        // explicitly scoped this turn (no @datei, no @notebook, no system notebook).
+        const hasExplicitScope =
+          explicitDocIds.length > 0 ||
+          userNotebookDocIds.length > 0 ||
+          (state.notebookCollectionIds?.length ?? 0) > 0;
+        const defaultNotebookDocIds = hasExplicitScope
+          ? []
+          : (state.defaultNotebookDocumentIds ?? []);
+        const scopeDocIds = [
+          ...new Set([...explicitDocIds, ...userNotebookDocIds, ...defaultNotebookDocIds]),
+        ];
 
         if (scopeDocIds.length > 0) {
-          const fromUserNotebook = userNotebookDocIds.length > 0;
+          const fromUserNotebook =
+            userNotebookDocIds.length > 0 || defaultNotebookDocIds.length > 0;
           log.info(
             `[Search] Using document-scoped search: ${scopeDocIds.length} doc(s)${
               fromUserNotebook ? ` (incl. ${userNotebookDocIds.length} from user notebook)` : ''

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -300,6 +300,12 @@ export interface ChatGraphInput {
    */
   notebookDocumentIds?: string[] | undefined;
   defaultNotebookId?: string | undefined;
+  /**
+   * Document IDs from a user-owned notebook bound to the agent as its default
+   * knowledge base (`defaultNotebookId` resolved to a UUID). Scopes search only
+   * when the user hasn't explicitly picked/mentioned a notebook this turn.
+   */
+  defaultNotebookDocumentIds?: string[] | undefined;
   documentIds?: string[] | undefined;
   textIds?: string[] | undefined;
   documentChatIds?: string[] | undefined;
@@ -353,6 +359,8 @@ export interface ChatGraphState {
 
   // Default notebook scoping (from persistent UI selection)
   defaultNotebookCollectionIds: string[];
+  // Document IDs from a user-owned notebook bound to the agent as its default.
+  defaultNotebookDocumentIds: string[];
 
   // Document scoping (from @datei mentions)
   documentIds: string[];

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -158,6 +158,13 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         rawDefaultNotebookId && isKnownNotebook(rawDefaultNotebookId)
           ? rawDefaultNotebookId
           : undefined;
+      // An agent can bind a user-owned notebook (UUID) as its default knowledge
+      // base. Resolve it to document IDs (ownership-checked) so search can scope
+      // to it — mirrors the mention path, but as a default rather than explicit.
+      const { documentIds: defaultNotebookDocumentIds } =
+        rawDefaultNotebookId && !defaultNotebookId && isUserNotebookId(rawDefaultNotebookId)
+          ? await resolveUserNotebookDocumentIds(userId, [rawDefaultNotebookId])
+          : { documentIds: [] };
 
       // Filter wolkeFiles to refs whose shareLinkId is still owned + active for this user.
       // Stale refs (deleted/deactivated share link) are dropped silently so the chat still works.
@@ -385,6 +392,8 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         notebookIds: notebookIds.length > 0 ? notebookIds : undefined,
         notebookDocumentIds: notebookDocumentIds.length > 0 ? notebookDocumentIds : undefined,
         defaultNotebookId,
+        defaultNotebookDocumentIds:
+          defaultNotebookDocumentIds.length > 0 ? defaultNotebookDocumentIds : undefined,
         documentIds: rawDocumentIds?.length ? rawDocumentIds : undefined,
         documentChatIds: rawDocumentChatIds?.length
           ? rawDocumentChatIds

--- a/apps/web/src/features/agents/AgentBuilderPage.tsx
+++ b/apps/web/src/features/agents/AgentBuilderPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useCreateUserAgent, useUpdateUserAgent, useUserAgent, type UserAgentInput } from './api';
 
 import { useDocumentTitle } from '@/components/hooks/useDocumentTitle';
+import { useNotebookCollections } from '@/features/auth/hooks/useProfileData';
 import { SYSTEM_NOTEBOOKS } from '@/features/notebook/config/notebooksConfig';
 
 type Locale = 'de-DE' | 'de-AT';
@@ -108,6 +109,9 @@ function AgentBuilderPage() {
     () => SKILLS.map((s) => ({ mention: s.mention, title: s.title })),
     []
   );
+
+  const { query: notebooksQuery } = useNotebookCollections({ isActive: true });
+  const userNotebooks = notebooksQuery.data ?? [];
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -321,11 +325,22 @@ function AgentBuilderPage() {
                 onChange={(e) => set('defaultNotebookId', e.target.value)}
               >
                 <option value="">Kein Standard-Notizbuch</option>
-                {SYSTEM_NOTEBOOKS.map((nb) => (
-                  <option key={nb.id} value={nb.id}>
-                    {nb.title}
-                  </option>
-                ))}
+                <optgroup label="Grünerator-Notizbücher">
+                  {SYSTEM_NOTEBOOKS.map((nb) => (
+                    <option key={nb.id} value={nb.id}>
+                      {nb.title}
+                    </option>
+                  ))}
+                </optgroup>
+                {userNotebooks.length > 0 && (
+                  <optgroup label="Meine Notizbücher">
+                    {userNotebooks.map((nb) => (
+                      <option key={String(nb.id)} value={String(nb.id)}>
+                        {nb.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                )}
               </select>
               <span className="text-xs text-foreground-muted">
                 Wird beim Öffnen der Agent*in automatisch als Wissensquelle ausgewählt.


### PR DESCRIPTION
Completes the follow-up deferred from #1052 so the agent builder can offer a user's **own** notebooks, not just system ones.

Why it was deferred: a user-notebook UUID set as `defaultNotebookId` was rejected by `isKnownNotebook` and never scoped search — offering it would have silently no-op'd.

What changed: when an agent binds a user-owned notebook, the chat router resolves the UUID to its backing document IDs (ownership-checked, reusing `resolveUserNotebookDocumentIds`) and carries them as `defaultNotebookDocumentIds` through ChatGraph state. `searchNode` folds them into the document-scoped search — but only when the user hasn't explicitly picked/mentioned a notebook that turn (explicit scope always wins). The wizard's notebook picker now lists "Meine Notizbücher" alongside the Grünerator notebooks.

The mention/picker path already scoped user notebooks; this adds the same for the agent-bound *default* path.

Verification: typecheck green for api + web.