### PR TITLE
chore: format landesverbaendeConfig with prettier

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -457,7 +457,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
         // $('body') fallback that swallowed header/nav/footer + the related-items
         // sidebar. Verified across Beschlüsse, Wahlprogramm chapters and Presse —
         // all share this template.
-        content: ['.xBlog.single .ce-bodytext', '.ce-bodytext', '.xBlog.single', 'article', 'main .content'],
+        content: [
+          '.xBlog.single .ce-bodytext',
+          '.ce-bodytext',
+          '.xBlog.single',
+          'article',
+          'main .content',
+        ],
         categories: ['.tx_xblog_pi1 .tags a', '.categories a'],
         author: ['.author', '.byline'],
       },
@@ -503,7 +509,13 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
         // $('body') fallback that swallowed header/nav/footer + the related-items
         // sidebar. Verified across Beschlüsse, Wahlprogramm chapters and Presse —
         // all share this template.
-        content: ['.xBlog.single .ce-bodytext', '.ce-bodytext', '.xBlog.single', 'article', 'main .content'],
+        content: [
+          '.xBlog.single .ce-bodytext',
+          '.ce-bodytext',
+          '.xBlog.single',
+          'article',
+          'main .content',
+        ],
         categories: ['.tx_xblog_pi1 .tags a', '.categories a'],
         author: ['.author', '.byline'],
       },


### PR DESCRIPTION
Master CI is red on the `Quality Checks → Prettier format check` step because `apps/api/config/landesverbaendeConfig.ts` was committed unformatted (two `content: [...]` arrays exceeded print width). Because every branch forks from master, that single unformatted file fails `format:check` on **every** open PR too.

This runs `prettier --write` on just that file to turn master CI green again and unblock other branches. No logic changes.