### PR TITLE
fix(ci): rebuild docs image without cache to stop stale-content drift

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -540,6 +540,12 @@ jobs:
           context: ./documentation
           file: documentation/Dockerfile
           push: true
+          # Always rebuild the static site from scratch. The Docusaurus output is
+          # cheap to build, but the registry buildcache has repeatedly served a
+          # stale COPY/build layer (missing newly-merged docs pages), so caching
+          # the build here causes silent content drift. cache-to still refreshes
+          # the buildcache with correct layers for any future cached consumer.
+          no-cache: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}-doku:buildcache


### PR DESCRIPTION
The new Landesverbände docs page (merged in #1040) never appeared on the live docs site even though it's on master. Root cause: the `build-doku` job's registry buildcache kept serving a cached `COPY . .` / `RUN npm run build` layer that predated the page, so every `build_doku` dispatch pushed a `:latest` image byte-identical to a pre-page build (verified: built image's filesystem `Created` timestamp matched the old served content, and `COPY . . → CACHED` in the build log). The Dockerfile's `ARG CACHEBUST` escape hatch is dead code — declared before `FROM`, never referenced.

Disabling the layer cache for this build guarantees the static site is recompiled from the checked-out source. The docs build is small and `build-doku` only runs when `documentation/**` changes, so the lost caching is negligible. `cache-to` is kept so the buildcache is refreshed with correct layers.