### PR TITLE
fix(build): complete @gruenerator/core wiring + dedupe assistant-ui

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -38,6 +38,10 @@ COPY packages/contracts ./packages/contracts
 COPY services/hocuspocus ./services/hocuspocus
 COPY apps/api ./apps/api
 
+# Compile core package (shared re-exports @gruenerator/core; must build first)
+WORKDIR /app/packages/core
+RUN pnpm exec tsc --project tsconfig.json
+
 # Compile shared package (API imports @gruenerator/shared/utils at runtime)
 WORKDIR /app/packages/shared
 RUN pnpm exec tsc --project tsconfig.json

--- a/apps/gruen-o-mat/vite.config.ts
+++ b/apps/gruen-o-mat/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig(({ command }) => ({
       // dist is only present in published builds. Aliasing the source
       // directly bypasses the dist requirement, matching apps/web's setup.
       '@gruenerator/shared': path.resolve(__dirname, '../../packages/shared/src'),
+      // shared/models re-exports from @gruenerator/core; aliases don't cascade,
+      // so core must be aliased to src too (same reason as shared above).
+      '@gruenerator/core': path.resolve(__dirname, '../../packages/core/src'),
     },
   },
   build: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -119,6 +119,12 @@ export default defineConfig(({ command }) => ({
       //   "Rolldown failed to resolve import '@gruenerator/contracts'
       //    from packages/shared/src/api/contractsClient.ts"
       '@gruenerator/contracts': path.resolve(__dirname, '../../packages/contracts/src'),
+      // @gruenerator/core is imported transitively from the @gruenerator/shared
+      // alias (shared/avatar + shared/models re-export from @gruenerator/core).
+      // Same cascade rule as contracts above — alias it to src or Rolldown fails:
+      //   "Rolldown failed to resolve import '@gruenerator/core/models'
+      //    from packages/shared/src/models/index.ts".
+      '@gruenerator/core': path.resolve(__dirname, '../../packages/core/src'),
     },
     // React MUST be deduped to a single physical copy. pnpm installs several
     // react versions (root 19.2.6, plus 19.2.3/19.2.4 nested under deps like
@@ -130,7 +136,24 @@ export default defineConfig(({ command }) => ({
     // We CANNOT pin react via root pnpm.overrides (that forces mobile off its
     // Expo-locked react and breaks the RN renderer — see CLAUDE.md), so the
     // web bundle dedupes here instead.
-    dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'd3-path'],
+    //
+    // @assistant-ui/* MUST be deduped for the same reason: the runtime provider
+    // (AuiProvider, lazy-loaded from @gruenerator/chat) and the thread-list
+    // primitives are pulled through different entry points (workspace src via the
+    // alias above vs. Vite's prebundled .vite/deps). Without dedupe they resolve
+    // to TWO physical instances of the same version, so the React context set by
+    // one is invisible to the other — "requires an AuiProvider" on /workplace
+    // even though the provider is mounted above the consumer.
+    dedupe: [
+      'react',
+      'react-dom',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
+      'd3-path',
+      '@assistant-ui/react',
+      '@assistant-ui/tap',
+      '@assistant-ui/core',
+    ],
   },
   optimizeDeps: {
     include: [

--- a/services/hocuspocus/Dockerfile
+++ b/services/hocuspocus/Dockerfile
@@ -32,6 +32,10 @@ COPY services/hocuspocus ./services/hocuspocus
 WORKDIR /app/packages/contracts
 RUN pnpm exec tsc --project tsconfig.json
 
+# Compile core (shared re-exports @gruenerator/core; must build first)
+WORKDIR /app/packages/core
+RUN pnpm exec tsc --project tsconfig.json
+
 # Compile shared (hocuspocus imports @gruenerator/shared/yjs at runtime)
 WORKDIR /app/packages/shared
 RUN pnpm exec tsc --project tsconfig.json

--- a/services/mcp/Dockerfile
+++ b/services/mcp/Dockerfile
@@ -28,6 +28,10 @@ COPY packages/core ./packages/core
 COPY packages/contracts ./packages/contracts
 COPY services/mcp ./services/mcp
 
+# Compile core package (shared re-exports @gruenerator/core; must build first)
+RUN pnpm --filter @gruenerator/core build
+RUN sed -i 's|"\./src/\(.*\)\.ts"|"./dist/\1.js"|g' /app/packages/core/package.json
+
 # Compile shared package (MCP imports @gruenerator/shared at runtime)
 RUN pnpm --filter @gruenerator/shared build
 # Redirect shared exports from .ts source to compiled .js/.d.ts so MCP's


### PR DESCRIPTION
Fixes the test-branch image build (core never built in Dockerfiles -> core/dist not found; web/gruen-o-mat missing @gruenerator/core vite alias -> Rolldown resolve failure) and the local /workplace crash (assistant-ui resolved to two instances across the Vite prebundle boundary -> 'requires an AuiProvider'; fixed via resolve.dedupe, same as the existing react dedupe).