### PR TITLE
feat(mobile): widen recent/docs/notebook grids on tablets

### DIFF
--- a/apps/mobile/app/(tabs)/(docs)/index.tsx
+++ b/apps/mobile/app/(tabs)/(docs)/index.tsx
@@ -24,6 +24,7 @@ import { DocPreview } from '../../../components/common/DocPreview';
 import { AIDocumentCreatorSheet } from '../../../components/docs/AIDocumentCreatorSheet';
 import { NativeShareModal } from '../../../components/docs/NativeShareModal';
 import { ScreenScaffold } from '../../../components/navigation/ScreenScaffold';
+import { useIsTablet } from '../../../hooks/useIsTablet';
 import { useDocsStore } from '../../../stores/docsStore';
 import { lightTheme, darkTheme, colors } from '../../../theme';
 
@@ -44,6 +45,7 @@ export default function DocumentsScreen() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const { user } = useAuth();
+  const gridCols = useIsTablet() ? 3 : 2;
 
   const {
     documents,
@@ -352,11 +354,11 @@ export default function DocumentsScreen() {
         </View>
       ) : viewMode === 'grid' ? (
         <FlatList
-          key="grid"
+          key={`grid-${gridCols}`}
           data={filteredDocuments}
           keyExtractor={(item) => item.id}
           renderItem={renderDocument}
-          numColumns={2}
+          numColumns={gridCols}
           columnWrapperStyle={styles.gridRow}
           contentContainerStyle={[
             styles.gridContent,

--- a/apps/mobile/app/(tabs)/(recherche)/index.tsx
+++ b/apps/mobile/app/(tabs)/(recherche)/index.tsx
@@ -17,7 +17,7 @@ import {
 
 import { ScreenScaffold } from '../../../components/navigation/ScreenScaffold';
 import { CommunityNotebooksSection } from '../../../components/notebook/CommunityNotebooksSection';
-import { NotebookCard } from '../../../components/notebook/NotebookCard';
+import { NotebookCard, notebookGridStyles } from '../../../components/notebook/NotebookCard';
 import { NotebookCreator } from '../../../components/notebook/NotebookCreator';
 import { NotebookSection } from '../../../components/notebook/NotebookSection';
 import { NotebooksHero } from '../../../components/notebook/NotebooksHero';
@@ -27,6 +27,7 @@ import {
   type MobileNotebookEntry,
 } from '../../../config/notebooksConfig';
 import { useNotebookSharing } from '../../../hooks/notebook/useNotebookSharing';
+import { useIsTablet } from '../../../hooks/useIsTablet';
 import {
   useNotebookCollections,
   type MobileNotebookCollection,
@@ -45,6 +46,7 @@ export default function NotebooksScreen() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const router = useRouter();
+  const isTablet = useIsTablet();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchOpen, setSearchOpen] = useState(false);
   const searchInputRef = useRef<TextInput>(null);
@@ -242,17 +244,20 @@ export default function NotebooksScreen() {
             {filteredCollections.length > 0 && (
               <View style={styles.section}>
                 <Text style={[styles.sectionTitle, { color: theme.text }]}>Meine Notebooks</Text>
-                {filteredCollections.map((c) => (
-                  <NotebookCard
-                    key={c.id}
-                    icon="book"
-                    title={c.name}
-                    subtitle={collectionSubtitle(c)}
-                    onPress={() => handleCollectionPress(c.id, c.name)}
-                    onLongPress={() => handleCollectionActions(c)}
-                    isProcessing={processingIds.has(c.id)}
-                  />
-                ))}
+                <View style={isTablet ? notebookGridStyles.grid : undefined}>
+                  {filteredCollections.map((c) => (
+                    <NotebookCard
+                      key={c.id}
+                      icon="book"
+                      title={c.name}
+                      subtitle={collectionSubtitle(c)}
+                      onPress={() => handleCollectionPress(c.id, c.name)}
+                      onLongPress={() => handleCollectionActions(c)}
+                      isProcessing={processingIds.has(c.id)}
+                      style={isTablet ? notebookGridStyles.item : undefined}
+                    />
+                  ))}
+                </View>
               </View>
             )}
             {filteredResults.length === 0 && filteredCollections.length === 0 && (
@@ -324,17 +329,20 @@ export default function NotebooksScreen() {
                   Noch keine eigenen Notebooks.
                 </Text>
               ) : (
-                collections.map((c) => (
-                  <NotebookCard
-                    key={c.id}
-                    icon="book"
-                    title={c.name}
-                    subtitle={collectionSubtitle(c)}
-                    onPress={() => handleCollectionPress(c.id, c.name)}
-                    onLongPress={() => handleCollectionActions(c)}
-                    isProcessing={processingIds.has(c.id)}
-                  />
-                ))
+                <View style={isTablet ? notebookGridStyles.grid : undefined}>
+                  {collections.map((c) => (
+                    <NotebookCard
+                      key={c.id}
+                      icon="book"
+                      title={c.name}
+                      subtitle={collectionSubtitle(c)}
+                      onPress={() => handleCollectionPress(c.id, c.name)}
+                      onLongPress={() => handleCollectionActions(c)}
+                      isProcessing={processingIds.has(c.id)}
+                      style={isTablet ? notebookGridStyles.item : undefined}
+                    />
+                  ))}
+                </View>
               )}
             </View>
 

--- a/apps/mobile/components/notebook/CommunityNotebooksSection.tsx
+++ b/apps/mobile/components/notebook/CommunityNotebooksSection.tsx
@@ -12,9 +12,10 @@ import {
 
 import { useNotebookLikes } from '../../hooks/notebook/useNotebookLikes';
 import { usePublicNotebookCollections } from '../../hooks/notebook/usePublicNotebookCollections';
+import { useIsTablet } from '../../hooks/useIsTablet';
 import { colors, spacing, typography, borderRadius, lightTheme, darkTheme } from '../../theme';
 
-import { NotebookCard } from './NotebookCard';
+import { NotebookCard, notebookGridStyles } from './NotebookCard';
 
 /**
  * "Von der Basis" — public community notebooks (web's VonDerBasisSection). Reuses
@@ -30,6 +31,7 @@ export function CommunityNotebooksSection({
 }) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const isTablet = useIsTablet();
   const [query, setQuery] = useState('');
   const { publicNotebooks, isLoading } = usePublicNotebookCollections(enabled);
   const { isLiked, toggleLike } = useNotebookLikes(enabled);
@@ -70,30 +72,33 @@ export function CommunityNotebooksSection({
           Keine Treffer für &ldquo;{query}&rdquo;
         </Text>
       ) : (
-        filtered.map((n) => {
-          const liked = isLiked(n.id);
-          return (
-            <NotebookCard
-              key={n.id}
-              icon="people-outline"
-              title={n.name}
-              subtitle={n.creator_name ? `von ${n.creator_name}` : undefined}
-              onPress={() => onOpen(n.id, n.name)}
-              trailing={
-                <Pressable onPress={() => toggleLike(n.id)} hitSlop={8} style={styles.likeButton}>
-                  <Ionicons
-                    name={liked ? 'heart' : 'heart-outline'}
-                    size={16}
-                    color={liked ? colors.primary[600] : theme.textSecondary}
-                  />
-                  <Text style={[styles.likeCount, { color: theme.textSecondary }]}>
-                    {n.likes_count ?? 0}
-                  </Text>
-                </Pressable>
-              }
-            />
-          );
-        })
+        <View style={isTablet ? notebookGridStyles.grid : undefined}>
+          {filtered.map((n) => {
+            const liked = isLiked(n.id);
+            return (
+              <NotebookCard
+                key={n.id}
+                icon="people-outline"
+                title={n.name}
+                subtitle={n.creator_name ? `von ${n.creator_name}` : undefined}
+                onPress={() => onOpen(n.id, n.name)}
+                style={isTablet ? notebookGridStyles.item : undefined}
+                trailing={
+                  <Pressable onPress={() => toggleLike(n.id)} hitSlop={8} style={styles.likeButton}>
+                    <Ionicons
+                      name={liked ? 'heart' : 'heart-outline'}
+                      size={16}
+                      color={liked ? colors.primary[600] : theme.textSecondary}
+                    />
+                    <Text style={[styles.likeCount, { color: theme.textSecondary }]}>
+                      {n.likes_count ?? 0}
+                    </Text>
+                  </Pressable>
+                }
+              />
+            );
+          })}
+        </View>
       )}
     </View>
   );

--- a/apps/mobile/components/notebook/NotebookCard.tsx
+++ b/apps/mobile/components/notebook/NotebookCard.tsx
@@ -1,6 +1,15 @@
 import { Ionicons, type IoniconsIconName } from '@react-native-vector-icons/ionicons';
 import { type ReactNode } from 'react';
-import { View, Text, Pressable, StyleSheet, ActivityIndicator, useColorScheme } from 'react-native';
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  ActivityIndicator,
+  useColorScheme,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
 
 import { colors, spacing, typography, borderRadius, lightTheme, darkTheme } from '../../theme';
 
@@ -18,6 +27,7 @@ export function NotebookCard({
   onLongPress,
   isProcessing,
   trailing,
+  style,
 }: {
   icon: IoniconsIconName;
   title: string;
@@ -29,6 +39,8 @@ export function NotebookCard({
   /** Replaces the default chevron (e.g. a like button). A nested Pressable here
    *  captures the touch, so tapping it won't also fire the card's onPress. */
   trailing?: ReactNode;
+  /** Extra root style — e.g. a width for laying cards out in a tablet grid. */
+  style?: StyleProp<ViewStyle>;
 }) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
@@ -40,6 +52,7 @@ export function NotebookCard({
       onLongPress={onLongPress}
       style={({ pressed }) => [
         styles.card,
+        style,
         {
           backgroundColor: pressed ? theme.surface : theme.card,
           borderColor: theme.cardBorder,
@@ -88,5 +101,21 @@ const styles = StyleSheet.create({
   cardMeta: {
     fontSize: 11,
     marginTop: 1,
+  },
+});
+
+/**
+ * Shared layout for rendering NotebookCards in a 2-column grid on tablets. Apply
+ * `grid` to the wrapping container and pass `item` as each card's `style`. On phones
+ * pass nothing — cards keep their default full-width stacked layout.
+ */
+export const notebookGridStyles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.xsmall,
+  },
+  item: {
+    width: '48%',
   },
 });

--- a/apps/mobile/components/notebook/NotebookSection.tsx
+++ b/apps/mobile/components/notebook/NotebookSection.tsx
@@ -1,11 +1,12 @@
 import { View, Text, StyleSheet, useColorScheme } from 'react-native';
 
 import { type MobileNotebookEntry } from '../../config/notebooksConfig';
+import { useIsTablet } from '../../hooks/useIsTablet';
 import { spacing, lightTheme, darkTheme } from '../../theme';
 
-import { NotebookCard } from './NotebookCard';
+import { NotebookCard, notebookGridStyles } from './NotebookCard';
 
-/** A titled 2-column grid of system notebooks. Renders nothing when empty. */
+/** A titled list of system notebooks (2 columns on tablet). Renders nothing when empty. */
 export function NotebookSection({
   title,
   notebooks,
@@ -19,22 +20,26 @@ export function NotebookSection({
 }) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const isTablet = useIsTablet();
 
   if (notebooks.length === 0) return null;
 
   return (
     <View style={styles.section}>
       <Text style={[styles.sectionTitle, { color: theme.text }]}>{title}</Text>
-      {notebooks.map((notebook) => (
-        <NotebookCard
-          key={notebook.id}
-          icon={notebook.icon}
-          title={notebook.title}
-          meta={notebook.meta}
-          onPress={() => onNotebookPress(notebook)}
-          onLongPress={onNotebookLongPress ? () => onNotebookLongPress(notebook) : undefined}
-        />
-      ))}
+      <View style={isTablet ? notebookGridStyles.grid : undefined}>
+        {notebooks.map((notebook) => (
+          <NotebookCard
+            key={notebook.id}
+            icon={notebook.icon}
+            title={notebook.title}
+            meta={notebook.meta}
+            onPress={() => onNotebookPress(notebook)}
+            onLongPress={onNotebookLongPress ? () => onNotebookLongPress(notebook) : undefined}
+            style={isTablet ? notebookGridStyles.item : undefined}
+          />
+        ))}
+      </View>
     </View>
   );
 }

--- a/apps/mobile/components/start/RecentlyCreatedSection.tsx
+++ b/apps/mobile/components/start/RecentlyCreatedSection.tsx
@@ -6,6 +6,7 @@ import { useRouter, type Href } from 'expo-router';
 import { memo, useCallback, useState } from 'react';
 import { View, Text, StyleSheet, Pressable, ActivityIndicator, Linking } from 'react-native';
 
+import { useIsTablet } from '../../hooks/useIsTablet';
 import { colors, spacing, borderRadius, type Theme } from '../../theme';
 import { DocPreview } from '../common/DocPreview';
 
@@ -54,6 +55,7 @@ const fetchRecentActivity = async (): Promise<RecentItem[]> => {
 
 export const RecentlyCreatedSection = memo(({ theme }: { theme: Theme }) => {
   const router = useRouter();
+  const isTablet = useIsTablet();
   const [failedThumbs, setFailedThumbs] = useState<Set<string>>(new Set());
 
   const { data: allItems = [], isLoading } = useQuery({
@@ -128,6 +130,7 @@ export const RecentlyCreatedSection = memo(({ theme }: { theme: Theme }) => {
               onPress={() => handleOpen(item)}
               style={({ pressed }) => [
                 styles.card,
+                { width: isTablet ? '31%' : '48%' },
                 {
                   backgroundColor: pressed ? theme.surface : theme.card,
                   borderColor: theme.cardBorder,
@@ -194,7 +197,6 @@ const styles = StyleSheet.create({
     gap: spacing.small,
   },
   card: {
-    width: '48%',
     flexGrow: 1,
     borderRadius: borderRadius.large,
     borderWidth: 1,

--- a/apps/mobile/hooks/useIsTablet.ts
+++ b/apps/mobile/hooks/useIsTablet.ts
@@ -1,0 +1,12 @@
+import { useWindowDimensions } from 'react-native';
+
+// Phones are portrait-locked (app.json orientation: "portrait") at ≤ ~440pt wide.
+// The smallest iPad in portrait is the mini at 744pt, so 700 cleanly separates tablets
+// from phones while still treating narrow iPad Split View columns as "phone".
+export const TABLET_MIN_WIDTH = 700;
+
+/** Reactive tablet check — recomputes on iPad Split View / window resize. */
+export function useIsTablet(): boolean {
+  const { width } = useWindowDimensions();
+  return width >= TABLET_MIN_WIDTH;
+}


### PR DESCRIPTION
On tablets (iPads, Android tablets) the app reused phone grid layouts, so cards were stretched and wasted horizontal space.

Adds a reactive `useIsTablet()` hook (built on `useWindowDimensions`, so iPad **Split View** resizing reflows the grids — a static device check would not). On tablets:

- **Recent ("Zuletzt")** and **Docs** grids render **3 columns** instead of 2.
- **Notebook** lists (system sections, "Meine Notebooks", "Von der Basis") render **2 columns** instead of 1.

Phones are unchanged. Pure-layout JS change — no native rebuild, ships in the normal bundle.

Verified: `@gruenerator/mobile` typecheck passes; ESLint/Prettier/commitlint green via pre-commit. Manual device check (3/3/2 columns on tablet, 2/2/1 on phone, Split-View reflow) pending on your side.