### PR TITLE
fix(monitor): add missing social_trends column migration

### DIFF
--- a/apps/api/database/postgres/migrations/add_monitor_social_trends.sql
+++ b/apps/api/database/postgres/migrations/add_monitor_social_trends.sql
@@ -1,0 +1,6 @@
+-- Add social_trends column to monitor_snapshots
+-- Stores Twitter/Bluesky trending topics captured during each refresh.
+-- saveSnapshotAggregates() has inserted into this column (and getLatestSnapshot()
+-- read it) since the feature shipped, but the column was never created — every
+-- refresh therefore failed with PG 42703 (undefined column).
+ALTER TABLE monitor_snapshots ADD COLUMN IF NOT EXISTS social_trends JSONB DEFAULT '[]'::jsonb;

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -1223,10 +1223,39 @@ CREATE TABLE IF NOT EXISTS monitor_snapshots (
     total_articles INT NOT NULL,
     sources TEXT[] NOT NULL,
     topic_scores JSONB NOT NULL,
-    articles JSONB NOT NULL
+    articles JSONB NOT NULL DEFAULT '[]', -- legacy blob; superseded by monitor_articles
+    keywords JSONB DEFAULT '[]',
+    social_trends JSONB DEFAULT '[]'
 );
 
 CREATE INDEX IF NOT EXISTS idx_monitor_snapshots_created ON monitor_snapshots(created_at DESC);
+
+-- Normalized, deduplicated article store for watcher search (replaces the
+-- snapshot `articles` JSONB blob). Trigram indexes back the ILIKE searches.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS monitor_articles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    excerpt TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    locale TEXT NOT NULL DEFAULT 'de',
+    published_at TIMESTAMPTZ,
+    primary_topic TEXT,
+    topic_scores JSONB DEFAULT '{}',
+    first_seen_at TIMESTAMPTZ DEFAULT now(),
+    last_seen_at TIMESTAMPTZ DEFAULT now(),
+    emotion_scores JSONB DEFAULT '{}',
+    top_nouns JSONB DEFAULT '[]',
+    er_sentiment FLOAT
+);
+
+CREATE INDEX IF NOT EXISTS idx_monitor_articles_title_trgm ON monitor_articles USING GIN(title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_monitor_articles_excerpt_trgm ON monitor_articles USING GIN(excerpt gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_monitor_articles_seen ON monitor_articles(last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS idx_monitor_articles_locale ON monitor_articles(locale);
+CREATE INDEX IF NOT EXISTS idx_monitor_articles_topic ON monitor_articles(primary_topic);
 
 
 -- ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The hourly `Monitor Refresh` workflow fails with PG `42703` (undefined column). `saveSnapshotAggregates()` inserts into `monitor_snapshots.social_trends` and `getLatestSnapshot()` reads it back, but **no migration ever created that column** — it has been referenced in code since the feature's original commit (`0e28ec76d`), so every refresh has thrown.

Adds the idempotent `ADD COLUMN IF NOT EXISTS social_trends` migration (matching the `add_monitor_keywords.sql` sibling) and re-syncs the monitor section of `schema.sql`, which had drifted badly: it was missing the `monitor_articles` table entirely plus the `keywords`/`social_trends`/emotion/sentiment columns added by later migrations.

This is the minimal runtime fix to restore the cron; the follow-up typesafe refactor (Drizzle + Zod + ts-rest) makes this class of column-drift bug a compile error rather than a runtime PG failure.