### PR TITLE
fix(mobile): persist login across app restarts

### DIFF
--- a/apps/mobile/hooks/useAppInitialization.ts
+++ b/apps/mobile/hooks/useAppInitialization.ts
@@ -1,6 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
 
 import { initializeApiClient } from '../services/api';
 import { configureAuthStore, checkAuthStatus } from '../services/auth';
@@ -33,6 +34,25 @@ export function useAppInitialization() {
 
     void initialize();
   }, [loadPreferences]);
+
+  // Re-validate the session when the app returns to the foreground after a
+  // spell in the background. Non-destructive: checkAuthStatus only logs out on
+  // a definitive 401/403 or 2xx-no-user, so a transient failure here can never
+  // bounce a valid session to login. Throttled so quick app switches (e.g. a
+  // permission dialog) don't trigger a probe.
+  useEffect(() => {
+    const REVALIDATE_AFTER_MS = 5 * 60 * 1000;
+    let lastValidatedAt = Date.now();
+
+    const subscription = AppState.addEventListener('change', (next: AppStateStatus) => {
+      if (next === 'active' && Date.now() - lastValidatedAt > REVALIDATE_AFTER_MS) {
+        lastValidatedAt = Date.now();
+        void checkAuthStatus();
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
 
   // Handle notification taps → deep link navigation
   useEffect(() => {

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -3,8 +3,10 @@ import {
   setGlobalApiClient,
   getGlobalApiClient,
   apiRequest,
+  type AuthRequestConfig,
 } from '@gruenerator/shared/api';
 import { useAuthStore } from '@gruenerator/shared/stores';
+import { isAxiosError } from 'axios';
 
 import { secureStorage } from './storage';
 
@@ -17,14 +19,41 @@ export function initializeApiClient(): void {
     getAuthToken: async () => {
       return secureStorage.getToken();
     },
-    // Better Auth sessions auto-extend on each request via `updateAge`.
-    // A 401 means the session is actually gone (rotated, revoked, or
-    // expired past the rolling window), so there's nothing to refresh —
-    // wipe local state and let the UI route back to login.
+    // A 401 isn't always a dead session — a flaky non-auth endpoint or a
+    // momentary server blip can return one, and wiping on the first 401 would
+    // log out a user whose session is actually fine. So re-probe the session
+    // endpoint ONCE before destroying local auth. `skipAuthRefresh` exempts the
+    // probe from this very interceptor so it can't recurse.
     onUnauthorized: async (): Promise<boolean> => {
+      try {
+        const client = getGlobalApiClient();
+        const probeConfig: AuthRequestConfig = { skipAuthRefresh: true };
+        const probe = await client.get<{ user?: unknown } | null>(
+          API_ENDPOINTS.AUTH_GET_SESSION,
+          probeConfig
+        );
+        if (probe.data?.user) {
+          // Session is alive — the original 401 was a fluke. Returning true
+          // tells the interceptor to retry the original request once.
+          return true;
+        }
+        // 2xx with no user → session really is gone → fall through to wipe.
+      } catch (error: unknown) {
+        // Only a definitive 401/403 on the probe confirms a dead session.
+        // Network / timeout / 5xx is indeterminate → keep the session.
+        const status = isAxiosError(error) ? error.response?.status : undefined;
+        if (status !== 401 && status !== 403) {
+          return false;
+        }
+      }
       await secureStorage.clearAll();
       useAuthStore.getState().clearAuth();
       return false;
+    },
+    // Persist a rotated bearer token (Better Auth `set-auth-token` header) so
+    // the stored token never drifts out of sync with the server session.
+    onTokenRefresh: async (token: string): Promise<void> => {
+      await secureStorage.setToken(token);
     },
     timeout: 120000,
   });

--- a/apps/mobile/services/auth.ts
+++ b/apps/mobile/services/auth.ts
@@ -1,4 +1,5 @@
 import { useAuthStore, setAuthStoreConfig } from '@gruenerator/shared/stores';
+import { isAxiosError } from 'axios';
 import { makeRedirectUri } from 'expo-auth-session';
 import * as WebBrowser from 'expo-web-browser';
 
@@ -168,6 +169,9 @@ async function exchangeCodeForTokens(code: string): Promise<{ success: boolean; 
     if (response.data.token && response.data.user) {
       await secureStorage.setToken(response.data.token);
       await secureStorage.setUser(JSON.stringify(response.data.user));
+      if (response.data.expiresAt) {
+        await secureStorage.setExpiresAt(response.data.expiresAt);
+      }
 
       useAuthStore.getState().setAuthState({
         user: response.data.user,
@@ -186,18 +190,51 @@ async function exchangeCodeForTokens(code: string): Promise<{ success: boolean; 
 }
 
 /**
- * Probe the Better Auth session for the stored bearer token. The bearer()
- * plugin lets /auth/v2/get-session accept `Authorization: Bearer <token>`
- * the same way it accepts a cookie on web.
+ * Restore the session on app launch. The bearer() plugin lets
+ * /auth/v2/get-session accept `Authorization: Bearer <token>` the same way it
+ * accepts a cookie on web.
+ *
+ * Persistence is optimistic and failure-aware: a stored token first restores
+ * the cached user so the UI is authenticated immediately (works offline, never
+ * flashes login on a slow start). The server probe then runs in the background
+ * and only logs the user out on a *definitive* "session gone" signal (a 2xx
+ * with no user, or a 401/403). A network/timeout/5xx is treated as "couldn't
+ * verify" — the session is kept, not destroyed.
  */
 export async function checkAuthStatus(): Promise<boolean> {
-  try {
-    const token = await secureStorage.getToken();
-    if (!token) {
-      useAuthStore.getState().setLoading(false);
+  const token = await secureStorage.getToken();
+  if (!token) {
+    useAuthStore.getState().setLoading(false);
+    return false;
+  }
+
+  // If we know the session is past its hard expiry, skip the optimistic restore
+  // and go straight to a clean login instead of flashing the authenticated UI.
+  const expiresAt = await secureStorage.getExpiresAt();
+  if (expiresAt) {
+    const expiresMs = Date.parse(expiresAt);
+    if (!Number.isNaN(expiresMs) && Date.now() > expiresMs) {
+      await secureStorage.clearAll();
+      useAuthStore.getState().clearAuth();
       return false;
     }
+  }
 
+  // Optimistic restore: show authenticated UI from the cached user immediately.
+  let restoredOptimistically = false;
+  const cachedUserJson = await secureStorage.getUser();
+  if (cachedUserJson) {
+    try {
+      const cachedUser = JSON.parse(cachedUserJson) as User;
+      useAuthStore.getState().setAuthState({ user: cachedUser });
+      restoredOptimistically = true;
+    } catch (error: unknown) {
+      console.warn('[Auth] Cached user parse failed:', getErrorMessage(error));
+    }
+  }
+
+  // Background verification against the server.
+  try {
     const apiClient = getGlobalApiClient();
     const response = await apiClient.get<{ user?: User; session?: unknown } | null>(
       API_ENDPOINTS.AUTH_GET_SESSION
@@ -209,13 +246,28 @@ export async function checkAuthStatus(): Promise<boolean> {
       return true;
     }
 
+    // 2xx with no user → session is definitively gone.
     await secureStorage.clearAll();
     useAuthStore.getState().clearAuth();
     return false;
   } catch (error: unknown) {
-    console.error('[Auth] Status check error:', error);
-    useAuthStore.getState().setLoading(false);
-    return false;
+    const status = isAxiosError(error) ? error.response?.status : undefined;
+    if (status === 401 || status === 403) {
+      // Server explicitly rejected the token → genuine logout.
+      await secureStorage.clearAll();
+      useAuthStore.getState().clearAuth();
+      return false;
+    }
+    // Network / timeout / 5xx → indeterminate. Keep the optimistically restored
+    // session; the user stays logged in on their cached identity.
+    console.error(
+      '[Auth] Could not verify session (keeping cached login):',
+      getErrorMessage(error)
+    );
+    if (!restoredOptimistically) {
+      useAuthStore.getState().setLoading(false);
+    }
+    return restoredOptimistically;
   }
 }
 

--- a/apps/mobile/services/storage.ts
+++ b/apps/mobile/services/storage.ts
@@ -5,6 +5,7 @@ import { getErrorMessage } from '../utils/errors';
 const STORAGE_KEYS = {
   AUTH_TOKEN: 'auth_token',
   AUTH_USER: 'auth_user',
+  AUTH_EXPIRES_AT: 'auth_expires_at',
 } as const;
 
 /**
@@ -64,8 +65,33 @@ export const secureStorage = {
     }
   },
 
+  async getExpiresAt(): Promise<string | null> {
+    try {
+      return await SecureStore.getItemAsync(STORAGE_KEYS.AUTH_EXPIRES_AT);
+    } catch (error: unknown) {
+      console.error('[SecureStorage] Failed to get expiresAt:', getErrorMessage(error));
+      return null;
+    }
+  },
+
+  async setExpiresAt(expiresAt: string): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(STORAGE_KEYS.AUTH_EXPIRES_AT, expiresAt);
+    } catch (error: unknown) {
+      console.error('[SecureStorage] Failed to set expiresAt:', getErrorMessage(error));
+    }
+  },
+
+  async removeExpiresAt(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(STORAGE_KEYS.AUTH_EXPIRES_AT);
+    } catch (error: unknown) {
+      console.error('[SecureStorage] Failed to remove expiresAt:', getErrorMessage(error));
+    }
+  },
+
   async clearAll(): Promise<void> {
-    await Promise.all([this.removeToken(), this.removeUser()]);
+    await Promise.all([this.removeToken(), this.removeUser(), this.removeExpiresAt()]);
   },
 };
 

--- a/packages/shared/src/api/client.ts
+++ b/packages/shared/src/api/client.ts
@@ -1,8 +1,20 @@
-import axios, { type AxiosInstance, type AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import axios, {
+  type AxiosInstance,
+  type AxiosError,
+  type AxiosRequestConfig,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 
 import type { ApiConfig } from '../types/auth.js';
 
 export type AuthMode = 'cookie' | 'bearer';
+
+/**
+ * Per-request config extension. Set `skipAuthRefresh: true` to exempt a request
+ * from the global 401 handler — used by the session re-probe inside
+ * `onUnauthorized` so the probe can't re-enter the interceptor and recurse.
+ */
+export type AuthRequestConfig = AxiosRequestConfig & { skipAuthRefresh?: boolean };
 
 export interface CreateApiClientOptions extends ApiConfig {
   authMode: AuthMode;
@@ -16,7 +28,14 @@ export interface CreateApiClientOptions extends ApiConfig {
  * Mobile: Uses Bearer token auth
  */
 export function createApiClient(options: CreateApiClientOptions): AxiosInstance {
-  const { baseURL, authMode, getAuthToken, onUnauthorized, timeout = 900000 } = options;
+  const {
+    baseURL,
+    authMode,
+    getAuthToken,
+    onUnauthorized,
+    onTokenRefresh,
+    timeout = 900000,
+  } = options;
 
   const client = axios.create({
     baseURL,
@@ -40,16 +59,30 @@ export function createApiClient(options: CreateApiClientOptions): AxiosInstance 
 
   // Response interceptor - handle 401 errors with retry after token refresh
   client.interceptors.response.use(
-    (response) => response,
+    (response) => {
+      // Better Auth's bearer() plugin can return a refreshed session token via
+      // the `set-auth-token` response header. Persist it so the stored token
+      // never drifts from the server session. No-op on web (no handler passed).
+      if (onTokenRefresh) {
+        const refreshedToken: unknown = response.headers['set-auth-token'];
+        if (typeof refreshedToken === 'string' && refreshedToken.length > 0) {
+          void onTokenRefresh(refreshedToken);
+        }
+      }
+      return response;
+    },
     async (error: AxiosError) => {
-      const originalRequest = error.config;
+      const originalRequest = error.config as
+        | (InternalAxiosRequestConfig & { _retried?: boolean; skipAuthRefresh?: boolean })
+        | undefined;
       if (
         error.response?.status === 401 &&
         onUnauthorized &&
         originalRequest &&
-        !(originalRequest as InternalAxiosRequestConfig & { _retried?: boolean })._retried
+        !originalRequest._retried &&
+        !originalRequest.skipAuthRefresh
       ) {
-        (originalRequest as InternalAxiosRequestConfig & { _retried?: boolean })._retried = true;
+        originalRequest._retried = true;
         const refreshed = await onUnauthorized();
         if (refreshed) {
           if (authMode === 'bearer' && getAuthToken) {

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -51,6 +51,12 @@ export interface ApiConfig {
   baseURL: string;
   getAuthToken?: () => Promise<string | null>;
   onUnauthorized?: () => void | Promise<boolean>;
+  /**
+   * Called when a response carries a refreshed bearer token (Better Auth's
+   * `set-auth-token` header). Persist it so the stored token tracks the server
+   * session and never drifts. Bearer/mobile only — omitted on web (cookie mode).
+   */
+  onTokenRefresh?: (token: string) => void | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## Why

Mobile users were **sometimes** kicked back to the login screen on app restart even though their session was still valid (sessions last 30 days with a 24h sliding refresh). This is a UX defect, not a security gate.

The bearer token persists fine in `expo-secure-store` — the **boot logic** was the problem. `checkAuthStatus()` made the authenticated UI strictly conditional on a live `/auth/v2/get-session` round-trip and never read back the already-persisted cached user. Two paths turned a transient hiccup into a forced re-login:

1. **A transient network/5xx at cold start** left `user = null`, so `_layout.tsx` redirected to login while a perfectly valid token sat on disk. Tapping "Login" then ran a fresh OAuth that overwrote it. (The intermittent "sometimes".)
2. **Any stray 401 wiped the token** — including the `/auth/profile` hydration call that runs *after* a successful session check. One false 401 → guaranteed re-login next launch.

## Hardening layers

- **Optimistic restore** of the cached user before the network probe → instant authenticated UI, offline open, no login flash on a slow start.
- **Failure-aware verify** — only a *definitive* signal (2xx-no-user or 401/403) logs out; network/timeout/5xx keeps the session.
- **Surgical 401 handler** — re-probes the session once before wiping, so a false/transient 401 can't destroy a valid login (`skipAuthRefresh` guards interceptor recursion).
- **`set-auth-token` capture** — persists a rotated bearer token if Better Auth ever returns one.
- **Foreground re-validation** (throttled) + **persisted `expiresAt`** to skip the optimistic restore once past hard expiry.

Shared `client.ts` changes are bearer-only and additive — **web (cookie mode) behaviour is unchanged**. Pure JS, no native rebuild.

## Verification

`pnpm --filter @gruenerator/mobile typecheck` and `--filter @gruenerator/shared typecheck` both pass. Manual matrix (airplane-mode reopen stays logged in; false 401 survives; genuinely-dead session routes cleanly to login) in the PR plan.