### PR TITLE
feat(web): unify recent-activity cards into a document-preview schema

### DIFF
--- a/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
+++ b/apps/web/src/features/workplace/components/RecentlyCreatedSection.tsx
@@ -11,73 +11,16 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Download, Share2, Trash2 } from 'lucide-react';
 import React, { memo, useCallback, useState } from 'react';
 import { FaImage, FaVideo } from 'react-icons/fa';
-import {
-  FiCalendar,
-  FiCheckSquare,
-  FiClipboard,
-  FiEdit3,
-  FiFile,
-  FiFileText,
-  FiMail,
-  FiMonitor,
-  FiRadio,
-} from 'react-icons/fi';
-import { HiOutlineDocumentText } from 'react-icons/hi';
+import { FiClock, FiFileText, FiImage, FiMonitor } from 'react-icons/fi';
 import { PiKanban, PiPencilLine, PiStar, PiStarFill } from 'react-icons/pi';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { ShareMediaModal } from '../../../components/common/ShareMediaModal';
 import apiClient from '../../../components/utils/apiClient';
-import { getIcon } from '../../../config/icons';
 import { useBoardsTyped } from '../../../hooks/useBoardsTyped';
 import useSidebarFavouritesStore, { useIsFavourite } from '../../../stores/sidebarFavouritesStore';
 import { formatRelativeDate } from '../../../utils/dateFormatter';
 import { Lightbox } from '../../image-studio/components/Lightbox';
-
-const DocsIcon = getIcon('navigation', 'docs');
-const BoardIcon = getIcon('navigation', 'boards');
-
-const DOC_SUBTYPE_STYLE: Record<
-  string,
-  { icon: React.ComponentType<{ size?: number; className?: string }>; bg: string; text: string }
-> = {
-  blank: { icon: FiFile, bg: 'bg-grey-100 dark:bg-grey-800', text: 'text-grey-500' },
-  antrag: {
-    icon: FiFileText,
-    bg: 'bg-blue-100 dark:bg-blue-900/30',
-    text: 'text-blue-600 dark:text-blue-400',
-  },
-  pressemitteilung: {
-    icon: FiRadio,
-    bg: 'bg-amber-100 dark:bg-amber-900/30',
-    text: 'text-amber-600 dark:text-amber-400',
-  },
-  protokoll: {
-    icon: FiClipboard,
-    bg: 'bg-violet-100 dark:bg-violet-900/30',
-    text: 'text-violet-600 dark:text-violet-400',
-  },
-  notizen: {
-    icon: FiEdit3,
-    bg: 'bg-yellow-100 dark:bg-yellow-900/30',
-    text: 'text-yellow-600 dark:text-yellow-400',
-  },
-  redaktionsplan: {
-    icon: FiCalendar,
-    bg: 'bg-teal-100 dark:bg-teal-900/30',
-    text: 'text-teal-600 dark:text-teal-400',
-  },
-  checkliste: {
-    icon: FiCheckSquare,
-    bg: 'bg-green-100 dark:bg-green-900/30',
-    text: 'text-green-600 dark:text-green-400',
-  },
-  einladung: {
-    icon: FiMail,
-    bg: 'bg-rose-100 dark:bg-rose-900/30',
-    text: 'text-rose-600 dark:text-rose-400',
-  },
-};
 
 type RecentItemType = 'doc' | 'board' | 'image' | 'video' | 'text' | 'presentation';
 
@@ -97,6 +40,30 @@ interface RecentItem {
   content?: string;
   documentType?: string;
 }
