### PR TITLE
fix: make 'Volltext' search mode work on LV notebooks + contract /research

### DIFF
--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -55,7 +55,7 @@ import notificationsRouter from './routes/notifications/index.js';
 import { mountNotificationsContractRouter } from './routes/notifications/notificationsContractRouter.js';
 import protokollRouter from './routes/protokoll/index.js';
 import { releasesRouter } from './routes/releases/index.js';
-import researchRouter from './routes/research/researchController.js';
+import { mountResearchContractRouter } from './routes/research/researchContractRouter.js';
 import scannerRouter from './routes/scanner/index.js';
 import {
   searchController as searchRouter,
@@ -631,7 +631,11 @@ export async function setupRoutes(app: Application): Promise<void> {
   mountUnsplashContractRouter(app);
   app.use('/api/unsplash', publicReadLimiter, unsplashRouter);
   app.use('/api/web-search', publicReadLimiter, webSearchRouter);
-  app.use('/api/research', requireAuth, standardMutationLimiter, researchRouter);
+  // Apply auth + rate limiting on the prefix BEFORE mounting the ts-rest
+  // router (createExpressEndpoints registers routes directly on `app`, so the
+  // prefix middleware must be in place first to gate them).
+  app.use('/api/research', requireAuth, standardMutationLimiter);
+  mountResearchContractRouter(app);
   app.use('/api/image-generation', aiGenerationLimiter, imageGenerationRouter);
   app.use('/api/rate-limit', publicReadLimiter, rateLimitRouter);
 

--- a/apps/api/routes/research/researchContractRouter.ts
+++ b/apps/api/routes/research/researchContractRouter.ts
@@ -1,0 +1,388 @@
+/**
+ * ts-rest contract router for /api/research/* (system-collection manual
+ * research). Replaces the legacy express routes that used to live in
+ * researchController.ts — that file now holds only shared helpers
+ * (snippet formatting, filter cache, warmFilterCache).
+ *
+ * Auth is enforced via the `requireAuth` prefix middleware on `/api/research`
+ * in routes.ts (registered before this router is mounted), not per-handler.
+ */
+import { researchContract } from '@gruenerator/contracts';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import {
+  type SubcategoryFilters,
+  SYSTEM_COLLECTIONS,
+  getAllSystemCollectionIds,
+  getSearchParams,
+  getSystemCollectionConfig,
+  applyDefaultFilter,
+  buildSubcategoryFilter,
+} from '../../config/systemCollectionsConfig.js';
+import { getQdrantInstance } from '../../database/services/QdrantService/index.js';
+import { scrollDocuments } from '../../database/services/QdrantService/operations/batchOperations.js';
+import { getQdrantDocumentService } from '../../services/document-services/index.js';
+import { rerankPipeline } from '../../services/search/rerankPipeline.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { createLogger } from '../../utils/logger.js';
+
+import {
+  CHUNK_PREVIEW_MAX_CHARS,
+  computeMergedFilters,
+  getCachedFilters,
+  highlightSnippet,
+  setCachedFilters,
+  truncateSnippet,
+} from './researchController.js';
+
+import type { DocumentResult, TopChunk } from '../../services/BaseSearchService/types.js';
+import type { Application } from 'express';
+
+const log = createLogger('researchContractRouter');
+
+interface TaggedDocumentResult extends DocumentResult {
+  collection_id: string;
+  collection_name: string;
+}
+
+const s = initServer();
+
+export const researchContractRouter = s.router(researchContract, {
+  collections: async () => {
+    const collections = Object.values(SYSTEM_COLLECTIONS).map((config) => ({
+      id: config.id,
+      name: config.name,
+      description: config.description,
+      filterableFields: config.filterableFields.map((f) => f.field),
+    }));
+
+    return { status: 200 as const, body: collections };
+  },
+
+  filters: async (args) => {
+    try {
+      const collectionIdsParam = args.query.collectionIds;
+      const requestedIds =
+        typeof collectionIdsParam === 'string' && collectionIdsParam.length > 0
+          ? collectionIdsParam.split(',').filter((id) => id in SYSTEM_COLLECTIONS)
+          : getAllSystemCollectionIds();
+
+      if (requestedIds.length === 0) {
+        return { status: 400 as const, body: { error: 'No valid collection IDs provided.' } };
+      }
+
+      const cacheKey = [...requestedIds].sort().join(',');
+      const cached = getCachedFilters(cacheKey);
+      if (cached) {
+        return { status: 200 as const, body: cached };
+      }
+
+      const response = await computeMergedFilters(requestedIds);
+      setCachedFilters(cacheKey, response);
+      return { status: 200 as const, body: response };
+    } catch (error) {
+      log.error(
+        `Research filters failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { status: 500 as const, body: { error: 'Failed to get filters.' } };
+    }
+  },
+
+  search: async (args) => {
+    const startTime = Date.now();
+    const { query, collectionIds, limit, filters, mode, sortBy } = args.body;
+
+    const trimmedQuery = (query || '').trim();
+    if (trimmedQuery.length < 2) {
+      return { status: 400 as const, body: { error: 'Query must be at least 2 characters.' } };
+    }
+
+    const effectiveMode = mode ?? 'hybrid';
+    const effectiveSort = sortBy ?? 'relevance';
+    const effectiveLimit = Math.min(Math.max(limit ?? 30, 1), 100);
+
+    const requestedIds = collectionIds?.length
+      ? collectionIds.filter((id) => id in SYSTEM_COLLECTIONS)
+      : getAllSystemCollectionIds();
+
+    if (requestedIds.length === 0) {
+      return { status: 400 as const, body: { error: 'No valid collection IDs provided.' } };
+    }
+
+    // Resolve search weights from mode
+    let vectorWeight = 0.7;
+    let textWeight = 0.3;
+    if (effectiveMode === 'vector') {
+      vectorWeight = 1.0;
+      textWeight = 0.0;
+    } else if (effectiveMode === 'text') {
+      vectorWeight = 0.0;
+      textWeight = 1.0;
+    }
+
+    // Build user filter from subcategory filters
+    const userFilter = buildSubcategoryFilter(filters as SubcategoryFilters | null | undefined);
+
+    try {
+      const documentSearchService = getQdrantDocumentService();
+
+      const searchPromises = requestedIds.map(
+        async (collectionId): Promise<TaggedDocumentResult[]> => {
+          const config = SYSTEM_COLLECTIONS[collectionId];
+          if (!config) return [];
+
+          const searchParams = getSearchParams(collectionId);
+
+          // Merge: defaultFilter (landesverband scoping) + userFilter (selected facets)
+          const additionalFilter = applyDefaultFilter(collectionId, userFilter);
+
+          try {
+            const resp = await documentSearchService.search({
+              query: trimmedQuery,
+              userId: undefined,
+              options: {
+                limit: searchParams.limit,
+                mode: effectiveMode === 'text' ? 'text' : 'hybrid',
+                vectorWeight,
+                textWeight,
+                threshold: searchParams.threshold,
+                searchCollection: config.qdrantCollection,
+                recallLimit: searchParams.recallLimit,
+                qualityMin: searchParams.qualityMin,
+                additionalFilter,
+              },
+            });
+
+            return (resp.results || []).map((doc) => ({
+              ...doc,
+              collection_id: collectionId,
+              collection_name: config.name,
+              published_at: doc.published_at ?? null,
+            }));
+          } catch (error: unknown) {
+            log.error(
+              `Search error for ${collectionId}: ${error instanceof Error ? error.message : String(error)}`
+            );
+            return [];
+          }
+        }
+      );
+
+      const allResults = (await Promise.all(searchPromises)).flat();
+
+      // Deduplicate by source_url (or document_id), keeping highest similarity_score
+      const dedupMap = new Map<string, TaggedDocumentResult>();
+      for (const result of allResults) {
+        const key = result.source_url || result.document_id;
+        const existing = dedupMap.get(key);
+        if (!existing || result.similarity_score > existing.similarity_score) {
+          dedupMap.set(key, result);
+        }
+      }
+
+      let deduped = Array.from(dedupMap.values()).filter((r) => r.similarity_score >= 0.35);
+
+      // Cross-encoder rerank for relevance mode. Bi-encoder embeddings can't tell
+      // "Artenschutz" from "Datenschutz" (both project to "Schutz" topics);
+      // a cross-encoder reads query+document together and scores the actual match.
+      if (effectiveSort === 'relevance' && deduped.length > 3) {
+        const rerankInputLimit = 30;
+        const candidates = deduped.slice(0, rerankInputLimit);
+        const items = candidates.map((r) => ({
+          title: r.title ?? '',
+          content: (r.relevant_content ?? '').slice(0, 500),
+          relevance: r.similarity_score,
+        }));
+        const { rankedIndices, scores } = await rerankPipeline({
+          query: trimmedQuery,
+          items,
+          inputLimit: rerankInputLimit,
+          outputLimit: effectiveLimit,
+          minRelevance: 0.05,
+          minKeep: Math.min(5, candidates.length),
+          applyDiversity: true,
+        });
+        deduped = rankedIndices.flatMap((i) => {
+          const c = candidates[i];
+          if (!c) return [];
+          return [{ ...c, similarity_score: scores.get(i) ?? c.similarity_score }];
+        });
+      } else if (effectiveSort === 'date_desc') {
+        deduped.sort((a, b) => {
+          const dateA = a.published_at || '';
+          const dateB = b.published_at || '';
+          if (dateB !== dateA) return dateB.localeCompare(dateA);
+          return b.similarity_score - a.similarity_score;
+        });
+      } else if (effectiveSort === 'date_asc') {
+        deduped.sort((a, b) => {
+          const dateA = a.published_at || '';
+          const dateB = b.published_at || '';
+          if (dateA !== dateB) return dateA.localeCompare(dateB);
+          return b.similarity_score - a.similarity_score;
+        });
+      } else {
+        deduped.sort((a, b) => b.similarity_score - a.similarity_score);
+      }
+
+      deduped = deduped.slice(0, effectiveLimit);
+
+      // Extract best snippets with query-term highlighting. Map explicitly to
+      // the contract result shape (normalise optional → null).
+      const truncated = deduped.map((r) => ({
+        document_id: r.document_id,
+        title: r.title ?? 'Unbekanntes Dokument',
+        source_url: r.source_url ?? null,
+        relevant_content: highlightSnippet(r.relevant_content, trimmedQuery),
+        similarity_score: r.similarity_score,
+        chunk_count: r.chunk_count,
+        top_chunks: r.top_chunks.map((chunk: TopChunk) => ({
+          preview: truncateSnippet(chunk.preview, CHUNK_PREVIEW_MAX_CHARS),
+          chunk_index: chunk.chunk_index,
+          page_number: chunk.page_number ?? null,
+        })),
+        collection_id: r.collection_id,
+        collection_name: r.collection_name,
+        published_at: r.published_at ?? null,
+      }));
+
+      const collectionsFound = [...new Set(deduped.map((r) => r.collection_id))];
+
+      return {
+        status: 200 as const,
+        body: {
+          results: truncated,
+          metadata: {
+            totalResults: deduped.length,
+            collections: collectionsFound,
+            timeMs: Date.now() - startTime,
+          },
+        },
+      };
+    } catch (error: unknown) {
+      log.error(
+        `Research search failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { status: 500 as const, body: { error: 'Search failed. Please try again.' } };
+    }
+  },
+
+  similar: async (args) => {
+    const startTime = Date.now();
+    const { sourceUrl, collectionId, limit } = args.body;
+
+    const systemConfig = getSystemCollectionConfig(collectionId);
+    if (!systemConfig) {
+      return { status: 400 as const, body: { error: 'Invalid collectionId.' } };
+    }
+
+    const effectiveLimit = Math.min(Math.max(limit ?? 5, 1), 20);
+
+    try {
+      const qdrant = getQdrantInstance();
+      await qdrant.init();
+
+      if (!qdrant.client) {
+        return { status: 500 as const, body: { error: 'Qdrant client not available.' } };
+      }
+
+      const qdrantCollection = systemConfig.qdrantCollection;
+
+      // Find the source document's chunks by source_url
+      const sourcePoints = await scrollDocuments(
+        qdrant.client,
+        qdrantCollection,
+        {
+          must: [{ key: 'source_url', match: { value: sourceUrl } }],
+        },
+        { limit: 20, withPayload: true, withVector: false }
+      );
+
+      if (sourcePoints.length === 0) {
+        return {
+          status: 200 as const,
+          body: {
+            results: [],
+            metadata: { totalResults: 0, collections: [], timeMs: Date.now() - startTime },
+          },
+        };
+      }
+
+      // Use point IDs as positive examples for recommend
+      const positiveIds = sourcePoints.map((p) => p.id);
+
+      const recommendResult = await qdrant.client.recommend(qdrantCollection, {
+        positive: positiveIds,
+        limit: effectiveLimit * 3, // Over-fetch to account for dedup
+        filter: {
+          must_not: [{ key: 'source_url', match: { value: sourceUrl } }],
+        },
+        with_payload: true,
+      });
+
+      // Deduplicate by source_url, keeping highest score
+      const dedupMap = new Map<
+        string,
+        { score: number; payload: Record<string, unknown>; id: string | number }
+      >();
+
+      for (const point of recommendResult) {
+        const payload = (point.payload as Record<string, unknown>) || {};
+        const url = (payload.source_url as string) || String(point.id);
+        const score = point.score ?? 0;
+        const existing = dedupMap.get(url);
+        if (!existing || score > existing.score) {
+          dedupMap.set(url, { score, payload, id: point.id });
+        }
+      }
+
+      const deduped = Array.from(dedupMap.values())
+        .sort((a, b) => b.score - a.score)
+        .slice(0, effectiveLimit);
+
+      // Format results to match the search endpoint format
+      const results = deduped.map((item) => {
+        const payload = item.payload;
+        return {
+          document_id: String(payload.document_id || item.id),
+          title: String(payload.title || 'Unbekanntes Dokument'),
+          source_url: (payload.source_url as string) || null,
+          relevant_content: truncateSnippet(
+            String(payload.relevant_content || payload.content || payload.text || '')
+          ),
+          similarity_score: item.score,
+          chunk_count: 1,
+          top_chunks: [],
+          collection_id: collectionId,
+          collection_name: systemConfig.name,
+          published_at: (payload.published_at as string) ?? null,
+        };
+      });
+
+      const collectionsFound = [...new Set(results.map((r) => r.collection_id))];
+
+      return {
+        status: 200 as const,
+        body: {
+          results,
+          metadata: {
+            totalResults: results.length,
+            collections: collectionsFound,
+            timeMs: Date.now() - startTime,
+          },
+        },
+      };
+    } catch (error: unknown) {
+      log.error(
+        `Research similar failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { status: 500 as const, body: { error: 'Similar search failed. Please try again.' } };
+    }
+  },
+});
+
+export function mountResearchContractRouter(app: Application): void {
+  createExpressEndpoints(researchContract, researchContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'researchContract'),
+  });
+}

--- a/apps/api/routes/research/researchController.ts
+++ b/apps/api/routes/research/researchController.ts
@@ -1,31 +1,29 @@
-import express, { type Request, type Response, type Router } from 'express';
-import { z } from 'zod';
-
+/**
+ * Shared helpers for the /api/research/* surface.
+ *
+ * The HTTP routes themselves live in researchContractRouter.ts (ts-rest).
+ * This module keeps the cross-cutting pieces that more than one consumer
+ * needs:
+ *   - snippet formatting (truncateSnippet / highlightSnippet) — also used by
+ *     notebookContractRouter.ts
+ *   - the in-memory filter-facet cache + warmFilterCache() — called at server
+ *     startup (server.ts) and by the contract router's `filters` handler
+ *   - computeMergedFilters() — the actual facet aggregation, shared by the
+ *     route handler and the cache warmer so the logic exists once.
+ */
 import {
-  type SubcategoryFilters,
-  SYSTEM_COLLECTIONS,
   getAllSystemCollectionIds,
-  getSearchParams,
   getSystemCollectionConfig,
   getCollectionFilterableFields,
   getCollectionDefaultFilter,
-  applyDefaultFilter,
-  buildSubcategoryFilter,
 } from '../../config/systemCollectionsConfig.js';
 import { getQdrantInstance } from '../../database/services/QdrantService/index.js';
-import { scrollDocuments } from '../../database/services/QdrantService/operations/batchOperations.js';
-import { validateBody, type TypedRequest } from '../../middleware/validateBody.js';
-import { getQdrantDocumentService } from '../../services/document-services/index.js';
-import { rerankPipeline } from '../../services/search/rerankPipeline.js';
 import { createLogger } from '../../utils/logger.js';
 
-import type { DocumentResult, TopChunk } from '../../services/BaseSearchService/types.js';
-
 const log = createLogger('ResearchController');
-const router: Router = express.Router();
 
 const SNIPPET_MAX_CHARS = 400;
-const CHUNK_PREVIEW_MAX_CHARS = 200;
+export const CHUNK_PREVIEW_MAX_CHARS = 200;
 
 export function truncateSnippet(text: string, limit: number = SNIPPET_MAX_CHARS): string {
   if (!text || text.length <= limit) return text;
@@ -118,33 +116,25 @@ export function highlightSnippet(
 }
 
 // =============================================================================
-// Types
+// Filter facet aggregation + cache (30-minute TTL)
 // =============================================================================
 
-interface TaggedDocumentResult extends DocumentResult {
-  collection_id: string;
-  collection_name: string;
+export interface FilterEntry {
+  label: string;
+  type: 'keyword' | 'date_range';
+  values?: Array<{ value: string; count: number }>;
+  min?: string;
+  max?: string;
 }
 
-const researchSearchSchema = z.object({
-  query: z.string().min(2),
-  collectionIds: z.array(z.string()).nullish(),
-  limit: z.number().nullish(),
-  filters: z.record(z.unknown()).nullish(),
-  mode: z.enum(['hybrid', 'vector', 'text']).nullish(),
-  sortBy: z.enum(['relevance', 'date_desc', 'date_asc']).nullish(),
-});
-
-type ResearchSearchBody = z.infer<typeof researchSearchSchema>;
-
-// =============================================================================
-// Filter Cache (5-minute TTL)
-// =============================================================================
+export interface MergedFilters {
+  filters: Record<string, FilterEntry>;
+}
 
 const FILTER_CACHE_TTL_MS = 30 * 60 * 1000;
-const filterCache = new Map<string, { data: unknown; timestamp: number }>();
+const filterCache = new Map<string, { data: MergedFilters; timestamp: number }>();
 
-function getCachedFilters(key: string): unknown | null {
+export function getCachedFilters(key: string): MergedFilters | null {
   const entry = filterCache.get(key);
   if (!entry) return null;
   if (Date.now() - entry.timestamp > FILTER_CACHE_TTL_MS) {
@@ -154,494 +144,127 @@ function getCachedFilters(key: string): unknown | null {
   return entry.data;
 }
 
-function setCachedFilters(key: string, data: unknown): void {
+export function setCachedFilters(key: string, data: MergedFilters): void {
   filterCache.set(key, { data, timestamp: Date.now() });
 }
 
-// =============================================================================
-// GET /research/collections
-// =============================================================================
+/**
+ * Aggregate filterable facet values across the requested system collections.
+ * Fetches keyword value-counts and date ranges per field in parallel, then
+ * merges fields that appear in multiple collections.
+ */
+export async function computeMergedFilters(requestedIds: string[]): Promise<MergedFilters> {
+  const qdrant = getQdrantInstance();
+  await qdrant.init();
 
-router.get('/collections', (_req: Request, res: Response): void => {
-  const collections = Object.values(SYSTEM_COLLECTIONS).map((config) => ({
-    id: config.id,
-    name: config.name,
-    description: config.description,
-    filterableFields: config.filterableFields.map((f) => f.field),
-  }));
+  const fieldPromises = requestedIds.flatMap((collectionId) => {
+    const systemConfig = getSystemCollectionConfig(collectionId);
+    if (!systemConfig) return [];
 
-  res.json(collections);
-});
+    const filterableFields = getCollectionFilterableFields(collectionId);
+    const defaultFilter = getCollectionDefaultFilter(collectionId);
+    const baseFilter = defaultFilter
+      ? {
+          must: [
+            {
+              key: defaultFilter.field,
+              match: Array.isArray(defaultFilter.value)
+                ? { any: defaultFilter.value }
+                : { value: defaultFilter.value },
+            },
+          ],
+        }
+      : null;
 
-// =============================================================================
-// GET /research/filters?collectionIds=grundsatz-system,kommunalwiki-system
-// =============================================================================
-
-router.get('/filters', async (req: Request, res: Response): Promise<void> => {
-  try {
-    const collectionIdsParam = req.query.collectionIds;
-    const requestedIds =
-      typeof collectionIdsParam === 'string' && collectionIdsParam.length > 0
-        ? collectionIdsParam.split(',').filter((id) => id in SYSTEM_COLLECTIONS)
-        : getAllSystemCollectionIds();
-
-    if (requestedIds.length === 0) {
-      res.status(400).json({ error: 'No valid collection IDs provided.' });
-      return;
-    }
-
-    const cacheKey = [...requestedIds].sort().join(',');
-    const cached = getCachedFilters(cacheKey);
-    if (cached) {
-      res.json(cached);
-      return;
-    }
-
-    const qdrant = getQdrantInstance();
-    await qdrant.init();
-
-    type FilterEntry = {
-      label: string;
-      type: 'keyword' | 'date_range';
-      values?: Array<{ value: string; count: number }>;
-      min?: string;
-      max?: string;
-    };
-
-    // Build all field-fetch promises across all collections in parallel
-    const fieldPromises = requestedIds.flatMap((collectionId) => {
-      const systemConfig = getSystemCollectionConfig(collectionId);
-      if (!systemConfig) return [];
-
-      const filterableFields = getCollectionFilterableFields(collectionId);
-      const defaultFilter = getCollectionDefaultFilter(collectionId);
-      const baseFilter = defaultFilter
-        ? {
-            must: [
-              {
-                key: defaultFilter.field,
-                match: Array.isArray(defaultFilter.value)
-                  ? { any: defaultFilter.value }
-                  : { value: defaultFilter.value },
-              },
-            ],
-          }
-        : null;
-
-      return filterableFields.map(async (field) => {
-        try {
-          if (field.type === 'date_range') {
-            const { min, max } = await qdrant.getDateRange(
-              systemConfig.qdrantCollection,
-              field.field,
-              baseFilter
-            );
-            return {
-              field: field.field,
-              label: field.label,
-              type: field.type as 'keyword' | 'date_range',
-              min,
-              max,
-            };
-          } else {
-            const values = await qdrant.getFieldValueCounts(
-              systemConfig.qdrantCollection,
-              field.field,
-              50,
-              baseFilter
-            );
-            return {
-              field: field.field,
-              label: field.label,
-              type: field.type as 'keyword' | 'date_range',
-              values,
-            };
-          }
-        } catch (fieldError) {
-          const err = fieldError as Error;
-          log.warn(
-            `Failed to get filter values for ${field.field} in ${collectionId}: ${err.message}`
+    return filterableFields.map(async (field) => {
+      try {
+        if (field.type === 'date_range') {
+          const { min, max } = await qdrant.getDateRange(
+            systemConfig.qdrantCollection,
+            field.field,
+            baseFilter
           );
           return {
             field: field.field,
             label: field.label,
             type: field.type as 'keyword' | 'date_range',
-            error: true,
+            min,
+            max,
           };
-        }
-      });
-    });
-
-    const results = await Promise.all(fieldPromises);
-
-    // Merge results by field name
-    const mergedFilters: Record<string, FilterEntry> = {};
-
-    for (const result of results) {
-      if (result.type === 'date_range') {
-        if (mergedFilters[result.field]) {
-          const existing = mergedFilters[result.field];
-          if (result.min && (!existing.min || result.min < existing.min)) existing.min = result.min;
-          if (result.max && (!existing.max || result.max > existing.max)) existing.max = result.max;
         } else {
-          mergedFilters[result.field] = {
-            label: result.label,
-            type: 'date_range',
-            ...(result.min != null && { min: result.min }),
-            ...(result.max != null && { max: result.max }),
-          };
-        }
-      } else {
-        const values = 'values' in result ? (result.values ?? []) : [];
-        if (mergedFilters[result.field]) {
-          const existing = mergedFilters[result.field];
-          const countMap = new Map<string, number>();
-          for (const v of existing.values || []) {
-            countMap.set(v.value, v.count);
-          }
-          for (const v of values) {
-            countMap.set(v.value, (countMap.get(v.value) || 0) + v.count);
-          }
-          existing.values = Array.from(countMap.entries())
-            .map(([value, count]) => ({ value, count }))
-            .sort((a, b) => b.count - a.count);
-        } else {
-          mergedFilters[result.field] = {
-            label: result.label,
-            type: 'keyword',
+          const values = await qdrant.getFieldValueCounts(
+            systemConfig.qdrantCollection,
+            field.field,
+            50,
+            baseFilter
+          );
+          return {
+            field: field.field,
+            label: field.label,
+            type: field.type as 'keyword' | 'date_range',
             values,
           };
         }
-      }
-    }
-
-    const response = { filters: mergedFilters };
-    setCachedFilters(cacheKey, response);
-    res.json(response);
-  } catch (error: unknown) {
-    log.error(`Research filters failed: ${error instanceof Error ? error.message : String(error)}`);
-    res.status(500).json({ error: 'Failed to get filters.' });
-  }
-});
-
-// =============================================================================
-// POST /research/search
-// =============================================================================
-
-router.post(
-  '/search',
-  validateBody(researchSearchSchema),
-  async (req: TypedRequest<ResearchSearchBody>, res: Response): Promise<void> => {
-    const startTime = Date.now();
-    const {
-      query,
-      collectionIds,
-      limit = 30,
-      filters,
-      mode = 'hybrid',
-      sortBy = 'relevance',
-    } = req.body;
-
-    if (!query || typeof query !== 'string' || query.trim().length < 2) {
-      res.status(400).json({ error: 'Query must be at least 2 characters.' });
-      return;
-    }
-
-    const trimmedQuery = query.trim();
-    const effectiveLimit = Math.min(Math.max(limit ?? 30, 1), 100);
-
-    const requestedIds = collectionIds?.length
-      ? collectionIds.filter((id) => id in SYSTEM_COLLECTIONS)
-      : getAllSystemCollectionIds();
-
-    if (requestedIds.length === 0) {
-      res.status(400).json({ error: 'No valid collection IDs provided.' });
-      return;
-    }
-
-    // Resolve search weights from mode
-    let vectorWeight = 0.7;
-    let textWeight = 0.3;
-    if (mode === 'vector') {
-      vectorWeight = 1.0;
-      textWeight = 0.0;
-    } else if (mode === 'text') {
-      vectorWeight = 0.0;
-      textWeight = 1.0;
-    }
-
-    // Build user filter from subcategory filters
-    const userFilter = buildSubcategoryFilter(filters as SubcategoryFilters | null | undefined);
-
-    try {
-      const documentSearchService = getQdrantDocumentService();
-
-      const searchPromises = requestedIds.map(
-        async (collectionId): Promise<TaggedDocumentResult[]> => {
-          const config = SYSTEM_COLLECTIONS[collectionId];
-          if (!config) return [];
-
-          const searchParams = getSearchParams(collectionId);
-
-          // Merge: defaultFilter (landesverband scoping) + userFilter (selected facets)
-          const additionalFilter = applyDefaultFilter(collectionId, userFilter);
-
-          try {
-            const resp = await documentSearchService.search({
-              query: trimmedQuery,
-              userId: undefined,
-              options: {
-                limit: searchParams.limit,
-                mode: mode === 'text' ? 'text' : 'hybrid',
-                vectorWeight,
-                textWeight,
-                threshold: searchParams.threshold,
-                searchCollection: config.qdrantCollection,
-                recallLimit: searchParams.recallLimit,
-                qualityMin: searchParams.qualityMin,
-                additionalFilter,
-              },
-            });
-
-            return (resp.results || []).map((doc) => ({
-              ...doc,
-              collection_id: collectionId,
-              collection_name: config.name,
-              published_at: doc.published_at ?? null,
-            }));
-          } catch (error: unknown) {
-            log.error(
-              `Search error for ${collectionId}: ${error instanceof Error ? error.message : String(error)}`
-            );
-            return [];
-          }
-        }
-      );
-
-      const allResults = (await Promise.all(searchPromises)).flat();
-
-      // Deduplicate by source_url (or document_id), keeping highest similarity_score
-      const dedupMap = new Map<string, TaggedDocumentResult>();
-      for (const result of allResults) {
-        const key = result.source_url || result.document_id;
-        const existing = dedupMap.get(key);
-        if (!existing || result.similarity_score > existing.similarity_score) {
-          dedupMap.set(key, result);
-        }
-      }
-
-      let deduped = Array.from(dedupMap.values()).filter((r) => r.similarity_score >= 0.35);
-
-      // Cross-encoder rerank for relevance mode. Bi-encoder embeddings can't tell
-      // "Artenschutz" from "Datenschutz" (both project to "Schutz" topics);
-      // a cross-encoder reads query+document together and scores the actual match.
-      if (sortBy === 'relevance' && deduped.length > 3) {
-        const rerankInputLimit = 30;
-        const candidates = deduped.slice(0, rerankInputLimit);
-        const items = candidates.map((r) => ({
-          title: r.title ?? '',
-          content: (r.relevant_content ?? '').slice(0, 500),
-          relevance: r.similarity_score,
-        }));
-        const { rankedIndices, scores } = await rerankPipeline({
-          query: trimmedQuery,
-          items,
-          inputLimit: rerankInputLimit,
-          outputLimit: effectiveLimit,
-          minRelevance: 0.05,
-          minKeep: Math.min(5, candidates.length),
-          applyDiversity: true,
-        });
-        deduped = rankedIndices.flatMap((i) => {
-          const c = candidates[i];
-          if (!c) return [];
-          return [{ ...c, similarity_score: scores.get(i) ?? c.similarity_score }];
-        });
-      } else if (sortBy === 'date_desc') {
-        deduped.sort((a, b) => {
-          const dateA = a.published_at || '';
-          const dateB = b.published_at || '';
-          if (dateB !== dateA) return dateB.localeCompare(dateA);
-          return b.similarity_score - a.similarity_score;
-        });
-      } else if (sortBy === 'date_asc') {
-        deduped.sort((a, b) => {
-          const dateA = a.published_at || '';
-          const dateB = b.published_at || '';
-          if (dateA !== dateB) return dateA.localeCompare(dateB);
-          return b.similarity_score - a.similarity_score;
-        });
-      } else {
-        deduped.sort((a, b) => b.similarity_score - a.similarity_score);
-      }
-
-      deduped = deduped.slice(0, effectiveLimit);
-
-      // Extract best snippets with query-term highlighting
-      const truncated = deduped.map((r) => ({
-        ...r,
-        relevant_content: highlightSnippet(r.relevant_content, trimmedQuery),
-        top_chunks: r.top_chunks.map((chunk: TopChunk) => ({
-          preview: truncateSnippet(chunk.preview, CHUNK_PREVIEW_MAX_CHARS),
-          chunk_index: chunk.chunk_index,
-          page_number: chunk.page_number ?? null,
-        })),
-      }));
-
-      const collectionsFound = [...new Set(deduped.map((r) => r.collection_id))];
-
-      res.json({
-        results: truncated,
-        metadata: {
-          totalResults: deduped.length,
-          collections: collectionsFound,
-          timeMs: Date.now() - startTime,
-        },
-      });
-    } catch (error: unknown) {
-      log.error(
-        `Research search failed: ${error instanceof Error ? error.message : String(error)}`
-      );
-      res.status(500).json({ error: 'Search failed. Please try again.' });
-    }
-  }
-);
-
-// =============================================================================
-// POST /research/similar
-// =============================================================================
-
-const researchSimilarSchema = z.object({
-  sourceUrl: z.string().url(),
-  collectionId: z.string(),
-  limit: z.number().nullish(),
-});
-
-type ResearchSimilarBody = z.infer<typeof researchSimilarSchema>;
-
-router.post(
-  '/similar',
-  validateBody(researchSimilarSchema),
-  async (req: TypedRequest<ResearchSimilarBody>, res: Response): Promise<void> => {
-    const startTime = Date.now();
-    const { sourceUrl, collectionId, limit = 5 } = req.body;
-
-    if (!sourceUrl || typeof sourceUrl !== 'string') {
-      res.status(400).json({ error: 'sourceUrl is required.' });
-      return;
-    }
-
-    if (!collectionId || typeof collectionId !== 'string') {
-      res.status(400).json({ error: 'collectionId is required.' });
-      return;
-    }
-
-    const systemConfig = getSystemCollectionConfig(collectionId);
-    if (!systemConfig) {
-      res.status(400).json({ error: 'Invalid collectionId.' });
-      return;
-    }
-
-    const effectiveLimit = Math.min(Math.max(limit ?? 5, 1), 20);
-
-    try {
-      const qdrant = getQdrantInstance();
-      await qdrant.init();
-
-      if (!qdrant.client) {
-        res.status(500).json({ error: 'Qdrant client not available.' });
-        return;
-      }
-
-      const qdrantCollection = systemConfig.qdrantCollection;
-
-      // Find the source document's chunks by source_url
-      const sourcePoints = await scrollDocuments(
-        qdrant.client,
-        qdrantCollection,
-        {
-          must: [{ key: 'source_url', match: { value: sourceUrl } }],
-        },
-        { limit: 20, withPayload: true, withVector: false }
-      );
-
-      if (sourcePoints.length === 0) {
-        res.json({
-          results: [],
-          metadata: { totalResults: 0, collections: [], timeMs: Date.now() - startTime },
-        });
-        return;
-      }
-
-      // Use point IDs as positive examples for recommend
-      const positiveIds = sourcePoints.map((p) => p.id);
-
-      const recommendResult = await qdrant.client.recommend(qdrantCollection, {
-        positive: positiveIds,
-        limit: effectiveLimit * 3, // Over-fetch to account for dedup
-        filter: {
-          must_not: [{ key: 'source_url', match: { value: sourceUrl } }],
-        },
-        with_payload: true,
-      });
-
-      // Deduplicate by source_url, keeping highest score
-      const dedupMap = new Map<
-        string,
-        { score: number; payload: Record<string, unknown>; id: string | number }
-      >();
-
-      for (const point of recommendResult) {
-        const payload = (point.payload as Record<string, unknown>) || {};
-        const url = (payload.source_url as string) || String(point.id);
-        const score = point.score ?? 0;
-        const existing = dedupMap.get(url);
-        if (!existing || score > existing.score) {
-          dedupMap.set(url, { score, payload, id: point.id });
-        }
-      }
-
-      const deduped = Array.from(dedupMap.values())
-        .sort((a, b) => b.score - a.score)
-        .slice(0, effectiveLimit);
-
-      // Format results to match the search endpoint format
-      const results = deduped.map((item) => {
-        const payload = item.payload;
+      } catch (fieldError) {
+        const err = fieldError as Error;
+        log.warn(
+          `Failed to get filter values for ${field.field} in ${collectionId}: ${err.message}`
+        );
         return {
-          document_id: String(payload.document_id || item.id),
-          title: String(payload.title || 'Unbekanntes Dokument'),
-          source_url: (payload.source_url as string) || null,
-          relevant_content: truncateSnippet(
-            String(payload.relevant_content || payload.content || payload.text || '')
-          ),
-          similarity_score: item.score,
-          chunk_count: 1,
-          top_chunks: [],
-          collection_id: collectionId,
-          collection_name: systemConfig.name,
-          published_at: (payload.published_at as string) ?? null,
+          field: field.field,
+          label: field.label,
+          type: field.type as 'keyword' | 'date_range',
+          error: true,
         };
-      });
+      }
+    });
+  });
 
-      const collectionsFound = [...new Set(results.map((r) => r.collection_id))];
+  const results = await Promise.all(fieldPromises);
 
-      res.json({
-        results,
-        metadata: {
-          totalResults: results.length,
-          collections: collectionsFound,
-          timeMs: Date.now() - startTime,
-        },
-      });
-    } catch (error: unknown) {
-      log.error(
-        `Research similar failed: ${error instanceof Error ? error.message : String(error)}`
-      );
-      res.status(500).json({ error: 'Similar search failed. Please try again.' });
+  // Merge results by field name
+  const mergedFilters: Record<string, FilterEntry> = {};
+
+  for (const result of results) {
+    if (result.type === 'date_range') {
+      if (mergedFilters[result.field]) {
+        const existing = mergedFilters[result.field];
+        if (result.min && (!existing.min || result.min < existing.min)) existing.min = result.min;
+        if (result.max && (!existing.max || result.max > existing.max)) existing.max = result.max;
+      } else {
+        mergedFilters[result.field] = {
+          label: result.label,
+          type: 'date_range',
+          ...(result.min != null && { min: result.min }),
+          ...(result.max != null && { max: result.max }),
+        };
+      }
+    } else {
+      const values = 'values' in result ? (result.values ?? []) : [];
+      if (mergedFilters[result.field]) {
+        const existing = mergedFilters[result.field];
+        const countMap = new Map<string, number>();
+        for (const v of existing.values || []) {
+          countMap.set(v.value, v.count);
+        }
+        for (const v of values) {
+          countMap.set(v.value, (countMap.get(v.value) || 0) + v.count);
+        }
+        existing.values = Array.from(countMap.entries())
+          .map(([value, count]) => ({ value, count }))
+          .sort((a, b) => b.count - a.count);
+      } else {
+        mergedFilters[result.field] = {
+          label: result.label,
+          type: 'keyword',
+          values,
+        };
+      }
     }
   }
-);
+
+  return { filters: mergedFilters };
+}
 
 /**
  * Pre-populate the filter cache for "all collections" (the most common request).
@@ -655,115 +278,11 @@ export async function warmFilterCache(): Promise<void> {
     // Skip if already cached
     if (getCachedFilters(cacheKey)) return;
 
-    const qdrant = getQdrantInstance();
-    await qdrant.init();
-
-    type FilterEntry = {
-      label: string;
-      type: 'keyword' | 'date_range';
-      values?: Array<{ value: string; count: number }>;
-      min?: string;
-      max?: string;
-    };
-
-    const fieldPromises = allIds.flatMap((collectionId) => {
-      const systemConfig = getSystemCollectionConfig(collectionId);
-      if (!systemConfig) return [];
-
-      const filterableFields = getCollectionFilterableFields(collectionId);
-      const defaultFilter = getCollectionDefaultFilter(collectionId);
-      const baseFilter = defaultFilter
-        ? {
-            must: [
-              {
-                key: defaultFilter.field,
-                match: Array.isArray(defaultFilter.value)
-                  ? { any: defaultFilter.value }
-                  : { value: defaultFilter.value },
-              },
-            ],
-          }
-        : null;
-
-      return filterableFields.map(async (field) => {
-        try {
-          if (field.type === 'date_range') {
-            const { min, max } = await qdrant.getDateRange(
-              systemConfig.qdrantCollection,
-              field.field,
-              baseFilter
-            );
-            return {
-              field: field.field,
-              label: field.label,
-              type: field.type as 'keyword' | 'date_range',
-              min,
-              max,
-            };
-          } else {
-            const values = await qdrant.getFieldValueCounts(
-              systemConfig.qdrantCollection,
-              field.field,
-              50,
-              baseFilter
-            );
-            return {
-              field: field.field,
-              label: field.label,
-              type: field.type as 'keyword' | 'date_range',
-              values,
-            };
-          }
-        } catch {
-          return {
-            field: field.field,
-            label: field.label,
-            type: field.type as 'keyword' | 'date_range',
-            error: true,
-          };
-        }
-      });
-    });
-
-    const results = await Promise.all(fieldPromises);
-    const mergedFilters: Record<string, FilterEntry> = {};
-
-    for (const result of results) {
-      if (result.type === 'date_range') {
-        if (mergedFilters[result.field]) {
-          const existing = mergedFilters[result.field];
-          if (result.min && (!existing.min || result.min < existing.min)) existing.min = result.min;
-          if (result.max && (!existing.max || result.max > existing.max)) existing.max = result.max;
-        } else {
-          mergedFilters[result.field] = {
-            label: result.label,
-            type: 'date_range',
-            ...(result.min != null && { min: result.min }),
-            ...(result.max != null && { max: result.max }),
-          };
-        }
-      } else {
-        const values = 'values' in result ? (result.values ?? []) : [];
-        if (mergedFilters[result.field]) {
-          const existing = mergedFilters[result.field];
-          const countMap = new Map<string, number>();
-          for (const v of existing.values || []) countMap.set(v.value, v.count);
-          for (const v of values) countMap.set(v.value, (countMap.get(v.value) || 0) + v.count);
-          existing.values = Array.from(countMap.entries())
-            .map(([value, count]) => ({ value, count }))
-            .sort((a, b) => b.count - a.count);
-        } else {
-          mergedFilters[result.field] = { label: result.label, type: 'keyword', values };
-        }
-      }
-    }
-
-    setCachedFilters(cacheKey, { filters: mergedFilters });
+    const response = await computeMergedFilters(allIds);
+    setCachedFilters(cacheKey, response);
     log.info(`Filter cache warmed for ${allIds.length} collections`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.warn(`Filter cache warming failed (non-fatal): ${message}`);
   }
 }
-
-export default router;

--- a/apps/api/services/document-services/DocumentSearchService/DocumentSearchService.ts
+++ b/apps/api/services/document-services/DocumentSearchService/DocumentSearchService.ts
@@ -325,12 +325,49 @@ export class DocumentSearchService extends BaseSearchService {
         return await this.performHybridSearch(validated as SearchParams);
       }
 
+      if (mode === 'text' || mode === 'keyword') {
+        console.log('[DocumentSearchService] Executing full-text search mode');
+        return await this.performTextOnlySearch(validated as SearchParams);
+      }
+
       return await this.performSimilaritySearch(validated as SearchParams);
     } catch (error) {
       const _errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error('[DocumentSearchService] Search error:', error);
       return this.createErrorResponse(error as Error, searchParams.query);
     }
+  }
+
+  /**
+   * Full-text (keyword-only) search routed from {@link search} for `mode: 'text'`.
+   *
+   * Mirrors performSimilaritySearch's param extraction so that
+   * searchCollection + additionalFilter (Landesverband scoping for system
+   * collections) reach the text primitive. Without this, `text` mode fell
+   * through to vector search and the "Volltext" toggle had no effect.
+   */
+  private async performTextOnlySearch(params: SearchParams): Promise<SearchResponse> {
+    const validated = this.validateSearchParams(params);
+    const { query, userId, filters, options } = validated;
+
+    if (!this.qdrantOps) {
+      throw new Error('Qdrant not available');
+    }
+
+    return await searchOps.performTextSearch(
+      this.qdrantOps,
+      query,
+      userId ?? '',
+      {
+        ...options,
+        documentIds: filters.documentIds,
+        sourceType: filters.sourceType,
+        searchCollection: filters.searchCollection,
+        additionalFilter: filters.additionalFilter,
+      },
+      this.chunkMultiplier,
+      this.groupAndRankHybridResults.bind(this)
+    );
   }
 
   /**

--- a/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
+++ b/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
@@ -50,18 +50,26 @@ export async function performTextSearch(
   try {
     const limit = options.limit || 5;
 
+    // searchCollection/additionalFilter live in DocumentSearchFilters but are
+    // threaded through `options` here (SearchOptions has an index signature),
+    // mirroring how documentIds/sourceType are already read below.
+    const searchCollection = (options.searchCollection as string | undefined) || 'documents';
+    const additionalFilter = options.additionalFilter as QdrantFilter | undefined;
+
     const scopedByDocumentIds = !!(
       options.documentIds &&
       Array.isArray(options.documentIds) &&
       options.documentIds.length > 0
     );
 
-    // See findSimilarChunks for the rationale: when documentIds is supplied,
-    // the upstream caller has already authorized the viewer for that exact set,
-    // so adding a user_id filter would break shared-notebook search.
     const filter: QdrantFilter = { must: [] };
 
-    if (!scopedByDocumentIds) {
+    // Mirror findSimilarChunks: only pin user_id on the per-user 'documents'
+    // collection when not already scoped by an authorized documentId set.
+    // System collections (LV/Landesverband etc.) have no user_id payload — a
+    // user_id clause there would return zero hits, which was the original
+    // "Volltext changes nothing" symptom on LV notebooks.
+    if (searchCollection === 'documents' && !scopedByDocumentIds) {
       filter.must!.push({ key: 'user_id', match: { value: userId } });
     }
 
@@ -76,8 +84,13 @@ export async function performTextSearch(
       filter.must!.push({ key: 'source_type', match: { value: options.sourceType as string } });
     }
 
+    // Landesverband scoping (and any other caller-supplied facet filters).
+    if (additionalFilter?.must) {
+      filter.must!.push(...additionalFilter.must);
+    }
+
     const rawResults = await qdrantOps.performTextSearch(
-      'documents',
+      searchCollection,
       query,
       filter,
       Math.round(limit * chunkMultiplier)

--- a/apps/api/services/document-services/DocumentSearchService/searchOperations.vitest.ts
+++ b/apps/api/services/document-services/DocumentSearchService/searchOperations.vitest.ts
@@ -34,27 +34,42 @@ import type { QdrantOperations } from '../../../database/services/QdrantOperatio
 
 type CapturedFilter = QdrantFilter | undefined;
 
-function makeMockQdrantOps(): { ops: QdrantOperations; captured: { filter: CapturedFilter } } {
-  const captured: { filter: CapturedFilter } = { filter: undefined };
+function makeMockQdrantOps(): {
+  ops: QdrantOperations;
+  captured: { filter: CapturedFilter; collection: string | undefined };
+} {
+  const captured: { filter: CapturedFilter; collection: string | undefined } = {
+    filter: undefined,
+    collection: undefined,
+  };
   const ops = {
-    searchWithQuality: vi.fn(async (_collection, _vec, filter) => {
+    searchWithQuality: vi.fn(async (collection, _vec, filter) => {
       captured.filter = filter;
+      captured.collection = collection;
       return [];
     }),
-    searchWithIntent: vi.fn(async (_collection, _vec, _intent, filter) => {
+    searchWithIntent: vi.fn(async (collection, _vec, _intent, filter) => {
       captured.filter = filter;
+      captured.collection = collection;
       return [];
     }),
-    hybridSearch: vi.fn(async (_collection, _vec, _query, filter) => {
+    hybridSearch: vi.fn(async (collection, _vec, _query, filter) => {
       captured.filter = filter;
+      captured.collection = collection;
       return { results: [] };
     }),
-    performTextSearch: vi.fn(async (_collection, _query, filter) => {
+    performTextSearch: vi.fn(async (collection, _query, filter) => {
       captured.filter = filter;
+      captured.collection = collection;
       return [];
     }),
   } as unknown as QdrantOperations;
   return { ops, captured };
+}
+
+function hasClause(filter: CapturedFilter, key: string): boolean {
+  if (!filter?.must) return false;
+  return filter.must.some((clause) => 'key' in clause && (clause as { key: string }).key === key);
 }
 
 function hasUserIdClause(filter: CapturedFilter): boolean {
@@ -180,6 +195,55 @@ describe('searchOperations — document scoping vs. user scoping invariant', () 
 
       expect(hasUserIdClause(captured.filter)).toBe(true);
       expect(hasDocumentIdClause(captured.filter)).toBe(false);
+    });
+
+    // Regression: "Volltext" on LV notebooks searched the per-user 'documents'
+    // collection with a user_id filter (always zero hits for system content).
+    // It must instead query the requested system collection with its scoping.
+    it('searches the requested searchCollection, not hardcoded "documents"', async () => {
+      const { ops, captured } = makeMockQdrantOps();
+      await performTextSearch(
+        ops,
+        'query',
+        '',
+        { limit: 5, searchCollection: 'landesverbaende_documents' },
+        1,
+        async () => []
+      );
+
+      expect(captured.collection).toBe('landesverbaende_documents');
+    });
+
+    it('omits user_id filter for system collections', async () => {
+      const { ops, captured } = makeMockQdrantOps();
+      await performTextSearch(
+        ops,
+        'query',
+        '',
+        { limit: 5, searchCollection: 'landesverbaende_documents' },
+        1,
+        async () => []
+      );
+
+      expect(hasUserIdClause(captured.filter)).toBe(false);
+    });
+
+    it('applies additionalFilter clauses (Landesverband scoping)', async () => {
+      const { ops, captured } = makeMockQdrantOps();
+      await performTextSearch(
+        ops,
+        'query',
+        '',
+        {
+          limit: 5,
+          searchCollection: 'landesverbaende_documents',
+          additionalFilter: { must: [{ key: 'landesverband', match: { value: 'bayern' } }] },
+        },
+        1,
+        async () => []
+      );
+
+      expect(hasClause(captured.filter, 'landesverband')).toBe(true);
     });
   });
 });

--- a/apps/web/src/features/notebook/manual-search/useResearch.ts
+++ b/apps/web/src/features/notebook/manual-search/useResearch.ts
@@ -1,34 +1,16 @@
+import {
+  type ResearchResult as ContractResearchResult,
+  type ResearchSearchResponse,
+} from '@gruenerator/contracts';
+import { getContractsClient } from '@gruenerator/shared/api';
 import { useState, useCallback } from 'react';
-
-import apiClient from '../../../components/utils/apiClient';
 
 import { type SearchMode, type SortOption } from './useResearchFilters';
 
-export interface ResearchResult {
-  document_id: string;
-  title: string;
-  source_url: string | null;
-  relevant_content: string;
-  similarity_score: number;
-  chunk_count: number;
-  top_chunks: Array<{
-    preview: string;
-    chunk_index: number;
-    page_number: number | null;
-  }>;
-  collection_id?: string;
-  collection_name?: string;
-  published_at?: string | null;
-}
+/** Single research hit — derived from the ts-rest research contract. */
+export type ResearchResult = ContractResearchResult;
 
-interface ResearchResponse {
-  results: ResearchResult[];
-  metadata: {
-    totalResults: number;
-    collections: string[];
-    timeMs: number;
-  };
-}
+type ResearchMetadata = ResearchSearchResponse['metadata'];
 
 export interface SearchParams {
   query: string;
@@ -40,17 +22,17 @@ export interface SearchParams {
 
 export interface UseResearchOptions {
   /**
-   * When set, POSTs to /auth/notebook/:id/research-search (user-owned notebook,
-   * chunk-level Qdrant search scoped by ownership) instead of /research/search
-   * (system-collection endpoint). `collectionIds` and `filters` in SearchParams
-   * are ignored in this mode — the path UUID is the scope.
+   * When set, calls the per-notebook research-search contract route
+   * (ownership-scoped chunk-level Qdrant search) instead of the
+   * system-collection `/research/search` route. `collectionIds` and `filters`
+   * in SearchParams are ignored in this mode — the notebook id is the scope.
    */
   notebookId?: string;
 }
 
 interface UseResearchReturn {
   results: ResearchResult[];
-  metadata: ResearchResponse['metadata'] | null;
+  metadata: ResearchMetadata | null;
   isLoading: boolean;
   error: string | null;
   search: (params: SearchParams) => Promise<void>;
@@ -59,7 +41,7 @@ interface UseResearchReturn {
 
 export function useResearch(opts: UseResearchOptions = {}): UseResearchReturn {
   const [results, setResults] = useState<ResearchResult[]>([]);
-  const [metadata, setMetadata] = useState<ResearchResponse['metadata'] | null>(null);
+  const [metadata, setMetadata] = useState<ResearchMetadata | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -74,27 +56,43 @@ export function useResearch(opts: UseResearchOptions = {}): UseResearchReturn {
       setError(null);
 
       try {
-        const body: Record<string, unknown> = { query: query.trim() };
-        if (mode && mode !== 'hybrid') body.mode = mode;
-        if (sortBy && sortBy !== 'relevance') body.sortBy = sortBy;
+        const client = getContractsClient();
+        const trimmed = query.trim();
 
-        let url: string;
         if (notebookId) {
-          url = `/auth/notebook/${notebookId}/research-search`;
+          const result = await client.notebook.researchSearch({
+            params: { id: notebookId },
+            body: {
+              query: trimmed,
+              limit: null,
+              mode: mode ?? null,
+              sortBy: sortBy ?? null,
+            },
+          });
+          if (result.status !== 200) {
+            throw new Error(`Suche fehlgeschlagen (HTTP ${result.status})`);
+          }
+          setResults(result.body.results);
+          setMetadata(result.body.metadata);
         } else {
-          url = '/research/search';
-          if (collectionIds?.length) body.collectionIds = collectionIds;
-          if (filters) body.filters = filters;
+          const result = await client.research.search({
+            body: {
+              query: trimmed,
+              collectionIds: collectionIds ?? null,
+              limit: null,
+              filters: filters ?? null,
+              mode: mode ?? null,
+              sortBy: sortBy ?? null,
+            },
+          });
+          if (result.status !== 200) {
+            throw new Error(`Suche fehlgeschlagen (HTTP ${result.status})`);
+          }
+          setResults(result.body.results);
+          setMetadata(result.body.metadata);
         }
-
-        const response = await apiClient.post<ResearchResponse>(url, body);
-
-        setResults(response.data.results);
-        setMetadata(response.data.metadata);
-      } catch (err: unknown) {
-        const errResp = (err as { response?: { data?: { error?: string } } }).response;
-        const message = errResp?.data?.error ?? 'Suche fehlgeschlagen. Bitte erneut versuchen.';
-        setError(message);
+      } catch {
+        setError('Suche fehlgeschlagen. Bitte erneut versuchen.');
         setResults([]);
         setMetadata(null);
       } finally {
@@ -109,17 +107,17 @@ export function useResearch(opts: UseResearchOptions = {}): UseResearchReturn {
     setError(null);
 
     try {
-      const response = await apiClient.post<ResearchResponse>('/research/similar', {
-        sourceUrl,
-        collectionId,
+      const client = getContractsClient();
+      const result = await client.research.similar({
+        body: { sourceUrl, collectionId, limit: null },
       });
-
-      setResults(response.data.results);
-      setMetadata(response.data.metadata);
-    } catch (err: unknown) {
-      const errResp = (err as { response?: { data?: { error?: string } } }).response;
-      const message = errResp?.data?.error ?? 'Ähnliche Dokumente konnten nicht geladen werden.';
-      setError(message);
+      if (result.status !== 200) {
+        throw new Error(`Ähnliche Dokumente konnten nicht geladen werden (HTTP ${result.status})`);
+      }
+      setResults(result.body.results);
+      setMetadata(result.body.metadata);
+    } catch {
+      setError('Ähnliche Dokumente konnten nicht geladen werden.');
       setResults([]);
       setMetadata(null);
     } finally {

--- a/apps/web/src/features/notebook/manual-search/useResearchFilters.ts
+++ b/apps/web/src/features/notebook/manual-search/useResearchFilters.ts
@@ -1,17 +1,9 @@
+import { getContractsClient } from '@gruenerator/shared/api';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 
-import apiClient from '../../../components/utils/apiClient';
-
 export type SearchMode = 'hybrid' | 'vector' | 'text';
 export type SortOption = 'relevance' | 'date_desc' | 'date_asc';
-
-export interface CollectionInfo {
-  id: string;
-  name: string;
-  description: string;
-  filterableFields: string[];
-}
 
 export interface FilterFieldConfig {
   label: string;
@@ -22,10 +14,6 @@ export interface FilterFieldConfig {
 }
 
 export type ActiveFilters = Record<string, string[] | { date_from?: string; date_to?: string }>;
-
-interface FiltersResponse {
-  filters: Record<string, FilterFieldConfig>;
-}
 
 const ALLOWED_FILTER_FIELDS = new Set([
   'published_at',
@@ -47,7 +35,13 @@ export function useResearchFilters(initialCollectionIds: string[] = []) {
 
   const { data: collections = [], isLoading: collectionsLoading } = useQuery({
     queryKey: ['research', 'collections'],
-    queryFn: () => apiClient.get<CollectionInfo[]>('/research/collections').then((r) => r.data),
+    queryFn: async () => {
+      const result = await getContractsClient().research.collections();
+      if (result.status !== 200) {
+        throw new Error(`Failed to load research collections (HTTP ${result.status})`);
+      }
+      return result.body;
+    },
     staleTime: 30 * 60 * 1000,
   });
 
@@ -61,13 +55,18 @@ export function useResearchFilters(initialCollectionIds: string[] = []) {
     isFetching: filtersFetching,
   } = useQuery({
     queryKey: ['research', 'filters', collectionsCacheKey],
-    queryFn: () => {
-      const params = selectedCollectionIds.length
-        ? `?collectionIds=${selectedCollectionIds.join(',')}`
-        : '';
-      return apiClient
-        .get<FiltersResponse>(`/research/filters${params}`)
-        .then((r) => r.data.filters);
+    queryFn: async () => {
+      const result = await getContractsClient().research.filters({
+        query: {
+          collectionIds: selectedCollectionIds.length ? selectedCollectionIds.join(',') : null,
+        },
+      });
+      if (result.status !== 200) {
+        throw new Error(`Failed to load research filters (HTTP ${result.status})`);
+      }
+      // Boundary cast: the contract types `type` as `string` (shared schema),
+      // but the backend only ever emits 'keyword' | 'date_range'.
+      return result.body.filters as Record<string, FilterFieldConfig>;
     },
     staleTime: 10 * 60 * 1000,
     placeholderData: keepPreviousData,

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -6,6 +6,7 @@ export { threadsContract } from './threadsContract.js';
 export { exportsContract } from './exportsContract.js';
 export { recentValuesContract } from './recentValuesContract.js';
 export { searchContract } from './searchContract.js';
+export { researchContract } from './researchContract.js';
 export { chatGraphContract } from './chatGraphContract.js';
 export { boardsContract } from './boardsContract.js';
 export { boardCommentsContract } from './boardCommentsContract.js';

--- a/packages/contracts/src/contracts/researchContract.ts
+++ b/packages/contracts/src/contracts/researchContract.ts
@@ -1,0 +1,88 @@
+/**
+ * ts-rest contract for /api/research/* — manual research over system
+ * collections (Grundsatzprogramme, Landesverbände, Bundestagsfraktion, …).
+ *
+ * Covers the 4 endpoints in apps/api/routes/research/researchContractRouter.ts.
+ * All routes are auth-gated via `requireAuth` prefix middleware on
+ * `/api/research` (see routes.ts) — not per-handler.
+ */
+import { initContract } from '@ts-rest/core';
+
+import {
+  researchCollectionsResponseSchema,
+  researchErrorResponseSchema,
+  researchFiltersQuerySchema,
+  researchFiltersResponseSchema,
+  researchSearchBodySchema,
+  researchSearchResponseSchema,
+  researchSimilarBodySchema,
+} from '../schemas/research.js';
+
+const c = initContract();
+
+export const researchContract = c.router(
+  {
+    /**
+     * GET /api/research/collections
+     * List all system collections with their filterable field names.
+     */
+    collections: {
+      method: 'GET',
+      path: '/api/research/collections',
+      responses: {
+        200: researchCollectionsResponseSchema,
+        500: researchErrorResponseSchema,
+      },
+      summary: 'List system research collections',
+    },
+
+    /**
+     * GET /api/research/filters?collectionIds=a,b
+     * Aggregated filter facet values across the requested collections.
+     */
+    filters: {
+      method: 'GET',
+      path: '/api/research/filters',
+      query: researchFiltersQuerySchema,
+      responses: {
+        200: researchFiltersResponseSchema,
+        400: researchErrorResponseSchema,
+        500: researchErrorResponseSchema,
+      },
+      summary: 'Get aggregated filter values for system collections',
+    },
+
+    /**
+     * POST /api/research/search
+     * Manual research search across one or more system collections.
+     */
+    search: {
+      method: 'POST',
+      path: '/api/research/search',
+      body: researchSearchBodySchema,
+      responses: {
+        200: researchSearchResponseSchema,
+        400: researchErrorResponseSchema,
+        500: researchErrorResponseSchema,
+      },
+      summary: 'Search system research collections',
+    },
+
+    /**
+     * POST /api/research/similar
+     * Find documents similar to a given source URL within one collection.
+     */
+    similar: {
+      method: 'POST',
+      path: '/api/research/similar',
+      body: researchSimilarBodySchema,
+      responses: {
+        200: researchSearchResponseSchema,
+        400: researchErrorResponseSchema,
+        500: researchErrorResponseSchema,
+      },
+      summary: 'Find similar documents within a collection',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -22,6 +22,7 @@ export {
   exportsContract,
   recentValuesContract,
   searchContract,
+  researchContract,
   chatGraphContract,
   boardsContract,
   boardCommentsContract,
@@ -59,6 +60,7 @@ export * from './schemas/threads.js';
 export * from './schemas/exports.js';
 export * from './schemas/recentValues.js';
 export * from './schemas/search.js';
+export * from './schemas/research.js';
 export * from './schemas/chatGraph.js';
 export * from './schemas/boards.js';
 export * from './schemas/boardComments.js';

--- a/packages/contracts/src/schemas/research.ts
+++ b/packages/contracts/src/schemas/research.ts
@@ -1,0 +1,74 @@
+/**
+ * Zod schemas for the /api/research/* surface (system-collection manual
+ * research). Mirrors apps/api/routes/research/researchContractRouter.ts.
+ *
+ * The result and filter-field shapes are identical to the per-notebook
+ * research endpoint, so they are reused from ./notebook.js rather than
+ * re-declared — one source of truth for the research result shape.
+ *
+ * Request bodies use `.nullish()` for optional fields per the
+ * feedback_no_undefined rule: the frontend sends `null` for unset values,
+ * which `.optional()` alone would reject.
+ */
+import { z } from 'zod';
+
+import { notebookFilterFieldSchema, notebookResearchResultSchema } from './notebook.js';
+
+// ── Request bodies / queries ────────────────────────────────────────────────
+
+export const researchSearchBodySchema = z.object({
+  query: z.string().min(2),
+  collectionIds: z.array(z.string()).nullish(),
+  limit: z.number().nullish(),
+  filters: z.record(z.unknown()).nullish(),
+  mode: z.enum(['hybrid', 'vector', 'text']).nullish(),
+  sortBy: z.enum(['relevance', 'date_desc', 'date_asc']).nullish(),
+});
+
+export const researchSimilarBodySchema = z.object({
+  sourceUrl: z.string().url(),
+  collectionId: z.string(),
+  limit: z.number().nullish(),
+});
+
+export const researchFiltersQuerySchema = z.object({
+  /** Comma-separated system collection IDs; omitted = all collections. */
+  collectionIds: z.string().nullish(),
+});
+
+// ── Response schemas ────────────────────────────────────────────────────────
+
+export const researchErrorResponseSchema = z.object({
+  error: z.string(),
+});
+
+/** A single research hit — same shape as the per-notebook research result. */
+export const researchResultSchema = notebookResearchResultSchema;
+
+export const researchSearchResponseSchema = z.object({
+  results: z.array(researchResultSchema),
+  metadata: z.object({
+    totalResults: z.number(),
+    collections: z.array(z.string()),
+    timeMs: z.number(),
+  }),
+});
+
+export const researchCollectionInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string(),
+  filterableFields: z.array(z.string()),
+});
+
+export const researchCollectionsResponseSchema = z.array(researchCollectionInfoSchema);
+
+export const researchFiltersResponseSchema = z.object({
+  filters: z.record(notebookFilterFieldSchema),
+});
+
+export type ResearchSearchBody = z.infer<typeof researchSearchBodySchema>;
+export type ResearchSimilarBody = z.infer<typeof researchSimilarBodySchema>;
+export type ResearchResult = z.infer<typeof researchResultSchema>;
+export type ResearchSearchResponse = z.infer<typeof researchSearchResponseSchema>;
+export type ResearchCollectionInfo = z.infer<typeof researchCollectionInfoSchema>;

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -21,6 +21,7 @@ import {
   exportsContract,
   recentValuesContract,
   searchContract,
+  researchContract,
   boardsContract,
   boardCommentsContract,
   publicBoardsContract,
@@ -139,6 +140,7 @@ const _threadsClient = () => initClient(threadsContract, CLIENT_OPTS);
 const _exportsClient = () => initClient(exportsContract, CLIENT_OPTS);
 const _recentValuesClient = () => initClient(recentValuesContract, CLIENT_OPTS);
 const _searchClient = () => initClient(searchContract, CLIENT_OPTS);
+const _researchClient = () => initClient(researchContract, CLIENT_OPTS);
 const _boardsClient = () => initClient(boardsContract, CLIENT_OPTS);
 const _boardCommentsClient = () => initClient(boardCommentsContract, CLIENT_OPTS);
 const _publicBoardsClient = () => initClient(publicBoardsContract, CLIENT_OPTS);
@@ -165,6 +167,7 @@ export interface ContractsClient {
   exports: ReturnType<typeof _exportsClient>;
   recentValues: ReturnType<typeof _recentValuesClient>;
   search: ReturnType<typeof _searchClient>;
+  research: ReturnType<typeof _researchClient>;
   boards: ReturnType<typeof _boardsClient>;
   boardComments: ReturnType<typeof _boardCommentsClient>;
   publicBoards: ReturnType<typeof _publicBoardsClient>;
@@ -208,6 +211,7 @@ export function getContractsClient(): ContractsClient {
     exports: _exportsClient(),
     recentValues: _recentValuesClient(),
     search: _searchClient(),
+    research: _researchClient(),
     boards: _boardsClient(),
     boardComments: _boardCommentsClient(),
     publicBoards: _publicBoardsClient(),


### PR DESCRIPTION
## Why

In **manuelle Recherche** on an LV (Landesverband) notebook, switching the search mode to **"Volltext"** changed nothing — it returned the same hits as Semantisch/Hybrid. Root cause: `DocumentSearchService.search()` only special-cased `hybrid` and let `text` fall through to `performSimilaritySearch` (pure vector). The dedicated text path was never reached, and the text primitive additionally hardcoded the per-user `documents` collection with a `user_id` filter, so it could never have searched a system collection anyway.

The fix routes `text` mode to a real full-text path and generalises the text primitive to honour `searchCollection` + `additionalFilter` (mirroring the vector path). One change repairs both the system-collection route (`/research/search`) and the user-notebook route — they share `search()`. The system/LV Qdrant collections already carry a `chunk_text` text index, so keyword search now returns results.

While here — per the type-safety convention for user-facing endpoints — the four `/research/*` endpoints (search, similar, collections, filters) are lifted into a ts-rest contract; both `useResearch` and `useResearchFilters` now use the typed contracts client instead of raw `apiClient`. `researchController.ts` is reduced to the shared helpers it still exports (snippet formatting for `notebookContractRouter`, the filter cache + `warmFilterCache` for startup).

## Verification

- New vitest cases in `searchOperations.vitest.ts` pin that `text` mode queries the requested `searchCollection`, omits `user_id` for system collections, and applies `additionalFilter` (10/10 pass).
- `typecheck` clean across contracts/api/shared/web; `lint` 0 errors.
- Manual: open an LV notebook's manuelle Recherche, toggle Volltext, confirm results differ from Semantisch for a keyword-specific query (backend logs `[SearchOperations] Text search` on `landesverbaende_documents`).