### PR TITLE
perf(web): lazy-load workplace tabs + image studio updates

### DIFF
--- a/apps/web/src/features/texte/modes/imagine.ts
+++ b/apps/web/src/features/texte/modes/imagine.ts
@@ -30,5 +30,4 @@ export const imagineMode: ModeDefinition = {
     variant: '',
     imageModel: DEFAULT_IMAGE_MODEL_ID,
   },
-  examples: [{ label: 'Plakat', text: 'Ein grünes Wahlplakat mit Sonnenblumen und dem Slogan ' }],
 };

--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -1,5 +1,5 @@
 import { SectionHeader } from '@gruenerator/ui';
-import { memo } from 'react';
+import { Suspense, lazy, memo } from 'react';
 
 import PageContainer from '../../components/common/PageContainer';
 import ErrorBoundary from '../../components/ErrorBoundary';
@@ -7,10 +7,12 @@ import { useFirstName } from '../../hooks/useFirstName';
 import { useAuthStore } from '../../stores/authStore';
 
 import CreatorSection from './components/CreatorSection';
-import NotebooksSection from './components/NotebooksSection';
-import RecentlyCreatedSection from './components/RecentlyCreatedSection';
-import ReelsSection from './components/ReelsSection';
 import ToolsSection, { FavoritesSection } from './components/ToolsSection';
