### PR TITLE
fix(docs): repoint footer links to consolidated ki-modelle page

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -210,12 +210,8 @@ const config: Config = {
           title: 'Anleitung',
           items: [
             {
-              label: 'Pro-Modus',
-              to: '/docs/gruenerieren/pro-modus',
-            },
-            {
-              label: 'Privacy-Mode',
-              to: '/docs/gruenerieren/privacy-mode',
+              label: 'KI-Modelle',
+              to: '/docs/gruenerieren/ki-modelle',
             },
             {
               label: 'Grüne Wolke Tutorial',


### PR DESCRIPTION
The doku container build on master is failing: `onBrokenLinks: 'throw'` aborts the Docusaurus build because the footer still links to `/docs/gruenerieren/pro-modus` and `/docs/gruenerieren/privacy-mode`, which were merged into `ki-modelle.md` in 3ecd871fd. Since the dead links live in the site footer, every generated page was flagged.

Repoints the footer to the surviving `/docs/gruenerieren/ki-modelle` page. Verified by running `npm install && npm run build` against an isolated copy of `documentation/` (matching the Dockerfile context) — build succeeds with zero broken links.

Failing run: https://github.com/netzbegruenung/Gruenerator/actions/runs/26540747103