### PR TITLE
fix(web): render sidebar nav icons white in dark mode

### DIFF
--- a/apps/web/src/components/layout/Sidebar/sidebarStyles.ts
+++ b/apps/web/src/components/layout/Sidebar/sidebarStyles.ts
@@ -8,6 +8,6 @@ export const menuLinkClass = (active: boolean, disabled?: boolean, collapsed?: b
     disabled && 'opacity-55 cursor-default pointer-events-none'
   );
 
-// Eucalyptus (secondary-600) — matches the agent icons for one consistent icon colour.
+// Eucalyptus (secondary-600) in light mode; white in dark mode for legibility against the dark sidebar.
 export const iconClass =
-  'text-[1.25rem] text-secondary-600 shrink-0 w-5 flex items-center justify-center transition-colors duration-150';
+  'text-[1.25rem] text-secondary-600 dark:text-white shrink-0 w-5 flex items-center justify-center transition-colors duration-150';


### PR DESCRIPTION
## Problem
The web sidebar nav icons used a hardcoded `text-secondary-600` (eucalyptus) with no dark-mode variant, so they stayed eucalyptus-on-dark and were hard to read in dark mode.

## Fix
Add `dark:text-white` to the `iconClass` in `apps/web/src/components/layout/Sidebar/sidebarStyles.ts`. Light mode is unchanged (still eucalyptus); dark mode renders icons white for legibility against the dark sidebar.

The separate `iconClass` in `SidebarSection.tsx` already uses `text-foreground` (theme-aware) and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)