### PR TITLE
perf(content-sync): never re-fetch settled (>2yr) Landesverband content

### DIFF
--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -59,6 +59,16 @@ import type { ScraperResult } from '../../types.js';
 const RECHECK_AFTER_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
 
 /**
+ * Content published longer ago than this is treated as settled: it no longer
+ * changes in place, so once indexed we never re-fetch it. This bounds the
+ * per-run re-check set to recent/living content instead of re-walking a
+ * multi-year archive every run — the re-fetch cost that pushed big LVs (BE, HH)
+ * past the sync timeout. Pages without a parseable published date fall through
+ * to the RECHECK_AFTER_MS window, so unknown-age content is still re-checked.
+ */
+const RECHECK_MAX_CONTENT_AGE_MS = 2 * 365 * 24 * 60 * 60 * 1000; // ~2 years
+
+/**
  * Main scraper class - orchestrates all modules
  * Reduced from 1,139 lines to ~400 lines through modularization
  */
@@ -769,10 +779,14 @@ export class LandesverbandScraper extends BaseScraper {
   }
 
   /**
-   * Layer-1 freshness gate. Returns true when the URL is already indexed AND was
-   * last indexed within RECHECK_AFTER_MS, in which case the caller skips the fetch.
-   * Missing, timestamp-less (legacy), or stale points return false so the caller
-   * re-fetches and lets the DocumentProcessor content-hash diff decide on re-embed.
+   * Layer-1 freshness gate. Returns true when the caller should skip the fetch.
+   * Skips an already-indexed URL when EITHER:
+   *   - its content was published more than RECHECK_MAX_CONTENT_AGE_MS ago
+   *     (settled history — never re-fetched once indexed), OR
+   *   - it was last indexed within RECHECK_AFTER_MS (recently re-checked).
+   * Missing, timestamp-less (legacy), or stale recent points return false so the
+   * caller re-fetches and lets the DocumentProcessor content-hash diff decide on
+   * re-embed.
    */
   async #isFreshlyIndexed(url: string, targetCollection: string): Promise<boolean> {
     const points = await scrollDocuments(
@@ -782,7 +796,20 @@ export class LandesverbandScraper extends BaseScraper {
       { limit: 1, withPayload: true, withVector: false }
     );
     if (points.length === 0) return false;
-    const indexedAt = points[0].payload?.indexed_at as string | undefined;
+    const payload = points[0].payload;
+
+    // Settled history (published > 2 years ago) does not change in place, so we
+    // never re-fetch it regardless of when it was last re-checked. This keeps
+    // the per-run re-fetch set bounded to recent/living content.
+    const publishedAt = payload?.published_at as string | undefined;
+    if (publishedAt) {
+      const contentAge = Date.now() - new Date(publishedAt).getTime();
+      if (Number.isFinite(contentAge) && contentAge > RECHECK_MAX_CONTENT_AGE_MS) {
+        return true;
+      }
+    }
+
+    const indexedAt = payload?.indexed_at as string | undefined;
     if (!indexedAt) return false;
     const age = Date.now() - new Date(indexedAt).getTime();
     return Number.isFinite(age) && age >= 0 && age < RECHECK_AFTER_MS;


### PR DESCRIPTION
## Why

The freshness gate from ca04c4bfe (`#isFreshlyIndexed`) re-fetches every indexed Landesverband page older than 3 days on each run, so living documents (Wahlprogramme, revised Beschlüsse) stay current as they change in place. The cost: on large archives — BE's `berlin-fraktion-presse` walks up to `maxPages: 120`, HH `maxPages: 50` — every hourly run re-fetches and re-extracts *years* of settled history, not just the recent slice. That re-fetch load is what pushed the `Sync LV BE`/`Sync LV HH` jobs past the 30-min in-script timeout (the failures #1085 raised the ceiling for).

Content published more than ~2 years ago doesn't change in place, so once it's indexed there's no reason to ever re-fetch it. This caps the per-run re-check set to recent/living content (≤2yr) while keeping the 3-day window for everything that can still change. The `published_at` field is already in the Qdrant payload and `#isFreshlyIndexed` already reads the payload, so the guard adds no extra query. Pages without a parseable published date fall through to the existing 3-day window — unknown-age content is still treated as possibly-living.

Pairs with #1085 (timeout ceiling = safety net; this = the actual load reduction).