### PR TITLE
feat(notebook): date-aware ranking + source dates for the answer agent

### DIFF
--- a/apps/api/agents/langgraph/WebSearchGraph/verify-types.ts
+++ b/apps/api/agents/langgraph/WebSearchGraph/verify-types.ts
@@ -103,6 +103,7 @@ const _testCitation: Citation = {
   chunk_index: 0,
   filename: 'file',
   page_number: 1,
+  date: null,
 };
 
 const _testSource: Source = {
@@ -111,6 +112,7 @@ const _testSource: Source = {
   source_url: 'url',
   chunk_text: 'text',
   similarity_score: 0.9,
+  date: null,
   citations: [],
 };
 

--- a/apps/api/agents/langgraph/prompts.ts
+++ b/apps/api/agents/langgraph/prompts.ts
@@ -116,6 +116,7 @@ function buildDraftPrompt(collectionName: string, isPolitical: boolean): PromptC
     '- Verbinde Informationen aus verschiedenen Quellen zu kohärenten Aussagen',
     '- Erkläre auf Basis der Quellen, WARUM etwas wichtig ist, nicht nur WAS gesagt wird',
     '- Bei Widersprüchen in Quellen: Benenne sie transparent',
+    '- Aktualität: Tragen Quellen ein Datum (im Quellen-Block als "(Datum: ...)" angegeben), bevorzuge bei vergleichbarer Relevanz neuere Informationen und benenne relevante Daten im Text (z.B. „laut Beschluss vom März 2024"). Das heutige Datum steht im Nutzer-Prompt. Inhaltliche Qualität bleibt entscheidend.',
     '- Gendere Personenbezeichnungen mit Genderstern (z.B. Bürger*innen, der*die Sprecher*in)',
     '',
     '## QUELLENTREUE:',

--- a/apps/api/services/BaseSearchService/BaseSearchService.ts
+++ b/apps/api/services/BaseSearchService/BaseSearchService.ts
@@ -351,6 +351,7 @@ export class BaseSearchService {
           title: this.extractDocumentTitle(chunk),
           filename: this.extractDocumentFilename(chunk),
           created_at: this.extractDocumentCreatedAt(chunk),
+          published_at: this.extractPublishedAt(chunk),
           source_url: chunk.url || undefined,
           source_id: chunk.source_id ?? null,
           chunks: [],
@@ -365,6 +366,10 @@ export class BaseSearchService {
       }
       if (!docData.source_id && chunk.source_id) {
         docData.source_id = chunk.source_id;
+      }
+      if (!docData.published_at) {
+        const pub = this.extractPublishedAt(chunk);
+        if (pub) docData.published_at = pub;
       }
       const chunkData = this.extractChunkData(chunk);
 
@@ -446,6 +451,7 @@ export class BaseSearchService {
         title: doc.title,
         filename: doc.filename,
         created_at: doc.created_at,
+        published_at: doc.published_at ?? null,
         source_url: doc.source_url,
         source_id: doc.source_id ?? null,
         relevant_content: relevantContent,
@@ -610,6 +616,7 @@ export class BaseSearchService {
       similarity: chunk.similarity,
       token_count: chunk.token_count,
       created_at: chunk.created_at,
+      published_at: chunk.published_at ?? null,
       documents: {
         id: chunk.document_id,
         title: chunk.documents?.title || chunk.document_title,
@@ -645,6 +652,14 @@ export class BaseSearchService {
    */
   extractDocumentCreatedAt(chunk: TransformedChunk): string | undefined {
     return chunk.documents?.created_at;
+  }
+
+  /**
+   * Extract the real publication date from a chunk (Qdrant `published_at`
+   * payload, mapped by the search operations). Null for dateless sources.
+   */
+  extractPublishedAt(chunk: TransformedChunk): string | null {
+    return chunk.published_at ?? null;
   }
 
   /**
@@ -718,6 +733,7 @@ export class BaseSearchService {
           title: this.extractDocumentTitle(chunk),
           filename: this.extractDocumentFilename(chunk),
           created_at: this.extractDocumentCreatedAt(chunk),
+          published_at: this.extractPublishedAt(chunk),
           source_url: chunk.url || undefined,
           source_id: chunk.source_id ?? null,
           chunks: [],
@@ -843,6 +859,7 @@ export class BaseSearchService {
         title: doc.title,
         filename: doc.filename,
         created_at: doc.created_at,
+        published_at: doc.published_at ?? null,
         source_url: doc.source_url,
         source_id: doc.source_id ?? null,
         relevant_content: relevantContent,
@@ -1047,6 +1064,7 @@ export class BaseSearchService {
           title: chunk.documents?.title || chunk.document_title || 'Untitled',
           filename: chunk.documents?.filename || chunk.document_filename || '',
           created_at: chunk.documents?.created_at || chunk.document_created_at,
+          published_at: chunk.published_at ?? null,
           source_url: chunk.url || undefined,
           chunks: [],
           maxSimilarity: 0,
@@ -1094,6 +1112,7 @@ export class BaseSearchService {
         title: doc.title,
         filename: doc.filename,
         created_at: doc.created_at,
+        published_at: doc.published_at ?? null,
         source_url: doc.source_url,
         relevant_content: relevantContent,
         similarity_score: enhancedScore.finalScore,

--- a/apps/api/services/BaseSearchService/types.ts
+++ b/apps/api/services/BaseSearchService/types.ts
@@ -58,6 +58,7 @@ export interface RawChunk {
   similarity: number;
   token_count?: number | undefined;
   created_at?: string | undefined;
+  published_at?: string | null | undefined;
   content_type?: string | undefined;
   page_number?: number | undefined;
   url?: string | undefined;
@@ -102,6 +103,7 @@ export interface TransformedChunk {
   similarity: number;
   token_count?: number | undefined;
   created_at?: string | undefined;
+  published_at?: string | null | undefined;
   source_id?: string | null | undefined;
   url?: string | undefined;
   documents: {
@@ -154,6 +156,7 @@ export interface DocumentData {
   title?: string | undefined;
   filename?: string | undefined;
   created_at?: string | undefined;
+  published_at?: string | null | undefined;
   source_url?: string | undefined;
   source_id?: string | null | undefined;
   chunks: ChunkData[];

--- a/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
+++ b/apps/api/services/document-services/DocumentSearchService/searchOperations.ts
@@ -106,6 +106,8 @@ export async function performTextSearch(
         similarity: result.score || 0,
         token_count: (result.payload?.token_count as number) ?? 0,
         created_at: result.payload?.created_at as string | undefined,
+        published_at:
+          (result.payload?.published_at as string) ?? (metadata?.published_at as string) ?? null,
         searchMethod: 'text',
         originalVectorScore: null,
         originalTextScore: result.score || 0,
@@ -275,6 +277,10 @@ export async function findSimilarChunks(
     content_type: (result.payload.content_type as string) ?? null,
     page_number: (result.payload.page_number as number) ?? null,
     created_at: result.payload.created_at as string | undefined,
+    published_at:
+      (result.payload.published_at as string) ??
+      (result.payload.metadata?.published_at as string) ??
+      null,
     source_id: (result.payload.source_id as string) ?? null,
     url: (result.payload.source_url as string) || (result.payload.url as string) || undefined,
     documents: {
@@ -382,6 +388,8 @@ export async function findHybridChunks(
       content_type: (result.payload.content_type as string) ?? null,
       page_number: (result.payload.page_number as number) ?? null,
       created_at: result.payload.created_at as string | undefined,
+      published_at:
+        (result.payload.published_at as string) ?? (metadata?.published_at as string) ?? null,
       source_id: (result.payload.source_id as string) ?? null,
       url: (result.payload.source_url as string) || (result.payload.url as string) || undefined,
       searchMethod: result.searchMethod || 'hybrid',

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -14,7 +14,6 @@
  * - AI worker pool for draft generation
  */
 
-import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import {
   buildDraftPromptGrundsatz,
   buildDraftPromptGeneral,
@@ -30,6 +29,7 @@ import {
   applyDefaultFilter,
   type SubcategoryFilters,
 } from '../../config/systemCollectionsConfig.js';
+import { getPostgresInstance } from '../../database/services/PostgresService.js';
 import { checkNotebookAccess } from '../../routes/notebook/notebookAccess.js';
 import { createLogger } from '../../utils/logger.js';
 import { getEnrichedPersonSearchService } from '../bundestag/index.js';
@@ -43,6 +43,7 @@ import {
   renumberCitationsInOrder,
   filterAndSortResults,
   groupSourcesByCollection,
+  formatDe,
 } from '../search/index.js';
 
 import type {
@@ -376,7 +377,14 @@ export class NotebookQAService {
     const postFiltered = this._applySourceIdPostFilter(expanded, effectiveFilters);
 
     const deduped = deduplicateResults(postFiltered, false);
-    const sorted = filterAndSortResults(deduped, { threshold: 0.35, limit: 30 });
+    // User collections (!isSystem) may use upload `created_at` as a real date;
+    // system collections rank on `published_at` only (their created_at is index
+    // time). Recency is a mild secondary factor — quality stays decisive.
+    const sorted = filterAndSortResults(deduped, {
+      threshold: 0.35,
+      limit: 30,
+      allowCreatedAt: !isSystem,
+    });
 
     if (sorted.length === 0) {
       const corpus =
@@ -423,7 +431,7 @@ export class NotebookQAService {
     }
 
     // Generate response
-    const referencesMap = buildReferencesMap(sorted);
+    const referencesMap = buildReferencesMap(sorted, { allowCreatedAt: !isSystem });
     const draft = await this._generateDraft(trimmedQuestion, referencesMap, aiWorkerPool, isSystem);
 
     const { renumberedDraft, newReferencesMap } = renumberCitationsInOrder(draft, referencesMap);
@@ -667,14 +675,18 @@ export class NotebookQAService {
     const postFiltered = this._applySourceIdPostFilter(expanded, effectiveFilters);
 
     const deduped = deduplicateResults(postFiltered, false);
-    const sortedResults = filterAndSortResults(deduped, { threshold: 0.35, limit: 30 });
+    const sortedResults = filterAndSortResults(deduped, {
+      threshold: 0.35,
+      limit: 30,
+      allowCreatedAt: !isSystem,
+    });
 
     if (sortedResults.length === 0) {
       return null;
     }
 
     // Build references map and context
-    const referencesMap = buildReferencesMap(sortedResults);
+    const referencesMap = buildReferencesMap(sortedResults, { allowCreatedAt: !isSystem });
     const { systemPrompt, contextSummary } = this._buildStreamingContext(referencesMap, isSystem);
 
     return {
@@ -697,15 +709,23 @@ export class NotebookQAService {
     referencesMap: ReferencesMap,
     isSystemCollection: boolean
   ): { systemPrompt: string; contextSummary: string } {
-    const contextSummary = Object.keys(referencesMap)
+    const today = new Date().toLocaleDateString('de-DE', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+    const sourceLines = Object.keys(referencesMap)
       .map((id) => {
         const ref = referencesMap[id];
         const snippet = ref.snippets[0]?.[0] || '';
         const short = snippet.slice(0, 400).replace(/\s+/g, ' ').trim();
         const collectionTag = ref.collection_name ? `[${ref.collection_name}] ` : '';
-        return `${id}. ${collectionTag}${ref.title} — "${short}"`;
+        const dateLabel = formatDe(ref.date);
+        const datePart = dateLabel ? `(Datum: ${dateLabel}) ` : '';
+        return `${id}. ${collectionTag}${datePart}${ref.title} — "${short}"`;
       })
       .join('\n');
+    const contextSummary = `Heutiges Datum: ${today}\n\n${sourceLines}`;
 
     const { system: systemPrompt } = isSystemCollection
       ? buildDraftPromptGrundsatz('Grüne Dokumente')
@@ -884,7 +904,9 @@ export class NotebookQAService {
         const snippet = ref.snippets[0]?.[0] || '';
         const short = snippet.slice(0, 400).replace(/\s+/g, ' ').trim();
         const collectionTag = ref.collection_name ? `[${ref.collection_name}] ` : '';
-        return `${id}. ${collectionTag}${ref.title} — "${short}"`;
+        const dateLabel = formatDe(ref.date);
+        const datePart = dateLabel ? `(Datum: ${dateLabel}) ` : '';
+        return `${id}. ${collectionTag}${datePart}${ref.title} — "${short}"`;
       })
       .join('\n');
 
@@ -893,7 +915,12 @@ export class NotebookQAService {
       : buildDraftPromptGeneral('Ihre Dokumente');
 
     const validIds = refKeys.join(', ');
-    const userPrompt = `Frage: ${question}\n\nGültige Quellen-IDs: ${validIds}\nVerwende AUSSCHLIESSLICH diese IDs für Quellenangaben.\n\nVerfügbare Quellen:\n${refsSummary}`;
+    const today = new Date().toLocaleDateString('de-DE', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
+    const userPrompt = `Heutiges Datum: ${today}\n\nFrage: ${question}\n\nGültige Quellen-IDs: ${validIds}\nVerwende AUSSCHLIESSLICH diese IDs für Quellenangaben.\n\nVerfügbare Quellen:\n${refsSummary}`;
 
     const aiResult = await aiWorkerPool.processRequest({
       type: 'qa_draft',
@@ -924,12 +951,19 @@ export class NotebookQAService {
       .map((r) => {
         const snippet = r.snippet.slice(0, 300).replace(/\s+/g, ' ').trim();
         const collectionTag = r.collection_name ? `[${r.collection_name}] ` : '';
-        return `${collectionTag}${r.title}: "${snippet}"`;
+        const dateLabel = formatDe(r.published_at ?? r.date ?? null);
+        const datePart = dateLabel ? `(Datum: ${dateLabel}) ` : '';
+        return `${collectionTag}${datePart}${r.title}: "${snippet}"`;
       })
       .join('\n\n');
 
+    const today = new Date().toLocaleDateString('de-DE', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    });
     const { system: systemPrompt } = buildFastModePrompt();
-    const userPrompt = `Frage: ${question}\n\nKontext:\n${context}`;
+    const userPrompt = `Heutiges Datum: ${today}\n\nFrage: ${question}\n\nKontext:\n${context}`;
 
     const aiResult = await aiWorkerPool.processRequest({
       type: 'qa_draft_fast',

--- a/apps/api/services/notebook/types.ts
+++ b/apps/api/services/notebook/types.ts
@@ -10,6 +10,7 @@ import type {
   SourcesByCollection as SearchSourcesByCollection,
   ReferencesMap,
 } from '../search/types.js';
+import type { NotebookCitation } from '@gruenerator/contracts';
 
 /**
  * Request filters for search
@@ -19,27 +20,12 @@ export interface RequestFilters {
 }
 
 /**
- * Citation in QA response
- * Can be either a search citation or a custom citation format
+ * Citation in QA response. Single source of truth lives in the contract
+ * (`notebookCitationSchema`); we alias the inferred type so the service, the
+ * HTTP response, and the frontend all share one shape. Carries `date` (real
+ * publication/upload date of the source, or null).
  */
-export interface Citation {
-  index: string;
-  title?: string | undefined;
-  url?: string | null | undefined;
-  snippet?: string | undefined;
-  source?: string | undefined;
-  type?: string | undefined;
-  cited_text?: string | undefined;
-  document_title?: string | undefined;
-  document_id?: string | undefined;
-  source_url?: string | null | undefined;
-  similarity_score?: number | undefined;
-  chunk_index?: number | undefined;
-  filename?: string | null | undefined;
-  page_number?: number | null | undefined;
-  collection_id?: string | undefined;
-  collection_name?: string | undefined;
-}
+export type Citation = NotebookCitation;
 
 /**
  * Multi-collection metadata

--- a/apps/api/services/search/SearchResultProcessor.ts
+++ b/apps/api/services/search/SearchResultProcessor.ts
@@ -7,6 +7,8 @@
  * - Source grouping by collection
  */
 
+import { recencyBoost, resolveSourceDate } from './recency.js';
+
 import type {
   SearchResultInput,
   ExpandedChunkResult,
@@ -36,6 +38,9 @@ export function expandResultsToChunks(
     const sourceUrl = r.source_url || r.url || null;
     const docId = r.document_id || sourceUrl || '';
 
+    const publishedAt = r.published_at ?? null;
+    const createdAt = r.created_at;
+
     if (topChunks.length > 0) {
       for (const chunk of topChunks) {
         expanded.push({
@@ -48,6 +53,8 @@ export function expandResultsToChunks(
           similarity: r.similarity_score || 0,
           chunk_index: chunk.chunk_index,
           page_number: chunk.page_number ?? null,
+          published_at: publishedAt,
+          ...(createdAt && { created_at: createdAt }),
           ...(collectionId && { collection_id: collectionId }),
           ...(collectionName && { collection_name: collectionName }),
         });
@@ -63,6 +70,8 @@ export function expandResultsToChunks(
         similarity: typeof r.similarity_score === 'number' ? r.similarity_score : 0,
         chunk_index: r.chunk_index || 0,
         page_number: null,
+        published_at: publishedAt,
+        ...(createdAt && { created_at: createdAt }),
         ...(collectionId && { collection_id: collectionId }),
         ...(collectionName && { collection_name: collectionName }),
       });
@@ -96,9 +105,16 @@ export function deduplicateResults(
 }
 
 /**
- * Build references map from search results for citation processing
+ * Build references map from search results for citation processing.
+ *
+ * `date` is the source's real publication date (or upload date when
+ * `allowCreatedAt` is set for user collections), or null when none — NOT the
+ * response timestamp. Consumed by the answer prompt and returned in citations.
  */
-export function buildReferencesMap(results: ExpandedChunkResult[]): ReferencesMap {
+export function buildReferencesMap(
+  results: ExpandedChunkResult[],
+  options: { allowCreatedAt?: boolean | undefined } = {}
+): ReferencesMap {
   const referencesMap: ReferencesMap = {};
 
   for (let i = 0; i < results.length; i++) {
@@ -109,7 +125,7 @@ export function buildReferencesMap(results: ExpandedChunkResult[]): ReferencesMa
       title: r.title,
       snippets: [[r.snippet]],
       description: null,
-      date: new Date().toISOString(),
+      date: resolveSourceDate(r, { allowCreatedAt: options.allowCreatedAt }),
       source: 'qa_documents',
       document_id: r.document_id,
       source_url: r.source_url || null,
@@ -177,6 +193,7 @@ export function validateAndInjectCitations(
       chunk_index: ref.chunk_index,
       filename: ref.filename,
       page_number: ref.page_number,
+      date: ref.date ?? null,
       ...(ref.collection_id && { collection_id: ref.collection_id }),
       ...(ref.collection_name && { collection_name: ref.collection_name }),
     };
@@ -188,6 +205,7 @@ export function validateAndInjectCitations(
       document_id: string;
       document_title: string;
       source_url: string | null;
+      date: string | null;
       chunk_texts: string[];
       similarity_scores: number[];
       citations: Citation[];
@@ -201,6 +219,7 @@ export function validateAndInjectCitations(
         document_id: c.document_id,
         document_title: c.document_title,
         source_url: c.source_url || null,
+        date: c.date ?? null,
         chunk_texts: [c.cited_text],
         similarity_scores: [c.similarity_score],
         citations: [],
@@ -209,6 +228,7 @@ export function validateAndInjectCitations(
       const doc = byDoc.get(key)!;
       doc.chunk_texts.push(c.cited_text);
       doc.similarity_scores.push(c.similarity_score);
+      if (!doc.date && c.date) doc.date = c.date;
     }
     byDoc.get(key)!.citations.push(c);
   }
@@ -219,6 +239,7 @@ export function validateAndInjectCitations(
     source_url: source.source_url || null,
     chunk_text: source.chunk_texts.join(' [...] '),
     similarity_score: Math.max(...source.similarity_scores),
+    date: source.date,
     citations: source.citations,
   }));
 
@@ -269,17 +290,25 @@ export function renumberCitationsInOrder(
 }
 
 /**
- * Sort results by similarity score and apply quality threshold
+ * Sort results by similarity, with a mild recency boost as a secondary factor.
+ *
+ * The `threshold` gate is on raw `similarity` (recency only re-orders sources
+ * that already qualify — it never rescues a weak source). The boost is additive
+ * and small (see recency.ts), so content quality stays decisive; dateless
+ * sources get boost 0 and keep pure-similarity behaviour.
  */
 export function filterAndSortResults(
   results: ExpandedChunkResult[],
   options: FilterOptions = {}
 ): ExpandedChunkResult[] {
-  const { threshold = 0.35, limit = 40 } = options;
+  const { threshold = 0.35, limit = 40, now = new Date(), allowCreatedAt } = options;
+
+  const effective = (r: ExpandedChunkResult): number =>
+    r.similarity + recencyBoost(resolveSourceDate(r, { allowCreatedAt }), now);
 
   return results
     .filter((r) => r.similarity >= threshold)
-    .sort((a, b) => b.similarity - a.similarity)
+    .sort((a, b) => effective(b) - effective(a))
     .slice(0, limit);
 }
 
@@ -306,6 +335,7 @@ export function groupSourcesByCollection(
         document_id: string;
         document_title: string;
         source_url: string | null;
+        date: string | null;
         chunk_texts: string[];
         similarity_scores: number[];
         citations: Citation[];
@@ -319,6 +349,7 @@ export function groupSourcesByCollection(
           document_id: c.document_id,
           document_title: c.document_title,
           source_url: c.source_url || null,
+          date: c.date ?? null,
           chunk_texts: [c.cited_text],
           similarity_scores: [c.similarity_score],
           citations: [],
@@ -327,6 +358,7 @@ export function groupSourcesByCollection(
         const doc = byDoc.get(key)!;
         doc.chunk_texts.push(c.cited_text);
         doc.similarity_scores.push(c.similarity_score);
+        if (!doc.date && c.date) doc.date = c.date;
       }
       byDoc.get(key)!.citations.push(c);
     }
@@ -337,6 +369,7 @@ export function groupSourcesByCollection(
       source_url: source.source_url || null,
       chunk_text: source.chunk_texts.join(' [...] '),
       similarity_score: Math.max(...source.similarity_scores),
+      date: source.date,
       citations: source.citations,
     }));
 

--- a/apps/api/services/search/index.ts
+++ b/apps/api/services/search/index.ts
@@ -35,6 +35,16 @@ export type { RetryOptions } from './searchRetryStrategy.js';
 export { analyzeTemporality } from './TemporalAnalyzer.js';
 export type { TemporalAnalysis, TemporalUrgency } from './TemporalAnalyzer.js';
 
+// Export recency helpers (date-aware ranking + source-date formatting)
+export {
+  resolveSourceDate,
+  recencyBoost,
+  formatDe,
+  DEFAULT_HALF_LIFE_DAYS,
+  DEFAULT_MAX_BOOST,
+} from './recency.js';
+export type { DateResolvable, RecencyBoostOptions, ResolveDateOptions } from './recency.js';
+
 // Export crawling service
 export { selectAndCrawlTopUrls } from './CrawlingService.js';
 export type { CrawlableResult, CrawledResult } from './CrawlingService.js';

--- a/apps/api/services/search/recency.ts
+++ b/apps/api/services/search/recency.ts
@@ -1,0 +1,100 @@
+/**
+ * Recency helpers for date-aware ranking and source-date display.
+ *
+ * Content quality stays decisive — recency is one mild factor that only applies
+ * when a source carries a genuine date. Pure functions (the caller passes `now`)
+ * so they are deterministic and unit-testable, mirroring TemporalAnalyzer.ts.
+ */
+
+/** Mild defaults (see plan): a year half-life, small additive boost. */
+export const DEFAULT_HALF_LIFE_DAYS = 365;
+export const DEFAULT_MAX_BOOST = 0.06;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface RecencyBoostOptions {
+  halfLifeDays?: number | undefined;
+  maxBoost?: number | undefined;
+}
+
+/**
+ * Source-shaped input for {@link resolveSourceDate}. Matches the fields carried
+ * on SearchResultInput / ExpandedChunkResult.
+ */
+export interface DateResolvable {
+  published_at?: string | null | undefined;
+  created_at?: string | undefined;
+  date?: string | null | undefined;
+  metadata?: Record<string, unknown> | null | undefined;
+}
+
+export interface ResolveDateOptions {
+  /**
+   * Allow falling back to `created_at` as a genuine date. True only for the
+   * user `documents` collection (created_at = upload time). False for system
+   * collections, whose created_at is index time — not a real publication date,
+   * so timeless docs (Grundsatzprogramme) stay neutral.
+   */
+  allowCreatedAt?: boolean | undefined;
+}
+
+/**
+ * Resolve the best *real* date for a source, or null when none exists.
+ * Precedence: explicit `date` → `published_at` → metadata published/date →
+ * (optionally) `created_at`.
+ */
+export function resolveSourceDate(
+  input: DateResolvable,
+  options: ResolveDateOptions = {}
+): string | null {
+  if (input.date) return input.date;
+  if (input.published_at) return input.published_at;
+
+  const meta = input.metadata;
+  if (meta) {
+    const metaPublished = meta.published_at;
+    if (typeof metaPublished === 'string' && metaPublished) return metaPublished;
+    const metaDate = meta.date;
+    if (typeof metaDate === 'string' && metaDate) return metaDate;
+  }
+
+  if (options.allowCreatedAt && input.created_at) return input.created_at;
+
+  return null;
+}
+
+/**
+ * Mild recency boost in [0, maxBoost], added to a 0–1 similarity score.
+ * Exponential decay by age: `maxBoost * 0.5 ** (ageDays / halfLifeDays)`.
+ * Returns 0 for null / unparseable / future dates (never penalizes).
+ */
+export function recencyBoost(
+  dateIso: string | null | undefined,
+  now: Date,
+  options: RecencyBoostOptions = {}
+): number {
+  if (!dateIso) return 0;
+
+  const halfLifeDays = options.halfLifeDays ?? DEFAULT_HALF_LIFE_DAYS;
+  const maxBoost = options.maxBoost ?? DEFAULT_MAX_BOOST;
+
+  const parsed = Date.parse(dateIso);
+  if (Number.isNaN(parsed)) return 0;
+
+  const ageDays = (now.getTime() - parsed) / MS_PER_DAY;
+  if (ageDays <= 0) return maxBoost; // today or (clock-skew) future → freshest
+
+  const boost = maxBoost * Math.pow(0.5, ageDays / halfLifeDays);
+  return Math.max(0, Math.min(maxBoost, boost));
+}
+
+/**
+ * Format an ISO date for German prompts/UI (e.g. "März 2024"). Returns '' for
+ * empty/unparseable input so callers can omit the date cleanly.
+ */
+export function formatDe(dateIso: string | null | undefined): string {
+  if (!dateIso) return '';
+  const parsed = Date.parse(dateIso);
+  if (Number.isNaN(parsed)) return '';
+  return new Date(parsed).toLocaleDateString('de-DE', { year: 'numeric', month: 'long' });
+}

--- a/apps/api/services/search/recency.vitest.ts
+++ b/apps/api/services/search/recency.vitest.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for date-aware ranking helpers.
+ *
+ * Pins the contract: recency is a *mild* secondary factor — content quality
+ * (similarity) stays decisive. The boost is 0 for dateless/future sources, and
+ * `filterAndSortResults` only re-orders sources that already pass the similarity
+ * threshold (it never rescues a weak source).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  recencyBoost,
+  resolveSourceDate,
+  formatDe,
+  DEFAULT_MAX_BOOST,
+  DEFAULT_HALF_LIFE_DAYS,
+} from './recency.js';
+import { filterAndSortResults } from './SearchResultProcessor.js';
+import type { ExpandedChunkResult } from './types.js';
+
+const NOW = new Date('2026-06-05T00:00:00Z');
+const daysAgo = (n: number): string =>
+  new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+
+describe('recencyBoost', () => {
+  it('is 0 for null / unparseable dates', () => {
+    expect(recencyBoost(null, NOW)).toBe(0);
+    expect(recencyBoost(undefined, NOW)).toBe(0);
+    expect(recencyBoost('not-a-date', NOW)).toBe(0);
+  });
+
+  it('is 0 (no penalty) for future dates, capped at maxBoost otherwise', () => {
+    expect(recencyBoost(daysAgo(-30), NOW)).toBe(DEFAULT_MAX_BOOST); // future → freshest, not negative
+    expect(recencyBoost(daysAgo(0), NOW)).toBe(DEFAULT_MAX_BOOST);
+  });
+
+  it('decays to ~half of maxBoost after one half-life', () => {
+    const boost = recencyBoost(daysAgo(DEFAULT_HALF_LIFE_DAYS), NOW);
+    expect(boost).toBeCloseTo(DEFAULT_MAX_BOOST / 2, 5);
+  });
+
+  it('is monotonically decreasing with age', () => {
+    const young = recencyBoost(daysAgo(30), NOW);
+    const mid = recencyBoost(daysAgo(200), NOW);
+    const old = recencyBoost(daysAgo(1000), NOW);
+    expect(young).toBeGreaterThan(mid);
+    expect(mid).toBeGreaterThan(old);
+  });
+
+  it('stays small — never exceeds maxBoost', () => {
+    for (const d of [0, 1, 100, 365, 5000]) {
+      expect(recencyBoost(daysAgo(d), NOW)).toBeLessThanOrEqual(DEFAULT_MAX_BOOST);
+    }
+  });
+});
+
+describe('resolveSourceDate', () => {
+  it('prefers published_at, then metadata, then (opt-in) created_at', () => {
+    expect(resolveSourceDate({ published_at: '2024-01-01' })).toBe('2024-01-01');
+    expect(resolveSourceDate({ metadata: { published_at: '2023-05-05' } })).toBe('2023-05-05');
+    expect(resolveSourceDate({ metadata: { date: '2022-02-02' } })).toBe('2022-02-02');
+  });
+
+  it('returns null when only created_at exists and allowCreatedAt is off', () => {
+    expect(resolveSourceDate({ created_at: '2020-01-01' })).toBeNull();
+    expect(resolveSourceDate({ created_at: '2020-01-01' }, { allowCreatedAt: true })).toBe(
+      '2020-01-01'
+    );
+  });
+
+  it('returns null for a fully dateless source', () => {
+    expect(resolveSourceDate({})).toBeNull();
+  });
+});
+
+describe('formatDe', () => {
+  it('formats month + year and is empty for bad input', () => {
+    expect(formatDe('2024-03-15')).toMatch(/2024/);
+    expect(formatDe(null)).toBe('');
+    expect(formatDe('nope')).toBe('');
+  });
+});
+
+describe('filterAndSortResults recency', () => {
+  const make = (over: Partial<ExpandedChunkResult>): ExpandedChunkResult => ({
+    document_id: 'd',
+    source_url: null,
+    title: 't',
+    snippet: 's',
+    filename: null,
+    similarity: 0.5,
+    chunk_index: 0,
+    page_number: null,
+    ...over,
+  });
+
+  it('a clearly more relevant OLD doc still beats a fresh weaker one', () => {
+    const oldStrong = make({ document_id: 'old', similarity: 0.9, published_at: daysAgo(2000) });
+    const newWeak = make({ document_id: 'new', similarity: 0.6, published_at: daysAgo(1) });
+    const sorted = filterAndSortResults([newWeak, oldStrong], { now: NOW });
+    expect(sorted[0].document_id).toBe('old'); // quality decisive: 0.06 boost can't close a 0.3 gap
+  });
+
+  it('near-equal docs re-order newer-first', () => {
+    const olderA = make({ document_id: 'a', similarity: 0.7, published_at: daysAgo(1500) });
+    const newerB = make({ document_id: 'b', similarity: 0.7, published_at: daysAgo(10) });
+    const sorted = filterAndSortResults([olderA, newerB], { now: NOW });
+    expect(sorted[0].document_id).toBe('b');
+  });
+
+  it('dateless sources are unaffected (pure similarity)', () => {
+    const a = make({ document_id: 'a', similarity: 0.8 });
+    const b = make({ document_id: 'b', similarity: 0.6 });
+    const sorted = filterAndSortResults([b, a], { now: NOW });
+    expect(sorted.map((r) => r.document_id)).toEqual(['a', 'b']);
+  });
+
+  it('still gates on raw similarity — recency does not rescue a sub-threshold source', () => {
+    const fresh = make({ document_id: 'fresh', similarity: 0.2, published_at: daysAgo(0) });
+    const sorted = filterAndSortResults([fresh], { now: NOW, threshold: 0.35 });
+    expect(sorted).toHaveLength(0);
+  });
+});

--- a/apps/api/services/search/types.ts
+++ b/apps/api/services/search/types.ts
@@ -117,6 +117,11 @@ export interface SearchResultInput {
   relevant_content?: string | undefined;
   chunk_text?: string | undefined;
   chunk_index?: number | undefined;
+  // Real publication date from the Qdrant payload (web/scraped content) and
+  // upload timestamp; carried through from DocumentResult so the notebook layer
+  // can rank by recency and cite source dates. Absent on dateless sources.
+  published_at?: string | null | undefined;
+  created_at?: string | undefined;
 }
 
 export interface ExpandedChunkResult {
@@ -131,13 +136,19 @@ export interface ExpandedChunkResult {
   page_number: number | null;
   collection_id?: string | undefined;
   collection_name?: string | undefined;
+  // Resolved real date of the source (published_at, else upload created_at),
+  // or null when none. Used for recency ranking and source-date citation.
+  date?: string | null | undefined;
+  published_at?: string | null | undefined;
+  created_at?: string | undefined;
 }
 
 export interface ReferenceData {
   title: string;
   snippets: string[][];
   description: string | null;
-  date: string;
+  // Real source date (published_at, else upload date) or null when none.
+  date: string | null;
   source: string;
   document_id: string;
   source_url: string | null;
@@ -165,6 +176,9 @@ export interface Citation {
   page_number: number | null;
   collection_id?: string | undefined;
   collection_name?: string | undefined;
+  // Real source date (or null) — mirrors ReferenceData.date. Strict producer
+  // type; structurally assignable to the broad contract NotebookCitation.
+  date: string | null;
 }
 
 export interface Source {
@@ -173,6 +187,7 @@ export interface Source {
   source_url: string | null;
   chunk_text: string;
   similarity_score: number;
+  date: string | null;
   citations: Citation[];
 }
 
@@ -186,6 +201,11 @@ export interface ValidationResult {
 export interface FilterOptions {
   threshold?: number | undefined;
   limit?: number | undefined;
+  // Recency ranking: `now` is injectable for deterministic tests; when
+  // `allowCreatedAt` is set, upload `created_at` counts as a real date (user
+  // collections only). Omit both to keep pure-similarity ordering.
+  now?: Date | undefined;
+  allowCreatedAt?: boolean | undefined;
 }
 
 export interface DedupeOptions {

--- a/packages/chat/src/runtime/NotebookModelAdapter.ts
+++ b/packages/chat/src/runtime/NotebookModelAdapter.ts
@@ -3,6 +3,7 @@ import type {
   ChatModelRunOptions,
   ChatModelRunResult,
 } from '@assistant-ui/react';
+import type { NotebookCitation, NotebookSource } from '@gruenerator/contracts';
 import {
   type ChatProgress,
   type Citation as ChatCitation,
@@ -67,28 +68,10 @@ export interface NotebookAdapterConfig {
   onCustomEvent?: (event: string, data: unknown) => void;
 }
 
-export interface Citation {
-  index: string;
-  cited_text?: string;
-  document_title?: string;
-  document_id?: string;
-  source_url?: string | null;
-  similarity_score?: number;
-  chunk_index?: number;
-  filename?: string | null;
-  page_number?: number | null;
-  collection_id?: string;
-  collection_name?: string;
-}
-
-export interface Source {
-  document_id: string;
-  document_title: string;
-  source_url: string | null;
-  chunk_text: string;
-  similarity_score: number;
-  citations: Citation[];
-}
+// Single source of truth: the notebook ask contract. These carry `date`
+// (real source publication/upload date, or null) end-to-end.
+export type Citation = NotebookCitation;
+export type Source = NotebookSource;
 
 export interface LinkConfig {
   type: 'external' | 'vectorDocument';

--- a/packages/contracts/src/schemas/notebook.ts
+++ b/packages/contracts/src/schemas/notebook.ts
@@ -54,28 +54,72 @@ export const notebookPublicCollectionResponseSchema = z.object({
 });
 
 /**
- * QA response mirrors `QAResponse` from apps/api/services/notebook/types.ts.
- * Fields `citations`, `sources`, `allSources`, `metadata` are left loosely
- * typed (`z.unknown()`) because their inner shapes are deeply nested unions
- * of Citation / SearchSource / ExpandedChunkResult / multiple metadata types.
- * `.passthrough()` preserves any extra fields the service adds over time.
+ * Citation in a QA answer. Single source of truth for the cited-source shape
+ * returned by the notebook ask endpoints (mirrors the broad `Citation` union in
+ * apps/api/services/notebook/types.ts — most fields are `.nullish()` because the
+ * person-query path emits a different field subset than the document path).
  *
- * If a frontend consumer needs one of those inner shapes typed strictly,
- * add the inner schema here and narrow the field — fix at the source.
+ * `date` is the source's real publication date (or upload date for user docs);
+ * `null` when the source carries no usable date. Set in
+ * `buildReferencesMap` (SearchResultProcessor) from the Qdrant `published_at`
+ * payload — NOT the response timestamp.
+ */
+export const notebookCitationSchema = z.object({
+  index: z.string(),
+  // Nullability mirrors the producer types exactly: plain `.optional()` for
+  // `T | undefined` fields, `.nullable().optional()` only where the value is
+  // genuinely nullable. `date` is the real source date (or null).
+  date: z.string().nullable().optional(),
+  cited_text: z.string().optional(),
+  document_title: z.string().optional(),
+  document_id: z.string().optional(),
+  source_url: z.string().nullable().optional(),
+  similarity_score: z.number().optional(),
+  chunk_index: z.number().optional(),
+  filename: z.string().nullable().optional(),
+  page_number: z.number().nullable().optional(),
+  collection_id: z.string().optional(),
+  collection_name: z.string().optional(),
+  // Person-query / custom citation fields
+  title: z.string().optional(),
+  url: z.string().nullable().optional(),
+  snippet: z.string().optional(),
+  source: z.string().optional(),
+  type: z.string().optional(),
+});
+export type NotebookCitation = z.infer<typeof notebookCitationSchema>;
+
+/**
+ * A source (document) grouped from one or more citations. `date` mirrors
+ * `notebookCitationSchema.date`.
+ */
+export const notebookSourceSchema = z.object({
+  document_id: z.string(),
+  document_title: z.string(),
+  source_url: z.string().nullable(),
+  chunk_text: z.string(),
+  similarity_score: z.number(),
+  date: z.string().nullable().optional(),
+  citations: z.array(notebookCitationSchema),
+});
+export type NotebookSource = z.infer<typeof notebookSourceSchema>;
+
+/**
+ * QA response mirrors `QAResponse` from apps/api/services/notebook/types.ts.
+ * `citations` is strongly typed (it is the canonical cited-source list the UI
+ * renders, and now carries `date`). `sources`, `allSources`, `metadata` stay
+ * loosely typed (`z.unknown()`) — their inner shapes are deeply nested unions
+ * (SearchSource / ExpandedChunkResult / multiple metadata types) and narrowing
+ * them would strip branch-specific fields at serialize time.
  */
 export const notebookQAResponseSchema = z.object({
   success: z.boolean(),
   answer: z.string(),
+  citations: z.array(notebookCitationSchema).nullish(),
   // Loosely-typed fields use z.unknown() because the service returns strict
   // union types (MultiCollectionMetadata | SingleCollectionMetadata | ...)
   // that don't have index signatures. The inferred schema type for these
   // fields becomes `unknown`, which every concrete type assigns to.
-  //
-  // NOTE: no `.passthrough()` — Zod strips unknown fields at serialize time.
-  // This is safe for response validation; we only care about the shape above,
-  // and `.passthrough()` makes the inferred type require an index signature
-  // at the top level, which QAResponse doesn't have.
-  citations: z.unknown(),
   sources: z.unknown(),
   allSources: z.unknown(),
   sourcesByCollection: z.unknown().nullish(),


### PR DESCRIPTION
## Why

Notebook answers (MCP `gruenerator_notebook_ask` → `/ask` → `NotebookQAService`) ranked retrieved sources **purely by similarity** and gave the answer-writing LLM **no date information**. Two concrete gaps:

1. **Real source dates were discarded.** `buildReferencesMap` hard-coded each source's `date` to `new Date().toISOString()` (today).
2. **A latent wiring gap:** every scraper writes a real `published_at` into the Qdrant payload, and `DocumentResult.published_at` is declared — but `published_at` was **never mapped through the search pipeline**, so it was always `undefined`. As a result the existing research date-sort (`sortBy=date_desc`/`date_asc`) was effectively dead.

## What

- **Wire `published_at`** from the Qdrant payload through the chunk mappers and `BaseSearchService` aggregation onto `DocumentResult`. This also **revives the existing research date-sort** for free.
- **New pure helper `services/search/recency.ts`** — `resolveSourceDate`, `recencyBoost` (mild: ~365-day half-life, +0.06 max additive boost), `formatDe`.
- **`filterAndSortResults`** now sorts by `similarity + recencyBoost(...)`. Recency is a *secondary* factor — content quality/similarity stays decisive, the similarity `threshold` gate is unchanged (recency never rescues a weak source), and the boost applies **only to sources with a real date** (`published_at`, or upload `created_at` for user collections). Dateless/timeless docs (Grundsatzprogramme) stay neutral.
- **`buildReferencesMap`** stores the real source date; citations and sources now carry `date`.
- **Answer prompt** gets **today's date + each source's date**, plus a `STIL-REGELN` instruction to prefer newer info among comparable sources and name relevant dates (e.g. „laut Beschluss vom März 2024").

## Contract-first / type-safe

Per the repo 4-layer rule:
- Added `notebookCitationSchema` / `notebookSourceSchema` (with `date`) to `@gruenerator/contracts`; narrowed the ask response `citations` field from `z.unknown()`.
- API + chat `Citation`/`Source` types now **derive via `z.infer`** from the contract — removing the previous 3-way hand-written duplication.
- No DB migration / no Qdrant re-index (`published_at` already exists in the payload; `documents` keeps `created_at` only).

## Tests / checks

- `services/search/recency.vitest.ts` — 13 cases (boost decay/caps, date resolution precedence, sort behaviour: strong-old-still-wins, near-equal reorders newer-first, dateless unaffected, threshold still gates).
- `typecheck` green across **api / chat / web / contracts**; lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)