### PR TITLE
fix(docs): unhide user-facing Landesverband-Agents page

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -58,10 +58,9 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           // Hidden until ready — remove entries to re-enable in the sidebar.
-          // landesverbaende: dev-only LV-Korpus analysis pages.
           // monitor: Themen-Monitor not online yet.
           // briefings: Briefing-Archiv hidden for now.
-          exclude: ['landesverbaende/**', 'monitor/**', 'briefings/**'],
+          exclude: ['monitor/**', 'briefings/**'],
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:


### PR DESCRIPTION
The Landesverband-Agents page (`docs/landesverbaende/index.md`) never appeared on the live docs site — not in the sitemap, not in the sidebar nav, not as a route. Root cause: the docs plugin's `exclude` listed `landesverbaende/**`, so the page was dropped at compile time (an excluded page is invisible to the autogenerated sidebar and sitemap, which is why the nav entry was missing too).

The exclude's comment ("dev-only LV-Korpus analysis pages") was stale: those dev pages live under `docs/intern/landesverband-korpusanalyse/`; `docs/landesverbaende/` now contains only the public-facing agents page. Removing it from the exclude lets it compile. `monitor/**` and `briefings/**` stay hidden as intended.

(Pairs with #1074, which fixed the docs image build cache — necessary but not sufficient, since a perfect build still omits an excluded page.)