### PR TITLE
perf: defer assistant-ui (~400KB) off every initial page load

### DIFF
--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useAgentStore } from '@gruenerator/chat';
+import { useAgentStore } from '@gruenerator/chat/stores';
 import { getAgentSlug, getSystemAgent, type Agent } from '@gruenerator/shared/agents';
 import {
   Sheet,

--- a/apps/web/src/hooks/useHydrateUserProfile.ts
+++ b/apps/web/src/hooks/useHydrateUserProfile.ts
@@ -1,4 +1,4 @@
-import { useUserProfileStore } from '@gruenerator/chat';
+import { useUserProfileStore } from '@gruenerator/chat/stores';
 import { useEffect } from 'react';
 
 import { useUserDefaultsQuery } from '../features/user-defaults/userDefaultsQueries';

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -1,4 +1,4 @@
-import { useUserProfileStore } from '@gruenerator/chat';
+import { useUserProfileStore } from '@gruenerator/chat/stores';
 import { type UserProfile } from '@gruenerator/contracts';
 import { getContractsClient } from '@gruenerator/shared/api';
 import { create } from 'zustand';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -258,6 +258,12 @@ export default defineConfig(({ command }) => ({
                     test: /[\\/]node_modules[\\/]@blocknote[\\/]xl-/,
                   }, // 3.3 MB combined
                   { name: 'vendor-react-pdf', test: /[\\/]node_modules[\\/]@react-pdf[\\/]/ }, // 1.4 MB
+                  // assistant-ui is a leaf lib (like recharts) — splitting it keeps
+                  // its primitives out of the initial bundle. It renders only for
+                  // authenticated users (the chat runtime + thread list load lazily),
+                  // so this chunk is fetched on demand, never eagerly. Excluded from
+                  // modulepreload by the `vendor-` filter above.
+                  { name: 'vendor-assistant-ui', test: /[\\/]node_modules[\\/]@assistant-ui[\\/]/ },
                   {
                     name: 'vendor-cytoscape',
                     test: /[\\/]node_modules[\\/]cytoscape(-[a-z-]+)?[\\/]/,

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -15,6 +15,12 @@
       "require": "./src/index.ts",
       "types": "./src/index.ts"
     },
+    "./stores": {
+      "react-native": "./src/stores/index.ts",
+      "import": "./src/stores/index.ts",
+      "require": "./src/stores/index.ts",
+      "types": "./src/stores/index.ts"
+    },
     "./styles": "./src/styles/chat.css",
     "./styles/embedded": "./src/styles/chat-embedded.css"
   },

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -70,7 +70,7 @@ export {
 
 // Runtime
 export { GrueneratorChatProvider } from './runtime/GrueneratorChatProvider';
-export { convertToThreadMessageLike } from './runtime/GrueneratorChatRuntime';
+export { convertToThreadMessageLike } from './runtime/threadMessageConversion';
 export { GrueneratorAttachmentAdapter } from './runtime/GrueneratorAttachmentAdapter';
 export {
   createGrueneratorModelAdapter,

--- a/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
@@ -17,7 +17,6 @@ import {
   Suggestions,
   useRemoteThreadListRuntime,
   type RemoteThreadListAdapter,
-  type ThreadMessageLike,
   RuntimeAdapterProvider,
   ExportedMessageRepository,
 } from '@assistant-ui/react';
@@ -44,122 +43,8 @@ import {
 import { ExternalThreadProvider } from '../context/ExternalThreadContext';
 import { grueneratorToolkit } from '../components/tool-ui/GrueneratorToolUIs';
 import { chatSuggestions } from '../lib/suggestions';
-import type {
-  GeneratedImage,
-  Citation,
-  SearchResult,
-  StreamMetadata,
-} from '../hooks/useChatGraphStream';
-import { INTENT_TO_TOOL } from '../lib/toolMappings';
-
-interface PersistedToolCall {
-  toolCallId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-  result?: unknown;
-}
-
-interface LoadedMessage {
-  id: string;
-  role: string;
-  content: string;
-  metadata?: {
-    intent?: string;
-    searchCount?: number;
-    citations?: Citation[];
-    searchResults?: SearchResult[];
-    generatedImage?: GeneratedImage;
-    toolCalls?: PersistedToolCall[];
-    senderId?: string;
-    senderName?: string | null;
-    roleName?: string;
-  };
-}
-
-function extractContent(content: unknown): string {
-  if (typeof content !== 'string') return '';
-
-  if (content.startsWith('[{') && content.includes('"type":"text"')) {
-    try {
-      const parts = JSON.parse(content);
-      if (Array.isArray(parts)) {
-        return parts
-          .filter(
-            (p: unknown): p is { type: string; text: string } =>
-              p !== null && typeof p === 'object' && 'type' in p && p.type === 'text' && 'text' in p
-          )
-          .map((p) => p.text)
-          .join('');
-      }
-    } catch {
-      // Not valid JSON, return as-is
-    }
-  }
-
-  return content;
-}
-
-export function convertToThreadMessageLike(messages: LoadedMessage[]): ThreadMessageLike[] {
-  return messages.map((m) => {
-    const textContent = extractContent(m.content);
-
-    type ToolCallLike = {
-      readonly type: 'tool-call';
-      readonly toolCallId: string;
-      readonly toolName: string;
-      readonly args: Record<string, string>;
-      readonly result?: unknown;
-    };
-
-    const contentParts: Array<{ type: 'text'; text: string } | ToolCallLike> = [];
-
-    if (m.metadata?.toolCalls) {
-      for (const tc of m.metadata.toolCalls) {
-        contentParts.push({
-          type: 'tool-call' as const,
-          toolCallId: tc.toolCallId || `tc_${m.id}`,
-          toolName: tc.toolName,
-          args: { query: String((tc.args as Record<string, unknown>)?.query ?? '') },
-          result: tc.result,
-        });
-      }
-    } else if (m.role === 'assistant' && m.metadata?.intent && m.metadata.searchResults?.length) {
-      const toolName = INTENT_TO_TOOL[m.metadata.intent];
-      if (toolName) {
-        contentParts.push({
-          type: 'tool-call' as const,
-          toolCallId: `tc_legacy_${m.id}`,
-          toolName,
-          args: { query: '' },
-          result: { results: m.metadata.searchResults },
-        });
-      }
-    }
-
-    contentParts.push({ type: 'text' as const, text: textContent });
-
-    const custom: Record<string, unknown> = {};
-    if (m.metadata?.senderId) {
-      custom.senderId = m.metadata.senderId;
-      custom.senderName = m.metadata.senderName ?? null;
-    }
-    if (m.metadata?.roleName) custom.roleName = m.metadata.roleName;
-    if (m.metadata?.citations) custom.citations = m.metadata.citations;
-    if (m.metadata?.generatedImage) custom.generatedImage = m.metadata.generatedImage;
-    if (m.metadata?.intent)
-      custom.streamMetadata = {
-        intent: m.metadata.intent,
-        searchCount: m.metadata.searchCount ?? 0,
-      };
-
-    return {
-      role: m.role as 'user' | 'assistant',
-      content: contentParts,
-      id: m.id,
-      metadata: Object.keys(custom).length > 0 ? { custom } : undefined,
-    };
-  });
-}
+import type { StreamMetadata } from '../hooks/useChatGraphStream';
+import { convertToThreadMessageLike, type LoadedMessage } from './threadMessageConversion';
 
 function GrueneratorHistoryProvider({ children }: PropsWithChildren) {
   const aui = useAui();

--- a/packages/chat/src/runtime/threadMessageConversion.ts
+++ b/packages/chat/src/runtime/threadMessageConversion.ts
@@ -1,0 +1,119 @@
+// Pure message-shape conversion, deliberately free of any assistant-ui *runtime*
+// import. The only assistant-ui reference is the `ThreadMessageLike` TYPE, which
+// is erased at build time — so this module carries zero runtime weight and can
+// be imported from the eager graph (e.g. the package barrel re-export) without
+// dragging the assistant-ui runtime chunk back onto the initial load. The heavy
+// runtime lives in GrueneratorChatRuntime.tsx and is loaded lazily.
+
+import { type ThreadMessageLike } from '@assistant-ui/react';
+import { INTENT_TO_TOOL } from '../lib/toolMappings';
+import type { GeneratedImage, Citation, SearchResult } from '../hooks/useChatGraphStream';
+
+interface PersistedToolCall {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+}
+
+export interface LoadedMessage {
+  id: string;
+  role: string;
+  content: string;
+  metadata?: {
+    intent?: string;
+    searchCount?: number;
+    citations?: Citation[];
+    searchResults?: SearchResult[];
+    generatedImage?: GeneratedImage;
+    toolCalls?: PersistedToolCall[];
+    senderId?: string;
+    senderName?: string | null;
+    roleName?: string;
+  };
+}
+
+function extractContent(content: unknown): string {
+  if (typeof content !== 'string') return '';
+
+  if (content.startsWith('[{') && content.includes('"type":"text"')) {
+    try {
+      const parts = JSON.parse(content);
+      if (Array.isArray(parts)) {
+        return parts
+          .filter(
+            (p: unknown): p is { type: string; text: string } =>
+              p !== null && typeof p === 'object' && 'type' in p && p.type === 'text' && 'text' in p
+          )
+          .map((p) => p.text)
+          .join('');
+      }
+    } catch {
+      // Not valid JSON, return as-is
+    }
+  }
+
+  return content;
+}
+
+export function convertToThreadMessageLike(messages: LoadedMessage[]): ThreadMessageLike[] {
+  return messages.map((m) => {
+    const textContent = extractContent(m.content);
+
+    type ToolCallLike = {
+      readonly type: 'tool-call';
+      readonly toolCallId: string;
+      readonly toolName: string;
+      readonly args: Record<string, string>;
+      readonly result?: unknown;
+    };
+
+    const contentParts: Array<{ type: 'text'; text: string } | ToolCallLike> = [];
+
+    if (m.metadata?.toolCalls) {
+      for (const tc of m.metadata.toolCalls) {
+        contentParts.push({
+          type: 'tool-call' as const,
+          toolCallId: tc.toolCallId || `tc_${m.id}`,
+          toolName: tc.toolName,
+          args: { query: String((tc.args as Record<string, unknown>)?.query ?? '') },
+          result: tc.result,
+        });
+      }
+    } else if (m.role === 'assistant' && m.metadata?.intent && m.metadata.searchResults?.length) {
+      const toolName = INTENT_TO_TOOL[m.metadata.intent];
+      if (toolName) {
+        contentParts.push({
+          type: 'tool-call' as const,
+          toolCallId: `tc_legacy_${m.id}`,
+          toolName,
+          args: { query: '' },
+          result: { results: m.metadata.searchResults },
+        });
+      }
+    }
+
+    contentParts.push({ type: 'text' as const, text: textContent });
+
+    const custom: Record<string, unknown> = {};
+    if (m.metadata?.senderId) {
+      custom.senderId = m.metadata.senderId;
+      custom.senderName = m.metadata.senderName ?? null;
+    }
+    if (m.metadata?.roleName) custom.roleName = m.metadata.roleName;
+    if (m.metadata?.citations) custom.citations = m.metadata.citations;
+    if (m.metadata?.generatedImage) custom.generatedImage = m.metadata.generatedImage;
+    if (m.metadata?.intent)
+      custom.streamMetadata = {
+        intent: m.metadata.intent,
+        searchCount: m.metadata.searchCount ?? 0,
+      };
+
+    return {
+      role: m.role as 'user' | 'assistant',
+      content: contentParts,
+      id: m.id,
+      metadata: Object.keys(custom).length > 0 ? { custom } : undefined,
+    };
+  });
+}

--- a/packages/chat/src/stores/index.ts
+++ b/packages/chat/src/stores/index.ts
@@ -1,0 +1,13 @@
+// Lightweight store-only entry point.
+//
+// Boot code (auth store, profile hydration, sidebar) needs a couple of zustand
+// stores but must NOT reach them through the main package barrel: that barrel
+// statically re-exports the assistant-ui components, so importing anything from
+// it lets the bundler co-chunk those ~heavy components onto the initial load.
+//
+// Importing from `@gruenerator/chat/stores` gives boot code a module graph that
+// reaches only these plain zustand stores (no assistant-ui, no components), so
+// the primitives stay in lazy chunks. Keep this file free of any component or
+// assistant-ui import.
+export { useUserProfileStore, type UserRole } from './userProfileStore';
+export { useAgentStore } from './chatStore';


### PR DESCRIPTION
The global chat provider wraps every page, so assistant-ui was loaded on every initial visit — including logged-out visitors on public pages who never use chat. #1103 already made the chat runtime and thread list lazy, but the assistant-ui *primitives* stayed eager: the package barrel re-exported a conversion util co-located with the runtime, the boot stores were imported through that same barrel, and rolldown then co-chunked the clean zustand stores with the assistant-ui components.

Three complementary changes remove it from the eager graph:

1. **Decouple `convertToThreadMessageLike`** into a runtime-free module (its only assistant-ui reference is an erased type), so the barrel re-export no longer pulls the runtime module.
2. **A `@gruenerator/chat/stores` subpath** whose graph reaches only the plain zustand stores — boot code (`authStore`, `useHydrateUserProfile`, `Sidebar`) imports from it, so importing a store can't drag the components. (Same isolation pattern already used to keep react-icons out of the backend bundle.)
3. **Split `@assistant-ui` into its own vendor chunk** — a leaf lib like recharts, auto-excluded from modulepreload by the existing `vendor-` filter.

### Verification (prod ships the split build, `VITE_EXPERIMENTAL_SPLIT=1`)
- Built locally in split mode: **no assistant-ui in any eager chunk**; eager JS 1884KB → 1481KB raw (~400KB / ~100KB gz off the entry path).
- **Headless smoke test** of the split build (load `/`, watch console): app renders, **no React init-order error** — the failure class the config warns `manualChunks` can introduce and CI can't catch. The `vendor-assistant-ui` split is safe because assistant-ui is a leaf lib importing `react` (priority-100 `vendor-react`, initialized first), unlike the workspace `canvas-editor` that previously cycled.
- `pnpm --filter @gruenerator/chat typecheck` and `--filter @gruenerator/web typecheck` pass (the `/stores` subpath resolves).