### PR TITLE
fix(mobile): reel upload failure no longer shows spinner + error at once

### DIFF
--- a/apps/mobile/app/(tabs)/(tools)/reel.tsx
+++ b/apps/mobile/app/(tabs)/(tools)/reel.tsx
@@ -34,6 +34,7 @@ export default function ReelScreen() {
     stageName,
     uploadId,
     error,
+    errorDetail,
     transcribedSubtitles,
     startManualProcessing,
     cancelProcessing,
@@ -210,6 +211,20 @@ export default function ReelScreen() {
         );
       }
 
+      // On failure, drop the progress spinner (it would otherwise keep showing
+      // the stale "Video wird analysiert..." stage alongside the error overlay)
+      // and return to the picker so the user can retry. The error renders below.
+      if (status === 'error') {
+        return (
+          <VideoUploader
+            onVideoSelected={handleVideoSelected}
+            uploadProgress={0}
+            isUploading={false}
+            onBack={handleBackToProjects}
+          />
+        );
+      }
+
       return (
         <PulseLoader
           title={
@@ -246,6 +261,7 @@ export default function ReelScreen() {
         {error && screenMode !== 'projects' && (
           <View style={styles.errorContainer}>
             <Text style={styles.errorText}>{error}</Text>
+            {errorDetail && <Text style={styles.errorDetailText}>{errorDetail}</Text>}
           </View>
         )}
       </View>
@@ -261,6 +277,7 @@ const styles = StyleSheet.create<{
   loadingSubtext: TextStyle;
   errorContainer: ViewStyle;
   errorText: TextStyle;
+  errorDetailText: TextStyle;
 }>({
   container: {
     flex: 1,
@@ -292,5 +309,12 @@ const styles = StyleSheet.create<{
   errorText: {
     color: colors.error[500],
     textAlign: 'center',
+  },
+  errorDetailText: {
+    color: colors.error[500],
+    textAlign: 'center',
+    fontSize: 12,
+    opacity: 0.75,
+    marginTop: spacing.xxsmall,
   },
 });

--- a/apps/mobile/hooks/useReelProcessing.ts
+++ b/apps/mobile/hooks/useReelProcessing.ts
@@ -26,6 +26,7 @@ export interface ReelProcessingState {
   videoUri: string | null;
   savedToGallery: boolean;
   error: string | null;
+  errorDetail: string | null;
   transcribedSubtitles: string | null;
 }
 
@@ -57,6 +58,7 @@ const initialState: ReelProcessingState = {
   videoUri: null,
   savedToGallery: false,
   error: null,
+  errorDetail: null,
   transcribedSubtitles: null,
 };
 
@@ -98,6 +100,7 @@ export function useReelProcessing() {
       updateState({
         status: 'error',
         error: ERROR_MESSAGES[errorKey],
+        errorDetail: details ?? null,
       });
     },
     [updateState]


### PR DESCRIPTION
## Why

On Android, starting a reel surfaced two contradictory states at once: the "Video wird analysiert..." progress spinner *and* the "Video konnte nicht hochgeladen werden" error. The `transcribing` view only special-cased `status === 'uploading'`; every other status — including `error` — fell through to the progress spinner, which rendered the stale `initialState` stage label while the error overlay showed underneath.

This handles the `error` status explicitly (return to the picker so the user can retry) so the spinner and error can no longer coexist.

## Diagnostic note (upload still fails on Android)

The production `/subtitler/upload-binary` endpoint is confirmed working (a plain `curl` returns `201`, no auth required), and the failure is reported as *instant* — so it is a client-side error in the Android native uploader, not the server, auth, or a network timeout. The exact cause needs runtime evidence, so this PR also surfaces the underlying technical reason as a secondary line under the friendly error. The next failed attempt will show the real client error (e.g. an OkHttp message or HTTP status) to pin the root cause.

iOS is unaffected (works), consistent with a platform-specific native-uploader issue.