### PR TITLE
fix(mobile): dedupe React in Metro so notebook chat finds the QueryClient

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -49,6 +49,29 @@ config.resolver.unstable_conditionNames = ['development', 'require', 'react-nati
 
 // Custom resolver for various edge cases
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  // Dedupe React to a single physical copy for the whole bundle.
+  // pnpm's `node-linker=hoisted` leaves several react@19.2.3 dirs on disk
+  // (apps/mobile, react-native, @tanstack/react-query, @assistant-ui/*), and
+  // Metro resolves `react` from each importer's own folder — so the bundle
+  // otherwise ships multiple React instances with separate hook/context
+  // internals. Cross-package context then misses: react-query throws
+  // "No QueryClient set" once a subtree (e.g. the assistant-ui chat tree)
+  // resolves a different React copy than the QueryClientProvider. Resolving
+  // every react/react-dom request as if imported from the app root collapses
+  // them to one instance (apps/mobile/node_modules/react, the Expo-pinned one).
+  if (
+    moduleName === 'react' ||
+    moduleName.startsWith('react/') ||
+    moduleName === 'react-dom' ||
+    moduleName.startsWith('react-dom/')
+  ) {
+    return context.resolveRequest(
+      { ...context, originModulePath: path.join(projectRoot, 'index.js') },
+      moduleName,
+      platform
+    );
+  }
+
   // Fix 'use dom' component resolution in monorepo.
   // The DOM transformer generates a relative path from node_modules/expo/dom/entry.js
   // to the component, but miscounts directory levels in a pnpm monorepo.


### PR DESCRIPTION
## Why

Opening a notebook's **Chat** tab on mobile crashed with *"No QueryClient set, use QueryClientProvider to set one"*, even though the root `QueryClientProvider` is mounted in `app/_layout.tsx` and react-query works elsewhere (the same screen's **Recherche** tab uses `useQuery` fine).

Root cause is duplicate React in the Metro bundle. `pnpm`'s `node-linker=hoisted` leaves several physical `react@19.2.3` directories on disk — `apps/mobile`, `react-native`, `@tanstack/react-query`, and `@assistant-ui/react-native` each carry their own — and Metro resolves `react` from each importer's own folder. The bundle therefore shipped multiple React instances, each with its own hook/context internals. The chat tree renders through assistant-ui's nested React, so `useQueryClient` there read a *different* React's context than the one the provider wrote to, and came up empty.

This is the React Native analog of the documented web `null.useEffect` duplicate-React bug, which was fixed with Vite's `resolve.dedupe`. Here we force every `react`/`react-dom` request to resolve as if imported from the app root, collapsing them to one instance (the Expo-pinned `apps/mobile/node_modules/react`). All the copies are already `19.2.3`, so this is behavior-preserving — it only removes the instance multiplicity.

## Verification

- Resolution check: with the override, `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom`, `react-dom/client` all resolve to the single `apps/mobile/node_modules/react(-dom)` copy, regardless of importer (incl. `react-native`'s internal `require('react')`).
- Needs an on-device smoke test (no device was attached in this session): notebook detail → **Chat** tab should mount without the error, and regular chat/`'use dom'` components should be unaffected.