+
+// Shared type vocabulary: every card surfaces the same eucalyptus-tinted badge
+// (icon + label) so a board and a document read as one system. `boardType`
+// disambiguates Kanban vs. Whiteboard at render time.
+const TYPE_META: Record<
+  RecentItemType,
+  { label: string; Icon: React.ComponentType<{ className?: string }> }
+> = {
+  doc: { label: 'Dokument', Icon: FiFileText },
+  board: { label: 'Board', Icon: PiKanban },
+  image: { label: 'Bild', Icon: FiImage },
+  video: { label: 'Video', Icon: FaVideo },
+  text: { label: 'Text', Icon: FiFileText },
+  presentation: { label: 'Präsentation', Icon: FiMonitor },
+};
+
+const getTypeMeta = (
+  item: RecentItem
+): { label: string; Icon: React.ComponentType<{ className?: string }> } => {
+  if (item.type === 'board' && item.boardType === 'whiteboard') {
+    return { label: 'Whiteboard', Icon: PiPencilLine };
+  }
+  return TYPE_META[item.type];
+};
 
 const formatDuration = (seconds?: number): string => {
   if (!seconds) return '';
@@ -121,22 +88,84 @@ const FALLBACK_TITLES: Record<RecentItemType, string> = {
   presentation: 'Neue Präsentation',
 };
 
-const TYPE_ICONS: Record<RecentItemType, React.ComponentType<{ className?: string }> | null> = {
-  doc: DocsIcon ?? null,
-  board: BoardIcon ?? null,
-  image: FaImage,
-  video: FaVideo,
-  text: HiOutlineDocumentText,
-  presentation: FiMonitor,
+// Recover lightweight structure from document HTML for the preview: the first
+// heading (h1–h6) becomes the title, the remaining text the body — mirroring the
+// mobile DocPreview so both platforms show the same legible excerpt instead of a
+// shrunken raw render. We have a real DOM here, so removing the heading node
+// before reading textContent keeps the body from repeating the title.
+const parseDocPreview = (html: string): { heading: string | null; body: string } => {
+  const tmp = document.createElement('div');
+  tmp.innerHTML = html;
+  const headingEl = tmp.querySelector('h1, h2, h3, h4, h5, h6');
+  const heading = headingEl?.textContent?.trim() ?? '';
+  headingEl?.remove();
+  const body = (tmp.textContent ?? '').replace(/\s+/g, ' ').trim();
+  return { heading: heading || null, body };
 };
 
-const TEXT_TYPE_LABELS: Record<string, string> = {
-  text: 'Text',
-  antrag: 'Antrag',
-  social: 'Social',
-  press: 'Presse',
-  universal: 'Universal',
-};
+// Stylised placeholder for content-less cards (boards, empty docs): one
+// eucalyptus "title" bar over greyed body bars — reads as a document outline
+// instead of an empty icon plate. Widths are deliberately uneven so it looks
+// like real prose.
+const PlaceholderBars = memo(() => (
+  <div className="flex flex-col gap-1.5 px-3 pt-3.5" aria-hidden>
+    <div className="h-1.5 w-3/5 rounded-full bg-secondary-300 dark:bg-secondary-500" />
+    <div className="h-1 w-[90%] rounded-full bg-grey-200 dark:bg-grey-300" />
+    <div className="h-1 w-[85%] rounded-full bg-grey-200 dark:bg-grey-300" />
+    <div className="h-1 w-[92%] rounded-full bg-grey-200 dark:bg-grey-300" />
+    <div className="h-1 w-[68%] rounded-full bg-grey-200 dark:bg-grey-300" />
+  </div>
+));
+PlaceholderBars.displayName = 'PlaceholderBars';
+
+// The "sheet": a white page anchored to the top of the preview zone that bleeds
+// past the bottom edge (height taller than its clipped parent, top-only radius,
+// no bottom border) so it always reads as a document. Stays pure white in dark
+// mode — a paper sheet, like Google Docs — so its text uses an explicit dark
+// colour rather than the theme foreground.
+const PreviewSheet = memo(({ item }: { item: RecentItem }) => {
+  let body: React.ReactNode;
+
+  if (item.type === 'image' || item.type === 'video') {
+    body = item.thumbnailUrl ? (
+      <img
+        src={item.thumbnailUrl}
+        alt={item.title || FALLBACK_TITLES[item.type]}
+        className="h-full w-full object-cover"
+        loading="lazy"
+      />
+    ) : (
+      <div className="flex h-full items-center justify-center text-3xl text-grey-300">
+        {item.type === 'video' ? <FaVideo /> : <FaImage />}
+      </div>
+    );
+  } else if ((item.type === 'doc' || item.type === 'text') && item.content?.trim()) {
+    const { heading, body: excerpt } = parseDocPreview(item.content);
+    body = (
+      <div className="flex flex-col gap-1.5 px-3.5 pt-4 text-left">
+        {heading && (
+          <p className="m-0 line-clamp-2 text-[13px] font-bold leading-snug text-grey-800">
+            {heading}
+          </p>
+        )}
+        {excerpt && (
+          <p className="m-0 line-clamp-6 text-[11px] leading-relaxed text-grey-500">{excerpt}</p>
+        )}
+      </div>
+    );
+  } else {
+    body = <PlaceholderBars />;
+  }
+
+  return (
+    <div className="relative aspect-[5/4] overflow-hidden bg-grey-50 dark:bg-grey-800/40">
+      <div className="absolute inset-x-0 top-3.5 mx-auto flex h-[130%] w-[78%] flex-col overflow-hidden rounded-t-[5px] border border-b-0 border-grey-200/80 bg-white shadow-[0_1px_4px_rgba(0,0,0,0.06)]">
+        {body}
+      </div>
+    </div>
+  );
+});
+PreviewSheet.displayName = 'PreviewSheet';
 
 const FavouriteMenuItem = memo(({ id }: { id: string }) => {
   const starred = useIsFavourite(id);
@@ -267,144 +296,55 @@ const RecentItemCard = memo(
     onShare: (item: RecentItem) => void;
     onConvertText?: (textId: string) => void;
   }) => {
-    const TypeIcon = TYPE_ICONS[item.type];
-    const isDoc = item.type === 'doc';
-    const docStyle = isDoc
-      ? (DOC_SUBTYPE_STYLE[item.documentType ?? 'blank'] ?? DOC_SUBTYPE_STYLE.blank)
-      : null;
-    const DocTypeIcon = docStyle?.icon;
-    const hasDocContent = isDoc && !!item.content?.trim();
+    const { label: typeLabel, Icon: TypeIcon } = getTypeMeta(item);
+    const isShared = !!item.accessType && item.accessType !== 'owner';
+    const durationLabel =
+      item.type === 'video' && item.duration ? formatDuration(item.duration) : null;
 
     const cardClass = cn(
-      'group relative flex flex-col bg-background border border-grey-200 dark:border-grey-700 overflow-hidden cursor-pointer transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md hover:border-grey-300 dark:hover:border-grey-600 no-underline',
-      isDoc ? 'rounded-xl aspect-[4/4.5] max-sm:aspect-[4/3]' : 'rounded-md'
+      'group relative flex flex-col overflow-hidden rounded-xl border border-grey-200/80 bg-background no-underline',
+      'cursor-pointer transition-all duration-200 ease-out',
+      'hover:-translate-y-0.5 hover:border-secondary-300 hover:shadow-md',
+      'dark:border-grey-700/60 dark:hover:border-secondary-700'
     );
 
     const cardContent = (
       <>
-        {isDoc &&
-          (hasDocContent ? (
-            <div className="relative flex-1 overflow-hidden bg-grey-50 dark:bg-grey-800/50">
-              <div
-                className={cn(
-                  'pointer-events-none w-[800px] origin-top-left scale-[0.3] select-none px-12 py-8',
-                  'font-[PT_Sans,Arial,sans-serif] leading-relaxed text-foreground',
-                  '[&_h1]:font-[Raleway,PT_Sans,Arial,sans-serif] [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:leading-tight [&_h1]:mb-3 [&_h1]:mt-0',
-                  '[&_h2]:font-[Raleway,PT_Sans,Arial,sans-serif] [&_h2]:text-[1.1rem] [&_h2]:font-semibold [&_h2]:leading-snug [&_h2]:mt-3.5 [&_h2]:mb-1.5',
-                  '[&_h3]:font-[Raleway,PT_Sans,Arial,sans-serif] [&_h3]:text-[0.95rem] [&_h3]:font-semibold [&_h3]:mt-2.5 [&_h3]:mb-1',
-                  '[&_p]:text-[0.8rem] [&_p]:mb-2 [&_p]:mt-0 [&_p]:leading-relaxed',
-                  '[&_ul]:text-[0.8rem] [&_ul]:mb-2 [&_ul]:pl-5 [&_ol]:text-[0.8rem] [&_ol]:mb-2 [&_ol]:pl-5',
-                  '[&_li]:mb-0.5',
-                  '[&_strong]:font-semibold',
-                  '[&_em]:italic'
-                )}
-                dangerouslySetInnerHTML={{ __html: item.content! }}
-              />
-            </div>
-          ) : (
-            <div className={`flex flex-1 items-center justify-center pb-10 ${docStyle!.bg}`}>
-              {DocTypeIcon && <DocTypeIcon size={32} className={docStyle!.text} />}
-            </div>
-          ))}
-        {item.type === 'board' && (
-          <div className="flex items-center justify-center bg-white dark:bg-grey-800 aspect-[4/3] select-none">
-            {item.boardType === 'whiteboard' ? (
-              <PiPencilLine className="text-2xl text-secondary-600" />
-            ) : (
-              <PiKanban className="text-2xl text-secondary-600" />
-            )}
-          </div>
-        )}
-        {item.type === 'presentation' && (
-          <div className="flex items-center justify-center bg-indigo-50 dark:bg-indigo-900/20 aspect-[4/3] select-none">
-            <FiMonitor className="text-2xl text-indigo-500 dark:text-indigo-400" />
-          </div>
-        )}
-        {item.type === 'text' && (
-          <div className="relative bg-white dark:bg-grey-800 aspect-[4/3] overflow-hidden">
-            {item.content ? (
-              <div className="w-[600px] origin-top-left scale-[0.25] p-8 pointer-events-none select-none text-foreground font-sans leading-relaxed">
-                <p className="text-base whitespace-pre-line">{item.content}</p>
-              </div>
-            ) : (
-              <div className="flex items-center justify-center h-full text-4xl select-none">📝</div>
-            )}
-            <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-white dark:to-grey-800 pointer-events-none" />
-          </div>
-        )}
-        {(item.type === 'image' || item.type === 'video') && (
-          <div
-            className={`relative ${item.type === 'video' ? 'bg-black' : 'bg-white dark:bg-grey-800'} aspect-[4/3] overflow-hidden`}
-          >
-            {item.thumbnailUrl ? (
-              <img
-                src={item.thumbnailUrl}
-                alt={item.title || FALLBACK_TITLES[item.type]}
-                className="w-full h-full object-cover"
-                loading="lazy"
-              />
-            ) : (
-              <div className="flex items-center justify-center h-full text-3xl text-grey-300">
-                {item.type === 'video' ? <FaVideo /> : <FaImage />}
-              </div>
-            )}
-            {item.type === 'video' && item.duration && (
-              <span className="absolute bottom-1 right-1 bg-black/70 text-white text-[10px] px-1.5 py-0.5 rounded">
-                {formatDuration(item.duration)}
-              </span>
-            )}
-          </div>
-        )}
-
-        <div
-          className="absolute top-1 right-1 max-sm:opacity-100 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-          onClick={(e) => e.preventDefault()}
-        >
-          <CardActionsMenu
-            onShare={() => onShare(item)}
-            onDelete={() => onDelete(item)}
-            className="[&_button]:bg-white/80 dark:[&_button]:bg-grey-800/80 [&_button]:backdrop-blur-sm"
-          >
-            {item.type === 'board' && <FavouriteMenuItem id={item.id} />}
-          </CardActionsMenu>
+        <div className="relative">
+          <PreviewSheet item={item} />
+          {durationLabel && (
+            <span className="absolute bottom-1.5 right-1.5 rounded bg-black/70 px-1.5 py-0.5 text-[10px] text-white">
+              {durationLabel}
+            </span>
+          )}
         </div>
 
-        {isDoc ? (
-          <div className="absolute inset-x-0 bottom-0 backdrop-blur-md bg-white/70 dark:bg-grey-900/70 px-2.5 py-2 border-t border-white/50 dark:border-grey-700/50">
-            <h3 className="truncate text-xs font-semibold text-foreground m-0">
-              {item.title || FALLBACK_TITLES.doc}
+        <div className="flex items-start gap-2 border-t border-grey-100 px-3 py-2.5 dark:border-grey-700/60">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <span className="inline-flex w-fit items-center gap-1 rounded-md bg-secondary-50 px-1.5 py-0.5 text-[11px] font-medium text-secondary-700 dark:bg-secondary-900/40 dark:text-secondary-300">
+              <TypeIcon className="size-3 shrink-0" />
+              {typeLabel}
+            </span>
+            <h3 className="m-0 min-w-0 truncate text-sm font-medium text-foreground-heading">
+              {item.title || FALLBACK_TITLES[item.type]}
             </h3>
-            <div className="mt-0.5 flex items-center gap-1 text-[10px] text-grey-500 dark:text-grey-400">
-              <span>{formatRelativeDate(item.date)}</span>
-              {item.accessType && item.accessType !== 'owner' && (
-                <>
-                  <span>·</span>
-                  <span className="text-primary-600 dark:text-primary-400">
-                    {item.creatorName ? `Von ${item.creatorName}` : 'Geteilt'}
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        ) : (
-          <div className="border-t border-grey-100 dark:border-grey-700 px-sm py-sm">
-            <div className="flex items-center gap-xs min-w-0">
-              {TypeIcon && <TypeIcon className="text-sm text-secondary-600 shrink-0" />}
-              <span className="text-sm font-medium text-foreground-heading truncate">
-                {item.title || FALLBACK_TITLES[item.type]}
+            <p className="m-0 flex min-w-0 items-center gap-1 truncate text-xs text-grey-500 dark:text-grey-400">
+              <FiClock className="size-3 shrink-0" />
+              <span className="truncate">
+                {formatRelativeDate(item.date)}
+                {isShared && (item.creatorName ? ` · Von ${item.creatorName}` : ' · Geteilt')}
               </span>
-            </div>
-            <p className="text-xs text-grey-400 mt-0.5 m-0 truncate">
-              {item.type === 'text' && item.documentType && TEXT_TYPE_LABELS[item.documentType]
-                ? `${TEXT_TYPE_LABELS[item.documentType]} · `
-                : ''}
-              {item.accessType && item.accessType !== 'owner' && item.creatorName
-                ? `Von ${item.creatorName} · `
-                : ''}
-              {formatRelativeDate(item.date)}
             </p>
           </div>
-        )}
+          {/* Menu lives in the footer (not an overlay on the preview) so its hit
+              target never overlaps the navigable card; CardActionsMenu stops
+              propagation internally, so a click here never opens the document. */}
+          <div className="-mr-1 shrink-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 max-sm:opacity-100">
+            <CardActionsMenu onShare={() => onShare(item)} onDelete={() => onDelete(item)}>
+              {item.type === 'board' && <FavouriteMenuItem id={item.id} />}
+            </CardActionsMenu>
+          </div>
+        </div>
       </>
     );
 
@@ -589,11 +529,12 @@ const RecentlyCreatedSection: React.FC = memo(() => {
           {Array.from({ length: 5 }, (_, i) => (
             <div
               key={i}
-              className="rounded-md border border-grey-200 dark:border-grey-700 overflow-hidden"
+              className="rounded-xl border border-grey-200/80 dark:border-grey-700/60 overflow-hidden"
             >
-              <Skeleton className="aspect-[4/3] rounded-none" />
-              <div className="px-sm py-sm">
-                <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="aspect-[5/4] rounded-none" />
+              <div className="px-3 py-2.5">
+                <Skeleton className="h-4 w-2/5" />
+                <Skeleton className="h-4 w-3/4 mt-1.5" />
                 <Skeleton className="h-3 w-1/2 mt-1.5" />
               </div>
             </div>


### PR DESCRIPTION
The startpage "Zuletzt" grid showed three inconsistent card treatments side by side — docs as a microscopic `scale-[0.3]` raw-HTML render, boards as an empty centered icon, and a differently-bordered footer per type — so the cards read as unrelated rather than one system.

This unifies them on a single schema in the white + eucalyptus palette: a white "sheet" that bleeds off the bottom of a grey preview zone (so every card reads as a document), a eucalyptus type badge, a title with ellipsis, and a consistent footer.

Two follow-up refinements from review of the live page:
- **Doc previews now match mobile.** Instead of shrinking the real HTML until it's unreadable, the doc content is parsed into a heading + body excerpt (mirroring the native `DocPreview` / `parseDocPreview`) and rendered at legible sizes. Boards get stylised placeholder bars instead of an empty icon plate.
- **Actions menu moved into the footer.** As an absolute overlay on the preview its 28px hit target overlapped the navigable card, so near-misses opened the document. In the footer row it has its own box and can't collide with the card click.

Scope is limited to `RecentlyCreatedSection.tsx`. Light + dark verified; the sheet stays white in dark mode (paper, like the editor) with explicitly-dark excerpt text. `pnpm --filter @gruenerator/web typecheck` and `prettier --check` pass.