### PR TITLE
fix(docker): copy packages/core into images (shared now depends on it)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY tsconfig.base.json tsconfig.strict-migration.json ./
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/core/package.json ./packages/core/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY services/hocuspocus/package.json ./services/hocuspocus/
 COPY apps/api/package.json ./apps/api/
@@ -32,6 +33,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source and compile
 COPY packages/shared ./packages/shared
+COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY services/hocuspocus ./services/hocuspocus
 COPY apps/api ./apps/api
@@ -99,6 +101,7 @@ COPY --from=builder --chown=gruenerator:gruenerator /app/pnpm-lock.yaml ./
 
 # Copy package.json files for workspace structure
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/package.json ./packages/shared/
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/package.json ./packages/core/
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/contracts/package.json ./packages/contracts/
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/hocuspocus/package.json ./services/hocuspocus/
 COPY --from=builder --chown=gruenerator:gruenerator /app/apps/api/package.json ./apps/api/
@@ -115,6 +118,7 @@ RUN --mount=type=cache,id=pnpm-prod,target=/home/gruenerator/.local/share/pnpm/s
 # is needed — prod Node resolution falls through the `development` condition
 # (not active here) and hits `default`, which points at the compiled dist.
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/dist ./packages/core/dist
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/contracts/dist ./packages/contracts/dist
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/hocuspocus/dist ./services/hocuspocus/dist
 

--- a/apps/gruen-o-mat/Dockerfile
+++ b/apps/gruen-o-mat/Dockerfile
@@ -19,6 +19,7 @@ COPY tsconfig.base.json tsconfig.strict-migration.json ./
 
 # Copy package.json files for workspace resolution
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/core/package.json ./packages/core/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/chat/package.json ./packages/chat/
 COPY packages/voice/package.json ./packages/voice/
@@ -32,6 +33,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source (changes here don't bust the install cache)
 COPY packages/shared ./packages/shared
+COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY packages/chat ./packages/chat
 COPY packages/voice ./packages/voice

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,6 +17,7 @@ COPY tsconfig.base.json tsconfig.strict-migration.json ./
 
 # Copy only package.json files needed by pnpm filter (better layer caching)
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/core/package.json ./packages/core/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY packages/docs/package.json ./packages/docs/
 COPY packages/chat/package.json ./packages/chat/
@@ -36,6 +37,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source (changes here don't bust the install cache)
 COPY packages/shared ./packages/shared
+COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY packages/docs ./packages/docs
 COPY packages/chat ./packages/chat

--- a/services/hocuspocus/Dockerfile
+++ b/services/hocuspocus/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY tsconfig.base.json tsconfig.strict-migration.json ./
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/core/package.json ./packages/core/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY services/hocuspocus/package.json ./services/hocuspocus/
 
@@ -23,6 +24,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source and compile
 COPY packages/shared ./packages/shared
+COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY services/hocuspocus ./services/hocuspocus
 
@@ -68,6 +70,7 @@ COPY --from=builder --chown=gruenerator:gruenerator /app/pnpm-lock.yaml ./
 
 # Copy package.json files for workspace structure (needed for pnpm to resolve workspace deps)
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/package.json ./packages/shared/
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/package.json ./packages/core/
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/contracts/package.json ./packages/contracts/
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/hocuspocus/package.json ./services/hocuspocus/
 
@@ -82,6 +85,7 @@ RUN --mount=type=cache,id=pnpm-prod,target=/home/gruenerator/.local/share/pnpm/s
 # the correct runtime exports map (`"default": "./dist/*.js"`), so Node's
 # resolution picks `default` in prod (the `development` condition is dev-only).
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/dist ./packages/core/dist
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/contracts/dist ./packages/contracts/dist
 
 # Copy compiled server

--- a/services/mcp/Dockerfile
+++ b/services/mcp/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY tsconfig.base.json tsconfig.strict-migration.json ./
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/core/package.json ./packages/core/
 COPY packages/contracts/package.json ./packages/contracts/
 COPY services/mcp/package.json ./services/mcp/
 
@@ -23,6 +24,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 
 # Copy source and compile
 COPY packages/shared ./packages/shared
+COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY services/mcp ./services/mcp
 
@@ -73,6 +75,7 @@ COPY --from=builder --chown=gruenerator:gruenerator /app/pnpm-lock.yaml ./
 
 # Copy package.json files for workspace structure
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/package.json ./packages/shared/
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/package.json ./packages/core/
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/contracts/package.json ./packages/contracts/
 COPY --from=builder --chown=gruenerator:gruenerator /app/services/mcp/package.json ./services/mcp/
 
@@ -85,6 +88,7 @@ RUN --mount=type=cache,id=pnpm-prod,target=/home/gruenerator/.local/share/pnpm/s
 
 # Copy compiled shared package (resolves @gruenerator/shared imports at runtime)
 COPY --from=builder --chown=gruenerator:gruenerator /app/packages/shared/dist ./packages/shared/dist
+COPY --from=builder --chown=gruenerator:gruenerator /app/packages/core/dist ./packages/core/dist
 # Redirect shared package exports from ./src/*.ts to ./dist/*.js for Node.js
 RUN sed -i 's|"\./src/\(.*\)\.ts"|"./dist/\1.js"|g' packages/shared/package.json
 


### PR DESCRIPTION
Fixes the test-branch build failure: the shared→core split (#1109) made @gruenerator/shared re-export from @gruenerator/core, but the Dockerfiles never copied packages/core, so tsc failed with 'Cannot find module @gruenerator/core/avatar|models' in all 5 image builds. Adds core next to shared in every COPY phase.