### PR TITLE
perf(search): collapse CMS alias duplicates in LV search results

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -844,8 +844,10 @@ export function getAllSourceIds(): string[] {
  * Extract the trailing TYPO3-style id (e.g. `_3763`) from a URL pathname,
  * keyed by hostname so /beschluesse/foo_3763 and /news/foo_3763 collide
  * but /beschluesse/foo_3763 on different domains do not.
+ *
+ * Exported so search-result assembly can collapse alias duplicates by node id.
  */
-function trailingSlugKey(url: string): string | null {
+export function trailingSlugKey(url: string): string | null {
   try {
     const u = new URL(url);
     const m = u.pathname.match(/_(\d+)$/);

--- a/apps/api/routes/chat/agents/directSearchExecutors.ts
+++ b/apps/api/routes/chat/agents/directSearchExecutors.ts
@@ -7,6 +7,7 @@
  */
 
 import { COLLECTION_MAP } from '../../../config/collectionMap.js';
+import { trailingSlugKey } from '../../../config/landesverbaendeConfig.js';
 import {
   getSearchParams,
   buildSubcategoryFilter,
@@ -103,6 +104,28 @@ export interface DirectWebSearchResult {
 }
 
 const documentSearchService = new DocumentSearchService();
+
+/**
+ * Collapse results that point at the same CMS node served under multiple path
+ * aliases (e.g. TYPO3 serves a press release at both /nachrichten/x_NNN and
+ * /pressemitteilungen/x_NNN). These share a trailing node id but get distinct
+ * content_hash → document_id (rendering drift), so upstream document_id dedup
+ * misses them. Results arrive relevance-ranked, so first-wins keeps the
+ * best-scoring copy. URLs without a node id are never collapsed.
+ */
+function collapseAliasDuplicates(results: DocumentResult[]): DocumentResult[] {
+  const seen = new Set<string>();
+  const out: DocumentResult[] = [];
+  for (const result of results) {
+    const key = result.source_url ? trailingSlugKey(result.source_url) : null;
+    if (key) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    out.push(result);
+  }
+  return out;
+}
 
 /**
  * Execute a direct document search against Qdrant.
@@ -235,7 +258,7 @@ export async function executeDirectSearch(params: {
       }
     }
 
-    const formattedResults = response.results
+    const formattedResults = collapseAliasDuplicates(response.results)
       .slice(0, limit)
       .map((result: DocumentResult, index: number) => ({
         rank: index + 1,


### PR DESCRIPTION
## Why

Auditing the live `landesverbaende_documents` index turned up heavy duplication on Berlin: the same TYPO3 node served under multiple path aliases (a press release at both `/nachrichten/x_NNN` and `/pressemitteilungen/x_NNN`; Wahlprogramm chapters at `/news/x_NNN` and `/beschluesse/x_NNN`). Because the two renderings produce slightly different extracted text, they get different `content_hash` → different `document_id`, so the existing document_id dedup in the search pipeline doesn't catch them — the same content can surface twice in one result set.

The stale legacy copies have already been purged from Berlin's index, so this is the durable guard against recurrence (e.g. a future CMS path migration re-introducing aliases). It collapses results sharing a trailing TYPO3 node id (`host#_NNN`) before truncating to the requested limit; results arrive relevance-ranked so first-wins keeps the best-scoring copy, and URLs without a node id are never collapsed (no-op for non-TYPO3 collections). Reuses `trailingSlugKey` — the same node-identity helper curated-list tagging already keys on — now exported.

Typecheck: `pnpm --filter @gruenerator/api typecheck` passes.