### PR TITLE
fix(docs): lift formatting toolbar above keyboard on iPad

### DIFF
--- a/packages/docs/src/components/editor/BlockNoteEditor.css
+++ b/packages/docs/src/components/editor/BlockNoteEditor.css
@@ -167,7 +167,7 @@
 @media (max-width: 767px) {
   .blocknote-static-toolbar .bn-formatting-toolbar {
     position: fixed;
-    bottom: var(--mobile-keyboard-offset, 0px);
+    bottom: 0;
     left: 0;
     right: 0;
     top: auto;
@@ -183,7 +183,7 @@
     border-radius: 0;
     z-index: 50;
     background: var(--grey-100, #f3f4f6);
-    transition: bottom 0.15s ease-out, opacity 0.15s ease-out, transform 0.15s ease-out;
+    transition: opacity 0.15s ease-out, transform 0.15s ease-out;
     touch-action: pan-x;
     opacity: 0;
     transform: translateY(100%);
@@ -192,7 +192,10 @@
 
   .blocknote-static-toolbar.has-selection .bn-formatting-toolbar {
     opacity: 1;
-    transform: translateY(0);
+    /* Lift above the on-screen keyboard via a compositor transform: iOS WebKit
+       (incl. Chrome for iPad) keeps `position: fixed` anchored to the layout
+       viewport, so `bottom` won't clear the keyboard, but a transform tracks it. */
+    transform: translateY(calc(-1 * var(--mobile-keyboard-offset, 0px)));
     pointer-events: auto;
   }
 

--- a/packages/shared/src/hooks/useMobileKeyboardOffset.ts
+++ b/packages/shared/src/hooks/useMobileKeyboardOffset.ts
@@ -72,8 +72,10 @@ export function useMobileKeyboardOffset<T extends HTMLElement>(
     let lastKnownKeyboardHeight = 0;
 
     const update = () => {
-      const layoutHeight = document.documentElement.clientHeight;
-      const keyboardHeight = layoutHeight - vp.height - vp.offsetTop;
+      // `window.innerHeight` stays the full layout-viewport height when the iOS
+      // keyboard opens; `documentElement.clientHeight` can collapse to the
+      // shrunken visual viewport, yielding ~0 and a bar that never lifts.
+      const keyboardHeight = window.innerHeight - vp.height - vp.offsetTop;
       if (keyboardHeight > 50) lastKnownKeyboardHeight = keyboardHeight;
       setOffset(keyboardHeight);
     };


### PR DESCRIPTION
On iPad in Chrome (which is WebKit under the hood), the docs formatting toolbar stayed pinned to the bottom edge and was hidden **behind** the on-screen keyboard instead of floating just above it.

Two WebKit-specific reasons it didn't track the keyboard:

- `position: fixed` anchors to the *layout* viewport, which doesn't shrink for the keyboard — so lifting the bar with an animated `bottom` can't clear the keyboard. Driving the lift with a compositor `transform` does track it.
- The keyboard height was derived from `document.documentElement.clientHeight`, which on iOS can collapse to the shrunken *visual* viewport and come out ~0, so the bar never moved. `window.innerHeight` stays the stable layout-viewport height.

`interactive-widget` (already set in the viewport meta) is a Blink-only hint and is ignored by iPad WebKit, so it isn't the lever here.

Device-specific WebKit rendering issue — verify on an actual iPad in Chrome: select text to reveal the toolbar, focus the editor so the keyboard is up, and confirm the bar sits flush on top of the keyboard and follows it as it opens/closes.