### PR TITLE
fix(web): stop splitting canvas-editor chunk (site-wide React-null crash)

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -264,7 +264,14 @@ export default defineConfig(({ command }) => ({
                     test: /[\\/]node_modules[\\/](@hocuspocus|yjs|y-protocols|y-indexeddb|lib0)[\\/]/,
                   }, // ~450 KB
                   { name: 'vendor-imgly', test: /[\\/]node_modules[\\/]@imgly[\\/]/ }, // 167 KB
-                  { name: 'pkg-canvas-editor', test: /[\\/]packages[\\/]canvas-editor[\\/]/ }, // 1.4 MB
+                  // NOTE: do NOT add `pkg-canvas-editor` (or any other workspace
+                  // package) back here. canvas-editor ships React Providers/hooks
+                  // and imports react-konva (already split into `vendor-konva`),
+                  // so splitting it forms a cross-chunk init cycle: the
+                  // canvas-editor chunk renders while its `react` import binding is
+                  // still null → "Cannot read properties of null (reading
+                  // 'useEffect')". This crashed prod on master (commit e49af52ea).
+                  // Per the strategy comment above, only leaf libraries are split.
                 ],
               },
             }),


### PR DESCRIPTION
On master, the whole site crashes with `TypeError: Cannot read properties of null (reading 'useEffect')` originating in the `pkg-canvas-editor` chunk.

The `React` object itself is null at render time — a cross-chunk module-init cycle, not a hook bug. `packages/canvas-editor` is a workspace package that ships React Providers/hooks and imports `react-konva` (already split into `vendor-konva`). Giving it its own manualChunk wires it into a chunk cycle where the canvas-editor chunk initializes before the chunk owning React assigns its export binding.

The Vite config's own strategy comment already documents this exact failure mode (it bit prod twice before) and states the invariant: only leaf libraries get split; React, Radix, and workspace packages stay in the entry chunk. The `pkg-canvas-editor` group added in e49af52ea violated that. Removing it restores the invariant and unblocks the site.