### PR TITLE
fix(sites): inject auth from host instead of unpopulated store

### DIFF
--- a/apps/web/src/features/sites/SitesProviderWeb.tsx
+++ b/apps/web/src/features/sites/SitesProviderWeb.tsx
@@ -1,5 +1,5 @@
-import { SitesProvider } from '@gruenerator/sites';
-import { useCallback, type ReactNode } from 'react';
+import { SitesProvider, type SitesAuth } from '@gruenerator/sites';
+import { useCallback, useMemo, type ReactNode } from 'react';
 
 import useAuth from '../../hooks/useAuth';
 
@@ -8,7 +8,7 @@ interface SitesProviderWebProps {
 }
 
 export function SitesProviderWeb({ children }: SitesProviderWebProps) {
-  const { logout: webLogout } = useAuth();
+  const { user, isAuthenticated, loading, error, logout: webLogout } = useAuth();
 
   const login = useCallback((redirectTo?: string) => {
     const target = redirectTo || window.location.pathname;
@@ -21,8 +21,27 @@ export function SitesProviderWeb({ children }: SitesProviderWebProps) {
     console.error('[sites]', error, context);
   }, []);
 
+  // Feed Sites its auth state from the web's React-Query-backed truth. Sites
+  // used to read the shared Zustand store, which the web app never populates —
+  // that left `isLoading` stuck `true` and the page hung on its spinner.
+  const auth = useMemo<SitesAuth>(
+    () => ({
+      user: user ? { id: user.id, email: user.email, display_name: user.display_name } : null,
+      isAuthenticated,
+      isLoading: loading,
+      error,
+    }),
+    [user, isAuthenticated, loading, error]
+  );
+
   return (
-    <SitesProvider basePath="/sites" login={login} logout={logout} reportError={reportError}>
+    <SitesProvider
+      basePath="/sites"
+      auth={auth}
+      login={login}
+      logout={logout}
+      reportError={reportError}
+    >
       {children}
     </SitesProvider>
   );

--- a/packages/sites/src/SitesContext.tsx
+++ b/packages/sites/src/SitesContext.tsx
@@ -1,10 +1,29 @@
-import { useAuth as useSharedAuth } from '@gruenerator/shared/hooks';
 import { createContext, useContext, useEffect, useMemo, type ReactNode } from 'react';
 
 import { setSitesUnauthorizedHandler } from './lib/apiClient';
 
+/**
+ * Minimal user shape Sites consumes. Satisfied by each host's own user object
+ * (web `UserProfile`, mobile shared `User`) — Sites only ever reads `email`
+ * and `display_name`, so it intentionally does not depend on either heavy type
+ * (which disagree on whether `email` is required).
+ */
+export interface SitesUser {
+  id: string;
+  email?: string;
+  display_name?: string;
+}
+
+export interface SitesAuth {
+  user: SitesUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
 export interface SitesContextValue {
   basePath: string;
+  auth: SitesAuth;
   login: (redirectTo?: string) => void;
   logout: () => void | Promise<void>;
   reportError: (error: unknown, context?: Record<string, unknown>) => void;
@@ -18,6 +37,7 @@ export interface SitesProviderProps extends SitesContextValue {
 
 export function SitesProvider({
   basePath,
+  auth,
   login,
   logout,
   reportError,
@@ -37,8 +57,8 @@ export function SitesProvider({
   }, [login]);
 
   const value = useMemo<SitesContextValue>(
-    () => ({ basePath, login, logout, reportError }),
-    [basePath, login, logout, reportError]
+    () => ({ basePath, auth, login, logout, reportError }),
+    [basePath, auth, login, logout, reportError]
   );
 
   return <SitesContext.Provider value={value}>{children}</SitesContext.Provider>;
@@ -62,12 +82,14 @@ export function useSitesActions(): Pick<SitesContextValue, 'login' | 'logout' | 
 }
 
 /**
- * Combined auth + actions hook. Reads auth state from the shared store
- * (populated by the host app's auth bootstrap) and pulls login/logout from context.
+ * Combined auth + actions hook. Auth state is injected by the host app via
+ * `<SitesProvider auth=...>` — the web host sources it from its React-Query
+ * `authStatus` truth, mobile from the shared store. Sites must NOT read a
+ * global auth store directly: the web app keeps its own store and never
+ * populates the shared one, so reading it pinned `isLoading: true` forever.
  */
 export function useAuth() {
-  const auth = useSharedAuth();
-  const { login, logout } = useSitesContext();
+  const { auth, login, logout } = useSitesContext();
   return {
     user: auth.user,
     isAuthenticated: auth.isAuthenticated,

--- a/packages/sites/src/index.ts
+++ b/packages/sites/src/index.ts
@@ -14,6 +14,8 @@ export {
   useSitesBasePath,
   useSitesActions,
   useAuth,
+  type SitesAuth,
+  type SitesUser,
   type SitesContextValue,
   type SitesProviderProps,
 } from './SitesContext';


### PR DESCRIPTION
Sites read auth from the shared Zustand store, which the web app never populates — so `isLoading` stayed `true` and the page hung on its spinner. Sites now takes an `auth` prop (DI) fed from the web's React-Query-backed auth truth; adds `SitesAuth`/`SitesUser` types.