### PR TITLE
fix(web): unify sidebar vertical rhythm to match nav rows

### DIFF
--- a/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
+++ b/apps/web/src/components/layout/Sidebar/NewItemDropdown.tsx
@@ -95,7 +95,7 @@ const NewItemDropdown = memo(function NewItemDropdown({
   }, [createBoard, navigate, onClose]);
 
   return (
-    <div className="flex flex-col gap-0.5 p-0">
+    <div className="flex flex-col gap-0 p-0">
       <DropdownMenu open={open} onOpenChange={handleOpenChange}>
         <DropdownMenuTrigger asChild>
           <button className={menuLinkClass(false, false, collapsed)} type="button">

--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -454,7 +454,7 @@ const SidebarFavourites = memo(function SidebarFavourites({
   };
 
   return (
-    <div className="flex flex-col gap-0 p-0 mt-1 pt-1">
+    <div className="flex flex-col gap-0 p-0 mt-2">
       {configItems.map((item) =>
         renderRow(
           item.id,

--- a/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
+++ b/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
@@ -175,7 +175,7 @@ const SidebarAccount = memo(function SidebarAccount({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-hover-alt"
+                className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-1 transition-colors hover:bg-hover-alt"
                 aria-label="Benachrichtigungen öffnen"
               >
                 <span className="relative shrink-0">

--- a/packages/chat/src/components/ChatThreadList.tsx
+++ b/packages/chat/src/components/ChatThreadList.tsx
@@ -49,7 +49,7 @@ export function ChatThreadList({ noScroll = false }: ChatThreadListProps = {}) {
   }, []);
 
   const rootClass = noScroll ? 'flex flex-col' : 'flex flex-1 flex-col overflow-hidden';
-  const innerClass = noScroll ? 'px-2 pt-2' : 'flex-1 overflow-y-auto px-2 pt-2 scrollbar-thin';
+  const innerClass = noScroll ? 'px-2' : 'flex-1 overflow-y-auto px-2 pt-2 scrollbar-thin';
 
   return (
     <ThreadListPrimitive.Root className={rootClass}>
@@ -71,10 +71,10 @@ export function ChatThreadList({ noScroll = false }: ChatThreadListProps = {}) {
           <>
             <ThreadListPrimitive.Items components={threadComponents} />
 
-            <div className="mt-4">
+            <div className="mt-2">
               <button
                 onClick={toggleArchived}
-                className="flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium text-foreground-muted transition-colors hover:text-foreground"
+                className="flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium text-foreground-muted transition-colors hover:text-foreground"
               >
                 <Archive className="h-3.5 w-3.5" />
                 Archiviert

--- a/packages/chat/src/components/thread/ThreadListItem.tsx
+++ b/packages/chat/src/components/thread/ThreadListItem.tsx
@@ -38,7 +38,7 @@ function ExternalThreadItem() {
   return (
     <div
       className={cn(
-        'group flex w-full items-center gap-2 rounded-lg px-3 py-2.5 transition-colors',
+        'group flex w-full items-center gap-2 rounded-md px-3 py-1.5 min-h-[34px] transition-colors',
         'hover:bg-secondary-50 dark:hover:bg-secondary-800/40',
         isActive && 'bg-secondary-100 dark:bg-secondary-800/60 font-medium'
       )}
@@ -100,7 +100,7 @@ export function GrueneratorThreadListItem() {
     <>
       <ThreadListItemPrimitive.Root
         className={cn(
-          'group flex w-full items-center gap-2 rounded-lg px-3 py-2.5 transition-colors',
+          'group flex w-full items-center gap-2 rounded-md px-3 py-1.5 min-h-[34px] transition-colors',
           'hover:bg-secondary-50 dark:hover:bg-secondary-800/40',
           'data-[active]:bg-secondary-100 dark:data-[active]:bg-secondary-800/60 data-[active]:font-medium'
         )}
@@ -187,7 +187,7 @@ export function GrueneratorArchivedThreadListItem() {
   return (
     <ThreadListItemPrimitive.Root
       className={cn(
-        'group flex w-full items-center gap-2 rounded-lg px-3 py-2.5 transition-colors',
+        'group flex w-full items-center gap-2 rounded-md px-3 py-1.5 min-h-[34px] transition-colors',
         'hover:bg-secondary-50 dark:hover:bg-secondary-800/40 opacity-60',
         'data-[active]:bg-secondary-100 dark:data-[active]:bg-secondary-800/60 data-[active]:font-medium data-[active]:opacity-100'
       )}


### PR DESCRIPTION
The sidebar was assembled from four independently-styled row systems that never agreed on a vertical rhythm: nav items, the chat list, section margins in the shell, and the account block. The result was three different row heights, ad-hoc section gaps (8/16px), mismatched pill radii (`rounded-md` vs `rounded-lg`), a doubled top gap above "Chats", and an account avatar sitting ~6px left of the icon column. Next to ChatGPT's sidebar the misalignment was obvious.

This standardizes every row on the existing nav rhythm — `py-1.5 min-h-[34px]`, `rounded-md`, an 8px left inset (icon column at 20px), and a single `mt-2` gap between groups — so the sidebar reads as one aligned column. Pure `className` edits; no behavior, color, or type changes. `@gruenerator/web` typecheck is green.

Best checked visually: open the expanded sidebar and confirm one row height across nav / Neu / favourites / chat list / account, the 20px column running through icons and the avatar, and uniform group gaps.