### PR TITLE
fix(web): dedupe React to one copy — fixes site-wide null-dispatcher whitescreen

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -120,7 +120,17 @@ export default defineConfig(({ command }) => ({
       //    from packages/shared/src/api/contractsClient.ts"
       '@gruenerator/contracts': path.resolve(__dirname, '../../packages/contracts/src'),
     },
-    dedupe: ['d3-path'],
+    // React MUST be deduped to a single physical copy. pnpm installs several
+    // react versions (root 19.2.6, plus 19.2.3/19.2.4 nested under deps like
+    // @tanstack/react-query); without dedupe, Rolldown links TWO Reacts into
+    // the bundle. The second copy's dispatcher (ReactCurrentDispatcher.current)
+    // is null, so the first hook call from a component that imported it —
+    // QueryClientProvider's useEffect — throws "Cannot read properties of null
+    // (reading 'useEffect')" and white-screens the whole app.
+    // We CANNOT pin react via root pnpm.overrides (that forces mobile off its
+    // Expo-locked react and breaks the RN renderer — see CLAUDE.md), so the
+    // web bundle dedupes here instead.
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'd3-path'],
   },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
## The actual root cause

The site white-screens on load with `TypeError: Cannot read properties of null (reading 'useEffect')`. Resolving the deployed (hidden) sourcemap pinpoints it exactly:

- null access → `@tanstack/react-query/node_modules/react/cjs/react.production.js`
- failing component → react-query's `QueryClientProvider` (its `useEffect(() => client.mount())`)

**There are two physical React copies in the web bundle.** pnpm installs `react@19.2.6` at the root, but `@tanstack/react-query@5.100.9` nests its own `react@19.2.3`. Rolldown links both. react-query's provider imported the *second* copy, whose internal dispatcher (`ReactCurrentDispatcher.current`) is null when React-DOM (the root copy) is doing the rendering — so its first hook call throws, and the app's ErrorBoundary shows the white screen.

## Why the earlier PRs didn't fix it

#1062 (drop canvas chunk) and #1063 (disable code-splitting) chased a chunk-init-cycle theory. That was a red herring: the crash reproduced in the **single bundle** too, because duplicate React survives any chunking. Splitting only changed *which* React copy got the null binding.

## The fix

Add `react`, `react-dom`, and the jsx runtimes to Vite `resolve.dedupe` so every `react` specifier (including react-query's nested one) resolves to a single physical copy.

We deliberately do **not** pin react via root `pnpm.overrides` — that forces `apps/mobile` off its Expo-SDK-locked react and breaks the React Native renderer (documented in CLAUDE.md). Deduping in the web bundler is the mobile-safe fix.

## Verification

Build green; new bundle's sourcemap contains only the root `react/cjs/react.production.js` (react-query's nested copy is gone). Follow-up: code-splitting (reverted in #1063) can now be restored safely to claw back the single-bundle initial-load size, ideally behind a runtime smoke test.