### PR TITLE
feat: gate agent creator behind flag + fix code-review findings

### DIFF
--- a/apps/api/services/userAgents/agentDraftService.ts
+++ b/apps/api/services/userAgents/agentDraftService.ts
@@ -34,15 +34,23 @@ const SKILL_CATALOG = SKILLS.map((s) => `- ${s.mention}: ${s.title}`).join('\n')
 // LLM output schema. `enabledTools`/`skillMentions` are free arrays here and
 // filtered against the catalogs after generation — strict enums would make the
 // call fail on a single near-miss value.
+// Min/max here mirror the create contract (createUserAgentBodySchema) so a
+// synthesized spec can always be persisted — otherwise a thin conversation
+// could 200 on /draft but 400 on create.
 const DraftSchema = z.object({
-  title: z.string().describe('Kurzer Anzeigename, z.B. "Pressestelle Kreisverband"'),
-  description: z.string().describe('Ein bis zwei Sätze: was der*die Agent*in tut'),
+  title: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe('Kurzer Anzeigename, z.B. "Pressestelle Kreisverband"'),
+  description: z.string().min(1).max(500).describe('Ein bis zwei Sätze: was der*die Agent*in tut'),
   systemRole: z
     .string()
+    .min(20)
     .describe(
       'Ausführlicher System-Prompt für den*die Agent*in: Rolle, Aufgabe, Ton, Arbeitsweise. Du-Form, Genderstern (*innen).'
     ),
-  avatar: z.string().describe('Ein einzelnes passendes Emoji'),
+  avatar: z.string().min(1).describe('Ein einzelnes passendes Emoji'),
   backgroundColor: z.string().describe('Hex-Farbe wie #316049'),
   enabledTools: z.array(z.string()).describe('Werkzeug-Schlüssel, ausschließlich aus dem Katalog'),
   skillMentions: z

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -33,6 +33,7 @@ import NewItemDropdown from './NewItemDropdown';
 import { getDefaultAgentEntries, getPinnedAgentIds, getAgentIcon } from './sidebarAgentConfig';
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
+import { SHOW_AGENT_CREATOR } from '@/config/featureFlags';
 import { cn } from '@/utils/cn';
 import '../../../assets/styles/components/layout/sidebar.css';
 
@@ -581,17 +582,22 @@ const SidebarAgents = memo(function SidebarAgents({
             </li>
           )}
 
-          {/* Entry point to the conversational agent creator (/agents/new). */}
-          <li>
-            <button
-              type="button"
-              onClick={() => onLinkClick('/agents/new', 'Neue*r Agent*in')}
-              className={cn(menuLinkClass(false), 'text-primary-600 dark:text-primary-300')}
-            >
-              <span className="shrink-0 w-6 h-6 flex items-center justify-center text-base">+</span>
-              <span className={titleClass}>Neue*r Agent*in</span>
-            </button>
-          </li>
+          {/* Entry point to the conversational agent creator (/agents/new),
+              gated behind SHOW_AGENT_CREATOR (dev or VITE_SHOW_AGENT_CREATOR). */}
+          {SHOW_AGENT_CREATOR && (
+            <li>
+              <button
+                type="button"
+                onClick={() => onLinkClick('/agents/new', 'Neue*r Agent*in')}
+                className={cn(menuLinkClass(false), 'text-primary-600 dark:text-primary-300')}
+              >
+                <span className="shrink-0 w-6 h-6 flex items-center justify-center text-base">
+                  +
+                </span>
+                <span className={titleClass}>Neue*r Agent*in</span>
+              </button>
+            </li>
+          )}
         </ul>
       )}
     </div>

--- a/apps/web/src/config/featureFlags.ts
+++ b/apps/web/src/config/featureFlags.ts
@@ -1,0 +1,13 @@
+/**
+ * Build-time feature flags for the web app.
+ */
+
+/**
+ * Whether the agent creator (conversational creator + manual builder + their
+ * sidebar entry) is exposed. Hidden in production by default; shown in dev, or
+ * on a deploy that sets `VITE_SHOW_AGENT_CREATOR=true`. Note this only gates the
+ * creation/editing surface — `/agents/:slug` (chatting with an existing agent)
+ * is always available.
+ */
+export const SHOW_AGENT_CREATOR =
+  import.meta.env.DEV || import.meta.env.VITE_SHOW_AGENT_CREATOR === 'true';

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -3,6 +3,8 @@ import { Navigate, useLocation, useParams } from 'react-router-dom';
 
 import { isDesktopApp } from '../utils/platform';
 
+import { SHOW_AGENT_CREATOR } from './featureFlags';
+
 /**
  * Route configuration interface
  */
@@ -235,21 +237,16 @@ const standardRoutes: RouteConfig[] = [
   // Unified Text Generator route (wildcard for path-based tab navigation)
   { path: '/texte/*', component: GrueneratorenBundle.Texte, withForm: true },
   { path: '/workplace', component: WorkplacePage },
-  // Conversational agent creator (default entry) + form editor. The list/
-  // overview lives on the unified Library page at /skills.
-  {
-    path: '/agents/new',
-    component: AgentCreatorPage,
-    layoutMode: 'sidebarOnly',
-  },
-  {
-    path: '/agents/new/manual',
-    component: AgentBuilderPage,
-  },
-  {
-    path: '/agents/:identifier/edit',
-    component: AgentBuilderPage,
-  },
+  // Conversational agent creator (default entry) + form editor. Gated behind
+  // SHOW_AGENT_CREATOR (dev, or a deploy with VITE_SHOW_AGENT_CREATOR=true);
+  // `/agents/:slug` below stays available so existing agents remain usable.
+  ...(SHOW_AGENT_CREATOR
+    ? ([
+        { path: '/agents/new', component: AgentCreatorPage, layoutMode: 'sidebarOnly' },
+        { path: '/agents/new/manual', component: AgentBuilderPage },
+        { path: '/agents/:identifier/edit', component: AgentBuilderPage },
+      ] satisfies RouteConfig[])
+    : []),
   // Chat with a specific system agent at /agents/<slug>. Slug is the agent
   // identifier with the `gruenerator-` prefix stripped (see `getAgentSlug`
   // in @gruenerator/shared/agents). ChatPage handles both this path-based

--- a/apps/web/src/features/agents/AgentBuilderPage.tsx
+++ b/apps/web/src/features/agents/AgentBuilderPage.tsx
@@ -1,5 +1,9 @@
 import { type UpdateUserAgentBody } from '@gruenerator/contracts';
-import { SKILLS, USER_SELECTABLE_TOOLS } from '@gruenerator/shared/agents';
+import {
+  DEFAULT_USER_AGENT_TOOLS,
+  SKILLS,
+  USER_SELECTABLE_TOOLS,
+} from '@gruenerator/shared/agents';
 import { generateSlugSuffix, slugifyName } from '@gruenerator/shared/utils';
 import { MultiStepForm } from '@gruenerator/ui';
 import { useMemo, useState, type FormEvent } from 'react';
@@ -91,7 +95,9 @@ function AgentBuilderPage() {
       locale: existing.locale === 'de-AT' ? 'de-AT' : 'de-DE',
       openingMessage: existing.openingMessage,
       openingQuestions: existing.openingQuestions.join('\n'),
-      enabledTools: [...(existing.enabledTools ?? [])],
+      // Fall back to defaults (not []) so editing a legacy agent that had no
+      // enabledTools doesn't silently narrow it to zero tools.
+      enabledTools: [...(existing.enabledTools ?? DEFAULT_USER_AGENT_TOOLS)],
       skillMentions: [...(existing.skillMentions ?? [])],
       defaultNotebookId: existing.defaultNotebookId ?? '',
       tags: existing.tags.join(', '),
@@ -149,7 +155,9 @@ function AgentBuilderPage() {
       } else {
         const slug = slugifyName(form.title, 'agent');
         const payload: UserAgentInput = {
-          identifier: `${slug}-${generateSlugSuffix()}`,
+          // Suffix lowercased to satisfy the identifier regex `^[a-z0-9-]+$`
+          // (generateSlugSuffix's alphabet includes uppercase letters).
+          identifier: `${slug}-${generateSlugSuffix().toLowerCase()}`,
           title: form.title.trim(),
           description: form.description.trim(),
           systemRole: form.systemRole.trim(),
@@ -177,6 +185,9 @@ function AgentBuilderPage() {
 
   const canProceed = step < STEP_COUNT - 1;
   const titleValid = form.title.trim().length > 0;
+  const descValid = form.description.trim().length > 0;
+  const avatarValid = form.avatar.trim().length > 0;
+  const basicsValid = titleValid && descValid && avatarValid;
   const roleValid = form.systemRole.trim().length >= 10;
 
   return (
@@ -437,7 +448,7 @@ function AgentBuilderPage() {
             <button
               type="button"
               className="rounded bg-primary-600 px-md py-sm text-white hover:bg-primary-700 disabled:opacity-50"
-              disabled={(step === 0 && !titleValid) || (step === 1 && !roleValid)}
+              disabled={(step === 0 && !basicsValid) || (step === 1 && !roleValid)}
               onClick={() => setStep((s) => Math.min(STEP_COUNT - 1, s + 1))}
             >
               Weiter
@@ -446,7 +457,7 @@ function AgentBuilderPage() {
             <button
               type="submit"
               className="rounded bg-primary-600 px-md py-sm text-white hover:bg-primary-700 disabled:opacity-50"
-              disabled={!titleValid || !roleValid || createMut.isPending || updateMut.isPending}
+              disabled={!basicsValid || !roleValid || createMut.isPending || updateMut.isPending}
             >
               {isEdit ? 'Speichern' : 'Erstellen'}
             </button>

--- a/apps/web/src/features/agents/AgentCreatorPage.tsx
+++ b/apps/web/src/features/agents/AgentCreatorPage.tsx
@@ -22,7 +22,9 @@ const TOOL_LABELS = new Map(USER_SELECTABLE_TOOLS.map((t) => [t.key, t.label]));
  *  them); the notebook can be added later via the editor. */
 function specToInput(spec: DraftedAgentSpec): UserAgentInput {
   return {
-    identifier: `${slugifyName(spec.title, 'agent')}-${generateSlugSuffix()}`,
+    // Suffix lowercased: the create schema's identifier is `^[a-z0-9-]+$`, but
+    // generateSlugSuffix()'s alphabet includes uppercase letters.
+    identifier: `${slugifyName(spec.title, 'agent')}-${generateSlugSuffix().toLowerCase()}`,
     title: spec.title,
     description: spec.description,
     systemRole: spec.systemRole,

--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -6,7 +6,7 @@ import {
   type UserRole,
 } from '@gruenerator/chat';
 import { getSystemAgent, resolveAgentSlug } from '@gruenerator/shared/agents';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired';
@@ -40,6 +40,10 @@ function ChatPage() {
   const firstName = useFirstName();
   const userLocale = useAuthStore((s) => s.locale) ?? 'de-DE';
   const { data: userAgents } = useUserAgents();
+  // The agent we've already auto-applied a default notebook for. Prevents the
+  // effect from re-applying (and clobbering a manual notebook pick) when the
+  // `userAgents` query reference changes on an unrelated cache invalidation.
+  const notebookAppliedForRef = useRef<string | null>(null);
   // Path-based /agents/:slug is the canonical form; ?agent= is legacy but
   // still wins when explicitly set so old deep links keep their behavior.
   const agentParam = searchParams.get('agent') ?? (slug ? resolveAgentSlug(slug) : null);
@@ -63,32 +67,40 @@ function ChatPage() {
         store.setSelectedAgent(agentParam);
         store.setChatViewMode('thread');
       }
-      // Per-LV PR agents (and any future agent that declares a
-      // defaultNotebookId) auto-pair their notebook so RAG and @notebook
-      // lookups align with the agent's regional identity. We always re-apply
-      // on agent change — the agent IS the source of truth here, and picking
-      // a different notebook manually after the agent is selected is an
-      // unusual flow we'd revisit only if users complain.
-      const agentMeta = getSystemAgent(agentParam);
-      // User-created agents aren't in the system registry — resolve their
-      // notebook binding from the user-agents list (a system notebook id).
-      const userAgentNotebook = agentMeta
-        ? undefined
-        : userAgents?.find((a) => a.identifier === agentParam)?.defaultNotebookId;
-      const boundNotebookId = agentMeta?.defaultNotebookId ?? userAgentNotebook;
-      if (boundNotebookId && store.selectedNotebookId !== boundNotebookId) {
-        store.setSelectedNotebook(boundNotebookId);
-      } else if (
-        !boundNotebookId &&
-        userLocale === 'de-AT' &&
-        store.selectedNotebookId !== AT_DEFAULT_NOTEBOOK_ID
-      ) {
-        // AT-first: agents without an explicit notebook pair with the
-        // Österreich notebook so RAG / @notebook queries stay in-locale.
-        store.setSelectedNotebook(AT_DEFAULT_NOTEBOOK_ID);
+      // Auto-pair the agent's default notebook — but only ONCE per agent, not
+      // on every effect run. System agents (per-LV PR agents etc.) resolve
+      // synchronously; user-created agents resolve from the user-agents list
+      // (which may load late), so we wait until it's available before marking
+      // this agent handled. Applying once avoids clobbering a manual notebook
+      // pick when the user-agents query reference changes later.
+      if (notebookAppliedForRef.current !== agentParam) {
+        const agentMeta = getSystemAgent(agentParam);
+        const userAgentNotebook = agentMeta
+          ? undefined
+          : userAgents?.find((a) => a.identifier === agentParam)?.defaultNotebookId;
+        const boundNotebookId = agentMeta?.defaultNotebookId ?? userAgentNotebook;
+        // "Resolved" = a system agent (sync) or the user-agents list has loaded.
+        const resolved = !!agentMeta || userAgents !== undefined;
+        if (boundNotebookId) {
+          if (store.selectedNotebookId !== boundNotebookId) {
+            store.setSelectedNotebook(boundNotebookId);
+          }
+          notebookAppliedForRef.current = agentParam;
+        } else if (resolved) {
+          // AT-first: agents without an explicit notebook pair with the
+          // Österreich notebook so RAG / @notebook queries stay in-locale.
+          if (userLocale === 'de-AT' && store.selectedNotebookId !== AT_DEFAULT_NOTEBOOK_ID) {
+            store.setSelectedNotebook(AT_DEFAULT_NOTEBOOK_ID);
+          }
+          notebookAppliedForRef.current = agentParam;
+        }
+        // else: user agent whose data hasn't loaded yet — wait for the next run.
       }
-    } else if (store.selectedAgentId !== null) {
-      store.setSelectedAgent(null);
+    } else {
+      notebookAppliedForRef.current = null;
+      if (store.selectedAgentId !== null) {
+        store.setSelectedAgent(null);
+      }
     }
     if (
       modeParam &&

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,8 @@ import type { QueryClient } from '@tanstack/react-query';
 declare global {
   interface ImportMetaEnv {
     readonly VITE_BACKEND_URL: string;
+    // Opt-in flag to expose the agent creator on a non-dev deploy.
+    readonly VITE_SHOW_AGENT_CREATOR?: string;
   }
 
   // Umami analytics


### PR DESCRIPTION
Two things, both about the just-shipped agent creator:

**Gate the creator navigation.** The conversational creator, manual wizard, and the sidebar "Neue*r Agent*in" entry are now hidden in production by default — shown only in dev or on a deploy that sets `VITE_SHOW_AGENT_CREATOR=true` (`SHOW_AGENT_CREATOR`). `/agents/:slug` (chatting with an existing agent) stays available, so already-created agents keep working.

**Fix code-review findings** (a max-effort multi-angle review surfaced these):
- **Critical:** the generated identifier appended `generateSlugSuffix()`, whose alphabet includes uppercase letters, but the create schema is `^[a-z0-9-]+$` — so ~96% of creations 400'd. Suffix is now lowercased at both build sites.
- ChatPage now applies an agent's default notebook **once per agent** (ref-guarded), so a `user-agents` cache refresh no longer re-fires the effect and clobbers a manual notebook pick.
- The draft LLM schema is constrained (title/description/systemRole min lengths) so a synthesized spec always satisfies the create contract — previously a thin conversation could 200 on `/draft` then 400 on create.
- The wizard gates step 1 / submit on description + avatar (not just title), and hydrates a legacy agent's empty `enabledTools` to the defaults instead of `[]`.

Lower-severity/latent findings (response-schema `reasoning`/`provider` strictness, 40s draft timeout vs proxy, avatar emoji slicing, 404→null edit URL) are noted for a follow-up.

Verification: typecheck green for api + web.