### PR TITLE
fix(auth): disable requireLocalEmailVerified for trusted Keycloak account linking

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -200,8 +200,21 @@ export const auth = betterAuth({
     // a verified email claim, which causes `account_not_linked` errors on
     // sign-in. All four IdPs route through trusted Keycloak realms operated
     // by netzbegruenung, so trusting them is safe.
+    // `requireLocalEmailVerified` defaults to `true` since better-auth 1.6.11.
+    // It's a SECOND, separate gate from `trustedProviders`: even a trusted
+    // provider is refused with `account_not_linked` when the *existing local*
+    // user has `email_verified = false` (link-account.mjs: `requireLocalEmailVerified
+    // && !dbUser.user.emailVerified`). Many of our profiles were created via OAuth
+    // before the email_verified claim was reliably stored, so they sit at false —
+    // and the upgrade to 1.6.11 silently started rejecting their first login via a
+    // second IdP (e.g. an existing Grünerator-login account signing in via Grünes
+    // Netz). We disable it because the threat it defends against (ghost-account
+    // hijacking via local email/password signup) does not exist here: there is no
+    // `emailAndPassword` provider, all auth flows through the four Keycloak realms
+    // we operate, and `trustedProviders` is restricted to exactly those realms.
     accountLinking: {
       enabled: true,
+      requireLocalEmailVerified: false,
       trustedProviders: [
         'keycloak-netzbegruenung',
         'keycloak-gruenes-netz',


### PR DESCRIPTION
## Why

better-auth **1.6.11** introduced `account.accountLinking.requireLocalEmailVerified`, defaulting to **`true`**. It is a *second* gate, **independent of `trustedProviders`**: even a fully trusted provider is refused with `account_not_linked` when the *existing local* user has `email_verified = false` (`link-account.mjs`: `requireLocalEmailVerified && !dbUser.user.emailVerified`).

Many of our `profiles` rows were created via OAuth before the `email_verified` claim was reliably stored, so they sit at `false`. The silent upgrade to 1.6.11 therefore started rejecting these users' **first sign-in via a second IdP** — e.g. a user with an existing Grünerator-login account signing in via **Grünes Netz** lands on `gruenerator.eu/?error=account_not_linked`. Keycloak completes successfully (issues the token); the rejection happens in better-auth's link step, so it left no backend error log and was invisible to the Keycloak admin.

## Why disabling it is safe here

The threat `requireLocalEmailVerified` defends against is ghost-account hijacking via a local email/password signup. That vector does not exist in this setup:
- there is **no `emailAndPassword` provider** — every flow goes through Keycloak OAuth;
- `trustedProviders` is restricted to exactly the four Keycloak realms we operate (netzbegruenung);
- we treat the IdP's `email_verified` as the source of truth.

Confirmed with a Better Auth expert: this is the recommended knob, it disables only this one check (trust / `allowDifferentEmails` / `disableImplicitLinking` stay active), and it is strictly global (no per-provider toggle).

## Immediate unblock for the reported user

Independent of this deploy, an affected user can be unblocked now via the local flag:
`UPDATE profiles SET email_verified = true WHERE lower(email) = lower('<email>');`