### PR TITLE
refactor(contracts): type notebook QA person + collection settings (zero-risk)

### DIFF
--- a/packages/contracts/src/schemas/notebook.ts
+++ b/packages/contracts/src/schemas/notebook.ts
@@ -54,34 +54,34 @@ export const notebookPublicCollectionResponseSchema = z.object({
 });
 
 /**
+ * Person info returned by the bundestagsfraktion person-query path. Mirrors
+ * `PersonInfo` in apps/api/services/notebook/types.ts.
+ */
+export const notebookPersonInfoSchema = z.object({
+  name: z.string().optional(),
+  fraktion: z.union([z.string(), z.array(z.string())]).optional(),
+  wahlkreis: z.string().optional(),
+  biografie: z.string().optional(),
+});
+export type NotebookPersonInfo = z.infer<typeof notebookPersonInfoSchema>;
+
+/**
  * QA response mirrors `QAResponse` from apps/api/services/notebook/types.ts.
- * Fields `citations`, `sources`, `allSources`, `metadata` are left loosely
- * typed (`z.unknown()`) because their inner shapes are deeply nested unions
- * of Citation / SearchSource / ExpandedChunkResult / multiple metadata types.
- * `.passthrough()` preserves any extra fields the service adds over time.
- *
- * If a frontend consumer needs one of those inner shapes typed strictly,
- * add the inner schema here and narrow the field — fix at the source.
+ * `person` is strongly typed; `citations`, `sources`, `allSources`, `metadata`
+ * stay loosely typed (`z.unknown()`) because their inner shapes are deeply
+ * nested unions (Citation / SearchSource / ExpandedChunkResult / multiple
+ * metadata types) and narrowing them would strip branch-specific fields.
  */
 export const notebookQAResponseSchema = z.object({
   success: z.boolean(),
   answer: z.string(),
-  // Loosely-typed fields use z.unknown() because the service returns strict
-  // union types (MultiCollectionMetadata | SingleCollectionMetadata | ...)
-  // that don't have index signatures. The inferred schema type for these
-  // fields becomes `unknown`, which every concrete type assigns to.
-  //
-  // NOTE: no `.passthrough()` — Zod strips unknown fields at serialize time.
-  // This is safe for response validation; we only care about the shape above,
-  // and `.passthrough()` makes the inferred type require an index signature
-  // at the top level, which QAResponse doesn't have.
   citations: z.unknown(),
   sources: z.unknown(),
   allSources: z.unknown(),
   sourcesByCollection: z.unknown().nullish(),
   metadata: z.unknown(),
   isPersonQuery: z.boolean().nullish(),
-  person: z.unknown().nullish(),
+  person: notebookPersonInfoSchema.nullish(),
 });
 
 // ── Per-notebook manual research (chunk-level Qdrant search) ────────────────

--- a/packages/contracts/src/schemas/notebookCollections.ts
+++ b/packages/contracts/src/schemas/notebookCollections.ts
@@ -181,8 +181,11 @@ export const transformedCollectionSchema = z.object({
   wolke_share_links: z.array(wolkeShareLinkSchema),
   has_wolke_sources: z.boolean(),
   documents_from_wolke: z.number(),
-  // Optional fields that may be present on the raw Qdrant shape
-  settings: z.unknown().nullish(),
+  // Optional fields that may be present on the raw Qdrant shape. `settings` is
+  // a JSONB bag (labels / wolke_folders / linked_docs + future keys) — typed as
+  // an indexable record (not opaque `unknown`) so consumers can read keys
+  // without a cast; values stay `unknown` and nothing is stripped on the wire.
+  settings: z.record(z.unknown()).nullish(),
   notebook_collection_documents: z.array(z.object({ document_id: z.string() })).nullish(),
   labels: z.array(z.string()).nullish(),
   is_public: z.boolean().nullish(),
@@ -239,7 +242,7 @@ export const createCollectionResponseSchema = z.object({
     wolke_share_link_ids: z.array(z.string()).nullish(),
     auto_sync: z.boolean().nullish(),
     remove_missing_on_sync: z.boolean().nullish(),
-    settings: z.unknown().nullish(),
+    settings: z.record(z.unknown()).nullish(),
     slug_suffix: z.string().nullish(),
   }),
   message: z.string(),


### PR DESCRIPTION
Independent of #1127/#1130. Zero-risk tightening of two `z.unknown()` notebook
response fields the audit flagged — no handler or frontend changes, nothing
stripped on the wire.

- `notebookQAResponseSchema.person` → `notebookPersonInfoSchema` (mirrors the
  service `PersonInfo`: name / fraktion / wahlkreis / biografie).
- `transformedCollectionSchema.settings` + create-response `settings` →
  `z.record(z.unknown())` instead of opaque `unknown`, so consumers can index the
  JSONB bag (labels / wolke_folders / linked_docs) without a cast.

Why values stay `unknown` (not fully typed): the backend handlers return
`settings` as `Record<string, unknown>`; fully typing the keys would make that
non-assignable and force handler-side validation — a behavior change, which was
deliberately deferred. `z.record(z.unknown())` is the zero-risk middle ground.

typecheck green across api + web + contracts; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)