### PR TITLE
feat(monitor): Bundesländer-Tab mit GERDA-Wahlergebnissen und KI-Lookup

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/tools/lookupBundesland.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/lookupBundesland.ts
@@ -1,0 +1,39 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+
+import { lookupBundeslandProfile } from '../../../../services/monitor/StateElectionsService.js';
+import { createLogger } from '../../../../utils/logger.js';
+
+import type { ToolDependencies } from './registry.js';
+
+const log = createLogger('Tool:Bundesland');
+
+export function createLookupBundeslandTool(_deps: ToolDependencies): DynamicStructuredTool {
+  // @ts-expect-error - Zod schema type compatibility with LangChain ToolInputSchemaBase
+  return new DynamicStructuredTool({
+    name: 'lookup_bundesland',
+    description:
+      'Liefert ein kompaktes Datenprofil zu einem deutschen Bundesland: aktuelle Sonntagsfrage, ' +
+      'das jüngste Landtagswahlergebnis und das Meinungsbild (MRP-Schätzung der öffentlichen Meinung ' +
+      'zu politischen Themen) für dieses Land. Nutze dieses Tool, wenn nach einem konkreten Bundesland ' +
+      'gefragt wird (z.B. "Was denkt Bayern?", "Umfragen in Sachsen", "Wahlergebnis Hessen").',
+    schema: z
+      .object({
+        bundesland: z
+          .string()
+          .describe('Name des Bundeslandes, z.B. "Bayern", "Sachsen", "Nordrhein-Westfalen"'),
+      })
+      .describe('Bundesland Lookup'),
+    func: async (input: { bundesland: string }) => {
+      const { bundesland } = input;
+      log.info(`[Bundesland] Lookup: "${bundesland}"`);
+
+      const result = await lookupBundeslandProfile(bundesland);
+      if (!result) {
+        return 'Kein Datenprofil zu diesem Bundesland gefunden. Verfügbar sind die 16 deutschen Bundesländer, z.B. Bayern, Sachsen, Nordrhein-Westfalen, Berlin, Hamburg.';
+      }
+
+      return result;
+    },
+  });
+}

--- a/apps/api/agents/langgraph/ChatGraph/tools/registry.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/registry.ts
@@ -10,6 +10,7 @@ import { createAnalyzeImageTool } from './analyzeImage.js';
 import { createDraftStructuredTool } from './draftStructured.js';
 import { createEditImageTool } from './editImage.js';
 import { createGenerateImageTool } from './generateImage.js';
+import { createLookupBundeslandTool } from './lookupBundesland.js';
 import { createLookupMeinungsbildTool } from './lookupMeinungsbild.js';
 import { createRecallMemoryTool } from './recallMemory.js';
 import { createResearchTool } from './research.js';
@@ -62,6 +63,7 @@ const TOOL_ENTRIES: ToolEntry[] = [
   { key: 'draft_structured', factory: createDraftStructuredTool },
   { key: 'user_content', factory: createSearchUserContentTool },
   { key: 'meinungsbild', factory: createLookupMeinungsbildTool },
+  { key: 'bundesland', factory: createLookupBundeslandTool },
 ];
 
 /**
@@ -82,6 +84,7 @@ export function buildTools(deps: ToolDependencies): DynamicStructuredTool[] {
     'memory_save',
     'user_content',
     'meinungsbild',
+    'bundesland',
   ]);
   const agentWhitelist = deps.agentConfig.enabledTools;
   const tools: DynamicStructuredTool[] = [];
@@ -124,4 +127,5 @@ export const TOOL_LABELS: Record<string, string> = {
   draft_structured: 'Erstelle strukturierten Entwurf...',
   search_user_content: 'Durchsuche Nutzerdokumente...',
   lookup_meinungsbild: 'Suche Meinungsumfragen...',
+  lookup_bundesland: 'Suche Bundesland-Daten...',
 };

--- a/apps/api/database/postgres/migrations/create_monitor_state_elections.sql
+++ b/apps/api/database/postgres/migrations/create_monitor_state_elections.sql
@@ -1,0 +1,15 @@
+-- State election results for the Grünerator Monitor "Bundesländer" tab.
+-- Latest Landtagswahl per Bundesland, vote-weighted to state level from GERDA.
+-- 16 static rows, refreshed by scripts/seed-gerda-state-elections.ts.
+
+CREATE TABLE IF NOT EXISTS monitor_state_elections (
+  state_code TEXT PRIMARY KEY,
+  state_name TEXT NOT NULL,
+  polit_pro_id TEXT NOT NULL,
+  short TEXT NOT NULL,
+  election_year INT NOT NULL,
+  election_date TEXT,
+  turnout DOUBLE PRECISION,
+  results JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/apps/api/database/schema/monitor.ts
+++ b/apps/api/database/schema/monitor.ts
@@ -16,6 +16,7 @@ import {
   type MonitorLocale,
   type NounCount,
   type SocialTrend,
+  type StateElectionResult,
   type TopicCategory,
   type TopicScore,
 } from '@gruenerator/contracts';
@@ -73,3 +74,24 @@ export const monitorArticles = pgTable(
   ]
 );
 export type MonitorArticleRow = InferSelectModel<typeof monitorArticles>;
+
+/**
+ * Latest Landtagswahl result per Bundesland (GERDA, vote-weighted to state level).
+ * Static reference data: 16 rows, refreshed after each state election by
+ * `scripts/seed-gerda-state-elections.ts`. Keyed by GERDA state code "01"–"16".
+ */
+export const monitorStateElections = pgTable('monitor_state_elections', {
+  state_code: text('state_code').primaryKey(),
+  state_name: text('state_name').notNull(),
+  polit_pro_id: text('polit_pro_id').notNull(),
+  short: text('short').notNull(),
+  election_year: integer('election_year').notNull(),
+  election_date: text('election_date'),
+  turnout: doublePrecision('turnout'),
+  // Party display name → vote share (0–1); includes a "Sonstige" bucket.
+  results: jsonb('results').$type<StateElectionResult['results']>().notNull(),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' })
+    .notNull()
+    .defaultNow(),
+});
+export type MonitorStateElectionRow = InferSelectModel<typeof monitorStateElections>;

