### PR TITLE
fix(mobile): make safe areas + layout work on iPad

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -13,6 +13,8 @@
       "infoPlist": {
         "CFBundleAllowMixedLocalizations": true,
         "ITSAppUsesNonExemptEncryption": false,
+        "NSMicrophoneUsageDescription": "Grünerator braucht das Mikrofon, um deine Spracheingabe in Text umzuwandeln.",
+        "NSSpeechRecognitionUsageDescription": "Grünerator nutzt die Spracherkennung, um deine gesprochenen Eingaben in Text umzuwandeln.",
         "UISupportedInterfaceOrientations~ipad": [
           "UIInterfaceOrientationPortrait",
           "UIInterfaceOrientationPortraitUpsideDown",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -12,7 +12,13 @@
       "bundleIdentifier": "de.gruenerator.app",
       "infoPlist": {
         "CFBundleAllowMixedLocalizations": true,
-        "ITSAppUsesNonExemptEncryption": false
+        "ITSAppUsesNonExemptEncryption": false,
+        "UISupportedInterfaceOrientations~ipad": [
+          "UIInterfaceOrientationPortrait",
+          "UIInterfaceOrientationPortraitUpsideDown",
+          "UIInterfaceOrientationLandscapeLeft",
+          "UIInterfaceOrientationLandscapeRight"
+        ]
       }
     },
     "android": {

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -9,7 +9,6 @@ import {
   Pressable,
   useColorScheme,
   ActivityIndicator,
-  Image,
   Linking,
   type ImageSourcePropType,
 } from 'react-native';
@@ -114,7 +113,9 @@ export default function LoginScreen() {
         onPress={() => handleLogin(provider.source)}
         disabled={isLoading}
       >
-        {provider.logo && <Image source={provider.logo} style={styles.loginLogo} />}
+        {provider.logo && (
+          <BrandImage source={provider.logo} style={styles.loginLogo} contentFit="contain" />
+        )}
         <View style={styles.loginTextContent}>
           {isButtonLoading ? (
             <ActivityIndicator color={theme.text} />
@@ -227,7 +228,6 @@ const styles = StyleSheet.create({
     width: 50,
     height: 50,
     marginRight: spacing.medium,
-    resizeMode: 'contain',
   },
   loginTextContent: {
     flex: 1,

--- a/apps/mobile/app/(fullscreen)/image-studio-editor.tsx
+++ b/apps/mobile/app/(fullscreen)/image-studio-editor.tsx
@@ -8,15 +8,15 @@
  */
 
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { router } from 'expo-router';
 import { useCallback, useRef, useState, useEffect } from 'react';
 import {
   View,
-  Image,
   Pressable,
   StyleSheet,
   useColorScheme,
-  Dimensions,
+  useWindowDimensions,
   ActivityIndicator,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -40,12 +40,12 @@ import { getImageDataUri } from '../../services/imageStudio';
 import { useImageStudioStore } from '../../stores/imageStudioStore';
 import { lightTheme, darkTheme, colors, spacing, borderRadius } from '../../theme';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-
 export default function FullscreenImageStudioEditor() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  const imageWidth = width - spacing.medium * 2;
   const categoryModalRef = useRef<EditCategoryModalRef>(null);
 
   const [selectedCategory, setSelectedCategory] = useState<EditCategory | null>(null);
@@ -124,7 +124,11 @@ export default function FullscreenImageStudioEditor() {
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       <View style={styles.imageContainer}>
-        <Image source={{ uri: imageUri }} style={styles.image} resizeMode="contain" />
+        <Image
+          source={{ uri: imageUri }}
+          style={[styles.image, { width: imageWidth, maxWidth: imageWidth }]}
+          contentFit="contain"
+        />
         {isRegenerating && (
           <View style={styles.loadingOverlay}>
             <ActivityIndicator size="large" color={colors.white} />
@@ -171,9 +175,7 @@ const styles = StyleSheet.create({
     paddingBottom: 120,
   },
   image: {
-    width: SCREEN_WIDTH - spacing.medium * 2,
     aspectRatio: 1,
-    maxWidth: SCREEN_WIDTH - spacing.medium * 2,
     borderRadius: borderRadius.large,
   },
   loadingOverlay: {

--- a/apps/mobile/app/(fullscreen)/pushed-content.tsx
+++ b/apps/mobile/app/(fullscreen)/pushed-content.tsx
@@ -6,19 +6,12 @@
 
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { File } from 'expo-file-system';
+import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useState, useEffect, useCallback } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  Image,
-  Pressable,
-  ActivityIndicator,
-  useColorScheme,
-} from 'react-native';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator, useColorScheme } from 'react-native';
 
 import { Button } from '../../components/common/Button';
 import { shareFile } from '../../services/share';
@@ -197,7 +190,7 @@ export default function PushedContentScreen() {
         {isVideo && localUri ? (
           <VideoView player={player} style={styles.preview} contentFit="contain" nativeControls />
         ) : localUri ? (
-          <Image source={{ uri: localUri }} style={styles.preview} resizeMode="contain" />
+          <Image source={{ uri: localUri }} style={styles.preview} contentFit="contain" />
         ) : null}
       </View>
 

--- a/apps/mobile/app/(tabs)/(tools)/image-studio/gallery.tsx
+++ b/apps/mobile/app/(tabs)/(tools)/image-studio/gallery.tsx
@@ -5,6 +5,7 @@
 
 import { useShareStore, type Share } from '@gruenerator/shared/share';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
@@ -12,13 +13,12 @@ import {
   Text,
   StyleSheet,
   FlatList,
-  Image,
   Pressable,
   ActivityIndicator,
   useColorScheme,
+  useWindowDimensions,
   RefreshControl,
   Alert,
-  Dimensions,
 } from 'react-native';
 
 import { shareImage } from '../../../../services/imageStudio';
@@ -31,15 +31,15 @@ import {
   typography,
 } from '../../../../theme';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const NUM_COLUMNS = 2;
 const ITEM_GAP = spacing.small;
-const ITEM_SIZE = (SCREEN_WIDTH - spacing.medium * 2 - ITEM_GAP) / NUM_COLUMNS;
 
 export default function GalleryScreen() {
   const router = useRouter();
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const { width } = useWindowDimensions();
+  const numColumns = width >= 700 ? 3 : 2;
+  const itemSize = (width - spacing.medium * 2 - ITEM_GAP * (numColumns - 1)) / numColumns;
 
   const { shares, isLoading, fetchUserShares, deleteShare } = useShareStore();
   const [refreshing, setRefreshing] = useState(false);
@@ -119,12 +119,16 @@ export default function GalleryScreen() {
         item.thumbnailUrl || `https://gruenerator.eu/share/${item.shareToken}/thumbnail`;
 
       return (
-        <View style={styles.itemContainer}>
+        <View style={[styles.itemContainer, { width: itemSize }]}>
           <Pressable
             style={({ pressed }) => [styles.item, pressed && styles.itemPressed]}
             onPress={() => void handleShare(item)}
           >
-            <Image source={{ uri: imageUrl }} style={styles.itemImage} resizeMode="cover" />
+            <Image
+              source={{ uri: imageUrl }}
+              style={[styles.itemImage, { width: itemSize, height: itemSize }]}
+              contentFit="cover"
+            />
             <View style={styles.itemOverlay}>
               <Text style={styles.itemTitle} numberOfLines={1}>
                 {item.title || 'Sharepic'}
@@ -145,7 +149,7 @@ export default function GalleryScreen() {
         </View>
       );
     },
-    [handleShare, handleDelete]
+    [handleShare, handleDelete, itemSize]
   );
 
   const getEmptyStateContent = () => {
@@ -231,10 +235,11 @@ export default function GalleryScreen() {
       </View>
 
       <FlatList
+        key={numColumns}
         data={filteredShares}
         renderItem={renderItem}
         keyExtractor={(item) => item.shareToken}
-        numColumns={NUM_COLUMNS}
+        numColumns={numColumns}
         contentContainerStyle={styles.listContent}
         columnWrapperStyle={styles.columnWrapper}
         ListEmptyComponent={renderEmpty}
@@ -308,9 +313,7 @@ const styles = StyleSheet.create({
     gap: ITEM_GAP,
     marginBottom: ITEM_GAP,
   },
-  itemContainer: {
-    width: ITEM_SIZE,
-  },
+  itemContainer: {},
   item: {
     borderRadius: borderRadius.medium,
     overflow: 'hidden',
@@ -319,10 +322,7 @@ const styles = StyleSheet.create({
   itemPressed: {
     opacity: 0.8,
   },
-  itemImage: {
-    width: ITEM_SIZE,
-    height: ITEM_SIZE,
-  },
+  itemImage: {},
   itemOverlay: {
     position: 'absolute',
     bottom: 0,

--- a/apps/mobile/app/(tabs)/(tools)/vorlagen.tsx
+++ b/apps/mobile/app/(tabs)/(tools)/vorlagen.tsx
@@ -1,16 +1,16 @@
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   FlatList,
-  Image,
   Pressable,
   ActivityIndicator,
   useColorScheme,
+  useWindowDimensions,
   RefreshControl,
-  Dimensions,
   Linking,
   Alert,
 } from 'react-native';
@@ -26,14 +26,14 @@ import {
 } from '../../../services/vorlagen';
 import { colors, spacing, borderRadius, lightTheme, darkTheme, typography } from '../../../theme';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const NUM_COLUMNS = 2;
 const ITEM_GAP = spacing.small;
-const ITEM_SIZE = (SCREEN_WIDTH - spacing.medium * 2 - ITEM_GAP) / NUM_COLUMNS;
 
 export default function VorlagenScreen() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const { width } = useWindowDimensions();
+  const numColumns = width >= 700 ? 3 : 2;
+  const itemSize = (width - spacing.medium * 2 - ITEM_GAP * (numColumns - 1)) / numColumns;
 
   const [templates, setTemplates] = useState<Template[]>([]);
   const [categories, setCategories] = useState<TemplateCategory[]>([]);
@@ -158,15 +158,25 @@ export default function VorlagenScreen() {
       const isLiked = likedTemplates.has(item.id);
 
       return (
-        <View style={styles.itemContainer}>
+        <View style={[styles.itemContainer, { width: itemSize }]}>
           <Pressable
             style={({ pressed }) => [styles.item, pressed && styles.itemPressed]}
             onPress={() => void handleTemplatePress(item)}
           >
             {imageUrl ? (
-              <Image source={{ uri: imageUrl }} style={styles.itemImage} resizeMode="cover" />
+              <Image
+                source={{ uri: imageUrl }}
+                style={[styles.itemImage, { width: itemSize, height: itemSize * 0.75 }]}
+                contentFit="cover"
+              />
             ) : (
-              <View style={[styles.itemImage, styles.itemImagePlaceholder]}>
+              <View
+                style={[
+                  styles.itemImage,
+                  styles.itemImagePlaceholder,
+                  { width: itemSize, height: itemSize * 0.75 },
+                ]}
+              >
                 <Ionicons name="image-outline" size={32} color={colors.grey[400]} />
               </View>
             )}
@@ -204,7 +214,7 @@ export default function VorlagenScreen() {
         </View>
       );
     },
-    [handleTemplatePress, handleLikeToggle, likedTemplates, theme.textSecondary]
+    [handleTemplatePress, handleLikeToggle, likedTemplates, theme.textSecondary, itemSize]
   );
 
   const renderEmpty = () => (
@@ -248,10 +258,11 @@ export default function VorlagenScreen() {
       )}
 
       <FlatList
+        key={numColumns}
         data={filteredTemplates}
         renderItem={renderItem}
         keyExtractor={(item) => item.id}
-        numColumns={NUM_COLUMNS}
+        numColumns={numColumns}
         contentContainerStyle={styles.listContent}
         columnWrapperStyle={styles.columnWrapper}
         ListEmptyComponent={renderEmpty}
@@ -311,9 +322,7 @@ const styles = StyleSheet.create({
     gap: ITEM_GAP,
     marginBottom: ITEM_GAP,
   },
-  itemContainer: {
-    width: ITEM_SIZE,
-  },
+  itemContainer: {},
   item: {
     borderRadius: borderRadius.medium,
     overflow: 'hidden',
@@ -322,10 +331,7 @@ const styles = StyleSheet.create({
   itemPressed: {
     opacity: 0.8,
   },
-  itemImage: {
-    width: ITEM_SIZE,
-    height: ITEM_SIZE * 0.75,
-  },
+  itemImage: {},
   itemImagePlaceholder: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -140,7 +140,7 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider initialWindowMetrics={initialWindowMetrics}>
+      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
         <QueryClientProvider client={queryClient}>
           <KeyboardProvider>
             <ActionSheetProvider>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -16,6 +16,7 @@ import { useEffect } from 'react';
 import { View, useColorScheme } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
+import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
 import { AppDrawer } from '../components/navigation';
@@ -139,19 +140,21 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <QueryClientProvider client={queryClient}>
-        <KeyboardProvider>
-          <ActionSheetProvider>
-            <ErrorBoundary>
-              {/* AppDrawer (thread-list) wraps the whole Stack so threads/new-chat
-                  are reachable from any screen — incl. the pushed (focused)
-                  conversation. Gated on `user` to avoid an unauthenticated
-                  thread-list fetch during the login flow. */}
-              {user ? <AppDrawer>{appContent}</AppDrawer> : appContent}
-            </ErrorBoundary>
-          </ActionSheetProvider>
-        </KeyboardProvider>
-      </QueryClientProvider>
+      <SafeAreaProvider initialWindowMetrics={initialWindowMetrics}>
+        <QueryClientProvider client={queryClient}>
+          <KeyboardProvider>
+            <ActionSheetProvider>
+              <ErrorBoundary>
+                {/* AppDrawer (thread-list) wraps the whole Stack so threads/new-chat
+                    are reachable from any screen — incl. the pushed (focused)
+                    conversation. Gated on `user` to avoid an unauthenticated
+                    thread-list fetch during the login flow. */}
+                {user ? <AppDrawer>{appContent}</AppDrawer> : appContent}
+              </ErrorBoundary>
+            </ActionSheetProvider>
+          </KeyboardProvider>
+        </QueryClientProvider>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/apps/mobile/components/common/ImagePicker.tsx
+++ b/apps/mobile/components/common/ImagePicker.tsx
@@ -1,7 +1,8 @@
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import * as ExpoImagePicker from 'expo-image-picker';
 import { useState, useCallback } from 'react';
-import { View, Text, StyleSheet, Image, Pressable, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, Pressable, ActivityIndicator } from 'react-native';
 
 import { colors, spacing, borderRadius, typography } from '../../theme';
 
@@ -118,8 +119,13 @@ export function ImagePicker({
     return (
       <View style={styles.container}>
         <View style={styles.previewContainer}>
-          <Image source={{ uri: selectedImage.uri }} style={styles.preview} resizeMode="cover" />
-          <Pressable style={styles.clearButton} onPress={onClear}>
+          <Image source={{ uri: selectedImage.uri }} style={styles.preview} contentFit="cover" />
+          <Pressable
+            style={styles.clearButton}
+            onPress={onClear}
+            accessibilityLabel="Bild entfernen"
+            accessibilityRole="button"
+          >
             <Ionicons name="close-circle" size={28} color={colors.white} />
           </Pressable>
         </View>

--- a/apps/mobile/components/image-studio/ImageCardGrid.tsx
+++ b/apps/mobile/components/image-studio/ImageCardGrid.tsx
@@ -8,7 +8,14 @@
 import { Ionicons, type IoniconsIconName } from '@react-native-vector-icons/ionicons';
 import { Image, type ImageSource } from 'expo-image';
 import { useState } from 'react';
-import { View, Text, StyleSheet, Pressable, useColorScheme, Dimensions } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  useColorScheme,
+  useWindowDimensions,
+} from 'react-native';
 
 import { colors, spacing, lightTheme, darkTheme, typography } from '../../theme';
 
@@ -30,7 +37,7 @@ export function ImageCardGrid<T extends ImageCard>({ items, onPress }: ImageCard
   const isDark = colorScheme === 'dark';
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
 
-  const screenWidth = Dimensions.get('window').width;
+  const { width: screenWidth } = useWindowDimensions();
   const gridPadding = spacing.medium * 2;
   const gap = spacing.small;
   const cardWidth = (screenWidth - gridPadding - gap) / 2;

--- a/apps/mobile/components/image-studio/KiInputStep.tsx
+++ b/apps/mobile/components/image-studio/KiInputStep.tsx
@@ -5,7 +5,8 @@
 
 import { getKiTypeConfig } from '@gruenerator/shared/image-studio';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
-import { View, Text, TextInput, StyleSheet, useColorScheme, Image } from 'react-native';
+import { Image } from 'expo-image';
+import { View, Text, TextInput, StyleSheet, useColorScheme } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 
 import { useSpeechToText, appendTranscript } from '../../hooks/useSpeechToText';
@@ -133,7 +134,7 @@ export function KiInputStep({
           <Image
             source={{ uri: uploadedImageUri }}
             style={styles.previewImage}
-            resizeMode="cover"
+            contentFit="cover"
           />
           <View
             style={[

--- a/apps/mobile/components/image-studio/MediathekSelector.tsx
+++ b/apps/mobile/components/image-studio/MediathekSelector.tsx
@@ -5,6 +5,7 @@
 
 import { useShareStore, type Share } from '@gruenerator/shared/share';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   View,
@@ -13,20 +14,17 @@ import {
   Modal,
   Pressable,
   FlatList,
-  Image,
   ActivityIndicator,
   useColorScheme,
-  Dimensions,
+  useWindowDimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { fetchMediathekImage } from '../../services/imageStudio';
 import { colors, spacing, borderRadius, lightTheme, darkTheme, typography } from '../../theme';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const NUM_COLUMNS = 3;
 const ITEM_GAP = spacing.xsmall;
-const ITEM_SIZE = (SCREEN_WIDTH - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
 interface MediathekSelectorProps {
   visible: boolean;
@@ -38,6 +36,8 @@ export function MediathekSelector({ visible, onClose, onImageSelect }: Mediathek
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  const itemSize = (width - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
   const { shares, isLoading, fetchUserShares } = useShareStore();
   const [selectedToken, setSelectedToken] = useState<string | null>(null);
@@ -88,11 +88,15 @@ export function MediathekSelector({ visible, onClose, onImageSelect }: Mediathek
 
       return (
         <Pressable
-          style={[styles.imageItem, isSelected && styles.imageItemSelected]}
+          style={[
+            styles.imageItem,
+            { width: itemSize, height: itemSize },
+            isSelected && styles.imageItemSelected,
+          ]}
           onPress={() => handleImagePress(item)}
           disabled={loadingImage}
         >
-          <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} resizeMode="cover" />
+          <Image source={{ uri: thumbnailUrl }} style={styles.thumbnail} contentFit="cover" />
           {isSelected && loadingImage && (
             <View style={styles.loadingOverlay}>
               <ActivityIndicator size="small" color={colors.white} />
@@ -108,7 +112,7 @@ export function MediathekSelector({ visible, onClose, onImageSelect }: Mediathek
         </Pressable>
       );
     },
-    [selectedToken, loadingImage, handleImagePress]
+    [selectedToken, loadingImage, handleImagePress, itemSize]
   );
 
   const renderEmpty = () => (
@@ -231,8 +235,6 @@ const styles = StyleSheet.create({
     marginBottom: ITEM_GAP,
   },
   imageItem: {
-    width: ITEM_SIZE,
-    height: ITEM_SIZE,
     borderRadius: borderRadius.medium,
     overflow: 'hidden',
     backgroundColor: colors.gray[100],

--- a/apps/mobile/components/image-studio/ResultDisplay.tsx
+++ b/apps/mobile/components/image-studio/ResultDisplay.tsx
@@ -4,12 +4,12 @@
  */
 
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 import {
   View,
   Text,
-  Image,
   StyleSheet,
   Pressable,
   ActivityIndicator,
@@ -125,7 +125,7 @@ export function ResultDisplay({
       </View>
 
       <View style={styles.imageContainer}>
-        <Image source={{ uri: imageUri }} style={styles.image} resizeMode="cover" />
+        <Image source={{ uri: imageUri }} style={styles.image} contentFit="cover" />
         {/* Device gallery saved badge */}
         {saved && (
           <View style={styles.savedBadge}>

--- a/apps/mobile/components/image-studio/StockImagesGrid.tsx
+++ b/apps/mobile/components/image-studio/StockImagesGrid.tsx
@@ -12,7 +12,7 @@ import {
   ScrollView,
   ActivityIndicator,
   useColorScheme,
-  Dimensions,
+  useWindowDimensions,
   Alert,
 } from 'react-native';
 
@@ -23,10 +23,8 @@ import { UnsplashAttribution } from './UnsplashAttribution';
 
 import type { StockImage } from '@gruenerator/shared/image-studio';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const NUM_COLUMNS = 3;
 const ITEM_GAP = spacing.xsmall;
-const ITEM_SIZE = (SCREEN_WIDTH - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
 interface StockImagesGridProps {
   onImageSelected: (uri: string, base64: string) => void;
@@ -36,6 +34,8 @@ export function StockImagesGrid({ onImageSelected }: StockImagesGridProps) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const isDark = colorScheme === 'dark';
+  const { width } = useWindowDimensions();
+  const itemSize = (width - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
   const [images, setImages] = useState<StockImage[]>([]);
   const [categories, setCategories] = useState<string[]>([]);
@@ -118,7 +118,11 @@ export function StockImagesGrid({ onImageSelected }: StockImagesGridProps) {
 
       return (
         <Pressable
-          style={[styles.imageItem, isSelected && styles.imageItemSelected]}
+          style={[
+            styles.imageItem,
+            { width: itemSize, height: itemSize },
+            isSelected && styles.imageItemSelected,
+          ]}
           onPress={() => handleImagePress(item)}
           disabled={loadingImage !== null}
         >
@@ -132,7 +136,7 @@ export function StockImagesGrid({ onImageSelected }: StockImagesGridProps) {
         </Pressable>
       );
     },
-    [loadingImage, handleImagePress]
+    [loadingImage, handleImagePress, itemSize]
   );
 
   return (
@@ -215,8 +219,6 @@ const styles = StyleSheet.create({
     marginBottom: ITEM_GAP,
   },
   imageItem: {
-    width: ITEM_SIZE,
-    height: ITEM_SIZE,
     borderRadius: borderRadius.medium,
     overflow: 'hidden',
   },

--- a/apps/mobile/components/image-studio/UnsplashSearchTab.tsx
+++ b/apps/mobile/components/image-studio/UnsplashSearchTab.tsx
@@ -16,7 +16,7 @@ import {
   Pressable,
   ActivityIndicator,
   useColorScheme,
-  Dimensions,
+  useWindowDimensions,
   Alert,
 } from 'react-native';
 
@@ -28,10 +28,8 @@ import { UnsplashAttribution } from './UnsplashAttribution';
 
 import type { StockImage } from '@gruenerator/shared/image-studio';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const NUM_COLUMNS = 3;
 const ITEM_GAP = spacing.xsmall;
-const ITEM_SIZE = (SCREEN_WIDTH - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
 interface UnsplashSearchTabProps {
   onImageSelected: (uri: string, base64: string) => void;
@@ -41,6 +39,8 @@ export function UnsplashSearchTab({ onImageSelected }: UnsplashSearchTabProps) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const isDark = colorScheme === 'dark';
+  const { width } = useWindowDimensions();
+  const itemSize = (width - spacing.medium * 2 - ITEM_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
 
   const searchFn = useMemo(
     () => (q: string, p: number, pp: number) =>
@@ -101,7 +101,11 @@ export function UnsplashSearchTab({ onImageSelected }: UnsplashSearchTabProps) {
 
       return (
         <Pressable
-          style={[styles.imageItem, isSelected && styles.imageItemSelected]}
+          style={[
+            styles.imageItem,
+            { width: itemSize, height: itemSize },
+            isSelected && styles.imageItemSelected,
+          ]}
           onPress={() => void handleImagePress(item)}
           disabled={loadingImage !== null}
         >
@@ -115,7 +119,7 @@ export function UnsplashSearchTab({ onImageSelected }: UnsplashSearchTabProps) {
         </Pressable>
       );
     },
-    [loadingImage, handleImagePress]
+    [loadingImage, handleImagePress, itemSize]
   );
 
   const renderFooter = () => {
@@ -232,8 +236,6 @@ const styles = StyleSheet.create({
     marginBottom: ITEM_GAP,
   },
   imageItem: {
-    width: ITEM_SIZE,
-    height: ITEM_SIZE,
     borderRadius: borderRadius.medium,
     overflow: 'hidden',
   },

--- a/apps/mobile/components/navigation/AppDrawer.tsx
+++ b/apps/mobile/components/navigation/AppDrawer.tsx
@@ -1,6 +1,6 @@
 import { AssistantRuntimeProvider } from '@assistant-ui/react-native';
 import { type ReactNode } from 'react';
-import { useColorScheme } from 'react-native';
+import { useColorScheme, useWindowDimensions } from 'react-native';
 import { Drawer } from 'react-native-drawer-layout';
 
 import { useChatDrawerRuntime } from '../../hooks/useChatDrawerRuntime';
@@ -12,6 +12,10 @@ import { ThreadSync } from '../chat/ThreadSync';
 export function AppDrawer({ children }: { children: ReactNode }) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
+  const { width } = useWindowDimensions();
+  // Cap the drawer so it stays readable on wide / Split View iPad panes
+  // instead of spanning 80% of a large screen.
+  const drawerWidth = Math.min(width * 0.8, 360);
   const runtime = useChatDrawerRuntime();
   const open = useDrawerStore((s) => s.open);
   const openDrawer = useDrawerStore((s) => s.openDrawer);
@@ -25,7 +29,7 @@ export function AppDrawer({ children }: { children: ReactNode }) {
         onOpen={openDrawer}
         onClose={closeDrawer}
         drawerType="slide"
-        drawerStyle={{ width: '80%', backgroundColor: theme.background }}
+        drawerStyle={{ width: drawerWidth, backgroundColor: theme.background }}
         renderDrawerContent={() => <ThreadListDrawer theme={theme} />}
       >
         {children}

--- a/apps/mobile/components/navigation/ScreenScaffold.tsx
+++ b/apps/mobile/components/navigation/ScreenScaffold.tsx
@@ -19,7 +19,7 @@ export function ScreenScaffold({ title, children }: { title: string; children: R
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
 
   return (
-    <SafeAreaView style={styles.container} edges={['top']}>
+    <SafeAreaView style={styles.container} edges={['top', 'left', 'right']}>
       <LinearGradient
         colors={
           colorScheme === 'dark'

--- a/apps/mobile/components/reel/ProjectList.tsx
+++ b/apps/mobile/components/reel/ProjectList.tsx
@@ -8,13 +8,13 @@ import {
 } from '@gruenerator/shared';
 import { useAuthStore } from '@gruenerator/shared/stores';
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import { useEffect, useState, useCallback } from 'react';
 import {
   View,
   Text,
   FlatList,
   TouchableOpacity,
-  Image,
   StyleSheet,
   useColorScheme,
   ActivityIndicator,
@@ -152,7 +152,7 @@ export function ProjectList({
                   headers: { Authorization: `Bearer ${authToken}` },
                 }}
                 style={styles.thumbnail}
-                resizeMode="cover"
+                contentFit="cover"
               />
             ) : (
               <View style={[styles.thumbnailPlaceholder, { backgroundColor: theme.border }]}>

--- a/apps/mobile/components/reel/VideoUploader.tsx
+++ b/apps/mobile/components/reel/VideoUploader.tsx
@@ -1,11 +1,11 @@
 import { Ionicons } from '@react-native-vector-icons/ionicons';
+import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { useState, useCallback } from 'react';
 import {
   View,
   Text,
   StyleSheet,
-  Image,
   Pressable,
   ActivityIndicator,
   type ViewStyle,
@@ -170,7 +170,7 @@ export function VideoUploader({
       ) : (
         <>
           <View style={styles.previewContainer}>
-            <Image source={{ uri: selectedVideo.uri }} style={styles.preview} resizeMode="cover" />
+            <Image source={{ uri: selectedVideo.uri }} style={styles.preview} contentFit="cover" />
             <Pressable style={styles.clearButton} onPress={clearSelection}>
               <Ionicons name="close-circle" size={28} color={colors.white} />
             </Pressable>

--- a/apps/mobile/components/sharepic/SharepicResult.tsx
+++ b/apps/mobile/components/sharepic/SharepicResult.tsx
@@ -1,17 +1,17 @@
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { File, Paths } from 'expo-file-system';
+import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import { useState, useCallback } from 'react';
 import {
   View,
   Text,
-  Image,
   StyleSheet,
   ScrollView,
   Pressable,
   useColorScheme,
+  useWindowDimensions,
   Alert,
-  Dimensions,
 } from 'react-native';
 
 import { shareFile } from '../../services/share';
@@ -25,13 +25,12 @@ interface SharepicResultProps {
   onNewGeneration?: () => void;
 }
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
-const IMAGE_WIDTH = SCREEN_WIDTH - spacing.medium * 2;
-
 export function SharepicResult({ sharepics, onNewGeneration }: SharepicResultProps) {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const isDark = colorScheme === 'dark';
+  const { width } = useWindowDimensions();
+  const imageWidth = width - spacing.medium * 2;
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [savedIndices, setSavedIndices] = useState<Set<number>>(new Set());
@@ -137,7 +136,7 @@ export function SharepicResult({ sharepics, onNewGeneration }: SharepicResultPro
         pagingEnabled
         showsHorizontalScrollIndicator={false}
         onMomentumScrollEnd={(e) => {
-          const newIndex = Math.round(e.nativeEvent.contentOffset.x / IMAGE_WIDTH);
+          const newIndex = Math.round(e.nativeEvent.contentOffset.x / imageWidth);
           if (newIndex >= 0 && newIndex < sharepics.length) {
             setCurrentIndex(newIndex);
           }
@@ -145,8 +144,8 @@ export function SharepicResult({ sharepics, onNewGeneration }: SharepicResultPro
         contentContainerStyle={styles.scrollContent}
       >
         {sharepics.map((sharepic, index) => (
-          <View key={sharepic.id || index} style={styles.imageContainer}>
-            <Image source={{ uri: sharepic.image }} style={styles.image} resizeMode="contain" />
+          <View key={sharepic.id || index} style={[styles.imageContainer, { width: imageWidth }]}>
+            <Image source={{ uri: sharepic.image }} style={styles.image} contentFit="contain" />
             {savedIndices.has(index) && (
               <View style={styles.savedBadge}>
                 <Ionicons name="checkmark-circle" size={16} color={colors.white} />
@@ -235,7 +234,6 @@ const styles = StyleSheet.create({
     gap: spacing.medium,
   },
   imageContainer: {
-    width: IMAGE_WIDTH,
     aspectRatio: 1,
     borderRadius: borderRadius.large,
     overflow: 'hidden',


### PR DESCRIPTION
Safe areas rendered incorrectly on iPad (content under the status bar) while looking fine on an Android phone. Root cause: the app had no `SafeAreaProvider`, so `useSafeAreaInsets()` (used in 40+ files) fell back to its zero-inset default. The phone hid this by staying portrait-locked; iPad ignores the portrait lock and allows rotation + Split View, which needs a live provider to re-measure.

This mounts the provider, then completes the iPad story so the now-correct insets actually have a layout that reflows into them:

- Mount `SafeAreaProvider` (seeded with `initialMetrics`) at the root; widen the shared `ScreenScaffold` chrome to left/right edges.
- Allow iPad rotation + Split View via `UISupportedInterfaceOrientations~ipad` (iPhone stays portrait-locked).
- Adaptive drawer width and `useWindowDimensions`-based grids (adaptive column count) so layouts reflow on rotate/resize instead of freezing module-load dimensions.
- Migrate the media screens touched here from RN `Image` to `expo-image` (repo rule).
- Add iOS microphone / speech-recognition usage strings (the speech-to-text hook requests them).

Verified via `pnpm --filter @gruenerator/mobile typecheck`. Visual confirmation needs a TestFlight build on a real iPad (rotate + Split View). Accessibility and remaining perf cleanup ship as separate follow-up PRs.