### PR TITLE
fix(scrapers): stop Landesverband content going stale + extract clean body

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -451,7 +451,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       contentSelectors: {
         title: ['h1', 'meta[property="og:title"]'],
         date: ['time[datetime]', '.tx_xblog_pi1 .date', 'meta[property="article:published_time"]'],
-        content: ['.tx_xblog_pi1', '.bodytext', 'article', 'main .content'],
+        // gruene.berlin (TYPO3 xBlog) renders the page body in .ce-bodytext inside
+        // the single-view .xBlog.single — NOT .tx_xblog_pi1 (empty in the rendered
+        // DOM) or .bodytext (wrong class). Targeting the body element avoids the
+        // $('body') fallback that swallowed header/nav/footer + the related-items
+        // sidebar. Verified across Beschlüsse, Wahlprogramm chapters and Presse —
+        // all share this template.
+        content: ['.xBlog.single .ce-bodytext', '.ce-bodytext', '.xBlog.single', 'article', 'main .content'],
         categories: ['.tx_xblog_pi1 .tags a', '.categories a'],
         author: ['.author', '.byline'],
       },
@@ -491,7 +497,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       contentSelectors: {
         title: ['h1', 'meta[property="og:title"]'],
         date: ['time[datetime]', '.tx_xblog_pi1 .date', 'meta[property="article:published_time"]'],
-        content: ['.tx_xblog_pi1', '.bodytext', 'article', 'main .content'],
+        // gruene.berlin (TYPO3 xBlog) renders the page body in .ce-bodytext inside
+        // the single-view .xBlog.single — NOT .tx_xblog_pi1 (empty in the rendered
+        // DOM) or .bodytext (wrong class). Targeting the body element avoids the
+        // $('body') fallback that swallowed header/nav/footer + the related-items
+        // sidebar. Verified across Beschlüsse, Wahlprogramm chapters and Presse —
+        // all share this template.
+        content: ['.xBlog.single .ce-bodytext', '.ce-bodytext', '.xBlog.single', 'article', 'main .content'],
         categories: ['.tx_xblog_pi1 .tags a', '.categories a'],
         author: ['.author', '.byline'],
       },

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -50,6 +50,15 @@ import type {
 import type { ScraperResult } from '../../types.js';
 
 /**
+ * Re-fetch an already-indexed URL once its last indexing is older than this.
+ * Living documents (Wahlprogramme, revised Beschlüsse) keep a stable URL but
+ * change in place; a permanent "URL exists → skip" gate froze them forever.
+ * On a re-fetch the content-hash diff in DocumentProcessor decides whether to
+ * actually re-embed, so unchanged pages cost only an HTTP GET, not embeddings.
+ */
+const RECHECK_AFTER_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+/**
  * Main scraper class - orchestrates all modules
  * Reduced from 1,139 lines to ~400 lines through modularization
  */
@@ -213,17 +222,9 @@ export class LandesverbandScraper extends BaseScraper {
       for (let i = 0; i < toProcess.length; i++) {
         const pdf = toProcess[i];
         try {
-          if (!forceUpdate) {
-            const points = await scrollDocuments(
-              this.qdrantClient,
-              targetCollection,
-              { must: [{ key: 'source_url', match: { value: pdf.url } }] },
-              { limit: 1, withPayload: false, withVector: false }
-            );
-            if (points.length > 0) {
-              result.skipped++;
-              continue;
-            }
+          if (!forceUpdate && (await this.#isFreshlyIndexed(pdf.url, targetCollection))) {
+            result.skipped++;
+            continue;
           }
 
           const response = await this.#fetchUrl(pdf.url);
@@ -388,17 +389,9 @@ export class LandesverbandScraper extends BaseScraper {
       for (let i = 0; i < toProcess.length; i++) {
         const url = toProcess[i];
         try {
-          if (!forceUpdate) {
-            const points = await scrollDocuments(
-              this.qdrantClient,
-              targetCollection,
-              { must: [{ key: 'source_url', match: { value: url } }] },
-              { limit: 1, withPayload: false, withVector: false }
-            );
-            if (points.length > 0) {
-              result.skipped++;
-              continue;
-            }
+          if (!forceUpdate && (await this.#isFreshlyIndexed(url, targetCollection))) {
+            result.skipped++;
+            continue;
           }
 
           const content = await ContentExtractor.extractPageContent(
@@ -773,6 +766,26 @@ export class LandesverbandScraper extends BaseScraper {
   #shouldExcludeUrl(url: string, excludePatterns?: string[]): boolean {
     if (!url || !excludePatterns) return false;
     return excludePatterns.some((pattern) => url.includes(pattern));
+  }
+
+  /**
+   * Layer-1 freshness gate. Returns true when the URL is already indexed AND was
+   * last indexed within RECHECK_AFTER_MS, in which case the caller skips the fetch.
+   * Missing, timestamp-less (legacy), or stale points return false so the caller
+   * re-fetches and lets the DocumentProcessor content-hash diff decide on re-embed.
+   */
+  async #isFreshlyIndexed(url: string, targetCollection: string): Promise<boolean> {
+    const points = await scrollDocuments(
+      this.qdrantClient,
+      targetCollection,
+      { must: [{ key: 'source_url', match: { value: url } }] },
+      { limit: 1, withPayload: true, withVector: false }
+    );
+    if (points.length === 0) return false;
+    const indexedAt = points[0].payload?.indexed_at as string | undefined;
+    if (!indexedAt) return false;
+    const age = Date.now() - new Date(indexedAt).getTime();
+    return Number.isFinite(age) && age >= 0 && age < RECHECK_AFTER_MS;
   }
 
   /**


### PR DESCRIPTION
Landesverband content stopped updating once a URL was first indexed. The scraper skipped any URL already present in Qdrant *before* fetching it, so content edited in place at a stable URL — e.g. the Berlin Wahlprogramm chapters being revised after the LDK — never propagated. The smart content-hash diff that handles updates was structurally unreachable. This surfaced concretely: the Kapitel-4 GEAS paragraph on the live site differed from Qdrant, which was frozen at the March indexing.

While verifying, a second bug turned up: the two gruene.berlin TYPO3 sources used content selectors that match nothing in the rendered DOM (`.tx_xblog_pi1` is empty, `.bodytext` is the wrong class — TYPO3 uses `.ce-bodytext`). Extraction fell back to `$('body')` and stored page chrome (header/nav/footer + the related-items sidebar) alongside the real text.

The first commit demotes the permanent "URL exists → skip" guard to a 3-day freshness gate, so known-but-stale URLs fall through to the existing hash diff (which re-embeds only on a real change; unchanged pages cost just an HTTP GET). The second targets the xBlog single-view `.ce-bodytext`, verified across regular Beschlüsse, Wahlprogramm chapters and Presse — which share the template — since the Wahlprogramm is discovered through the same `berlin-lv-beschluesse` source as every other Beschluss.

Verified against production Qdrant: re-running Berlin **without** `--force` refreshed the GEAS paragraph to match the live site (proving the cron now self-heals), and a force re-index of both gruene.berlin sources produced clean, chrome-free chunks across 343 documents.

Operational note: the first hourly cron run per LV after deploy will find everything stale and re-fetch in 30-minute chunks, completing the catch-up over a few runs before settling to near-zero steady state. A separate data-cleanup is still needed for ~118 older Berlin press releases that pagination discovery no longer surfaces (pre-existing pollution the force run couldn't reach).