### PR TITLE
perf(mobile): virtualize gruppen lists + haptic Button feedback

### DIFF
--- a/apps/mobile/app/(focused)/gruppen/[id]/links.tsx
+++ b/apps/mobile/app/(focused)/gruppen/[id]/links.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  FlatList,
   Pressable,
   TextInput,
   Modal,
@@ -140,10 +141,12 @@ export default function GroupLinksScreen() {
           ) : null}
         </View>
       ) : (
-        <ScrollView contentContainerStyle={styles.list}>
-          {links.map((link) => (
+        <FlatList
+          data={links}
+          keyExtractor={(link) => link.id}
+          contentContainerStyle={styles.list}
+          renderItem={({ item: link }) => (
             <Pressable
-              key={link.id}
               onPress={() => void openLink(link.url)}
               onLongPress={isAdmin ? () => setEditing(link) : undefined}
               style={({ pressed }) => [
@@ -179,13 +182,15 @@ export default function GroupLinksScreen() {
                 </Pressable>
               ) : null}
             </Pressable>
-          ))}
-          {isAdmin ? (
-            <Text style={[styles.hint, { color: theme.textSecondary }]}>
-              Lange tippen zum Bearbeiten.
-            </Text>
-          ) : null}
-        </ScrollView>
+          )}
+          ListFooterComponent={
+            isAdmin ? (
+              <Text style={[styles.hint, { color: theme.textSecondary }]}>
+                Lange tippen zum Bearbeiten.
+              </Text>
+            ) : null
+          }
+        />
       )}
 
       <LinkEditor

--- a/apps/mobile/app/(focused)/gruppen/[id]/members.tsx
+++ b/apps/mobile/app/(focused)/gruppen/[id]/members.tsx
@@ -6,7 +6,7 @@ import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
+  FlatList,
   Pressable,
   ActivityIndicator,
   useColorScheme,
@@ -107,7 +107,9 @@ export default function GroupMembersScreen() {
           </Text>
         </View>
       ) : (
-        <ScrollView
+        <FlatList
+          data={members}
+          keyExtractor={(member) => member.user_id}
           contentContainerStyle={styles.list}
           refreshControl={
             <RefreshControl
@@ -115,13 +117,11 @@ export default function GroupMembersScreen() {
               onRefresh={() => void membersQuery.refetch()}
             />
           }
-        >
-          {members.map((member) => {
+          renderItem={({ item: member }) => {
             const isCreator = String(member.user_id) === String(createdBy);
             const canChange = isAdmin && !isCreator;
             return (
               <Pressable
-                key={member.user_id}
                 onPress={() => openMemberMenu(member)}
                 disabled={!canChange}
                 style={({ pressed }) => [
@@ -148,8 +148,8 @@ export default function GroupMembersScreen() {
                 ) : null}
               </Pressable>
             );
-          })}
-        </ScrollView>
+          }}
+        />
       )}
     </SafeAreaView>
   );

--- a/apps/mobile/app/(focused)/gruppen/index.tsx
+++ b/apps/mobile/app/(focused)/gruppen/index.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  FlatList,
   useColorScheme,
   ActivityIndicator,
   Pressable,
@@ -121,16 +122,16 @@ export default function GruppenScreen() {
     );
   } else {
     body = (
-      <ScrollView
+      <FlatList
         style={styles.container}
+        data={groups}
+        keyExtractor={(group: GroupSummary) => group.id}
         contentContainerStyle={styles.scrollContent}
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={() => void refetch()} />
         }
-      >
-        {groups.map((group: GroupSummary) => (
+        renderItem={({ item: group }: { item: GroupSummary }) => (
           <Pressable
-            key={group.id}
             onPress={() => openGroup(group.id)}
             style={({ pressed }) => [
               styles.groupCard,
@@ -168,8 +169,8 @@ export default function GruppenScreen() {
               </Text>
             ) : null}
           </Pressable>
-        ))}
-      </ScrollView>
+        )}
+      />
     );
   }
 

--- a/apps/mobile/components/common/Button.tsx
+++ b/apps/mobile/components/common/Button.tsx
@@ -1,3 +1,4 @@
+import * as Haptics from 'expo-haptics';
 import { type ReactNode } from 'react';
 import {
   Pressable,
@@ -34,6 +35,12 @@ export function Button({
 }: ButtonProps) {
   const isDisabled = disabled || loading;
 
+  const handlePress = () => {
+    if (isDisabled) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onPress();
+  };
+
   const getButtonStyle = (): ViewStyle => {
     switch (variant) {
       case 'primary':
@@ -64,15 +71,19 @@ export function Button({
     switch (variant) {
       case 'primary':
         return colors.white;
-      default:
+      case 'secondary':
+      case 'outline':
+      case 'ghost':
         return colors.primary[600];
     }
   };
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={handlePress}
       disabled={isDisabled}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled }}
       style={({ pressed }) => [
         styles.button,
         getButtonStyle(),

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -57,6 +57,7 @@
     "expo-file-system": "~56.0.7",
     "expo-font": "~56.0.5",
     "expo-glass-effect": "~56.0.4",
+    "expo-haptics": "~56.0.3",
     "expo-image": "~56.0.8",
     "expo-image-picker": "~56.0.12",
     "expo-linear-gradient": "~56.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -552,6 +552,9 @@ importers:
       expo-glass-effect:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.3)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      expo-haptics:
+        specifier: ~56.0.3
+        version: 56.0.3(expo@56.0.3)
       expo-image:
         specifier: ~56.0.8
         version: 56.0.8(expo@56.0.3)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -13898,6 +13901,11 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
+
+  expo-haptics@56.0.3:
+    resolution: {integrity: sha512-ycoahZJnR9tWAVh/0mJYxbETtHRYaWjiWS8cHlP6aDGU6Q6Y8rZ5NKsuBwWw6HR2Pe30mfVFgbF2HrBR6gtYmw==}
+    peerDependencies:
+      expo: '*'
 
   expo-image-loader@56.0.3:
     resolution: {integrity: sha512-JgUo4fUeU1ZC+z8iBFj8v7yoGQnZrLbOVPyNE+DWVrld55F2F6R1ck+rmdm/8TNWLz1LhNQfD7c3XYP1ZikxXA==}
@@ -39310,6 +39318,10 @@ snapshots:
       expo: 56.0.3(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.11)(expo-router@56.2.5)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+
+  expo-haptics@56.0.3(expo@56.0.3):
+    dependencies:
+      expo: 56.0.3(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.11)(expo-router@56.2.5)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.84.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
 
   expo-image-loader@56.0.3(expo@56.0.3):
     dependencies:


### PR DESCRIPTION
Two small mobile polish items, split out from the iPad work (#1067):

- Members, links and group lists rendered every row via `.map()` inside a `ScrollView`; switched to `FlatList` so they virtualize.
- Added a light haptic impact to the shared `Button` on press (most buttons route through it), plus `accessibilityRole`/`accessibilityState`.

Typecheck-clean. The indicator-color switch was made exhaustive to satisfy the root eslint config (lint-staged is stricter than per-package CI).