### PR TITLE
fix(mobile): comply with Google Play photo/video permissions policy

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -36,11 +36,7 @@
       "permissions": [
         "android.permission.RECORD_AUDIO",
         "android.permission.READ_EXTERNAL_STORAGE",
-        "android.permission.WRITE_EXTERNAL_STORAGE",
-        "android.permission.READ_MEDIA_VISUAL_USER_SELECTED",
-        "android.permission.READ_MEDIA_IMAGES",
-        "android.permission.READ_MEDIA_VIDEO",
-        "android.permission.READ_MEDIA_AUDIO"
+        "android.permission.WRITE_EXTERNAL_STORAGE"
       ]
     },
     "web": {
@@ -102,7 +98,8 @@
         }
       ],
       "expo-status-bar",
-      "@react-native-vector-icons/ionicons"
+      "@react-native-vector-icons/ionicons",
+      "./config/withBlockedAndroidMediaPermissions"
     ],
     "experiments": {
       "typedRoutes": true

--- a/apps/mobile/app/(fullscreen)/pushed-content.tsx
+++ b/apps/mobile/app/(fullscreen)/pushed-content.tsx
@@ -120,7 +120,7 @@ export default function PushedContentScreen() {
 
   const handleSaveToGallery = useCallback(async () => {
     if (!localUri) return;
-    const { status } = await MediaLibrary.requestPermissionsAsync();
+    const { status } = await MediaLibrary.requestPermissionsAsync(true);
     if (status !== 'granted') return;
     await MediaLibrary.Asset.create(localUri);
     setSavedToGallery(true);

--- a/apps/mobile/components/common/ImagePicker.tsx
+++ b/apps/mobile/components/common/ImagePicker.tsx
@@ -28,13 +28,8 @@ export function ImagePicker({
     setLoading(true);
 
     try {
-      const permissionResult = await ExpoImagePicker.requestMediaLibraryPermissionsAsync();
-      if (!permissionResult.granted) {
-        onError('Zugriff auf die Galerie wurde verweigert');
-        setLoading(false);
-        return;
-      }
-
+      // No permission request: launchImageLibraryAsync uses the Android Photo
+      // Picker, which needs no runtime permission (Google Play media policy).
       const result = await ExpoImagePicker.launchImageLibraryAsync({
         mediaTypes: ['images'],
         allowsEditing: false,

--- a/apps/mobile/components/reel/VideoUploader.tsx
+++ b/apps/mobile/components/reel/VideoUploader.tsx
@@ -43,12 +43,8 @@ export function VideoUploader({
   const pickVideo = useCallback(async () => {
     setError(null);
 
-    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (!permissionResult.granted) {
-      setError('Zugriff auf die Galerie wurde verweigert');
-      return;
-    }
-
+    // No permission request: launchImageLibraryAsync uses the Android Photo
+    // Picker, which needs no runtime permission (Google Play media policy).
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['videos'],
       allowsEditing: false,

--- a/apps/mobile/components/sharepic/SharepicResult.tsx
+++ b/apps/mobile/components/sharepic/SharepicResult.tsx
@@ -45,7 +45,7 @@ export function SharepicResult({ sharepics, onNewGeneration }: SharepicResultPro
 
     setSaving(true);
     try {
-      const { status } = await MediaLibrary.requestPermissionsAsync();
+      const { status } = await MediaLibrary.requestPermissionsAsync(true);
       if (status !== 'granted') {
         Alert.alert('Berechtigung erforderlich', 'Bitte erlaube den Zugriff auf die Galerie.');
         return;

--- a/apps/mobile/components/subtitle-editor/ExportResultScreen.tsx
+++ b/apps/mobile/components/subtitle-editor/ExportResultScreen.tsx
@@ -129,7 +129,7 @@ export function ExportScreen({
 
   const handleSaveToGallery = useCallback(async () => {
     if (!videoUri) return;
-    const { status: permStatus } = await MediaLibrary.requestPermissionsAsync();
+    const { status: permStatus } = await MediaLibrary.requestPermissionsAsync(true);
     if (permStatus !== 'granted') return;
     await MediaLibrary.Asset.create(videoUri);
     setSavedToGallery(true);

--- a/apps/mobile/config/withBlockedAndroidMediaPermissions.ts
+++ b/apps/mobile/config/withBlockedAndroidMediaPermissions.ts
@@ -1,0 +1,42 @@
+import { withAndroidManifest, type ConfigPlugin, type AndroidConfig } from 'expo/config-plugins';
+
+/**
+ * Broad media-read permissions that expo-media-library's native module manifest
+ * merges in. The app only writes to the gallery (write-only saves) and picks via
+ * the Android Photo Picker, so Google Play's Photo & Video Permissions policy
+ * forbids declaring these. Stripping them is required to pass Play review.
+ */
+const BLOCKED_PERMISSIONS = [
+  'android.permission.READ_MEDIA_IMAGES',
+  'android.permission.READ_MEDIA_VIDEO',
+  'android.permission.READ_MEDIA_AUDIO',
+  'android.permission.READ_MEDIA_VISUAL_USER_SELECTED',
+  'android.permission.ACCESS_MEDIA_LOCATION',
+];
+
+type UsesPermission = AndroidConfig.Manifest.ManifestUsesPermission;
+
+/**
+ * Removes the blocked permissions and re-declares each with `tools:node="remove"`,
+ * which instructs the Android manifest merger to delete the node from the final
+ * merged manifest even though a dependency's manifest declares it.
+ */
+const withBlockedAndroidMediaPermissions: ConfigPlugin = (config) =>
+  withAndroidManifest(config, (cfg) => {
+    const { manifest } = cfg.modResults;
+    manifest.$['xmlns:tools'] ??= 'http://schemas.android.com/tools';
+
+    const existing = manifest['uses-permission'] ?? [];
+    const kept = existing.filter(
+      (permission) => !BLOCKED_PERMISSIONS.includes(permission.$['android:name'] ?? '')
+    );
+
+    const removals = BLOCKED_PERMISSIONS.map(
+      (name): UsesPermission => ({ $: { 'android:name': name, 'tools:node': 'remove' } })
+    );
+
+    manifest['uses-permission'] = [...kept, ...removals];
+    return cfg;
+  });
+
+export default withBlockedAndroidMediaPermissions;

--- a/apps/mobile/hooks/useReelProcessing.ts
+++ b/apps/mobile/hooks/useReelProcessing.ts
@@ -106,7 +106,9 @@ export function useReelProcessing() {
   const saveToGallery = useCallback(
     async (videoUri: string): Promise<boolean> => {
       try {
-        const { status } = await MediaLibrary.requestPermissionsAsync();
+        // Write-only: we only save to the gallery, never read it (Google Play
+        // media-permission policy — avoids requesting READ_MEDIA_IMAGES/VIDEO).
+        const { status } = await MediaLibrary.requestPermissionsAsync(true);
         if (status !== 'granted') {
           handleError('permission_denied');
           return false;

--- a/apps/mobile/services/imageStudio.ts
+++ b/apps/mobile/services/imageStudio.ts
@@ -42,27 +42,11 @@ export async function requestCameraPermission(): Promise<boolean> {
 }
 
 /**
- * Request media library permissions
- */
-export async function requestMediaLibraryPermission(): Promise<boolean> {
-  const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-  if (status !== 'granted') {
-    Alert.alert(
-      'Galerie-Berechtigung',
-      'Bitte erlaube den Zugriff auf die Galerie, um Bilder auszuwählen.'
-    );
-    return false;
-  }
-  return true;
-}
-
-/**
  * Pick an image from the device gallery
  */
 export async function pickImageFromGallery(): Promise<ImagePickerResult | null> {
-  const hasPermission = await requestMediaLibraryPermission();
-  if (!hasPermission) return null;
-
+  // No permission request: launchImageLibraryAsync uses the Android Photo
+  // Picker, which needs no runtime permission (Google Play media policy).
   try {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
@@ -165,7 +149,8 @@ export async function base64ToFileUri(
  */
 export async function saveImageToGallery(base64Data: string): Promise<boolean> {
   try {
-    const { status } = await MediaLibrary.requestPermissionsAsync();
+    // Write-only: saving only, never reading the library.
+    const { status } = await MediaLibrary.requestPermissionsAsync(true);
     if (status !== 'granted') {
       Alert.alert(
         'Galerie-Berechtigung',
@@ -439,7 +424,6 @@ export async function generateProfilbild(
  */
 export const imageStudioService = {
   requestCameraPermission,
-  requestMediaLibraryPermission,
   pickImageFromGallery,
   takePhoto,
   base64ToFileUri,


### PR DESCRIPTION
Google Play rejected the Android build for declaring `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO`. Per Google's policy, apps that only need occasional media access must use the system Photo Picker instead of those broad permissions.

The app never browses the device library — it only **picks** (via `launchImageLibraryAsync`, which uses the Android Photo Picker) and **saves** (`MediaLibrary.Asset.create`). So the read permissions are unnecessary:

- Gallery saves now request **write-only** `MediaLibrary` permission (`requestPermissionsAsync(true)`), so they never pull in `READ_MEDIA_*`.
- Gallery-pick paths drop the `requestMediaLibraryPermissionsAsync` gate (the Photo Picker needs no runtime permission); camera gates stay.
- `app.json` no longer lists the `READ_MEDIA_*` permissions, and a config plugin marks them `tools:node="remove"` so the Android manifest merger strips the ones `expo-media-library`'s native manifest injects.

Verified with `expo prebuild`: the generated manifest shows `READ_MEDIA_IMAGES/VIDEO/AUDIO/VISUAL_USER_SELECTED` + `ACCESS_MEDIA_LOCATION` all carrying `tools:node="remove"`. Typecheck-clean. A new Android build + Play resubmission is needed to clear the rejection.