### PR TITLE
fix(content-sync): raise per-LV scrape timeout to 50 min

### DIFF
--- a/apps/api/update-all-content.ts
+++ b/apps/api/update-all-content.ts
@@ -377,6 +377,10 @@ async function main() {
       {
         id: `landesverband-${lvCode}`,
         name: `Landesverband ${lvCode} (${matchingSources.length} sources)`,
+        // Large LVs (BE, HH) crawl 4+ sources with PDF/OCR and outgrow the 30 min
+        // default. Kept under the workflow's 60 min job limit so the timeout still
+        // fires inside the script (clean summary/email) instead of a hard CI cancel.
+        timeoutMs: 50 * 60 * 1000,
         async run(a) {
           await landesverbandScraperService.init();
           const result = await landesverbandScraperService.scrapeAllSources({


### PR DESCRIPTION
The Content Sync workflow has been failing on the larger Landesverbände. Today's 06:15 run failed with `Sync LV BE` and `Sync LV HH` both killed at exactly 30:00 (`landesverband-BE: Timeout after 30 minutes`).

This is *not* the GitHub Actions `timeout-minutes: 60` job limit — those jobs ran ~31m. The trip is an in-script per-source timeout in `runSourceGroup`. The dynamically-built per-LV group omitted `timeoutMs`, so it fell through to the 30 min `DEFAULT_TIMEOUT_MS`, while the static heavy scrapers (boell, gruene-at) already carry explicit 45 min budgets. BE (4 sources, PDF/OCR) and HH simply outgrew 30 min; neighbouring LVs (MV 26m, LSA 25m) sit just under it.

The new 50 min budget stays below the 60 min CI job limit on purpose, so the timeout keeps firing inside the script (clean summary + email) rather than being hard-cancelled by the runner.