### PR TITLE
fix(notebook): render streaming progress as plain shimmer text

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -6,6 +6,7 @@ import {
   ExtraActionsProvider,
   NotebookChatProvider,
   NotebookComposer,
+  ProgressDisplayContext,
   UserMessage,
   notebookMentionables,
   useAgentStore,
@@ -346,53 +347,57 @@ export const NotebookPageContent = ({
     >
       <CitationPanelProvider>
         <ExtraActionsProvider factory={extraActionsFactory}>
-          <ThreadPrimitive.Root className="flex h-full min-h-0 flex-col">
-            <ThreadPrimitive.Empty>
-              <div className="flex flex-1 flex-col overflow-y-auto">
-                <NotebookStartpage
-                  title={config.startPageTitle}
-                  subtitle={config.infoPanelDescription}
-                  sources={config.sources}
-                  placeholder={config.placeholder}
-                  exampleQuestions={showExamples ? (config.exampleQuestions ?? []) : []}
-                  composerSourceFilters={sourceFilters}
-                  composerCategoryFilters={categoryFilters}
-                  mode={mode}
-                  onModeChange={setMode}
-                  recentCollectionIds={recentCollectionIds}
-                  showRecentSourceLabel={isMulti}
-                  showStats={showStats}
-                  showLastAdded={showLastAdded}
-                  showManualSearch={showManualSearch}
-                  hideGlobalChat={hideGlobalChat}
-                  manualSearchNotebookId={manualSearchNotebookId}
-                  notebookMention={notebookMention}
-                  footer={startpageFooter}
-                />
-              </div>
-            </ThreadPrimitive.Empty>
-            <ThreadPrimitive.If empty={false}>
-              <div className="flex min-h-0 h-full flex-col">
-                <ThreadPrimitive.Viewport className="flex flex-1 flex-col overflow-y-auto px-4">
-                  <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-4">
-                    <ThreadPrimitive.Messages
-                      components={{
-                        UserMessage,
-                        AssistantMessage,
-                      }}
-                    />
-                  </div>
-                </ThreadPrimitive.Viewport>
-                <NotebookComposer
-                  placeholder={config.placeholder}
-                  sourceFilters={sourceFilters}
-                  categoryFilters={categoryFilters}
-                  mode={mode}
-                  onModeChange={setMode}
-                />
-              </div>
-            </ThreadPrimitive.If>
-          </ThreadPrimitive.Root>
+          {/* Notebook search runs internally (no tool-call), so render the
+              streaming progress as plain shimmer text instead of the green box. */}
+          <ProgressDisplayContext.Provider value="plain">
+            <ThreadPrimitive.Root className="flex h-full min-h-0 flex-col">
+              <ThreadPrimitive.Empty>
+                <div className="flex flex-1 flex-col overflow-y-auto">
+                  <NotebookStartpage
+                    title={config.startPageTitle}
+                    subtitle={config.infoPanelDescription}
+                    sources={config.sources}
+                    placeholder={config.placeholder}
+                    exampleQuestions={showExamples ? (config.exampleQuestions ?? []) : []}
+                    composerSourceFilters={sourceFilters}
+                    composerCategoryFilters={categoryFilters}
+                    mode={mode}
+                    onModeChange={setMode}
+                    recentCollectionIds={recentCollectionIds}
+                    showRecentSourceLabel={isMulti}
+                    showStats={showStats}
+                    showLastAdded={showLastAdded}
+                    showManualSearch={showManualSearch}
+                    hideGlobalChat={hideGlobalChat}
+                    manualSearchNotebookId={manualSearchNotebookId}
+                    notebookMention={notebookMention}
+                    footer={startpageFooter}
+                  />
+                </div>
+              </ThreadPrimitive.Empty>
+              <ThreadPrimitive.If empty={false}>
+                <div className="flex min-h-0 h-full flex-col">
+                  <ThreadPrimitive.Viewport className="flex flex-1 flex-col overflow-y-auto px-4">
+                    <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-4">
+                      <ThreadPrimitive.Messages
+                        components={{
+                          UserMessage,
+                          AssistantMessage,
+                        }}
+                      />
+                    </div>
+                  </ThreadPrimitive.Viewport>
+                  <NotebookComposer
+                    placeholder={config.placeholder}
+                    sourceFilters={sourceFilters}
+                    categoryFilters={categoryFilters}
+                    mode={mode}
+                    onModeChange={setMode}
+                  />
+                </div>
+              </ThreadPrimitive.If>
+            </ThreadPrimitive.Root>
+          </ProgressDisplayContext.Provider>
         </ExtraActionsProvider>
         <CitationSidePanel />
       </CitationPanelProvider>

--- a/packages/chat/src/components/message-parts/ProgressIndicator.tsx
+++ b/packages/chat/src/components/message-parts/ProgressIndicator.tsx
@@ -3,14 +3,21 @@
 import { Search, Image } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import { ShimmerText } from './ShimmerText';
+import { type ProgressDisplay } from './progressDisplayContext';
 import type { ChatProgress } from '../../hooks/useChatGraphStream';
 
 interface ProgressIndicatorProps {
   progress: ChatProgress;
   agentColor: string;
+  /** `box` (default): tinted pill + agent dot. `plain`: shimmering text only. */
+  variant?: ProgressDisplay;
 }
 
-export function ProgressIndicator({ progress, agentColor }: ProgressIndicatorProps) {
+export function ProgressIndicator({
+  progress,
+  agentColor,
+  variant = 'box',
+}: ProgressIndicatorProps) {
   if (
     progress.stage === 'idle' ||
     progress.stage === 'complete' ||
@@ -18,6 +25,14 @@ export function ProgressIndicator({ progress, agentColor }: ProgressIndicatorPro
     progress.intent === 'direct'
   ) {
     return null;
+  }
+
+  if (variant === 'plain') {
+    return progress.stage === 'error' ? (
+      <span className="text-sm text-error">{progress.message}</span>
+    ) : (
+      <ShimmerText className="text-sm">{progress.message}</ShimmerText>
+    );
   }
 
   const getIcon = () => {

--- a/packages/chat/src/components/message-parts/progressDisplayContext.ts
+++ b/packages/chat/src/components/message-parts/progressDisplayContext.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+/**
+ * Visual treatment of the inline streaming `ProgressIndicator`.
+ *
+ * `box` is the default chat surface: a tinted pill (`bg-primary/5`) with an
+ * agent-colored dot. In the main chat a search arrives as a tool-call, so this
+ * box is short-lived before the tool pill takes over.
+ *
+ * `plain` is for surfaces whose search runs internally and emits a `searching`
+ * progress without a tool-call — notably notebook QA. There the box would sit
+ * on screen for the whole search, so we render the shimmering message text
+ * alone (no box, no dot), matching the chat's "clear text only" loading feel.
+ */
+export type ProgressDisplay = 'box' | 'plain';
+
+export const ProgressDisplayContext = createContext<ProgressDisplay>('box');
+
+export function useProgressDisplay(): ProgressDisplay {
+  return useContext(ProgressDisplayContext);
+}

--- a/packages/chat/src/components/thread/AssistantMessage.tsx
+++ b/packages/chat/src/components/thread/AssistantMessage.tsx
@@ -7,6 +7,7 @@ import { GrueneratorHomeIconLoading } from '../icons';
 import { CitationMarkdownText } from '../message-parts/CitationMarkdownText';
 import { Reasoning, ReasoningGroup } from '../assistant-ui/reasoning';
 import { ProgressIndicator } from '../message-parts/ProgressIndicator';
+import { useProgressDisplay } from '../message-parts/progressDisplayContext';
 import { ProgressTracker } from '../tool-ui/progress-tracker/ProgressTracker';
 import { SkillBadge } from '../message-parts/SkillBadge';
 import { TypingIndicator } from '../message-parts/TypingIndicator';
@@ -42,6 +43,7 @@ const partComponents = { Text: AssistantMessageTextPart, Reasoning, ReasoningGro
 export const AssistantMessage = memo(function AssistantMessage() {
   const message = useMessage();
   const density = useChatDensity();
+  const progressDisplay = useProgressDisplay();
   const isCompact = density === 'compact';
   const custom = message.metadata?.custom as ChatMessageMetadata | undefined;
 
@@ -142,7 +144,13 @@ export const AssistantMessage = memo(function AssistantMessage() {
                   />
                 );
               }
-              return <ProgressIndicator progress={custom!.progress!} agentColor={agentColor} />;
+              return (
+                <ProgressIndicator
+                  progress={custom!.progress!}
+                  agentColor={agentColor}
+                  variant={progressDisplay}
+                />
+              );
             }
 
             if (!textContent) {
@@ -166,6 +174,7 @@ export const AssistantMessage = memo(function AssistantMessage() {
             <ProgressIndicator
               progress={custom.progress}
               agentColor={messageAgent?.backgroundColor || '#316049'}
+              variant={progressDisplay}
             />
           ))}
 

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -138,6 +138,11 @@ export {
 
 // Message Part Components
 export { ProgressIndicator } from './components/message-parts/ProgressIndicator';
+export {
+  ProgressDisplayContext,
+  useProgressDisplay,
+  type ProgressDisplay,
+} from './components/message-parts/progressDisplayContext';
 export { ProgressTracker } from './components/tool-ui/progress-tracker/ProgressTracker';
 export { TypingIndicator } from './components/message-parts/TypingIndicator';
 export {


### PR DESCRIPTION
In notebook QA, the loading state showed a green tinted box (a dot + shimmer text) for the whole search, while the main chat shows a cleaner text-only shimmer. The cause isn't two components — both surfaces share `AssistantMessage`. The chat's search arrives as a *tool-call*, which suppresses the inline `ProgressIndicator` box; notebook search runs internally with only a `searching` progress event (no tool-call), so the box stayed on screen.

This adds a `ProgressDisplay` context (`'box'` default, so the main chat is unchanged) and has the notebook surface opt into `'plain'`, rendering the progress message as shimmer text alone — matching the chat's loading feel. The "Grünerators Gedanken" reasoning collapsible is untouched.