### PR TITLE
feat(mobile): accessibility labels for icon-only controls

### DIFF
--- a/apps/mobile/components/chat/GeneratedImageDisplay.tsx
+++ b/apps/mobile/components/chat/GeneratedImageDisplay.tsx
@@ -49,6 +49,7 @@ export function GeneratedImageDisplay({ image, theme }: { image: GeneratedImage;
           source={{ uri: src }}
           style={[styles.image, { backgroundColor: theme.surface, borderColor: theme.border }]}
           contentFit="cover"
+          accessibilityLabel="Generiertes Bild"
         />
       </Pressable>
 
@@ -89,7 +90,11 @@ export function GeneratedImageDisplay({ image, theme }: { image: GeneratedImage;
       >
         <Pressable style={styles.lightbox} onPress={() => setZoomed(false)}>
           <Image source={{ uri: src }} style={styles.lightboxImage} contentFit="contain" />
-          <View style={styles.closeButton}>
+          <View
+            style={styles.closeButton}
+            accessibilityLabel="Schließen"
+            accessibilityRole="button"
+          >
             <Ionicons name="close" size={24} color={colors.white} />
           </View>
         </Pressable>

--- a/apps/mobile/components/common/BottomSheet.tsx
+++ b/apps/mobile/components/common/BottomSheet.tsx
@@ -54,7 +54,13 @@ export function BottomSheet({
   );
 
   return (
-    <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityViewIsModal={true}
+    >
       {keyboardAvoiding ? (
         <KeyboardAvoidingView behavior="padding" style={styles.container}>
           {content}

--- a/apps/mobile/components/common/editor-toolbar/ToolPill.tsx
+++ b/apps/mobile/components/common/editor-toolbar/ToolPill.tsx
@@ -79,6 +79,8 @@ export function ToolPill({
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       disabled={disabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
     >
       <Ionicons name={icon} size={18} color={isActive ? colors.primary[700] : colors.grey[600]} />
       <Text style={[styles.label, { color: isActive ? colors.primary[700] : colors.grey[600] }]}>

--- a/apps/mobile/components/docs/NativeFormattingToolbar.tsx
+++ b/apps/mobile/components/docs/NativeFormattingToolbar.tsx
@@ -24,6 +24,22 @@ function isDivider(item: ToolbarItem): item is ToolbarDivider {
   return 'divider' in item;
 }
 
+const A11Y_LABELS: Record<string, string> = {
+  bold: 'Fett',
+  italic: 'Kursiv',
+  underline: 'Unterstrichen',
+  strike: 'Durchgestrichen',
+  h1: 'Überschrift 1',
+  h2: 'Überschrift 2',
+  h3: 'Überschrift 3',
+  bullet: 'Aufzählung',
+  number: 'Nummerierte Liste',
+  check: 'Checkliste',
+  left: 'Linksbündig',
+  center: 'Zentriert',
+  right: 'Rechtsbündig',
+};
+
 export const NativeFormattingToolbar = memo(function NativeFormattingToolbar() {
   const colorScheme = useColorScheme();
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
@@ -163,6 +179,9 @@ export const NativeFormattingToolbar = memo(function NativeFormattingToolbar() {
             <Pressable
               key={item.id}
               onPress={item.action}
+              accessibilityLabel={A11Y_LABELS[item.id] ?? item.label}
+              accessibilityRole="button"
+              accessibilityState={{ selected: item.isActive }}
               style={[styles.button, item.isActive && { backgroundColor: activeColor }]}
             >
               {item.icon ? (

--- a/apps/mobile/components/navigation/FloatingBadgeTabs.tsx
+++ b/apps/mobile/components/navigation/FloatingBadgeTabs.tsx
@@ -43,6 +43,9 @@ export function FloatingBadgeTabs({ tabs, activeTab, onTabPress, style }: Floati
             key={tab.key}
             onPress={() => onTabPress(tab.key)}
             activeOpacity={0.7}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={tab.label}
             style={[
               styles.badge,
               isActive

--- a/apps/mobile/components/navigation/ProfileMenu.tsx
+++ b/apps/mobile/components/navigation/ProfileMenu.tsx
@@ -85,7 +85,14 @@ export function ProfileMenu() {
 
   return (
     <>
-      <Pressable ref={triggerRef} onPress={handleOpen} style={styles.trigger} hitSlop={8}>
+      <Pressable
+        ref={triggerRef}
+        onPress={handleOpen}
+        style={styles.trigger}
+        hitSlop={8}
+        accessibilityLabel="Profilmenü öffnen"
+        accessibilityRole="button"
+      >
         <ProfileAvatar
           avatarRobotId={user?.avatar_robot_id}
           displayName={user?.display_name}

--- a/apps/mobile/components/navigation/SidebarMenuButton.tsx
+++ b/apps/mobile/components/navigation/SidebarMenuButton.tsx
@@ -15,6 +15,8 @@ export function SidebarMenuButton({ color, size = 26 }: Props) {
     <Pressable
       onPress={openDrawer}
       hitSlop={8}
+      accessibilityLabel="Menü öffnen"
+      accessibilityRole="button"
       style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center' }}
     >
       <Ionicons name="menu" size={size} color={color} />

--- a/apps/mobile/components/notifications/NotificationList.tsx
+++ b/apps/mobile/components/notifications/NotificationList.tsx
@@ -117,7 +117,13 @@ export function NotificationList({ onNavigate }: Props) {
               {formatTimeAgo(item.created_at)}
             </Text>
           </View>
-          <Pressable onPress={() => dismiss(item.id)} hitSlop={8} style={styles.dismissBtn}>
+          <Pressable
+            onPress={() => dismiss(item.id)}
+            hitSlop={8}
+            style={styles.dismissBtn}
+            accessibilityLabel="Benachrichtigung schließen"
+            accessibilityRole="button"
+          >
             <Ionicons name="close" size={15} color={theme.textSecondary} />
           </Pressable>
         </Pressable>

--- a/apps/mobile/components/profile/RolesSection.tsx
+++ b/apps/mobile/components/profile/RolesSection.tsx
@@ -81,6 +81,8 @@ export function RolesSection() {
             onPress={() => router.push('/(modals)/role-add' as Href)}
             hitSlop={8}
             style={styles.addIconButton}
+            accessibilityLabel="Rolle hinzufügen"
+            accessibilityRole="button"
           >
             <Ionicons name="add" size={24} color={colors.primary[600]} />
           </Pressable>
@@ -137,7 +139,13 @@ export function RolesSection() {
                     </Text>
                   ) : null}
                 </View>
-                <Pressable onPress={() => handleDelete(i)} hitSlop={8} style={styles.deleteButton}>
+                <Pressable
+                  onPress={() => handleDelete(i)}
+                  hitSlop={8}
+                  style={styles.deleteButton}
+                  accessibilityLabel="Rolle entfernen"
+                  accessibilityRole="button"
+                >
                   <Ionicons name="trash-outline" size={18} color={colors.error[500]} />
                 </Pressable>
               </View>

--- a/apps/mobile/components/share/ShareModal.tsx
+++ b/apps/mobile/components/share/ShareModal.tsx
@@ -233,7 +233,12 @@ export function ShareModal({
       <KeyboardAvoidingView behavior="padding" style={styles.container}>
         <View style={styles.header}>
           <Text style={styles.title}>Teilen</Text>
-          <Pressable onPress={onClose} style={styles.closeButton}>
+          <Pressable
+            onPress={onClose}
+            style={styles.closeButton}
+            accessibilityLabel="Schließen"
+            accessibilityRole="button"
+          >
             <Ionicons name="close" size={24} color={colors.grey[600]} />
           </Pressable>
         </View>

--- a/apps/mobile/components/workplace/GroupAvatar.tsx
+++ b/apps/mobile/components/workplace/GroupAvatar.tsx
@@ -22,6 +22,7 @@ export function GroupAvatar({ name, avatarUrl, size = 64 }: Props) {
         source={{ uri: src }}
         style={{ width: size, height: size, borderRadius: radius }}
         contentFit="cover"
+        accessibilityLabel={name ? `Avatar von ${name}` : 'Gruppen-Avatar'}
       />
     );
   }


### PR DESCRIPTION
Icon-only buttons throughout the app (sidebar/drawer toggle, profile menu, share & notification & role buttons, the doc formatting toolbar, floating tabs, bottom sheet) had no accessible name, so VoiceOver read them as unlabeled "button". This adds German `accessibilityLabel` plus `accessibilityRole`/`accessibilityState` to those controls.

Pure accessibility-prop additions — no layout, styling, or behavior changes. Typecheck-clean. Split out from the iPad layout work (#1067) since it's a distinct concern.