--- a/apps/api/routes/monitor/monitorContractRouter.ts
+++ b/apps/api/routes/monitor/monitorContractRouter.ts
@@ -28,6 +28,7 @@ import {
 import { getEntitySummary } from '../../services/monitor/MonitorSummaryService.js';
 import { getPolitProPolls, POLITPRO_PARLIAMENTS } from '../../services/monitor/PolitProService.js';
 import { getPolls } from '../../services/monitor/PollScraper.js';
+import { getStateElections } from '../../services/monitor/StateElectionsService.js';
 import { getStimmungSummary } from '../../services/monitor/StimmungSummaryService.js';
 import { WATCHER_ENTITIES, getEntity } from '../../services/monitor/watcherEntities.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
@@ -184,6 +185,20 @@ export const monitorContractRouter = s.router(monitorContract, {
     } catch (error) {
       log.error(`GET /meinungsbild failed: ${toError(error).message}`);
       return { status: 500 as const, body: { error: 'Failed to fetch meinungsbild data' } };
+    }
+  },
+
+  elections: async ({ res }) => {
+    try {
+      const data = await getStateElections();
+      if (!data) {
+        return { status: 503 as const, body: { error: 'State election data unavailable' } };
+      }
+      cache(res, 'private, max-age=86400, stale-while-revalidate=172800');
+      return { status: 200 as const, body: data };
+    } catch (error) {
+      log.error(`GET /elections failed: ${toError(error).message}`);
+      return { status: 500 as const, body: { error: 'Failed to fetch state election data' } };
     }
   },
 

--- a/apps/api/scripts/seed-gerda-state-elections.ts
+++ b/apps/api/scripts/seed-gerda-state-elections.ts
@@ -1,0 +1,352 @@
+/**
+ * seed-gerda-state-elections.ts
+ *
+ * Populates the `monitor_state_elections` table for the Monitor "Bundesländer" tab.
+ *
+ * Downloads the GERDA state-election dataset (Landtagswahlen, harmonised to 2025
+ * boundaries, municipality level), aggregates the MOST RECENT Landtag election per
+ * Bundesland into a vote-weighted per-state party result, and UPSERTs the 16 rows
+ * via Drizzle. Re-run after each Landtagswahl / GERDA data update (idempotent).
+ *
+ * Source (same repo the Monitor already uses for the Meinungsbild data):
+ *   https://github.com/awiedem/german_election_data  (GERDA)
+ *   data/state_elections/final/state_harm_25.csv
+ *
+ * Cite: Heddesheimer, V., Hilbig, H., Sichart, F. & Wiedemann, A. (2025).
+ *   GERDA: German Election Database. Nature: Scientific Data, 12: 618.
+ *
+ * Usage (requires a reachable Postgres; the backend's migrations create the table):
+ *   npx tsx apps/api/scripts/seed-gerda-state-elections.ts
+ */
+
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const CSV_URL =
+  'https://github.com/awiedem/german_election_data/raw/refs/heads/main/data/state_elections/final/state_harm_25.csv';
+
+// ── State metadata: GERDA state code (AGS prefix 01–16) → German name + PolitPro id ──
+// politProId matches the LAENDER ids used by the poll endpoint; state_code matches
+// the Meinungsbild estimates `state_code`. Keeps the three data sources joinable.
+const STATE_META: Record<string, { nameDe: string; politProId: string; short: string }> = {
+  '01': { nameDe: 'Schleswig-Holstein', politProId: 'schleswig-holstein', short: 'SH' },
+  '02': { nameDe: 'Hamburg', politProId: 'hamburg', short: 'HH' },
+  '03': { nameDe: 'Niedersachsen', politProId: 'niedersachsen', short: 'NI' },
+  '04': { nameDe: 'Bremen', politProId: 'bremen', short: 'HB' },
+  '05': { nameDe: 'Nordrhein-Westfalen', politProId: 'nordrhein-westfalen', short: 'NW' },
+  '06': { nameDe: 'Hessen', politProId: 'hessen', short: 'HE' },
+  '07': { nameDe: 'Rheinland-Pfalz', politProId: 'rheinland-pfalz', short: 'RP' },
+  '08': { nameDe: 'Baden-Württemberg', politProId: 'baden-wuerttemberg', short: 'BW' },
+  '09': { nameDe: 'Bayern', politProId: 'bayern', short: 'BY' },
+  '10': { nameDe: 'Saarland', politProId: 'saarland', short: 'SL' },
+  '11': { nameDe: 'Berlin', politProId: 'berlin', short: 'BE' },
+  '12': { nameDe: 'Brandenburg', politProId: 'brandenburg', short: 'BB' },
+  '13': { nameDe: 'Mecklenburg-Vorpommern', politProId: 'mecklenburg-vorpommern', short: 'MV' },
+  '14': { nameDe: 'Sachsen', politProId: 'sachsen', short: 'SN' },
+  '15': { nameDe: 'Sachsen-Anhalt', politProId: 'sachsen-anhalt', short: 'ST' },
+  '16': { nameDe: 'Thüringen', politProId: 'thueringen', short: 'TH' },
+};
+
+// Non-party columns: structural fields, turnout flags, derived aggregates and
+// municipality covariates. Everything else in a row is treated as a party share.
+// `other` (GERDA's residual) is handled separately and folded into "Sonstige".
+const META_COLS = new Set([
+  'ags',
+  'election_year',
+  'election_date',
+  'state',
+  'state_name',
+  'eligible_voters',
+  'number_voters',
+  'valid_votes',
+  'invalid_votes',
+  'turnout',
+  'cdu_csu', // derived combined column — would double-count cdu + csu
+  'far_right',
+  'far_left',
+  'far_left_w_linke',
+  'total_vote_share',
+  'perc_total_votes_incongruence',
+  'pop',
+  'area_ags',
+  'population_ags',
+  'employees_ags',
+  'pop_density_ags',
+]);
+
+const isMetaCol = (c: string): boolean =>
+  META_COLS.has(c) || c === 'other' || c.startsWith('flag_') || c.endsWith('_ags');
+
+// Alias groups → canonical display name. Spelling/historical variants of the same
+// party are summed. Columns not listed keep their own (prettified) key.
+const PARTY_ALIASES: Record<string, string> = {
+  cdu: 'CDU',
+  csu: 'CSU',
+  spd: 'SPD',
+  fdp: 'FDP',
+  afd: 'AfD',
+  gruene: 'Grüne',
+  b90_gr: 'Grüne',
+  bue90_gruene: 'Grüne',
+  buendnis_90: 'Grüne',
+  grue_nf: 'Grüne',
+  linke_pds: 'Die Linke',
+  pds: 'Die Linke',
+  bsw: 'BSW',
+  freie_wahler: 'Freie Wähler',
+  freiewaehler: 'Freie Wähler',
+  fr_waehler: 'Freie Wähler',
+  ssw: 'SSW',
+  die_partei: 'Die PARTEI',
+  npd: 'NPD/Die Heimat',
+  die_heimat_heimat: 'NPD/Die Heimat',
+  piraten: 'Piraten',
+  volt: 'Volt',
+  diebasis: 'dieBasis',
+  tier_schutz_partei: 'Tierschutzpartei',
+  tierschutz: 'Tierschutzpartei',
+  odp: 'ÖDP',
+  werteunion: 'WerteUnion',
+  bayernpartei_bp: 'Bayernpartei',
+  rep: 'REP',
+};
+
+// Below this vote share a party is folded into "Sonstige".
+const DISPLAY_THRESHOLD = 0.01;
+
+function prettifyKey(key: string): string {
+  return key
+    .split('_')
+    .map((w) => (w.length <= 3 ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
+
+/** Minimal RFC-4180-ish CSV parser handling quoted fields with embedded commas. */
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          cur += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+interface StateAcc {
+  electionYear: number;
+  electionDate: string;
+  totalValid: number;
+  totalEligible: number;
+  totalVoters: number;
+  shares: Record<string, number>; // weighted: Σ(share · valid_votes)
+  otherWeighted: number; // GERDA residual, folded into "Sonstige"
+}
+
+interface AggregatedState {
+  stateCode: string;
+  stateName: string;
+  politProId: string;
+  short: string;
+  electionYear: number;
+  electionDate: string | null;
+  turnout: number | null;
+  results: Record<string, number>;
+}
+
+async function aggregate(): Promise<AggregatedState[]> {
+  console.log(`Downloading ${CSV_URL} ...`);
+  const res = await fetch(CSV_URL);
+  if (!res.ok) throw new Error(`Download failed: HTTP ${res.status}`);
+  const text = await res.text();
+  console.log(`Downloaded ${(text.length / 1e6).toFixed(1)} MB`);
+
+  const lines = text.split('\n');
+  const header = parseCsvLine(lines[0]);
+  const idx = (name: string) => header.indexOf(name);
+  const iState = idx('state');
+  const iYear = idx('election_year');
+  const iDate = idx('election_date');
+  const iValid = idx('valid_votes');
+  const iEligible = idx('eligible_voters');
+  const iVoters = idx('number_voters');
+  const iOther = idx('other');
+
+  const partyCols = header
+    .map((name, i) => ({ name, i }))
+    .filter((c) => c.name && !isMetaCol(c.name));
+
+  // Pass 1: latest election year per state.
+  const maxYear: Record<string, number> = {};
+  for (let r = 1; r < lines.length; r++) {
+    const line = lines[r];
+    if (!line) continue;
+    const row = parseCsvLine(line);
+    const state = row[iState];
+    const yearStr = row[iYear];
+    if (!state || !STATE_META[state] || !yearStr) continue;
+    const year = Math.round(parseFloat(yearStr));
+    if (!Number.isFinite(year)) continue;
+    if (year > (maxYear[state] ?? 0)) maxYear[state] = year;
+  }
+
+  // Pass 2: aggregate the latest election per state, vote-weighted.
+  const acc: Record<string, StateAcc> = {};
+  for (let r = 1; r < lines.length; r++) {
+    const line = lines[r];
+    if (!line) continue;
+    const row = parseCsvLine(line);
+    const state = row[iState];
+    if (!state || !STATE_META[state]) continue;
+    const year = Math.round(parseFloat(row[iYear]));
+    if (year !== maxYear[state]) continue;
+    const valid = parseFloat(row[iValid]);
+    if (!Number.isFinite(valid) || valid <= 0) continue;
+
+    const a =
+      acc[state] ??
+      (acc[state] = {
+        electionYear: year,
+        electionDate: row[iDate] || '',
+        totalValid: 0,
+        totalEligible: 0,
+        totalVoters: 0,
+        shares: {},
+        otherWeighted: 0,
+      });
+    a.totalValid += valid;
+    const eligible = parseFloat(row[iEligible]);
+    const voters = parseFloat(row[iVoters]);
+    if (Number.isFinite(eligible)) a.totalEligible += eligible;
+    if (Number.isFinite(voters)) a.totalVoters += voters;
+    if (!a.electionDate && row[iDate]) a.electionDate = row[iDate];
+
+    if (iOther >= 0) {
+      const o = parseFloat(row[iOther]);
+      if (Number.isFinite(o) && o > 0) a.otherWeighted += o * valid;
+    }
+
+    for (const { name, i } of partyCols) {
+      const v = parseFloat(row[i]);
+      if (!Number.isFinite(v) || v <= 0) continue;
+      a.shares[name] = (a.shares[name] ?? 0) + v * valid;
+    }
+  }
+
+  // Finalise: weighted shares, alias-grouping, threshold → Sonstige.
+  const out: AggregatedState[] = [];
+  for (const code of Object.keys(STATE_META).sort()) {
+    const a = acc[code];
+    const meta = STATE_META[code];
+    if (!a) {
+      console.warn(`No data aggregated for ${code} ${meta.nameDe}`);
+      continue;
+    }
+    const grouped: Record<string, number> = {};
+    for (const [col, weighted] of Object.entries(a.shares)) {
+      const share = weighted / a.totalValid;
+      if (share <= 0 || share > 1.2) continue; // drop covariate leftovers
+      const label = PARTY_ALIASES[col] ?? prettifyKey(col);
+      grouped[label] = (grouped[label] ?? 0) + share;
+    }
+
+    const results: Record<string, number> = {};
+    let sonstige = a.otherWeighted / a.totalValid;
+    for (const [label, share] of Object.entries(grouped)) {
+      if (share >= DISPLAY_THRESHOLD) results[label] = Math.round(share * 10000) / 10000;
+      else sonstige += share;
+    }
+    if (sonstige > 0) results['Sonstige'] = Math.round(sonstige * 10000) / 10000;
+
+    const turnout =
+      a.totalEligible > 0 ? Math.round((a.totalVoters / a.totalEligible) * 10000) / 10000 : null;
+
+    out.push({
+      stateCode: code,
+      stateName: meta.nameDe,
+      politProId: meta.politProId,
+      short: meta.short,
+      electionYear: a.electionYear,
+      electionDate: a.electionDate || null,
+      turnout,
+      results,
+    });
+
+    const sum = Object.values(results).reduce((s, v) => s + v, 0);
+    console.log(
+      `${code} ${meta.nameDe.padEnd(24)} ${a.electionYear}  parties=${Object.keys(results).length}  Σ=${(sum * 100).toFixed(1)}%`
+    );
+  }
+  return out;
+}
+
+async function main(): Promise<void> {
+  const states = await aggregate();
+  if (states.length === 0) throw new Error('Aggregation produced no states — aborting.');
+
+  // Dynamic imports so the heavy DB/env modules load only when actually seeding.
+  const { getPostgresInstance } = await import('../database/services/PostgresService.js');
+  const { getDrizzleInstance } = await import('../database/services/DrizzleService.js');
+  const { monitorStateElections } = await import('../database/schema/monitor.js');
+  const { sql } = await import('drizzle-orm');
+
+  console.log('\nConnecting to Postgres + running migrations ...');
+  await getPostgresInstance().init();
+  const db = getDrizzleInstance();
+
+  await db
+    .insert(monitorStateElections)
+    .values(
+      states.map((s) => ({
+        state_code: s.stateCode,
+        state_name: s.stateName,
+        polit_pro_id: s.politProId,
+        short: s.short,
+        election_year: s.electionYear,
+        election_date: s.electionDate,
+        turnout: s.turnout,
+        results: s.results,
+      }))
+    )
+    .onConflictDoUpdate({
+      target: monitorStateElections.state_code,
+      set: {
+        state_name: sql`EXCLUDED.state_name`,
+        polit_pro_id: sql`EXCLUDED.polit_pro_id`,
+        short: sql`EXCLUDED.short`,
+        election_year: sql`EXCLUDED.election_year`,
+        election_date: sql`EXCLUDED.election_date`,
+        turnout: sql`EXCLUDED.turnout`,
+        results: sql`EXCLUDED.results`,
+        updated_at: sql`now()`,
+      },
+    });
+
+  console.log(`\nUpserted ${states.length} states into monitor_state_elections.`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/api/services/monitor/StateElectionsService.ts
+++ b/apps/api/services/monitor/StateElectionsService.ts
@@ -1,0 +1,180 @@
+import { desc } from 'drizzle-orm';
+
+import { monitorStateElections } from '../../database/schema/monitor.js';
+import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
+import { createLogger } from '../../utils/logger.js';
+import redisClient from '../../utils/redis/client.js';
+
+import { getMeinungsbild } from './MeinungsbildService.js';
+import { getPolitProPolls } from './PolitProService.js';
+
+import type { StateElectionResult, StateElectionsData } from './types.js';
+
+const log = createLogger('StateElections');
+
+const CACHE_KEY = 'monitor:state-elections';
+const CACHE_TTL = 24 * 60 * 60;
+
+const SOURCE = 'GERDA: German Election Database (Heddesheimer, Hilbig, Sichart & Wiedemann, 2025)';
+const CITATION =
+  'Heddesheimer, V., Hilbig, H., Sichart, F. & Wiedemann, A. (2025). GERDA: German Election Database. Nature: Scientific Data, 12: 618.';
+const ELECTION_TYPE = 'Landtagswahl';
+
+/**
+ * Latest Landtagswahl result per Bundesland (GERDA, vote-weighted to state level).
+ * Read from the `monitor_state_elections` table seeded by
+ * `scripts/seed-gerda-state-elections.ts`. Cached in Redis.
+ */
+export async function getStateElections(): Promise<StateElectionsData | null> {
+  try {
+    const cached = await redisClient.get(CACHE_KEY);
+    if (cached) {
+      log.info('Cache hit');
+      return JSON.parse(cached) as StateElectionsData;
+    }
+  } catch {
+    // Fall through to DB read.
+  }
+
+  let rows;
+  try {
+    rows = await getDrizzleInstance()
+      .select()
+      .from(monitorStateElections)
+      .orderBy(desc(monitorStateElections.updated_at));
+  } catch (error) {
+    log.error(`DB read failed: ${error}`);
+    return null;
+  }
+
+  if (rows.length === 0) {
+    log.warn('No state-election rows — run scripts/seed-gerda-state-elections.ts');
+    return null;
+  }
+
+  const states: Record<string, StateElectionResult> = {};
+  let latest = '';
+  for (const row of rows) {
+    states[row.state_code] = {
+      stateCode: row.state_code,
+      stateName: row.state_name,
+      politProId: row.polit_pro_id,
+      short: row.short,
+      electionYear: row.election_year,
+      electionDate: row.election_date,
+      turnout: row.turnout,
+      results: row.results,
+    };
+    if (row.updated_at > latest) latest = row.updated_at;
+  }
+
+  const data: StateElectionsData = {
+    source: SOURCE,
+    citation: CITATION,
+    electionType: ELECTION_TYPE,
+    fetchedAt: latest || new Date().toISOString(),
+    states,
+  };
+
+  try {
+    await redisClient.set(CACHE_KEY, JSON.stringify(data), { EX: CACHE_TTL });
+  } catch {
+    // Non-critical.
+  }
+
+  return data;
+}
+
+/**
+ * Resolve a free-text Bundesland query (name, short code or PolitPro id) to its
+ * election result. Used by the AI Bundesland-lookup tool.
+ */
+export async function findStateElection(query: string): Promise<StateElectionResult | null> {
+  const data = await getStateElections();
+  if (!data) return null;
+
+  const q = query.trim().toLowerCase();
+  if (!q) return null;
+
+  const all = Object.values(data.states);
+  return (
+    all.find((s) => s.stateName.toLowerCase() === q) ??
+    all.find((s) => s.short.toLowerCase() === q || s.politProId === q) ??
+    all.find(
+      (s) => s.stateName.toLowerCase().includes(q) || q.includes(s.stateName.toLowerCase())
+    ) ??
+    null
+  );
+}
+
+function formatShares(record: Record<string, number>, limit = 8): string {
+  return Object.entries(record)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([party, share]) => `${party} ${(share * 100).toFixed(1)}%`)
+    .join(', ');
+}
+
+/**
+ * Combine everything the Monitor knows about one Bundesland into a single chat
+ * context block: latest Landtagswahl result, current Sonntagsfrage, and the
+ * Meinungsbild (MRP) topic ranking for that state. Used by the AI lookup tool.
+ */
+export async function lookupBundeslandProfile(query: string): Promise<string | null> {
+  const state = await findStateElection(query);
+  if (!state) return null;
+
+  const parts: string[] = [`Bundesland: ${state.stateName}`];
+
+  // Landtagswahl
+  const lt = [
+    `Letzte Landtagswahl (${state.electionYear}${state.electionDate ? `, ${state.electionDate}` : ''}):`,
+    `  ${formatShares(state.results, 10)}`,
+  ];
+  if (state.turnout != null) lt.push(`  Wahlbeteiligung: ${(state.turnout * 100).toFixed(1)}%`);
+  parts.push(lt.join('\n'));
+
+  // Sonntagsfrage (PolitPro)
+  try {
+    const polls = await getPolitProPolls(state.politProId);
+    if (polls && Object.keys(polls.average).length > 0) {
+      parts.push(`Aktuelle Sonntagsfrage:\n  ${formatShares(polls.average, 8)}`);
+    }
+  } catch {
+    // Polls are optional context.
+  }
+
+  // Meinungsbild (MRP) — topic ranking for this state
+  try {
+    const mb = await getMeinungsbild();
+    if (mb) {
+      const ranked = mb.issues
+        .map((issue) => {
+          const est = mb.estimates[issue.id]?.find((e) => e.state_code === state.stateCode);
+          return est ? { label: issue.label_de, estimate: est.estimate } : null;
+        })
+        .filter((x): x is { label: string; estimate: number } => x !== null)
+        .sort((a, b) => b.estimate - a.estimate);
+
+      if (ranked.length > 0) {
+        const top = ranked.slice(0, 5);
+        const bottom = ranked.slice(-5).reverse();
+        parts.push(
+          [
+            `Meinungsbild ${state.stateName} (MRP-Schätzung, Anteil Zustimmung):`,
+            `  Höchste Zustimmung: ${top.map((t) => `${t.label} ${(t.estimate * 100).toFixed(0)}%`).join(', ')}`,
+            `  Niedrigste Zustimmung: ${bottom.map((t) => `${t.label} ${(t.estimate * 100).toFixed(0)}%`).join(', ')}`,
+          ].join('\n')
+        );
+      }
+    }
+  } catch {
+    // Meinungsbild is optional context.
+  }
+
+  return (
+    parts.join('\n\n') +
+    '\n\nQuelle: GERDA — German Election Database (Heddesheimer, Hilbig, Sichart & Wiedemann, 2025), ' +
+    'Landtagswahlergebnisse & MRP-Meinungsbild; Sonntagsfrage via PolitPro.'
+  );
+}

--- a/apps/api/services/monitor/types.ts
+++ b/apps/api/services/monitor/types.ts
@@ -129,4 +129,27 @@ export interface MeinungsbildData {
   fetchedAt: string;
 }
 
+// --- State elections (GERDA Landtagswahl results) ---
+
+export interface StateElectionResult {
+  stateCode: string;
+  stateName: string;
+  politProId: string;
+  short: string;
+  electionYear: number;
+  electionDate: string | null;
+  turnout: number | null;
+  /** Party display name → vote share (0–1). Includes a "Sonstige" bucket. */
+  results: Record<string, number>;
+}
+
+export interface StateElectionsData {
+  source: string;
+  citation: string;
+  electionType: string;
+  fetchedAt: string;
+  /** Keyed by state code "01"–"16". */
+  states: Record<string, StateElectionResult>;
+}
+
 export type NlpClassificationResult = NlpClassificationResultBase<TopicCategory>;

--- a/apps/web/src/features/monitor/MonitorPage.tsx
+++ b/apps/web/src/features/monitor/MonitorPage.tsx
@@ -8,6 +8,7 @@ import PageContainer from '../../components/common/PageContainer';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import { useAuthStore } from '../../stores/authStore';
 
+import { BundeslandView } from './components/BundeslandView';
 import { KeywordInsightsCard } from './components/KeywordInsightsCard';
 import { KeywordRanking } from './components/KeywordRanking';
 import { MonitorOverview } from './components/MonitorOverview';
@@ -36,6 +37,7 @@ type MonitorTab =
   | 'social'
   | 'stimmung'
   | 'umfragen'
+  | 'bundesland'
   | 'watcher'
   | 'details';
 
@@ -110,6 +112,7 @@ function MonitorPage() {
                   <TabsTrigger value="topics">Themen</TabsTrigger>
                   <TabsTrigger value="stimmung">Stimmung</TabsTrigger>
                   <TabsTrigger value="umfragen">Umfragen</TabsTrigger>
+                  {locale === 'de' && <TabsTrigger value="bundesland">Bundesländer</TabsTrigger>}
                   <TabsTrigger value="watcher">Watcher</TabsTrigger>
                 </TabsList>
               </Tabs>
@@ -130,6 +133,8 @@ function MonitorPage() {
             {tab === 'stimmung' && <StimmungView locale={locale} />}
 
             {tab === 'umfragen' && <UmfragenView locale={locale} />}
+
+            {tab === 'bundesland' && <BundeslandView />}
 
             {tab === 'watcher' && <WatcherView locale={locale} />}
 

--- a/apps/web/src/features/monitor/bundeslaender.ts
+++ b/apps/web/src/features/monitor/bundeslaender.ts
@@ -1,0 +1,53 @@
+/**
+ * The 16 German Bundesländer, joined across the Monitor's data sources.
+ *
+ * - `id`   — PolitPro parliament id, used by the poll endpoint (`usePolls(id)`).
+ * - `code` — GERDA / Meinungsbild `state_code` ("01"–"16"), used to pivot the
+ *            MRP estimates and the Landtagswahl results to a single state.
+ * - `name` — full official name (used in the Bundesland selector).
+ * - `display` — optional compact label for tight UIs (defaults to `name`).
+ */
+export interface Bundesland {
+  id: string;
+  code: string;
+  name: string;
+  short: string;
+  display?: string;
+}
+
+export const BUNDESLAENDER: Bundesland[] = [
+  { id: 'schleswig-holstein', code: '01', name: 'Schleswig-Holstein', short: 'SH' },
+  { id: 'hamburg', code: '02', name: 'Hamburg', short: 'HH' },
+  { id: 'niedersachsen', code: '03', name: 'Niedersachsen', short: 'NI' },
+  { id: 'bremen', code: '04', name: 'Bremen', short: 'HB' },
+  {
+    id: 'nordrhein-westfalen',
+    code: '05',
+    name: 'Nordrhein-Westfalen',
+    short: 'NW',
+    display: 'NRW',
+  },
+  { id: 'hessen', code: '06', name: 'Hessen', short: 'HE' },
+  { id: 'rheinland-pfalz', code: '07', name: 'Rheinland-Pfalz', short: 'RP' },
+  { id: 'baden-wuerttemberg', code: '08', name: 'Baden-Württemberg', short: 'BW' },
+  { id: 'bayern', code: '09', name: 'Bayern', short: 'BY' },
+  { id: 'saarland', code: '10', name: 'Saarland', short: 'SL' },
+  { id: 'berlin', code: '11', name: 'Berlin', short: 'BE' },
+  { id: 'brandenburg', code: '12', name: 'Brandenburg', short: 'BB' },
+  {
+    id: 'mecklenburg-vorpommern',
+    code: '13',
+    name: 'Mecklenburg-Vorpommern',
+    short: 'MV',
+    display: 'Meck.-Vorpommern',
+  },
+  { id: 'sachsen', code: '14', name: 'Sachsen', short: 'SN' },
+  { id: 'sachsen-anhalt', code: '15', name: 'Sachsen-Anhalt', short: 'ST' },
+  { id: 'thueringen', code: '16', name: 'Thüringen', short: 'TH' },
+];
+
+export const bundeslandById = (id: string): Bundesland | undefined =>
+  BUNDESLAENDER.find((b) => b.id === id);
+
+export const bundeslandByCode = (code: string): Bundesland | undefined =>
+  BUNDESLAENDER.find((b) => b.code === code);

--- a/apps/web/src/features/monitor/components/BundeslandView.tsx
+++ b/apps/web/src/features/monitor/components/BundeslandView.tsx
@@ -1,0 +1,229 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Card,
+  CardContent,
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  LoadingSection,
+} from '@gruenerator/ui';
+import { ExternalLink } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { bundeslandByCode, BUNDESLAENDER } from '../bundeslaender';
+import { useMeinungsbild, useStateElections } from '../hooks/useMonitor';
+import { estimateColor } from '../meinungsbildConfig';
+
+import { PARTY_COLORS, SonntagsfrageChart } from './UmfragenView';
+
+function partyColor(party: string): string {
+  return PARTY_COLORS[party] ?? '#9ca3af';
+}
+
+/** Horizontal share bar (party result). */
+function ResultBar({ party, share }: { party: string; share: number }) {
+  const pct = (share * 100).toFixed(1);
+  const color = partyColor(party);
+  return (
+    <div className="flex items-center gap-xs">
+      <span className="text-xs font-medium text-foreground w-[7rem] truncate shrink-0">
+        {party}
+      </span>
+      <div className="flex-1 h-4 rounded-full bg-grey-100 dark:bg-grey-800 overflow-hidden">
+        <div
+          className="h-full rounded-full transition-all"
+          style={{ width: `${Math.max(share * 100, 2)}%`, backgroundColor: color }}
+        />
+      </div>
+      <span className="text-xs font-bold tabular-nums w-12 text-right shrink-0">{pct}%</span>
+    </div>
+  );
+}
+
+/** Approval bar for a Meinungsbild issue in the selected state. */
+function IssueBar({ label, estimate }: { label: string; estimate: number }) {
+  const pct = (estimate * 100).toFixed(0);
+  return (
+    <div className="flex items-center gap-xs p-xs rounded-lg border border-grey-200 dark:border-grey-700">
+      <span className="text-xs font-medium text-foreground flex-1 truncate" title={label}>
+        {label}
+      </span>
+      <div className="w-24 h-3 rounded-full bg-grey-100 dark:bg-grey-800 overflow-hidden shrink-0">
+        <div
+          className={`h-full rounded-full ${estimateColor(estimate)} transition-all`}
+          style={{ width: `${Math.max(estimate * 100, 4)}%` }}
+        />
+      </div>
+      <span className="text-xs font-bold tabular-nums w-8 text-right shrink-0">{pct}%</span>
+    </div>
+  );
+}
+
+function LandtagsergebnisCard({ code }: { code: string }) {
+  const { data, isLoading } = useStateElections();
+  if (isLoading) return <LoadingSection />;
+
+  const state = data?.states[code];
+  if (!state) {
+    return (
+      <Card>
+        <CardContent className="py-md text-sm text-grey-500">
+          Keine Wahlergebnisse für dieses Bundesland verfügbar.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const sorted = Object.entries(state.results).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-sm">
+        <h3 className="text-base font-semibold text-foreground-heading">
+          Letzte Landtagswahl {state.electionYear}
+        </h3>
+        {state.turnout != null && (
+          <span className="text-xs text-grey-500">
+            Wahlbeteiligung {(state.turnout * 100).toFixed(1)}%
+          </span>
+        )}
+      </div>
+      <div className="space-y-xs">
+        {sorted.map(([party, share]) => (
+          <ResultBar key={party} party={party} share={share} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MeinungsbildForState({ code }: { code: string }) {
+  const { data, isLoading } = useMeinungsbild();
+
+  const ranked = useMemo(() => {
+    if (!data) return [];
+    return data.issues
+      .map((issue) => {
+        const est = data.estimates[issue.id]?.find((e) => e.state_code === code);
+        return est ? { id: issue.id, label: issue.label_de, estimate: est.estimate } : null;
+      })
+      .filter((x): x is { id: string; label: string; estimate: number } => x !== null)
+      .sort((a, b) => b.estimate - a.estimate);
+  }, [data, code]);
+
+  if (isLoading) return <LoadingSection />;
+  if (ranked.length === 0) return null;
+
+  return (
+    <div>
+      <h3 className="text-base font-semibold text-foreground-heading mb-xs">
+        Meinungsbild — Was denkt das Land?
+      </h3>
+      <p className="text-xs text-grey-500 mb-md">
+        MRP-Schätzung des Zustimmungsanteils zu politischen Aussagen, sortiert nach Zustimmung.
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-xs">
+        {ranked.map((r) => (
+          <IssueBar key={r.id} label={r.label} estimate={r.estimate} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BundeslandView() {
+  const [code, setCode] = useState<string | null>(null);
+  const selected = code ? bundeslandByCode(code) : undefined;
+
+  // Combobox value is the state code; items sorted alphabetically by name.
+  const options = useMemo(
+    () => [...BUNDESLAENDER].sort((a, b) => a.name.localeCompare(b.name, 'de')),
+    []
+  );
+
+  return (
+    <div>
+      <div className="mb-lg max-w-sm">
+        <label className="text-xs font-semibold text-foreground-heading uppercase tracking-wide mb-xs block">
+          Bundesland suchen
+        </label>
+        <Combobox value={code} onValueChange={(v) => setCode(v)}>
+          <ComboboxInput placeholder="Bundesland eingeben oder wählen..." />
+          <ComboboxContent>
+            <ComboboxList>
+              <ComboboxEmpty>Kein Bundesland gefunden</ComboboxEmpty>
+              {options.map((b) => (
+                <ComboboxItem key={b.code} value={b.code}>
+                  {b.name}
+                </ComboboxItem>
+              ))}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      </div>
+
+      {!selected ? (
+        <Card>
+          <CardContent className="py-xl text-center text-sm text-grey-500">
+            Wähle ein Bundesland, um Wahlergebnisse, aktuelle Umfragen und das Meinungsbild
+            anzuzeigen.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-xl">
+          <h2 className="text-lg font-bold text-foreground-heading">{selected.name}</h2>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-lg items-start">
+            <LandtagsergebnisCard code={selected.code} />
+            <SonntagsfrageChart
+              key={selected.id}
+              parliament={selected.id}
+              title="Aktuelle Sonntagsfrage"
+              subtitle="Wenn am nächsten Sonntag Landtagswahl wäre… Wöchentlich aggregierter Durchschnitt."
+            />
+          </div>
+
+          <MeinungsbildForState code={selected.code} />
+
+          <Accordion type="single" collapsible>
+            <AccordionItem
+              value="gerda-info"
+              className="border border-grey-200 dark:border-grey-700 rounded-lg overflow-hidden"
+            >
+              <AccordionTrigger className="px-md py-sm text-sm font-medium text-foreground hover:bg-grey-50 dark:hover:bg-grey-800/50 hover:no-underline">
+                Daten: GERDA — German Election Database & PolitPro
+              </AccordionTrigger>
+              <AccordionContent className="px-md">
+                <div className="text-xs text-foreground/80 space-y-sm">
+                  <p>
+                    Wahlergebnisse und Meinungsbild (MRP-Schätzung) stammen aus GERDA; die
+                    Sonntagsfrage wird über PolitPro aggregiert.
+                  </p>
+                  <p>
+                    Heddesheimer, V., Hilbig, H., Sichart, F. &amp; Wiedemann, A. (2025). GERDA:
+                    German Election Database. <em>Nature: Scientific Data</em>, 12: 618.
+                  </p>
+                  <a
+                    href="https://github.com/awiedem/german_election_data"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline"
+                  >
+                    github.com/awiedem/german_election_data
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/monitor/components/UmfragenView.tsx
+++ b/apps/web/src/features/monitor/components/UmfragenView.tsx
@@ -10,6 +10,7 @@ import {
 import { ExternalLink, Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+import { BUNDESLAENDER } from '../bundeslaender';
 import { usePolls } from '../hooks/useMonitor';
 
 import { MeinungsbildSection } from './MeinungsbildSection';
@@ -20,7 +21,7 @@ interface UmfragenViewProps {
   locale: MonitorLocale;
 }
 
-const PARTY_COLORS: Record<string, string> = {
+export const PARTY_COLORS: Record<string, string> = {
   'CDU/CSU': '#000000',
   AfD: '#009ee0',
   SPD: '#e3000f',
@@ -37,24 +38,8 @@ const PARTY_COLORS: Record<string, string> = {
   FPÖ: '#0E6EB8',
 };
 
-const LAENDER = [
-  { id: 'baden-wuerttemberg', name: 'Baden-Württemberg', short: 'BW' },
-  { id: 'bayern', name: 'Bayern', short: 'BY' },
-  { id: 'berlin', name: 'Berlin', short: 'BE' },
-  { id: 'brandenburg', name: 'Brandenburg', short: 'BB' },
-  { id: 'bremen', name: 'Bremen', short: 'HB' },
-  { id: 'hamburg', name: 'Hamburg', short: 'HH' },
-  { id: 'hessen', name: 'Hessen', short: 'HE' },
-  { id: 'mecklenburg-vorpommern', name: 'Meck.-Vorpommern', short: 'MV' },
-  { id: 'niedersachsen', name: 'Niedersachsen', short: 'NI' },
-  { id: 'nordrhein-westfalen', name: 'NRW', short: 'NW' },
-  { id: 'rheinland-pfalz', name: 'Rheinland-Pfalz', short: 'RP' },
-  { id: 'saarland', name: 'Saarland', short: 'SL' },
-  { id: 'sachsen', name: 'Sachsen', short: 'SN' },
-  { id: 'sachsen-anhalt', name: 'Sachsen-Anhalt', short: 'ST' },
-  { id: 'schleswig-holstein', name: 'Schleswig-Holstein', short: 'SH' },
-  { id: 'thueringen', name: 'Thüringen', short: 'TH' },
-];
+// Compact labels for the tight 2-column "Grüne in den Ländern" grid.
+const LAENDER = BUNDESLAENDER.map((b) => ({ id: b.id, name: b.display ?? b.name }));
 
 function isGruene(party: string): boolean {
   return party === 'GRÜNE' || party === 'Grüne' || party.toLowerCase().includes('grüne');
@@ -146,7 +131,7 @@ function PartyColumn({
   );
 }
 
-function SonntagsfrageChart({
+export function SonntagsfrageChart({
   parliament,
   title,
   subtitle,

--- a/apps/web/src/features/monitor/hooks/useMonitor.ts
+++ b/apps/web/src/features/monitor/hooks/useMonitor.ts
@@ -13,6 +13,8 @@ import {
   type MonitorSnapshot,
   type PollData,
   type PollParliament,
+  type StateElectionResult,
+  type StateElectionsData,
   type StimmungResult,
   type TopicScore,
   type WatcherEntityInfo,
@@ -248,6 +250,19 @@ export function useMeinungsbild() {
   });
 }
 
+export function useStateElections() {
+  return useQuery({
+    queryKey: ['monitor', 'elections'],
+    queryFn: async (): Promise<StateElectionsData> => {
+      const res = await getContractsClient().monitor.elections();
+      if (res.status === 200) return res.body;
+      throw new Error('Wahlergebnisse konnten nicht geladen werden.');
+    },
+    staleTime: 24 * 60 * 60 * 1000,
+    gcTime: 48 * 60 * 60 * 1000,
+  });
+}
+
 // ─── Research-backed topic positions (not part of the monitor contract) ──────
 
 interface TopicPositionResult {
@@ -314,6 +329,8 @@ export type {
   MonitorLocale,
   MonitorSearchResult as SearchResult,
   PollParliament,
+  StateElectionResult,
+  StateElectionsData,
   TopicScore,
   MonitorSnapshot,
   WatcherEntityInfo,

--- a/packages/contracts/src/contracts/monitorContract.ts
+++ b/packages/contracts/src/contracts/monitorContract.ts
@@ -34,6 +34,7 @@ import {
   pollDataSchema,
   pollParliamentsResponseSchema,
   pollsQuerySchema,
+  stateElectionsResponseSchema,
   stimmungResponseSchema,
   topicArticlesQuerySchema,
   topicArticlesResponseSchema,
@@ -167,6 +168,18 @@ export const monitorContract = c.router(
         503: monitorErrorResponseSchema,
       },
       summary: 'Meinungsbild estimates',
+    },
+
+    /** GET /api/monitor/elections — latest Landtagswahl results per Bundesland (GERDA). */
+    elections: {
+      method: 'GET',
+      path: '/api/monitor/elections',
+      responses: {
+        200: stateElectionsResponseSchema,
+        500: monitorErrorResponseSchema,
+        503: monitorErrorResponseSchema,
+      },
+      summary: 'State election results (Landtagswahlen)',
     },
 
     /** GET /api/monitor/stimmung — emotion aggregation + AI mood summary. */

--- a/packages/contracts/src/schemas/monitor.ts
+++ b/packages/contracts/src/schemas/monitor.ts
@@ -238,6 +238,29 @@ export const meinungsbildResponseSchema = z.object({
   fetchedAt: z.string(),
 });
 
+// ── State elections (GERDA Landtagswahl results) ─────────────────────────────
+
+export const stateElectionResultSchema = z.object({
+  stateCode: z.string(),
+  stateName: z.string(),
+  politProId: z.string(),
+  short: z.string(),
+  electionYear: z.number(),
+  electionDate: z.string().nullable(),
+  turnout: z.number().nullable(),
+  // Party display name → vote share (0–1). Includes a "Sonstige" bucket.
+  results: z.record(z.string(), z.number()),
+});
+
+export const stateElectionsResponseSchema = z.object({
+  source: z.string(),
+  citation: z.string(),
+  electionType: z.string(),
+  fetchedAt: z.string(),
+  // Keyed by state code "01"–"16".
+  states: z.record(z.string(), stateElectionResultSchema),
+});
+
 // ── Stimmung (emotion aggregation) ───────────────────────────────────────────
 
 const stimmungEmotionsSchema = z.record(z.string(), z.number());
@@ -355,3 +378,5 @@ export type EntitySummaryResult = z.infer<typeof entitySummaryResponseSchema>;
 export type MeinungsbildIssue = z.infer<typeof meinungsbildIssueSchema>;
 export type MeinungsbildEstimate = z.infer<typeof meinungsbildEstimateSchema>;
 export type MeinungsbildData = z.infer<typeof meinungsbildResponseSchema>;
+export type StateElectionResult = z.infer<typeof stateElectionResultSchema>;
+export type StateElectionsData = z.infer<typeof stateElectionsResponseSchema>;


### PR DESCRIPTION
## Was & Warum

Der Monitor nutzt GERDA-Daten bisher **themen-zentriert** (Thema wählen → alle Länder). Dieser PR ergänzt den umgekehrten, **Bundesland-zentrierten** Einstieg: ein Bundesland suchen und automatisch *alle* Daten dazu sehen — und dasselbe per Chat-Assistent abfragbar machen.

## Was drin ist

**Daten — GERDA-Landtagswahlergebnisse (4 Schichten: Contract → Zod → Drizzle → ts-rest)**
- Seed-Skript `apps/api/scripts/seed-gerda-state-elections.ts` lädt die GERDA-CSV (`state_harm_25.csv`), aggregiert die *jüngste Landtagswahl je Bundesland* stimmgewichtet zu Parteianteilen und **upsertet 16 Zeilen via Drizzle** (idempotent, nach jeder Wahl neu ausführen).
- Neue Drizzle-Tabelle `monitor_state_elections` + DDL-Migration.
- `StateElectionsService` liest via Drizzle, mappt auf den Contract-Typ, Redis-Cache.
- Neuer Endpoint `GET /api/monitor/elections` (Zod-Schema + Contract + Handler).

**KI-Zugriff**
- Chat-Tool `lookup_bundesland` kombiniert Landtagswahl + aktuelle Sonntagsfrage (PolitPro) + Meinungsbild (MRP) zu einem Bundesland-Profil. „Was denkt Bayern?" funktioniert.

**Frontend (nur `@gruenerator/ui` wiederverwendet)**
- `BundeslandView`: Combobox-Suche → Landtagswahl-Balken, wiederverwendeter `SonntagsfrageChart`, Meinungsbild pro Land + GERDA-Quellenangabe.
- Neuer Tab „Bundesländer" in `MonitorPage` (de-Locale), Hook `useStateElections`.
- Geteilte `bundeslaender.ts`-Konstante; Duplikat aus `UmfragenView` entfernt.

## Verifikation
- Seed lief: 16 Zeilen in `monitor_state_elections` (Bayern 2023, Sachsen 2024 etc. = echte Ergebnisse, Σ≈100 %).
- Service + KI-Lookup end-to-end getestet; PolitPro-Ausfall wird graceful abgefangen.
- `pnpm typecheck` (20/20 grün), bestehende Monitor-Tests grün (15/15), neue Dateien lint-sauber.

## Hinweis
- Daten sind statische Referenzdaten — nach jeder Landtagswahl `pnpm tsx apps/api/scripts/seed-gerda-state-elections.ts` erneut laufen lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)