### PR TITLE
fix(chat): show real attachment validation error instead of generic notice

### DIFF
--- a/packages/chat/src/lib/attachmentErrorHandler.ts
+++ b/packages/chat/src/lib/attachmentErrorHandler.ts
@@ -8,12 +8,6 @@ function pushNotice(title: string, description: string): void {
   useAttachmentNoticeStore.getState().setNotice({ title, description });
 }
 
-export function handleAttachmentError(error: unknown): void {
-  const message = error instanceof Error ? error.message : 'Datei konnte nicht hinzugefügt werden.';
-  console.warn('[Attachment]', error);
-  pushNotice('Anhang nicht möglich', message);
-}
-
 // Extracts the rejected MIME type from AUI's English error message
 // ("File type X is not accepted. ..."). Returns null for any other shape.
 function extractRejectedContentType(message: string): string | null {
@@ -40,6 +34,15 @@ export function handleAttachmentAddError(event: AttachmentAddErrorEvent): void {
 
   if (event.reason === 'no-adapter') {
     pushNotice('Anhänge deaktiviert', 'In diesem Chat sind keine Anhänge möglich.');
+    return;
+  }
+
+  // 'adapter-error': our adapter's validateFile()/fileToBase64() threw. Those
+  // throw user-ready German messages (e.g. "Datei zu groß: x.pdf (26.0MB).
+  // Maximum: 25.0MB"), so surface event.message directly instead of a generic
+  // "try again" that hides the actual cause.
+  if (event.reason === 'adapter-error') {
+    pushNotice('Anhang nicht möglich', event.message);
     return;
   }
 

--- a/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorAttachmentAdapter.ts
@@ -10,7 +10,6 @@ import {
   fileToBase64,
   getAcceptedFileTypes,
 } from '../lib/fileUtils';
-import { handleAttachmentError } from '../lib/attachmentErrorHandler';
 
 // Synthetic content types used by @docs / @datei mention chips. These never
 // correspond to real File uploads — they flow through AUI's CreateAttachment
@@ -29,12 +28,11 @@ export class GrueneratorAttachmentAdapter implements AttachmentAdapter {
   accept = [getAcceptedFileTypes(), ...SYNTHETIC_MENTION_TYPES].join(',');
 
   async add({ file }: { file: File }): Promise<PendingAttachment> {
-    try {
-      validateFile(file);
-    } catch (error) {
-      handleAttachmentError(error);
-      throw error;
-    }
+    // Let validation errors propagate. AUI catches them and emits a structured
+    // `attachmentAddError` (reason: 'adapter-error') carrying this message —
+    // handleAttachmentAddError surfaces it as the user-facing notice. Catching
+    // here too would set a notice that the event handler then overwrites.
+    validateFile(file);
 
     return {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## Problem

A user uploaded a >25MB document into the chat and got no sensible error message. The 25MB limit *does* fire — but the precise message was being clobbered by a generic one.

## Root cause

For a rejected file, the failure was handled **twice** against a single-notice store (`attachmentNoticeStore`, last writer wins):

1. `GrueneratorAttachmentAdapter.add()` caught the `validateFile()` error, set the good notice (`Datei zu groß … Maximum: 25.0MB`), then **rethrew**.
2. assistant-ui caught the rethrow and emitted `attachmentAddError` with `reason: 'adapter-error'`. `handleAttachmentAddError` had no branch for that reason, so it fell through to the generic fallback `Anhang fehlgeschlagen – Bitte erneut versuchen`, **overwriting** the precise notice.

Result: the user saw a misleading "try again" with no mention of the size limit — retrying the same file fails identically.

AUI's only error reasons are `no-adapter | not-accepted | adapter-error` — there is no size-specific reason, so every `validateFile`/`fileToBase64` throw arrives as a generic `adapter-error`.

## Fix (single source of truth for the notice)

- `add()` no longer catches — `validateFile()` propagates so AUI emits exactly one structured event.
- `handleAttachmentAddError` handles `reason: 'adapter-error'` by surfacing `event.message`, which is already a user-ready German string from `fileUtils` (`Datei zu groß …`, `Dateityp nicht unterstützt …`).
- Removed the now-dead `handleAttachmentError` helper.
- Bonus: `fileToBase64` read errors in `send()` (previously unhandled) now surface through the same path.

Only one writer touches the notice store now, eliminating the race.

## Test plan

- [x] `pnpm --filter @gruenerator/chat typecheck`
- [ ] Manual: attach a >25MB PDF → expect notice `Anhang nicht möglich – Datei zu groß: <name> (X.XMB). Maximum: 25.0MB`
- [ ] Manual: attach an unsupported type → expect `Dateityp nicht unterstützt …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)