### PR TITLE
refactor(web): route canvas calls through the typed contracts client

### DIFF
--- a/apps/web/src/features/groups/hooks/useGroups.ts
+++ b/apps/web/src/features/groups/hooks/useGroups.ts
@@ -288,8 +288,14 @@ export const useGroupSharing = (groupId: string | null, _options: UseGroupsOptio
 export const useCloneCanvasTemplate = () => {
   return useMutation({
     mutationFn: async (canvasId: string) => {
-      const response = await apiClient.post<{ newCanvasId: string }>(`/canvas/${canvasId}/clone`);
-      return response.data;
+      const result = await getContractsClient().canvas.clone({
+        params: { id: canvasId },
+        body: {},
+      });
+      if (result.status !== 201) {
+        throw new Error(`Failed to clone canvas (HTTP ${result.status})`);
+      }
+      return result.body;
     },
   });
 };

--- a/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
+++ b/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
@@ -1,32 +1,21 @@
 import { useCanvasCollaboration, MasterCanvasEditor } from '@gruenerator/canvas-editor';
 import { PresenceAvatars, useCollaborators } from '@gruenerator/collab';
+import { type CanvasDocument } from '@gruenerator/contracts';
+import { getContractsClient } from '@gruenerator/shared/api';
 import { EditableTitle } from '@gruenerator/shared/components/EditableTitle';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DottedBackground } from '../../components/common/DottedBackground';
-import { useDocumentTitle } from '../../components/hooks/useDocumentTitle';
 import withAuthRequired from '../../components/common/LoginRequired/withAuthRequired';
 import ErrorBoundary from '../../components/ErrorBoundary';
-import apiClient from '../../components/utils/apiClient';
+import { useDocumentTitle } from '../../components/hooks/useDocumentTitle';
 import { useCollaborationConfig } from '../../hooks/useCollaborationConfig';
 import { useAuthStore } from '../../stores/authStore';
 
 import { ShareCanvasDialog } from './components/ShareCanvasDialog';
 import { WebCanvasEditorProvider } from './WebCanvasEditorProvider';
-
-interface CanvasDocument {
-  id: string;
-  title: string;
-  created_by: string;
-  permissions: Record<string, { level: string }> | null;
-  template_type: string;
-  base_template_id: string | null;
-  thumbnail_url: string | null;
-  page_count: number;
-  initial_state: Record<string, unknown>;
-}
 
 function CollabCanvasStudioContent() {
   const { id } = useParams<{ id: string }>();
@@ -40,8 +29,11 @@ function CollabCanvasStudioContent() {
   const { data: canvas, isLoading } = useQuery<CanvasDocument>({
     queryKey: ['canvas', id],
     queryFn: async () => {
-      const res = await apiClient.get<CanvasDocument>(`/canvas/${id}`);
-      return res.data;
+      const result = await getContractsClient().canvas.get({ params: { id: id! } });
+      if (result.status !== 200) {
+        throw new Error(`Failed to load canvas (HTTP ${result.status})`);
+      }
+      return result.body;
     },
     enabled: !!id,
   });
@@ -63,7 +55,13 @@ function CollabCanvasStudioContent() {
         old ? { ...old, title: newTitle } : old
       );
       try {
-        await apiClient.patch(`/canvas/${id}`, { title: newTitle });
+        const result = await getContractsClient().canvas.update({
+          params: { id },
+          body: { title: newTitle },
+        });
+        if (result.status !== 200) {
+          throw new Error(`PATCH returned HTTP ${result.status}`);
+        }
       } catch (err) {
         console.error('[canvas-rename] PATCH failed, reverting', err);
         queryClient.setQueryData(key, previous);

--- a/apps/web/src/features/image-studio/services/canvasMintService.ts
+++ b/apps/web/src/features/image-studio/services/canvasMintService.ts
@@ -1,3 +1,5 @@
+import { getContractsClient } from '@gruenerator/shared/api';
+
 import apiClient from '../../../components/utils/apiClient';
 
 import type { ImageStudioState } from '../types/storeTypes';
@@ -11,10 +13,6 @@ interface MediaUploadResponse {
     mediaType: string;
     createdAt: string;
   };
-}
-
-interface CanvasCreateResponse {
-  id: string;
 }
 
 async function uploadBlobToMediaLibrary(blob: Blob): Promise<string | null> {
@@ -122,13 +120,18 @@ export async function mintCanvasFromStudioStore(state: ImageStudioState): Promis
   const title = state.editTitle || 'Neuer Canvas';
   const format = state.selectedFormatId || 'post-portrait';
 
-  const res = await apiClient.post<CanvasCreateResponse>('/canvas', {
-    title,
-    template_type: state.type,
-    initial_state,
-    format,
-    page_count: 1,
+  const result = await getContractsClient().canvas.create({
+    body: {
+      title,
+      template_type: state.type,
+      initial_state,
+      format,
+      page_count: 1,
+    },
   });
+  if (result.status !== 201) {
+    throw new Error(`Failed to create canvas (HTTP ${result.status})`);
+  }
 
-  return { id: res.data.id };
+  return { id: result.body.id };
 }

--- a/apps/web/src/features/image-studio/steps/TemplateResultStep.tsx
+++ b/apps/web/src/features/image-studio/steps/TemplateResultStep.tsx
@@ -1,4 +1,5 @@
 import { ControllableCanvasWrapper } from '@gruenerator/canvas-editor';
+import { getContractsClient } from '@gruenerator/shared/api';
 import { useShareStore } from '@gruenerator/shared/share';
 import { Button } from '@gruenerator/ui';
 import { motion } from 'motion/react';
@@ -8,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { Markdown } from '../../../components/common/Markdown';
 import { ShareMediaModal } from '../../../components/common/ShareMediaModal';
-import apiClient from '../../../components/utils/apiClient';
 import useImageStudioStore from '../../../stores/imageStudioStore';
 import { cn } from '../../../utils/cn';
 import { AiHistoryTimeline } from '../components/AiHistoryTimeline';
@@ -176,12 +176,17 @@ const TemplateResultStep: React.FC<TemplateResultStepProps> = ({
         locationName,
         address,
       };
-      const res = await apiClient.post<{ id: string }>('/canvas', {
-        title: 'Neuer Canvas',
-        template_type: type,
-        initial_state,
+      const result = await getContractsClient().canvas.create({
+        body: {
+          title: 'Neuer Canvas',
+          template_type: type,
+          initial_state,
+        },
       });
-      void navigate(`/studio/canvas/${res.data.id}`);
+      if (result.status !== 201) {
+        throw new Error(`Failed to create canvas (HTTP ${result.status})`);
+      }
+      void navigate(`/studio/canvas/${result.body.id}`);
     } catch (err) {
       console.error('[TemplateResultStep] Failed to save as collab canvas:', err);
     } finally {


### PR DESCRIPTION
Follow-up to #1082 (canvas CRUD contract). Now that the canvas endpoints are contracted, the frontend can drop its hand-maintained `CanvasDocument` interface — which duplicated the backend shape and used a looser `permissions: Record<string, { level: string }>` than the real one — and let response types derive from the contract instead.

All five canvas call sites move from raw `apiClient` to `getContractsClient().canvas.*` with status-checked results, so the web app and backend stay in lockstep:
- `CollabCanvasStudioPage` — `get` (load) + `update` (rename)
- `canvasMintService` — `create`
- `TemplateResultStep` — `create`
- `useGroups` — `clone`

No resize caller exists in the web app yet (the contract covers it for completeness).

Verified: `@gruenerator/web` typecheck green; the 4 files lint clean (0 errors).