### PR TITLE
fix(qdrant): ensure schema payload indexes on existing collections

### DIFF
--- a/apps/api/database/services/QdrantService/collections.ts
+++ b/apps/api/database/services/QdrantService/collections.ts
@@ -69,37 +69,37 @@ export async function createCollections(
     const existingNames = new Set(existingCollections.collections.map((c) => c.name));
 
     for (const [_key, schema] of Object.entries(COLLECTION_SCHEMAS)) {
-      if (existingNames.has(schema.name)) {
-        log.debug(`Collection ${schema.name} already exists, skipping`);
-        continue;
-      }
-
-      try {
-        const config = getCollectionConfig(vectorSize, schema);
-        await client.createCollection(schema.name, config);
-        log.debug(`Created ${schema.name} collection (${vectorSize} dims)`);
-
-        // Create indexes for this collection
-        for (const index of schema.indexes || []) {
-          try {
-            await client.createPayloadIndex(schema.name, {
-              field_name: index.field,
-              field_schema: getIndexSchema(index.type),
-            });
-            log.debug(`Created index ${index.field} on ${schema.name}`);
-          } catch (indexError) {
-            const message = indexError instanceof Error ? indexError.message : String(indexError);
-            if (!message.includes('already exists')) {
-              log.warn(`Failed to create index ${index.field} on ${schema.name}: ${message}`);
-            }
+      if (!existingNames.has(schema.name)) {
+        try {
+          const config = getCollectionConfig(vectorSize, schema);
+          await client.createCollection(schema.name, config);
+          log.debug(`Created ${schema.name} collection (${vectorSize} dims)`);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (schema.handleRaceCondition && message.includes('already exists')) {
+            log.debug(`Collection ${schema.name} already exists (race condition)`);
+          } else {
+            throw error;
           }
         }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (schema.handleRaceCondition && message.includes('already exists')) {
-          log.debug(`Collection ${schema.name} already exists (race condition)`);
-        } else {
-          throw error;
+      }
+
+      // Ensure payload indexes for both new and pre-existing collections.
+      // createPayloadIndex is idempotent (already-exists is caught), so this
+      // backfills indexes added to a schema after its collection was created —
+      // without it, schema index additions silently never apply to existing
+      // collections (which broke the curated_lists facet → filter UI).
+      for (const index of schema.indexes || []) {
+        try {
+          await client.createPayloadIndex(schema.name, {
+            field_name: index.field,
+            field_schema: getIndexSchema(index.type),
+          });
+        } catch (indexError) {
+          const message = indexError instanceof Error ? indexError.message : String(indexError);
+          if (!message.includes('already exists')) {
+            log.warn(`Failed to create index ${index.field} on ${schema.name}: ${message}`);
+          }
         }
       }
     }


### PR DESCRIPTION
## Why

Payload indexes were created **only when a collection was first created** — for an already-existing collection the index step was `continue`'d past entirely, whereas text-search indexes are re-ensured on every boot. So any index added to a schema *after* its collection already existed silently never got built. That's a latent trap: the next time someone adds a keyword index to a schema, it won't apply to the existing prod collection, and facet-driven features over that field break with no obvious cause.

This ensures schema-declared payload indexes on **both new and pre-existing** collections every boot. `createPayloadIndex` is idempotent (already-exists is caught), so once an index exists it's a cheap no-op — matching how text-search indexes already work.

(Originally motivated by a missing `curated_lists` index; that specific filter was since reworked to use `content_type` instead — see #1090 — so this PR is now just the general hygiene fix.)

Typecheck: `pnpm --filter @gruenerator/api typecheck` passes.