### PR TITLE
feat(web): overhaul sidebar — account block, skills/agents nav, brand & icon polish

### DIFF
--- a/apps/web/src/assets/styles/components/layout/sidebar.css
+++ b/apps/web/src/assets/styles/components/layout/sidebar.css
@@ -3,7 +3,7 @@
   display: flex;
   min-height: 100vh;
   --sidebar-collapsed-width: 56px;
-  --sidebar-expanded-width: 280px;
+  --sidebar-expanded-width: 260px;
 }
 
 .app-content {
@@ -64,9 +64,5 @@
   }
 }
 
-@media (min-width: 1920px) {
-  :root {
-    --sidebar-collapsed-width: 64px;
-    --sidebar-expanded-width: 260px;
-  }
-}
+/* Width is uniform across breakpoints; the aside's Tailwind width
+   (md:w-14 / md:w-[260px]) must match these vars to keep .app-content aligned. */

--- a/apps/web/src/components/common/Layout/PageLayout.tsx
+++ b/apps/web/src/components/common/Layout/PageLayout.tsx
@@ -5,7 +5,6 @@ import { GlobalChatProvider } from '../../../providers/GlobalChatProvider';
 import { useDesktopTabsStore } from '../../../stores/desktopTabsStore';
 import useSidebarStore from '../../../stores/sidebarStore';
 import { isDesktopApp } from '../../../utils/platform';
-import ProfileButton from '../../layout/Header/ProfileButton';
 import { Sidebar } from '../../layout/Sidebar';
 import SidebarToggle from '../../layout/SidebarToggle';
 