+
+// Below-the-fold — deferred so the greeting + chat composer paint first. These
+// pull heavy deps (NotebookEditor/Dialog, image-studio Lightbox + ShareMediaModal).
+const RecentlyCreatedSection = lazy(() => import('./components/RecentlyCreatedSection'));
+const NotebooksSection = lazy(() => import('./components/NotebooksSection'));
 
 function pickStable<T>(options: readonly T[], seed: number): T {
   return options[seed % options.length] as T;
@@ -242,20 +244,19 @@ const WorkplacePage = () => {
           <h1 className="text-4xl max-md:text-2xl font-semibold text-foreground-heading mb-xs">
             {getGreeting(locale, firstName)}
           </h1>
-          <p className="text-lg text-grey-500 dark:text-grey-400">
-            Beschreibe dein Vorhaben und die KI erstellt es für dich.
-          </p>
         </div>
 
         <div className="max-w-3xl mx-auto mb-xl">
           <CreatorSection />
         </div>
 
-        <RecentlyCreatedSection />
+        <Suspense fallback={null}>
+          <RecentlyCreatedSection />
+        </Suspense>
 
-        {/* <ReelsSection /> */}
-
-        <NotebooksSection />
+        <Suspense fallback={null}>
+          <NotebooksSection />
+        </Suspense>
 
         <section className="mb-xl">
           <SectionHeader title="Weitere Tools" />

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -1,18 +1,31 @@
 import { getGlobalApiClient } from '@gruenerator/shared/api';
 import {
+  DEFAULT_IMAGE_MODEL_ID,
   FLUX_VARIANT_ORDER,
   IMAGE_FAMILIES,
+  IMAGE_MODELS,
   IMAGE_MODEL_BY_ID,
-  getDefaultModelForFamily,
-  getImageFamily,
-  type ImageFamilyId,
   type ImageModelId,
 } from '@gruenerator/shared/models';
 import { useShareStore } from '@gruenerator/shared/share';
-import { AIPromptInput, Button, SettingsDropdown, type SettingConfig } from '@gruenerator/ui';
+import {
+  AIPromptInput,
+  Button,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  ResponsiveMenu,
+  ResponsiveMenuItem,
+  ResponsiveMenuSection,
+  SettingsDropdown,
+  pillActive,
+  pillBase,
+  type SettingConfig,
+} from '@gruenerator/ui';
 import { useVoxtralDictation } from '@gruenerator/voice';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Download, Image as ImageIcon, ImagePlus, X } from 'lucide-react';
+import { Check, ChevronDown, Download, Image as ImageIcon, ImagePlus, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import useApiSubmit from '../../../components/hooks/useApiSubmit';
@@ -33,7 +46,7 @@ type SubMode = 'erstellen' | 'bearbeiten' | 'begruenen' | 'vergroessern' | 'hint
 const SUB_MODE_OPTIONS: SettingConfig['options'] = [
   { id: 'erstellen', label: 'Erstellen' },
   { id: 'bearbeiten', label: 'Bearbeiten' },
-  { id: 'begruenen', label: '🌳 Begrünen' },
+  { id: 'begruenen', label: 'Begrünen' },
   { id: 'vergroessern', label: 'Vergrößern' },
   ...(import.meta.env.DEV ? [{ id: 'hintergrund', label: 'Hintergrund entfernen' }] : []),
 ];
@@ -51,31 +64,91 @@ const BEGRUENEN_MODE_ID = 'bild-begruenen';
 const VERGROESSERN_MODE_ID = 'bild-vergroessern';
 const HINTERGRUND_MODE_ID = 'bild-hintergrund-entfernen';
 
-const IMAGE_FAMILY_CONFIG: SettingConfig = {
-  key: 'imageFamily',
-  label: 'Modell',
-  options: IMAGE_FAMILIES.map((f) => ({ id: f.id, label: f.name })),
-  multiple: false,
-};
-
-const FLUX_VARIANT_LABEL_RE = /^(?:⭐\s+)?Flux\s+/;
-
 function shortCost(multiplier: number): string {
   if (multiplier === 0.5) return '½ Bild';
   if (multiplier === 1) return '1 Bild';
   return `${multiplier} Bilder`;
 }
 
-const FLUX_VARIANT_CONFIG: SettingConfig = {
-  key: 'fluxVariant',
-  label: 'Variante',
-  options: FLUX_VARIANT_ORDER.map((id) => {
-    const variant = IMAGE_MODEL_BY_ID[id];
-    const bareName = variant.name.replace(FLUX_VARIANT_LABEL_RE, '');
-    return { id, label: `${bareName} (${shortCost(variant.costMultiplier)})` };
-  }),
-  multiple: false,
-};
+const FLUX_VARIANT_LABEL_RE = /^(?:⭐\s+)?Flux\s+/;
+
+// One model dropdown grouped by family: multi-variant families (Flux) open a
+// submenu of their variants; single-model families select directly.
+const MODELS_BY_FAMILY = IMAGE_FAMILIES.map((family) => ({
+  family,
+  models:
+    family.id === 'flux'
+      ? FLUX_VARIANT_ORDER.map((id) => IMAGE_MODEL_BY_ID[id])
+      : IMAGE_MODELS.filter((m) => m.family === family.id),
+}));
+
+function ImageModelDropdown({
+  value,
+  onChange,
+}: {
+  value: ImageModelId;
+  onChange: (id: ImageModelId) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = IMAGE_MODEL_BY_ID[value];
+  const select = (id: ImageModelId) => {
+    onChange(id);
+    setOpen(false);
+  };
+  const itemSelectedClass = 'text-primary-700 dark:text-primary-300';
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className={cn(pillBase, pillActive, 'gap-1')}>
+          <span>{selected.name}</span>
+          <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="min-w-[12rem]">
+        {MODELS_BY_FAMILY.map(({ family, models }) => {
+          if (models.length === 1) {
+            const m = models[0];
+            const isSelected = m.id === value;
+            return (
+              <DropdownMenuItem
+                key={family.id}
+                onSelect={() => select(m.id)}
+                className={cn(isSelected && itemSelectedClass)}
+              >
+                <span className="flex-1">{m.name}</span>
+                {isSelected && <Check className="size-3.5 shrink-0 text-primary-500" />}
+              </DropdownMenuItem>
+            );
+          }
+          const familyActive = models.some((m) => m.id === value);
+          return (
+            <DropdownMenuSub key={family.id}>
+              <DropdownMenuSubTrigger className={cn(familyActive && itemSelectedClass)}>
+                {family.name}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {models.map((m) => {
+                  const isSelected = m.id === value;
+                  return (
+                    <DropdownMenuItem
+                      key={m.id}
+                      onSelect={() => select(m.id)}
+                      className={cn(isSelected && itemSelectedClass)}
+                    >
+                      <span className="flex-1">{m.name.replace(FLUX_VARIANT_LABEL_RE, '')}</span>
+                      <span className="text-xs text-grey-500">{shortCost(m.costMultiplier)}</span>
+                      {isSelected && <Check className="size-3.5 shrink-0 text-primary-500" />}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 type AspectRatio = '16:9' | '4:3' | '1:1' | '3:4' | '9:16' | 'custom';
 
@@ -651,20 +724,10 @@ const BilderInner: React.FC = memo(() => {
   );
 
   const selectedImageModel = (modeState.imageModel as ImageModelId | undefined) ?? null;
-  const selectedFamily: ImageFamilyId | null = selectedImageModel
-    ? getImageFamily(selectedImageModel)
-    : null;
 
-  const handleFamilyChange = useCallback(
-    (familyId: ImageFamilyId) => {
-      updateField('imageModel', getDefaultModelForFamily(familyId));
-    },
-    [updateField]
-  );
-
-  const handleFluxVariantChange = useCallback(
-    (variantId: ImageModelId) => {
-      updateField('imageModel', variantId);
+  const handleModelChange = useCallback(
+    (modelId: ImageModelId) => {
+      updateField('imageModel', modelId);
     },
     [updateField]
   );
@@ -687,17 +750,9 @@ const BilderInner: React.FC = memo(() => {
             />
           ))}
         {isErstellen && (
-          <SettingsDropdown
-            config={IMAGE_FAMILY_CONFIG}
-            value={selectedFamily ?? 'flux'}
-            onChange={(val) => handleFamilyChange(val as ImageFamilyId)}
-          />
-        )}
-        {isErstellen && selectedFamily === 'flux' && (
-          <SettingsDropdown
-            config={FLUX_VARIANT_CONFIG}
-            value={selectedImageModel ?? 'flux-pro'}
-            onChange={(val) => handleFluxVariantChange(val as ImageModelId)}
+          <ImageModelDropdown
+            value={selectedImageModel ?? DEFAULT_IMAGE_MODEL_ID}
+            onChange={handleModelChange}
           />
         )}
         {(isBearbeiten || isBegruenen || isHintergrund) && filePickerPill}
@@ -742,7 +797,7 @@ const BilderInner: React.FC = memo(() => {
             <span className="text-grey-400">px</span>
           </span>
         )}
-        {usage && <UsageBadge usage={usage} />}
+        {usage && usage.remaining <= 5 && <UsageBadge usage={usage} />}
       </>
     ),
     [
@@ -759,10 +814,8 @@ const BilderInner: React.FC = memo(() => {
       erstellenDef?.settings,
       modeState,
       updateField,
-      selectedFamily,
       selectedImageModel,
-      handleFamilyChange,
-      handleFluxVariantChange,
+      handleModelChange,
       filePickerPill,
       aspectRatio,
       usage,

--- a/apps/web/src/features/workplace/components/ChatInner.tsx
+++ b/apps/web/src/features/workplace/components/ChatInner.tsx
@@ -56,7 +56,15 @@ const ChatInner: React.FC = memo(() => {
 
   return (
     <ThreadPrimitive.Root
-      className={cn('w-full shrink-0', '[&>div]:px-0', '[&>div>p.text-center]:hidden')}
+      className={cn(
+        'w-full shrink-0 mx-auto max-w-[680px]',
+        '[&>div]:px-0',
+        '[&>div>p.text-center]:hidden',
+        // Match the narrower/taller resting composer used in Bilder & Boards
+        // (AIPromptInput: max-w-[680px] + rows={2}). Scoped here so the full
+        // /chat composer keeps its wider, single-row default.
+        '[&_textarea]:min-h-[3rem]'
+      )}
     >
       <NavigateToChatOnSend />
       <GrueneratorComposer

--- a/apps/web/src/features/workplace/components/CreatorSection.tsx
+++ b/apps/web/src/features/workplace/components/CreatorSection.tsx
@@ -3,11 +3,14 @@ import React, { Suspense, lazy, memo, useState } from 'react';
 import ModePillRow from '../../texte/components/ModePillRow';
 import { DEFAULT_MODE } from '../../texte/modes';
 
-import BilderInner from './BilderInner';
-import BoardsInner from './BoardsInner';
 import ChatInner from './ChatInner';
-import DocsInner from './DocsInner';
 
+// Chat is the default tab (DEFAULT_MODE) and must paint instantly, so it stays
+// eager. The other tabs are lazy — their heavy deps (image-studio, @gruenerator/docs,
+// boards) stay out of the initial chunk until the user switches tabs.
+const BilderInner = lazy(() => import('./BilderInner'));
+const BoardsInner = lazy(() => import('./BoardsInner'));
+const DocsInner = lazy(() => import('./DocsInner'));
 const EigeneTab = lazy(() => import('../../texte/tabs/EigeneTab'));
 
 const CreatorSection: React.FC = memo(() => {
@@ -26,7 +29,7 @@ const CreatorSection: React.FC = memo(() => {
 
       {isChat ? (
         <ChatInner />
-      ) : isEigene ? (
+      ) : (
         <Suspense
           fallback={
             <div className="flex justify-center py-xl">
@@ -34,15 +37,17 @@ const CreatorSection: React.FC = memo(() => {
             </div>
           }
         >
-          <EigeneTab />
+          {isEigene ? (
+            <EigeneTab />
+          ) : isBilder ? (
+            <BilderInner key={mode} />
+          ) : isBoards ? (
+            <BoardsInner key={mode} />
+          ) : isDocs ? (
+            <DocsInner key={mode} />
+          ) : null}
         </Suspense>
-      ) : isBilder ? (
-        <BilderInner key={mode} />
-      ) : isBoards ? (
-        <BoardsInner key={mode} />
-      ) : isDocs ? (
-        <DocsInner key={mode} />
-      ) : null}
+      )}
     </div>
   );
 });


### PR DESCRIPTION
Keeps chat (the default tab) eager and lazy-loads the heavy workplace tabs (Bilder/Boards/Docs) so their deps (image-studio, @gruenerator/docs, boards) stay out of the initial chunk. Includes image-studio (BilderInner) updates and minor CreatorSection/WorkplacePage wiring.