### PR TITLE
refactor(canvas-editor): dedupe AdditionalText and IconState types

### DIFF
--- a/packages/canvas-editor/src/configs/dreizeilen.types.ts
+++ b/packages/canvas-editor/src/configs/dreizeilen.types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AdditionalText } from './types';
+import type { IconState } from './factory/baseTypes';
 import type { BalkenInstance } from '../primitives/BalkenGroup';
 import type { StockImageAttribution } from '../sidebar/types';
 import type { BalkenMode } from '../utils/balkenUtils';
@@ -61,17 +62,7 @@ export interface DreizeilenFullState {
 
   // === Icons & Shapes ===
   selectedIcons: string[];
-  iconStates: Record<
-    string,
-    {
-      x: number;
-      y: number;
-      scale: number;
-      rotation: number;
-      color?: string;
-      opacity?: number;
-    }
-  >;
+  iconStates: Record<string, IconState>;
   shapeInstances: ShapeInstance[];
   selectedShapeId: string | null;
 

--- a/packages/canvas-editor/src/sidebar/types.ts
+++ b/packages/canvas-editor/src/sidebar/types.ts
@@ -1,5 +1,7 @@
 import type { IconType } from 'react-icons';
 
+import type { AdditionalText } from '../configs/types';
+
 /**
  * All possible sidebar tab IDs.
  *
@@ -129,15 +131,4 @@ export interface SidebarPanelProps {
   isOpen: boolean;
   children: React.ReactNode;
   onClose?: () => void;
-}
-
-export interface AdditionalText {
-  id: string;
-  text: string;
-  type: 'header' | 'subheader' | 'body';
-  x?: number;
-  y?: number;
-  width?: number;
-  fontSize?: number;
-  align?: 'left' | 'center' | 'right';
 }


### PR DESCRIPTION
Two type definitions were duplicated *within* the canvas-editor package, both confusing and a drift risk:

- `AdditionalText` existed in both `configs/types.ts` (the strict rendered-element shape that every consumer actually imports) and `sidebar/types.ts` (a looser, all-optional draft shape carrying a vestigial `align`). No code imported the sidebar copy, so it's collapsed onto the canonical — one shape now describes additional texts everywhere.
- `dreizeilen.types.ts` inlined a `Record<string, { x; y; scale; rotation; color?; opacity? }>` that is byte-for-byte the canonical `IconState` in `factory/baseTypes.ts`; it now references the named type.

Independent of the canvas-contract PRs. Type-only change; `@gruenerator/canvas-editor` typecheck stays green.