@@ -122,16 +121,28 @@ const PageLayout = ({
       <GlobalBridges />
       <div className={layoutClasses}>
         {!hideHeader ? (
-          <header className="fixed top-0 left-0 right-0 z-[1002] flex items-center justify-between px-2 h-12 pointer-events-none">
-            <div className="pointer-events-auto">
+          <header className="fixed top-0 left-0 right-0 z-[1002] flex items-center px-2.5 h-12 pointer-events-none">
+            <div className="pointer-events-auto flex items-center gap-0">
               <SidebarToggle />
-            </div>
-            <div className="pointer-events-auto flex items-center gap-1">
-              <ProfileButton />
+              {sidebarOpen && (
+                <>
+                  <img
+                    src="/images/gruenerator_logo_gruen.svg"
+                    alt="Grünerator"
+                    className="h-7 w-auto shrink-0 dark:hidden"
+                  />
+                  <img
+                    src="/images/gruenerator_logo_weiss.svg"
+                    alt="Grünerator"
+                    aria-hidden="true"
+                    className="hidden h-7 w-auto shrink-0 dark:block"
+                  />
+                </>
+              )}
             </div>
           </header>
         ) : isSidebarOnly ? (
-          <div className="fixed top-0 left-0 z-[1002] px-2 h-12 flex items-center pointer-events-none">
+          <div className="fixed top-0 left-0 z-[1002] px-2.5 h-12 flex items-center pointer-events-none">
             <div className="pointer-events-auto">
               <SidebarToggle />
             </div>

--- a/apps/web/src/components/layout/Header/ProfileButton.tsx
+++ b/apps/web/src/components/layout/Header/ProfileButton.tsx
@@ -17,14 +17,14 @@ import type { IconType } from 'react-icons';
 
 import { cn } from '@/utils/cn';
 
-interface NavItem {
+export interface NavItem {
   key: string;
   label: string;
   path: string;
   icon: IconType;
 }
 
-const NAV_ITEMS: NavItem[] = [
+export const NAV_ITEMS: NavItem[] = [
   { key: 'gruppen', label: 'Gruppen', path: '/gruppen', icon: FaUsers },
   { key: 'inhalte', label: 'Dateien', path: '/profile/inhalte', icon: FaFolder },
   { key: 'wolke', label: 'Wolke', path: '/profile/wolke', icon: FaCloud },

--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -1,3 +1,5 @@
+import { PiGlobe } from 'react-icons/pi';
+import { RiSpyLine } from 'react-icons/ri';
 import { SlNotebook } from 'react-icons/sl';
 
 import { getIcon, getIconById as getIconFromRegistry } from '../../../config/icons';
@@ -69,13 +71,22 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
     activePaths: ['/notebooks', '/notebook'],
   };
 
+  items.agents = {
+    id: 'agents',
+    path: '/skills',
+    title: 'Skills & Agents',
+    description: 'KI-Assistent*innen und Schnellbefehle für deine Aufgaben',
+    icon: RiSpyLine,
+    activePaths: ['/skills', '/agents'],
+  };
+
   if (import.meta.env.DEV) {
     items.sites = {
       id: 'sites',
       path: '/sites',
       title: 'Sites',
       description: 'Kandidat*innen-Site-Builder',
-      icon: getIcon('navigation', 'sharepic'),
+      icon: PiGlobe,
       activePaths: ['/sites'],
     };
   }

--- a/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
+++ b/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
@@ -26,6 +26,7 @@ import { iconClass, menuLinkClass } from './sidebarStyles';
 interface NewItemDropdownProps {
   openRef: MutableRefObject<boolean>;
   titleClass: string;
+  collapsed: boolean;
   onChatClick: () => void;
   onLinkClick: (path: string, title: string) => void;
   onClose: () => void;
@@ -34,6 +35,7 @@ interface NewItemDropdownProps {
 const NewItemDropdown = memo(function NewItemDropdown({
   openRef,
   titleClass,
+  collapsed,
   onChatClick,
   onLinkClick,
   onClose,
@@ -93,10 +95,10 @@ const NewItemDropdown = memo(function NewItemDropdown({
   }, [createBoard, navigate, onClose]);
 
   return (
-    <div className="flex flex-col gap-0.5 p-0 mt-xs">
+    <div className="flex flex-col gap-0.5 p-0">
       <DropdownMenu open={open} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger asChild>
-          <button className={menuLinkClass(false)} type="button">
+          <button className={menuLinkClass(false, false, collapsed)} type="button">
             <PiPlus aria-hidden="true" className={iconClass} />
             <span className={titleClass}>Neu</span>
           </button>

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useAgentStore } from '@gruenerator/chat/stores';
-import { getAgentSlug, getSystemAgent, type Agent } from '@gruenerator/shared/agents';
+import { getAgentSlug, getSystemAgent } from '@gruenerator/shared/agents';
 import {
   Sheet,
   SheetContent,
@@ -9,8 +9,9 @@ import {
   TooltipTrigger,
   useIsMobile,
 } from '@gruenerator/ui';
-import { useEffect, useMemo, useCallback, useRef, useState, memo } from 'react';
-import { PiSun, PiMoon, PiSignIn, PiCaretRight, PiSparkle, PiStarFill } from 'react-icons/pi';
+import { useEffect, useMemo, useCallback, useRef, memo } from 'react';
+import { type IconType } from 'react-icons';
+import { PiSignIn, PiSparkle, PiStarFill } from 'react-icons/pi';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 
 import { getFavouriteItemsById } from '../../../config/sidebarFavouritesConfig';
@@ -20,20 +21,13 @@ import { useAuthStore } from '../../../stores/authStore';
 import useSidebarFavouritesStore from '../../../stores/sidebarFavouritesStore';
 import useSidebarStore from '../../../stores/sidebarStore';
 import { StatusBadge } from '../../common/StatusBadge';
-import useDarkMode from '../../hooks/useDarkMode';
-import {
-  getDirectMenuItems,
-  getMobileOnlyMenuItems,
-  getFooterLinks,
-  type MenuItemType,
-} from '../Header/menuData';
+import { getDirectMenuItems, getMobileOnlyMenuItems, type MenuItemType } from '../Header/menuData';
 
-import { AllAgentsDialog } from './AllAgentsDialog';
 import NewItemDropdown from './NewItemDropdown';
-import { getDefaultAgentEntries, getPinnedAgentIds, getAgentIcon } from './sidebarAgentConfig';
+import SidebarAccount from './SidebarAccount';
+import { getAgentIcon } from './sidebarAgentConfig';
 import { iconClass, menuLinkClass } from './sidebarStyles';
 
-import { SHOW_AGENT_CREATOR } from '@/config/featureFlags';
 import { cn } from '@/utils/cn';
 import '../../../assets/styles/components/layout/sidebar.css';
 
@@ -73,7 +67,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
   const isAustrian = locale === 'de-AT';
 
   const newMenuOpenRef = useRef(false);
-  const [darkMode, toggleDarkMode] = useDarkMode();
+  const accountMenuOpenRef = useRef(false);
 
   const directMenuItems = useMemo(() => getDirectMenuItems({ isAustrian }), [isAustrian]);
   const mobileOnlyItems = useMemo(() => getMobileOnlyMenuItems(), []);
@@ -81,8 +75,6 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
     () => [...Object.values(directMenuItems), ...Object.values(mobileOnlyItems)],
     [directMenuItems, mobileOnlyItems]
   );
-  const footerLinks = useMemo(() => getFooterLinks(), []);
-
   const sidebarExpanded = isOpen || forceExpanded;
 
   // Close sidebar on route change
@@ -151,19 +143,19 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
   }, [navigate, onNavigate, location.pathname]);
 
   const handleMouseLeave = useCallback(() => {
-    if (!newMenuOpenRef.current) {
+    if (!newMenuOpenRef.current && !accountMenuOpenRef.current) {
       close();
     }
   }, [close]);
 
   const titleClass = cn(
-    'font-semibold text-sm text-foreground-heading leading-tight transition-all duration-150 font-[Raleway,PT_Sans,Arial,sans-serif]',
-    sidebarExpanded ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2'
+    'min-w-0 flex-1 truncate text-sm font-medium leading-tight transition-all duration-150',
+    sidebarExpanded ? 'opacity-100 translate-x-0' : 'hidden'
   );
 
   const badgeClass = cn(
     'ml-auto transition-opacity duration-150',
-    sidebarExpanded ? 'opacity-100' : 'opacity-0'
+    sidebarExpanded ? 'opacity-100' : 'hidden'
   );
 
   // Shared sidebar content rendered in both mobile Sheet and desktop aside
@@ -192,7 +184,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
           <div className="flex flex-col gap-0 p-0">
             {additionalItems.map((item) =>
               !item.path ? (
-                <span key={item.id} className={menuLinkClass(false, true)}>
+                <span key={item.id} className={menuLinkClass(false, true, !sidebarExpanded)}>
                   {item.icon && <item.icon aria-hidden="true" className={iconClass} />}
                   <span className={titleClass}>{item.title}</span>
                   {item.badge && (
@@ -210,7 +202,9 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
                         : handleLinkClick(item.path!, item.title)
                     }
                     className={menuLinkClass(
-                      isActive(item.path!, item.activePaths, item.activeQuery)
+                      isActive(item.path!, item.activePaths, item.activeQuery),
+                      false,
+                      !sidebarExpanded
                     )}
                     aria-current={
                       isActive(item.path!, item.activePaths, item.activeQuery) ? 'page' : undefined
@@ -230,7 +224,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
                 <Link
                   key={item.id}
                   to={item.path!}
-                  className={menuLinkClass(false)}
+                  className={menuLinkClass(false, false, !sidebarExpanded)}
                   onClick={() =>
                     item.id === 'chat' ? handleChatClick() : handleLinkClick(item.path!, item.title)
                   }
@@ -252,6 +246,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
         <NewItemDropdown
           openRef={newMenuOpenRef}
           titleClass={titleClass}
+          collapsed={!sidebarExpanded}
           onChatClick={handleChatClick}
           onLinkClick={handleLinkClick}
           onClose={close}
@@ -267,59 +262,37 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
         />
       </nav>
 
-      {/* Unified scroll region: agents + threads scroll together (ChatGPT-style) */}
+      {/* Scroll region: chat threads */}
       <div
         className={cn(
           'flex-1 min-h-0 overflow-y-auto scrollbar-thin',
           !sidebarExpanded && 'hidden'
         )}
       >
-        {user && <SidebarAgents sidebarExpanded={sidebarExpanded} onLinkClick={handleLinkClick} />}
-
         <div id="chat-thread-portal-slot" className="mt-2" />
       </div>
 
-      {/* Login button for unauthenticated users */}
-      {!user && (
-        <div className="mt-auto px-2 pt-xs shrink-0">
+      {/* Account block (authenticated) or login button */}
+      {user ? (
+        <SidebarAccount
+          sidebarExpanded={sidebarExpanded}
+          openRef={accountMenuOpenRef}
+          onNavigate={handleLinkClick}
+        />
+      ) : (
+        <div className="mt-auto px-2 py-2 shrink-0">
           <NavTooltip label="Anmelden" collapsed={!sidebarExpanded}>
-            <Link to="/login" className={menuLinkClass(false)} onClick={() => setLoginIntent()}>
+            <Link
+              to="/login"
+              className={menuLinkClass(false, false, !sidebarExpanded)}
+              onClick={() => setLoginIntent()}
+            >
               <PiSignIn aria-hidden="true" className={iconClass} />
               <span className={titleClass}>Anmelden</span>
             </Link>
           </NavTooltip>
         </div>
       )}
-
-      {/* Footer - pushed to bottom */}
-      <div className={cn(user ? 'mt-auto' : '', 'px-2 py-xs shrink-0 flex items-center')}>
-        <NavTooltip
-          label={darkMode ? 'Heller Modus' : 'Dunkler Modus'}
-          collapsed={!sidebarExpanded}
-        >
-          <button
-            className="flex items-center justify-center w-10 h-10 p-0 ml-2 border-none bg-transparent rounded-full cursor-pointer text-foreground-heading hover:bg-hover-alt transition-colors shrink-0 [&_svg]:text-[1.4rem] [&_svg]:shrink-0 [&_svg]:w-6"
-            onClick={toggleDarkMode}
-            aria-label={darkMode ? 'Zum hellen Modus wechseln' : 'Zum dunklen Modus wechseln'}
-          >
-            {darkMode ? <PiMoon aria-hidden="true" /> : <PiSun aria-hidden="true" />}
-          </button>
-        </NavTooltip>
-        {!isDesktop &&
-          sidebarExpanded &&
-          footerLinks.map((item) => (
-            <Link
-              key={item.id}
-              to={item.path!}
-              className="flex items-center py-sm px-2.5 no-underline text-foreground rounded-sm transition-colors min-h-[40px] hover:bg-hover-alt"
-              onClick={() => handleLinkClick(item.path!, item.title)}
-            >
-              <span className="font-medium text-[0.7rem] text-foreground whitespace-nowrap font-[Raleway,PT_Sans,Arial,sans-serif]">
-                {item.title}
-              </span>
-            </Link>
-          ))}
-      </div>
     </>
   );
 
@@ -331,7 +304,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
           <SheetContent
             side="left"
             showCloseButton={false}
-            className="w-[85vw] max-w-[280px] p-0 bg-background/85 supports-[backdrop-filter]:bg-background/70 backdrop-blur-xl flex flex-col gap-0 [&>div]:gap-0"
+            className="w-[85vw] max-w-[260px] p-0 bg-background/85 supports-[backdrop-filter]:bg-background/70 backdrop-blur-xl flex flex-col gap-0 [&>div]:gap-0"
           >
             <SheetTitle className="sr-only">Navigation</SheetTitle>
             {sidebarInner}
@@ -347,7 +320,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
             // Desktop (non-Tauri) — frosted glass
             !isDesktop &&
               'md:w-14 bg-background/85 supports-[backdrop-filter]:bg-background/70 backdrop-blur-xl border-r border-grey-200/60 dark:border-grey-800/60',
-            !isDesktop && sidebarExpanded && 'md:w-[280px]',
+            !isDesktop && sidebarExpanded && 'md:w-[260px]',
             // Tauri desktop mode — keep native bar background, no blur
             isDesktop &&
               'top-[var(--titlebar-height)] h-[calc(100dvh-var(--titlebar-height))] bg-[var(--bar-background)]',
@@ -380,225 +353,125 @@ const SidebarFavourites = memo(function SidebarFavourites({
 }) {
   const favouriteIds = useSidebarFavouritesStore((s) => s.favouriteIds);
   const removeFavourite = useSidebarFavouritesStore((s) => s.removeFavourite);
-  const items = getFavouriteItemsById(favouriteIds);
+  const configItems = getFavouriteItemsById(favouriteIds);
 
-  if (items.length === 0) return null;
+  const favoriteIdentifiers = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
+  const toggleAgentFav = useAgentFavoritesStore((s) => s.toggle);
+  const { data: userAgents = [] } = useUserAgents();
+
+  // Agent favourites live in the normal favourites list (system + user agents).
+  const agentItems = useMemo(() => {
+    const rows: { identifier: string; title: string; Icon: IconType; path: string }[] = [];
+    for (const identifier of favoriteIdentifiers) {
+      const sys = getSystemAgent(identifier);
+      if (sys) {
+        rows.push({
+          identifier,
+          title: sys.title,
+          Icon: getAgentIcon(identifier),
+          path: `/agents/${getAgentSlug(identifier)}`,
+        });
+        continue;
+      }
+      const ua = userAgents.find((a) => a.identifier === identifier);
+      if (ua) {
+        rows.push({
+          identifier,
+          title: ua.title,
+          Icon: PiSparkle,
+          path: `/agents/${getAgentSlug(identifier)}`,
+        });
+      }
+    }
+    return rows;
+  }, [favoriteIdentifiers, userAgents]);
 
   const expanded = isOpen || forceExpanded;
 
-  const titleClass = cn(
-    'font-semibold text-sm text-foreground-heading leading-tight transition-all duration-150 font-[Raleway,PT_Sans,Arial,sans-serif]',
-    expanded ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2'
-  );
-
-  return (
-    <div className="flex flex-col gap-0 p-0 border-t border-grey-200 dark:border-grey-700 mt-1 pt-1">
-      {items.map((item) => {
-        const content = (
-          <>
-            {item.icon && <item.icon aria-hidden="true" className={iconClass} />}
-            <span className={titleClass}>{item.title}</span>
-            <button
-              type="button"
-              className={cn(
-                'ml-auto shrink-0 text-primary-600 hover:text-red-500 transition-all p-0.5',
-                expanded ? 'opacity-100' : 'opacity-0 pointer-events-none'
-              )}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                removeFavourite(item.id);
-              }}
-              aria-label={`${item.title} aus Favoriten entfernen`}
-              title="Aus Favoriten entfernen"
-            >
-              <PiStarFill size={14} />
-            </button>
-          </>
-        );
-
-        return isDesktop ? (
-          <NavTooltip key={item.id} label={item.title} collapsed={!expanded}>
-            <button
-              onClick={() => onLinkClick(item.path, item.title)}
-              className={cn(menuLinkClass(isActive(item.path)), 'group')}
-              aria-current={isActive(item.path) ? 'page' : undefined}
-              type="button"
-            >
-              {content}
-            </button>
-          </NavTooltip>
-        ) : (
-          <Link
-            key={item.id}
-            to={item.path}
-            className={cn(menuLinkClass(false), 'group')}
-            onClick={() => onLinkClick(item.path, item.title)}
-          >
-            {content}
-          </Link>
-        );
-      })}
-    </div>
-  );
-});
-
-const AGENTS_EXPANDED_KEY = 'sidebar-agents-expanded';
-
-const SidebarAgents = memo(function SidebarAgents({
-  sidebarExpanded,
-  onLinkClick,
-}: {
-  sidebarExpanded: boolean;
-  onLinkClick: (path: string, title: string) => void;
-}) {
-  const { data: userAgents = [] } = useUserAgents();
-  const userLocale = useAuthStore((state) => state.locale) ?? 'de-DE';
-  const pinnedAgentIds = useMemo(() => getPinnedAgentIds(userLocale), [userLocale]);
-  const defaultAgentEntries = useMemo(() => getDefaultAgentEntries(userLocale), [userLocale]);
-
-  const favoriteIdentifiers = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
-  const favoriteAgents = useMemo(() => {
-    const out: Agent[] = [];
-    for (const identifier of favoriteIdentifiers) {
-      if (pinnedAgentIds.has(identifier)) continue;
-      const agent = getSystemAgent(identifier);
-      if (!agent) continue; // covers deleted agents + migration unknowns
-      out.push(agent);
-    }
-    return out;
-  }, [favoriteIdentifiers, pinnedAgentIds]);
-
-  // Favorites store uses identifier strings as keys; user-agent identifiers
-  // don't collide with skill mentions (different namespaces).
-  const favoriteUserAgents = useMemo(() => {
-    if (!userAgents.length || !favoriteIdentifiers.length) return [];
-    const favSet = new Set(favoriteIdentifiers);
-    return userAgents.filter((a) => favSet.has(a.identifier));
-  }, [userAgents, favoriteIdentifiers]);
-
-  const [isExpanded, setIsExpanded] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(AGENTS_EXPANDED_KEY);
-      return stored === null ? true : stored === '1';
-    } catch {
-      return true;
-    }
-  });
-
-  const toggle = useCallback(() => {
-    setIsExpanded((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(AGENTS_EXPANDED_KEY, next ? '1' : '0');
-      } catch {
-        // localStorage unavailable
-      }
-      return next;
-    });
-  }, []);
+  // Favourites only show in the expanded sidebar (no icon-only rail entries).
+  if (!expanded) return null;
+  if (configItems.length === 0 && agentItems.length === 0) return null;
 
   const titleClass = cn(
-    'text-sm text-foreground leading-tight transition-all duration-150 truncate',
-    sidebarExpanded ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2'
+    'min-w-0 flex-1 truncate text-sm font-medium leading-tight transition-all duration-150',
+    expanded ? 'opacity-100 translate-x-0' : 'hidden'
   );
 
-  return (
-    <div className="mt-3 px-xs">
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={isExpanded}
-        className="flex w-full items-center gap-1.5 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-grey-500 hover:text-foreground transition-colors"
+  const removeStar = (onRemove: () => void, title: string) => (
+    <button
+      type="button"
+      className={cn(
+        'ml-auto shrink-0 text-primary-600 hover:text-red-500 transition-all p-0.5',
+        expanded ? 'opacity-100' : 'hidden'
+      )}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onRemove();
+      }}
+      aria-label={`${title} aus Favoriten entfernen`}
+      title="Aus Favoriten entfernen"
+    >
+      <PiStarFill size={14} />
+    </button>
+  );
+
+  const renderRow = (
+    key: string,
+    icon: React.ReactNode,
+    title: string,
+    path: string,
+    star: React.ReactNode
+  ) => {
+    const content = (
+      <>
+        {icon}
+        <span className={titleClass}>{title}</span>
+        {star}
+      </>
+    );
+    return isDesktop ? (
+      <NavTooltip key={key} label={title} collapsed={!expanded}>
+        <button
+          onClick={() => onLinkClick(path, title)}
+          className={cn(menuLinkClass(isActive(path), false, !expanded), 'group')}
+          aria-current={isActive(path) ? 'page' : undefined}
+          type="button"
+        >
+          {content}
+        </button>
+      </NavTooltip>
+    ) : (
+      <Link
+        key={key}
+        to={path}
+        className={cn(menuLinkClass(false, false, !expanded), 'group')}
+        onClick={() => onLinkClick(path, title)}
       >
-        <span>Grünerator Agents</span>
-        <PiCaretRight
-          className={cn('h-3 w-3 shrink-0 transition-transform', isExpanded && 'rotate-90')}
-          aria-hidden="true"
-        />
-      </button>
-      {isExpanded && (
-        <ul className="list-none m-0 p-0">
-          {defaultAgentEntries.map((entry) => {
-            const Icon = getAgentIcon(entry.identifier);
-            return (
-              <li key={entry.key}>
-                <button
-                  type="button"
-                  onClick={() =>
-                    onLinkClick(`/agents/${getAgentSlug(entry.identifier)}`, entry.label)
-                  }
-                  className={menuLinkClass(false)}
-                >
-                  <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
-                    <Icon aria-hidden="true" className="h-5 w-5" />
-                  </span>
-                  <span className={titleClass}>{entry.label}</span>
-                </button>
-              </li>
-            );
-          })}
+        {content}
+      </Link>
+    );
+  };
 
-          {favoriteAgents.map((agent) => {
-            const Icon = getAgentIcon(agent.identifier);
-            return (
-              <li key={`fav-${agent.identifier}`}>
-                <button
-                  type="button"
-                  onClick={() =>
-                    onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
-                  }
-                  className={menuLinkClass(false)}
-                >
-                  <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
-                    <Icon aria-hidden="true" className="h-5 w-5" />
-                  </span>
-                  <span className={titleClass}>{agent.title}</span>
-                </button>
-              </li>
-            );
-          })}
-
-          {favoriteUserAgents.map((agent) => (
-            <li key={agent.identifier}>
-              <button
-                type="button"
-                onClick={() =>
-                  onLinkClick(`/agents/${getAgentSlug(agent.identifier)}`, agent.title)
-                }
-                className={menuLinkClass(false)}
-              >
-                <span className="shrink-0 w-6 h-6 flex items-center justify-center text-secondary-600">
-                  <PiSparkle aria-hidden="true" className="h-4 w-4" />
-                </span>
-                <span className={titleClass}>{agent.title}</span>
-              </button>
-            </li>
-          ))}
-
-          {import.meta.env.DEV && (
-            <li>
-              <AllAgentsDialog onLinkClick={onLinkClick} titleClass={titleClass} />
-            </li>
-          )}
-
-          {/* Entry point to the conversational agent creator (/agents/new),
-              gated behind SHOW_AGENT_CREATOR (dev or VITE_SHOW_AGENT_CREATOR). */}
-          {SHOW_AGENT_CREATOR && (
-            <li>
-              <button
-                type="button"
-                onClick={() => onLinkClick('/agents/new', 'Neue*r Agent*in')}
-                className={cn(menuLinkClass(false), 'text-primary-600 dark:text-primary-300')}
-              >
-                <span className="shrink-0 w-6 h-6 flex items-center justify-center text-base">
-                  +
-                </span>
-                <span className={titleClass}>Neue*r Agent*in</span>
-              </button>
-            </li>
-          )}
-        </ul>
+  return (
+    <div className="flex flex-col gap-0 p-0 mt-1 pt-1">
+      {configItems.map((item) =>
+        renderRow(
+          item.id,
+          item.icon ? <item.icon aria-hidden="true" className={iconClass} /> : null,
+          item.title,
+          item.path,
+          removeStar(() => removeFavourite(item.id), item.title)
+        )
+      )}
+      {agentItems.map((a) =>
+        renderRow(
+          `agent-${a.identifier}`,
+          <a.Icon aria-hidden="true" className={iconClass} />,
+          a.title,
+          a.path,
+          removeStar(() => toggleAgentFav(a.identifier), a.title)
+        )
       )}
     </div>
   );

--- a/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
+++ b/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
@@ -1,0 +1,241 @@
+import {
+  Badge,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@gruenerator/ui';
+import { LogOut } from 'lucide-react';
+import { type MutableRefObject, type ReactNode, memo, useEffect, useState } from 'react';
+import { FaUserCircle } from 'react-icons/fa';
+import { HiCog, HiDotsVertical } from 'react-icons/hi';
+import { PiBell, PiMoon, PiQuestion, PiSun } from 'react-icons/pi';
+
+import { useProfile } from '../../../features/auth/hooks/useProfileData';
+import { getAvatarDisplayProps } from '../../../features/auth/services/profileApiService';
+import NotificationList from '../../../features/notifications/components/NotificationList';
+import { useUnreadCount } from '../../../features/notifications/hooks/useNotifications';
+import { useAuthStore } from '../../../stores/authStore';
+import useDarkMode from '../../hooks/useDarkMode';
+import { NAV_ITEMS } from '../Header/ProfileButton';
+
+import { cn } from '@/utils/cn';
+
+interface SidebarAccountProps {
+  sidebarExpanded: boolean;
+  openRef: MutableRefObject<boolean>;
+  onNavigate: (path: string, title: string) => void;
+}
+
+// Bottom-of-sidebar account block. Clicking the avatar + name opens the
+// notifications panel; the 3-dot kebab opens the account actions (nav targets,
+// theme toggle, logout). When collapsed, the avatar opens the actions menu.
+// Mirrors the ChatGPT/Gemini account anchor; replaces the standalone footer
+// theme-toggle and the removed top-right ProfileButton.
+const SidebarAccount = memo(function SidebarAccount({
+  sidebarExpanded,
+  openRef,
+  onNavigate,
+}: SidebarAccountProps) {
+  const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
+  const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
+  const [darkMode, toggleDarkMode] = useDarkMode();
+  const { data: unreadCount = 0 } = useUnreadCount();
+  const { data: profile } = useProfile(user?.id);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [notifOpen, setNotifOpen] = useState(false);
+
+  // Keep the sidebar from collapsing (hover-leave) while either popover is open.
+  useEffect(() => {
+    openRef.current = menuOpen || notifOpen;
+  }, [menuOpen, notifOpen, openRef]);
+
+  if (!user) return null;
+
+  const displayName = profile?.display_name || '';
+  const avatarRobotId = profile?.avatar_robot_id ?? null;
+  const avatarProps = getAvatarDisplayProps({
+    ...(avatarRobotId != null && { avatar_robot_id: avatarRobotId }),
+    display_name: displayName,
+    email: user.email,
+  });
+
+  const avatarEl =
+    avatarProps.type === 'robot' ? (
+      <img
+        src={avatarProps.src}
+        alt={avatarProps.alt}
+        className="size-7 rounded-full object-cover"
+      />
+    ) : (
+      <FaUserCircle className="size-7 text-foreground-heading" />
+    );
+
+  const unreadBadge = (offset: string) =>
+    unreadCount > 0 ? (
+      <Badge
+        variant="destructive"
+        className={cn(
+          'absolute flex size-4 items-center justify-center rounded-full p-0 text-[9px] font-bold',
+          offset
+        )}
+      >
+        {unreadCount > 9 ? '9+' : unreadCount}
+      </Badge>
+    ) : null;
+
+  const actionsMenu = (
+    <DropdownMenuContent
+      side={sidebarExpanded ? 'top' : 'right'}
+      align={sidebarExpanded ? 'end' : 'start'}
+      sideOffset={8}
+      className="w-56"
+    >
+      {/* Notifications live on the avatar+name when expanded; surface them here when collapsed */}
+      {!sidebarExpanded && (
+        <>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <PiBell className="size-4" />
+              <span>Benachrichtigungen</span>
+              {unreadCount > 0 && (
+                <Badge
+                  variant="destructive"
+                  className="ml-auto flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[9px] font-bold"
+                >
+                  {unreadCount > 9 ? '9+' : unreadCount}
+                </Badge>
+              )}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-80 p-0">
+              <NotificationList unreadCount={unreadCount} />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSeparator />
+        </>
+      )}
+      {/* Einstellungen lives on the gear when expanded; keep it in the menu when collapsed */}
+      {NAV_ITEMS.filter((item) => !(sidebarExpanded && item.key === 'einstellungen')).map(
+        (item) => (
+          <DropdownMenuItem key={item.key} onClick={() => onNavigate(item.path, item.label)}>
+            <item.icon className="size-4" />
+            <span>{item.label}</span>
+          </DropdownMenuItem>
+        )
+      )}
+      <DropdownMenuItem onClick={() => onNavigate('/support', 'Support')}>
+        <PiQuestion className="size-4" />
+        <span>Support</span>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        onSelect={(e) => {
+          e.preventDefault();
+          toggleDarkMode();
+        }}
+      >
+        {darkMode ? <PiSun className="size-4" /> : <PiMoon className="size-4" />}
+        <span>{darkMode ? 'Heller Modus' : 'Dunkler Modus'}</span>
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        variant="destructive"
+        disabled={isLoggingOut}
+        onClick={() => {
+          if (!isLoggingOut) void logout();
+        }}
+      >
+        <LogOut className="size-4" />
+        <span>{isLoggingOut ? 'Wird abgemeldet…' : 'Abmelden'}</span>
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  );
+
+  const kebabActions = (trigger: ReactNode) => (
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      {actionsMenu}
+    </DropdownMenu>
+  );
+
+  return (
+    <div className="mt-auto shrink-0 px-2 py-2">
+      {sidebarExpanded ? (
+        <div className="flex items-center gap-1">
+          {/* Avatar + name -> notifications */}
+          <DropdownMenu open={notifOpen} onOpenChange={setNotifOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-hover-alt"
+                aria-label="Benachrichtigungen öffnen"
+              >
+                <span className="relative shrink-0">
+                  {avatarEl}
+                  {unreadBadge('-top-1 -right-1')}
+                </span>
+                <span className="truncate text-sm font-medium text-foreground-heading">
+                  {displayName || 'Profil'}
+                </span>
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent side="top" align="start" sideOffset={8} className="w-80 p-0">
+              <NotificationList unreadCount={unreadCount} />
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Settings gear -> profile */}
+          <button
+            type="button"
+            onClick={() => onNavigate('/profile', 'Einstellungen')}
+            className="flex size-9 shrink-0 items-center justify-center rounded-md text-grey-500 transition-colors hover:bg-hover-alt hover:text-foreground"
+            aria-label="Einstellungen öffnen"
+          >
+            <HiCog className="size-5" />
+          </button>
+
+          {/* Kebab -> actions */}
+          {kebabActions(
+            <button
+              type="button"
+              className="flex size-9 shrink-0 items-center justify-center rounded-md text-grey-500 transition-colors hover:bg-hover-alt hover:text-foreground"
+              aria-label="Konto-Menü öffnen"
+            >
+              <HiDotsVertical className="size-5" />
+            </button>
+          )}
+        </div>
+      ) : (
+        /* Collapsed: only the profile button (avatar); it opens the account menu,
+           which carries notifications as a submenu. No standalone kebab. */
+        <div className="flex justify-center">
+          {kebabActions(
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="relative flex size-9 items-center justify-center rounded-full transition-colors hover:bg-hover-alt"
+                  aria-label="Konto-Menü öffnen"
+                >
+                  {avatarEl}
+                  {unreadBadge('-top-0.5 -right-0.5')}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{displayName || 'Konto'}</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default SidebarAccount;

--- a/apps/web/src/components/layout/Sidebar/sidebarStyles.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarStyles.ts
@@ -1,11 +1,13 @@
 import { cn } from '@/utils/cn';
 
-export const menuLinkClass = (active: boolean, disabled?: boolean) =>
+export const menuLinkClass = (active: boolean, disabled?: boolean, collapsed?: boolean) =>
   cn(
-    'group/link flex items-center gap-3 py-2 px-3 mx-2 rounded-md min-h-[40px] no-underline whitespace-nowrap transition-colors duration-150 text-foreground hover:bg-secondary-50 dark:hover:bg-secondary-800/40',
+    'group/link flex items-center py-1.5 mx-2 rounded-md min-h-[34px] no-underline whitespace-nowrap transition-colors duration-150 text-foreground hover:bg-secondary-50 dark:hover:bg-secondary-800/40',
+    collapsed ? 'justify-center px-0 gap-0' : 'gap-2.5 px-3',
     active && 'bg-secondary-100 dark:bg-secondary-800/60 font-medium',
     disabled && 'opacity-55 cursor-default pointer-events-none'
   );
 
+// Eucalyptus (secondary-600) — matches the agent icons for one consistent icon colour.
 export const iconClass =
-  'text-[1.25rem] text-foreground shrink-0 w-5 flex items-center justify-center transition-colors duration-150';
+  'text-[1.25rem] text-secondary-600 shrink-0 w-5 flex items-center justify-center transition-colors duration-150';

--- a/apps/web/src/components/layout/SidebarToggle/SidebarToggle.tsx
+++ b/apps/web/src/components/layout/SidebarToggle/SidebarToggle.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { PiX } from 'react-icons/pi';
+import { FiSidebar } from 'react-icons/fi';
 
 import useSidebarStore from '../../../stores/sidebarStore';
 
@@ -12,22 +12,14 @@ const SidebarToggle = memo(() => {
   return (
     <button
       className={cn(
-        'flex items-center justify-center w-10 h-10 p-0 border-none cursor-pointer rounded-sm transition-colors duration-150 hover:bg-hover-alt md:max-[767px]:w-[38px] md:max-[767px]:h-[38px] min-[1920px]:w-11 min-[1920px]:h-11',
+        'flex items-center justify-center w-10 h-10 p-0 border-none cursor-pointer rounded-sm transition-colors duration-150 hover:bg-hover-alt',
         'bg-transparent max-sm:bg-background/80 max-sm:backdrop-blur-sm max-sm:shadow-sm max-sm:rounded-lg'
       )}
       onClick={toggle}
       aria-label={isOpen ? 'Menü schließen' : 'Menü öffnen'}
       aria-expanded={isOpen}
     >
-      {isOpen ? (
-        <PiX className="text-[1.4rem] text-foreground-heading" aria-hidden="true" />
-      ) : (
-        <div className="flex flex-col justify-center items-center gap-1" aria-hidden="true">
-          <span className="block w-[18px] h-0.5 bg-foreground-heading rounded-[2px] max-[767px]:w-4 min-[1920px]:w-5" />
-          <span className="block w-[18px] h-0.5 bg-foreground-heading rounded-[2px] max-[767px]:w-4 min-[1920px]:w-5" />
-          <span className="block w-[18px] h-0.5 bg-foreground-heading rounded-[2px] max-[767px]:w-4 min-[1920px]:w-5" />
-        </div>
-      )}
+      <FiSidebar className="text-lg text-foreground-heading" aria-hidden="true" />
     </button>
   );
 });

--- a/packages/chat/src/components/ChatThreadList.tsx
+++ b/packages/chat/src/components/ChatThreadList.tsx
@@ -58,7 +58,7 @@ export function ChatThreadList({ noScroll = false }: ChatThreadListProps = {}) {
           type="button"
           onClick={toggleExpanded}
           aria-expanded={isExpanded}
-          className="flex w-full items-center gap-1.5 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-grey-500 hover:text-foreground transition-colors"
+          className="flex w-full items-center gap-1.5 px-3 py-1 text-xs font-medium text-grey-500 hover:text-foreground transition-colors"
         >
           <span>Chats</span>
           <ChevronRight


### PR DESCRIPTION
## Why

Brings the web sidebar in line with familiar assistant UIs (ChatGPT/Gemini) and resolves the inconsistencies it had: no brand anchor, no account block, a heavy mixed-font/heavy-weight nav, a separate agents section that duplicated favourites, and competing icon treatments. Iterated live with design feedback.

**Account (bottom):** avatar + name opens **notifications**; a gear opens the **profile**; a clean **3-dot kebab** holds Gruppen/Dateien/Wolke/Support, the light/dark toggle, and logout. Collapsed shows **only the avatar** (notifications as a submenu). The redundant top-right `ProfileButton` is removed so account lives in one place.

**Navigation:** "Skills & Agents" is now a single nav item (→ `/skills`, the upcoming agent overview) with a `RiSpyLine` icon — the dedicated agents section is gone and agent favourites surface in the **normal favourites list**. `Sites` gets a distinct `globe` icon (was sharing Studio's).

**Visual system:** one **eucalyptus** icon colour across nav + favourites; sentence-case section headers; tighter row rhythm; **long-favourite truncation**; divider lines removed; favourites hidden when collapsed (icons centered in the rail).

**Brand/header:** hamburger replaced with `FiSidebar`; the **GRÜNERATOR wordmark logo** (green/white, theme-aware) shows next to the toggle when expanded; header toggle + logo aligned to the nav icon and label columns. Expanded width set to **260px** (also fixes a pre-existing ≥1920px content-offset desync).

Icons stay otherwise unchanged. Verified locally: `tsc --noEmit` clean, ESLint 0 errors, Prettier clean.