### PR TITLE
fix(scrapers): surface Berlin Wahlprogramm under 'Typ', not 'Liste'

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -77,6 +77,13 @@ export interface CuratedList {
   label: string;
   shortName?: string;
   urls: string[];
+  /**
+   * When set, documents matched to this list are stored with this content_type
+   * instead of the scraping content path's type. Lets a curated subset of a
+   * generic sitemap (e.g. the Wahlprogramm inside /beschluesse) surface under
+   * the "Typ" filter as its own type — without a separate scraper or alias URLs.
+   */
+  contentType?: ContentType;
 }
 
 export interface LandesverbaendeConfig {
@@ -793,6 +800,9 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       id: 'wahlprogramm-be',
       label: 'Wahlprogramm',
       shortName: 'BE',
+      // Store these /beschluesse chapters as content_type 'wahlprogramm' so they
+      // surface under the "Typ" filter as Wahlprogramme, not "Beschluss".
+      contentType: 'wahlprogramm',
       urls: [
         'https://gruene.berlin/beschluesse/unser-wahlprogramm_3762',
         'https://gruene.berlin/beschluesse/unser-wahlprogramm-1_3763',
@@ -881,6 +891,27 @@ export function getCuratedListsForUrl(url: string): string[] {
   }
 
   return matched;
+}
+
+/**
+ * Return the content_type override for a URL if it belongs to a curated list
+ * that declares one (e.g. wahlprogramm-be → 'wahlprogramm'). Matches by exact
+ * URL or trailing TYPO3 slug id, same as getCuratedListsForUrl. Returns null
+ * when no matched list overrides the type, so the caller keeps the scraper's.
+ */
+export function getCuratedContentTypeForUrl(url: string): ContentType | null {
+  const lists = LANDESVERBAENDE_CONFIG.curatedLists;
+  if (!lists?.length) return null;
+
+  const targetSlug = trailingSlugKey(url);
+  for (const list of lists) {
+    if (!list.contentType) continue;
+    if (list.urls.includes(url)) return list.contentType;
+    if (targetSlug && list.urls.some((u) => trailingSlugKey(u) === targetSlug)) {
+      return list.contentType;
+    }
+  }
+  return null;
 }
 
 export default LANDESVERBAENDE_CONFIG;

--- a/apps/api/config/systemCollectionsConfig.ts
+++ b/apps/api/config/systemCollectionsConfig.ts
@@ -325,14 +325,6 @@ export const SYSTEM_COLLECTIONS: Record<string, SystemCollectionConfig> = {
     filterableFields: [
       LV_CONTENT_TYPE_FIELD,
       LV_SOURCE_TYPE_FIELD,
-      {
-        field: 'curated_lists',
-        label: 'Liste',
-        type: 'keyword',
-        valueLabels: {
-          'wahlprogramm-be': 'Wahlprogramm',
-        },
-      } satisfies FilterableField<'curated_lists'>,
       { field: 'published_at', label: 'Datum', type: 'date_range' },
     ],
     defaultFilter: { field: 'landesverband', value: ['BE', 'BE-F'] },

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
@@ -7,6 +7,7 @@
 import {
   CONTENT_TYPE_LABELS,
   getCuratedListsForUrl,
+  getCuratedContentTypeForUrl,
 } from '../../../../../config/landesverbaendeConfig.js';
 import {
   scrollDocuments,
@@ -52,6 +53,11 @@ export class DocumentProcessor {
     const { title, text, publishedAt, categories } = content;
     const targetCollection = collectionOverride || this.collectionName;
     const ageLimit = maxAgeYears ?? 10;
+
+    // A curated list (e.g. wahlprogramm-be) may override the scraping path's
+    // content type so a canonical subset surfaces under its own "Typ" filter
+    // value (Wahlprogramm) rather than the generic path type (Beschluss).
+    const effectiveContentType = getCuratedContentTypeForUrl(url) ?? contentType;
 
     // STEP 1: Validation - minimum length check
     if (!text || text.length < 100) {
@@ -103,7 +109,7 @@ export class DocumentProcessor {
     // STEP 5: Build document title
     const documentTitle =
       title ||
-      `${source.name} - ${(CONTENT_TYPE_LABELS as Record<string, string>)[contentType] || contentType}`;
+      `${source.name} - ${(CONTENT_TYPE_LABELS as Record<string, string>)[effectiveContentType] || effectiveContentType}`;
 
     // STEP 6: Chunk document
     const chunks = await smartChunkDocument(text, {
@@ -136,9 +142,10 @@ export class DocumentProcessor {
         source_name: source.name,
         landesverband: source.shortName,
         source_type: source.type,
-        content_type: contentType,
+        content_type: effectiveContentType,
         content_type_label:
-          (CONTENT_TYPE_LABELS as Record<string, string>)[contentType] || contentType,
+          (CONTENT_TYPE_LABELS as Record<string, string>)[effectiveContentType] ||
+          effectiveContentType,
         content_hash: contentHash,
         chunk_index: index,
         chunk_text: chunkTexts[index],

--- a/packages/shared/src/search/collections/config.ts
+++ b/packages/shared/src/search/collections/config.ts
@@ -213,13 +213,6 @@ export const COLLECTIONS: CollectionConfigMap = {
     filterableFields: {
       content_type: lvContentTypeField,
       source_type: lvSourceTypeField,
-      curated_lists: {
-        label: 'Liste',
-        type: 'keyword',
-        valueLabels: {
-          'wahlprogramm-be': 'Wahlprogramm',
-        },
-      } satisfies FilterFieldConfig<'curated_lists'>,
       published_at: { label: 'Datum', type: 'date_range' },
     },
     defaultSearchMode: 'hybrid',


### PR DESCRIPTION
## Why

The Berlin Wahlprogramm used to appear under the **Typ** filter as "Wahlprogramme" — but that entry came from the old `berlin-lv-wahlprogramm` scraper's `/news/…` copies (`content_type='wahlprogramm'`), which were the duplicate copies removed in the recent dedup cleanup. The surviving canonical `/beschluesse/…` copies are scraped via the generic Beschlüsse sitemap as `content_type='beschluss'`, with Wahlprogramm-ness expressed only as a `curated_lists` overlay exposed via a separate **Liste** filter. Net effect: the filter moved from "Typ" to "Liste".

This restores the prior behaviour on the *canonical* copies (no duplicate URLs): a curated list can now declare a `contentType` override, which `DocumentProcessor` applies at store time — so the 7 `/beschluesse` chapters are stored `content_type='wahlprogramm'` and group under **Typ: Wahlprogramme**. The redundant `curated_lists` **Liste** filter is removed from `berlin-system` in both the api and shared collection configs.

The 7 chapters were already re-tagged live on the prod collection so the filter is correct now; this PR makes the categorization durable so a future re-scrape (when the program text changes) keeps `content_type='wahlprogramm'` instead of reverting to `beschluss`.

Typecheck: api + shared pass.