### PR TITLE
feat(web): tri-state theme preference (light/dark/system)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -48,34 +48,53 @@
     <link rel="canonical" href="https://www.gruenerator.de" />
 
     <!-- Pre-paint theme application: prevents flash of wrong theme. Must mirror
-         the storage format used by src/components/hooks/useDarkMode.ts -->
+         the resolution used by src/components/hooks/useDarkMode.ts -->
     <script>
       (function () {
         try {
-          var EXPIRY = 7 * 24 * 60 * 60 * 1000;
-          var dark = null;
-          var saved = localStorage.getItem('darkMode');
-          if (saved) {
+          var EXPIRY = 7 * 24 * 60 * 60 * 1000; // explicit choice lapses to system after 7d inactivity
+          var isPref = function (v) { return v === 'light' || v === 'dark' || v === 'system'; };
+          var pref = null;
+          var ts = 0;
+
+          var stored = localStorage.getItem('themePreference');
+          if (stored) {
             try {
-              var parsed = JSON.parse(saved);
-              if (
-                parsed &&
-                typeof parsed.value === 'boolean' &&
-                typeof parsed.timestamp === 'number' &&
-                Date.now() - parsed.timestamp < EXPIRY
-              ) {
-                dark = parsed.value;
+              var parsed = JSON.parse(stored);
+              if (parsed && isPref(parsed.value)) {
+                pref = parsed.value;
+                ts = typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now();
               }
-            } catch (e) {}
+            } catch (e) {
+              if (isPref(stored)) { pref = stored; ts = Date.now(); }
+            }
           }
-          if (dark === null) {
-            var legacy = localStorage.getItem('theme');
-            if (legacy === 'dark') dark = true;
-            else if (legacy === 'light') dark = false;
+          // Migrate legacy `darkMode` JSON (honor its timestamp).
+          if (pref === null) {
+            var legacyDark = localStorage.getItem('darkMode');
+            if (legacyDark) {
+              try {
+                var p2 = JSON.parse(legacyDark);
+                if (p2 && typeof p2.value === 'boolean') {
+                  pref = p2.value ? 'dark' : 'light';
+                  ts = typeof p2.timestamp === 'number' ? p2.timestamp : Date.now();
+                }
+              } catch (e) {}
+            }
           }
-          if (dark === null) {
-            dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          // Migrate original `theme` string key.
+          if (pref === null) {
+            var legacyTheme = localStorage.getItem('theme');
+            if (legacyTheme === 'dark' || legacyTheme === 'light') { pref = legacyTheme; ts = Date.now(); }
           }
+
+          // Apply the inactivity rule (system never expires).
+          if (pref === null || pref === 'system' || Date.now() - ts >= EXPIRY) pref = 'system';
+
+          var dark =
+            pref === 'system'
+              ? window.matchMedia('(prefers-color-scheme: dark)').matches
+              : pref === 'dark';
           document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
         } catch (e) {}
       })();

--- a/apps/web/src/assets/styles/common/variables.css
+++ b/apps/web/src/assets/styles/common/variables.css
@@ -1,4 +1,9 @@
 :root {
+    /* Tell the browser which scheme native UI (scrollbars, form controls,
+       date pickers, spellcheck) should render in. Bound to data-theme so the
+       pre-paint script in index.html drives it with zero JS. */
+    color-scheme: light;
+
     /* Base Colors */
     --black: #000000;
     --white: #ffffff;
@@ -289,6 +294,7 @@
 
 
 [data-theme="dark"] {
+    color-scheme: dark;
     --background-color: var(--grey-950);
     --background-color-pure: var(--grey-900);
     --background-color-alt: var(--grey-800);
@@ -427,6 +433,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) {
+        color-scheme: dark;
         --background-color: var(--grey-950);
         --background-color-pure: var(--grey-900);
         --background-color-alt: var(--grey-800);

--- a/apps/web/src/components/hooks/useDarkMode.ts
+++ b/apps/web/src/components/hooks/useDarkMode.ts
@@ -1,78 +1,157 @@
 import { useState, useEffect } from 'react';
 
-const STORAGE_KEY = 'darkMode';
-const LEGACY_KEY = 'theme';
-const USER_PREFERENCE_EXPIRY = 7 * 24 * 60 * 60 * 1000;
+export type ThemePreference = 'light' | 'dark' | 'system';
 
-const readSavedPreference = (): boolean | null => {
-  const saved = localStorage.getItem(STORAGE_KEY);
-  if (saved) {
-    try {
-      const { value, timestamp } = JSON.parse(saved) as { value: boolean; timestamp: number };
-      if (Date.now() - timestamp < USER_PREFERENCE_EXPIRY) {
-        return value;
+const STORAGE_KEY = 'themePreference';
+const LEGACY_DARKMODE_KEY = 'darkMode';
+const LEGACY_THEME_KEY = 'theme';
+
+// An explicit Light/Dark choice persists while the user keeps visiting — the
+// timestamp is refreshed on every load (see the persist effect). Only after
+// this much *inactivity* does it lapse back to `system` (which follows the OS).
+const INACTIVITY_EXPIRY = 7 * 24 * 60 * 60 * 1000;
+
+const prefersDark = (): boolean => window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const isPreference = (v: unknown): v is ThemePreference =>
+  v === 'light' || v === 'dark' || v === 'system';
+
+// Reads the stored preference (and migrates older storage formats), applying the
+// inactivity rule: an explicit choice older than INACTIVITY_EXPIRY falls back to
+// `system`. `system` itself never expires — it is the fallback.
+const readPreference = (): ThemePreference => {
+  let value: ThemePreference | null = null;
+  let timestamp = 0;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as { value?: unknown; timestamp?: unknown };
+        if (isPreference(parsed.value)) {
+          value = parsed.value;
+          timestamp = typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now();
+        }
+      } catch {
+        // Tolerate a bare-string value from an interim format.
+        if (isPreference(stored)) {
+          value = stored;
+          timestamp = Date.now();
+        }
       }
-    } catch {
-      // fall through to legacy key
     }
+
+    // Migrate the old timestamped `darkMode` JSON (honor its timestamp so an
+    // already-stale choice expires immediately, per the inactivity rule).
+    if (value === null) {
+      const legacyDark = localStorage.getItem(LEGACY_DARKMODE_KEY);
+      if (legacyDark) {
+        try {
+          const parsed = JSON.parse(legacyDark) as { value?: unknown; timestamp?: unknown };
+          if (typeof parsed.value === 'boolean') {
+            value = parsed.value ? 'dark' : 'light';
+            timestamp = typeof parsed.timestamp === 'number' ? parsed.timestamp : Date.now();
+          }
+        } catch {
+          // fall through to the next legacy key
+        }
+      }
+    }
+
+    // Migrate the original `theme` string key.
+    if (value === null) {
+      const legacyTheme = localStorage.getItem(LEGACY_THEME_KEY);
+      if (legacyTheme === 'dark' || legacyTheme === 'light') {
+        value = legacyTheme;
+        timestamp = Date.now();
+      }
+    }
+  } catch {
+    // localStorage unavailable — fall back to following the OS.
+    return 'system';
   }
-  const legacy = localStorage.getItem(LEGACY_KEY);
-  if (legacy === 'dark' || legacy === 'light') {
-    return legacy === 'dark';
-  }
-  return null;
+
+  if (value === null || value === 'system') return 'system';
+  if (Date.now() - timestamp >= INACTIVITY_EXPIRY) return 'system';
+  return value;
 };
 
-const getInitialDarkMode = (): boolean => {
-  const saved = readSavedPreference();
-  if (saved !== null) return saved;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-};
+const resolve = (preference: ThemePreference): boolean =>
+  preference === 'system' ? prefersDark() : preference === 'dark';
 
-const listeners = new Set<(value: boolean) => void>();
+// Shared across all hook instances so a change in one (e.g. the account menu)
+// updates every other consumer in the same tab.
+const listeners = new Set<(preference: ThemePreference) => void>();
 
-const useDarkMode = (): [boolean, () => void] => {
-  const [darkMode, setDarkMode] = useState<boolean>(getInitialDarkMode);
+const useDarkMode = (): [boolean, () => void, ThemePreference, () => void] => {
+  const [preference, setPreferenceState] = useState<ThemePreference>(readPreference);
+  const [darkMode, setDarkMode] = useState<boolean>(() => resolve(preference));
 
+  // Persist + apply whenever the preference changes, and broadcast to siblings.
+  // Runs on mount too, so each visit refreshes the timestamp — that is what
+  // resets the 7-day inactivity window for an explicit choice.
   useEffect(() => {
-    listeners.add(setDarkMode);
+    try {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ value: preference, timestamp: Date.now() })
+      );
+      localStorage.removeItem(LEGACY_DARKMODE_KEY);
+      localStorage.removeItem(LEGACY_THEME_KEY);
+    } catch {
+      // ignore write failures (private mode etc.)
+    }
+    setDarkMode(resolve(preference));
+    listeners.forEach((cb) => {
+      if (cb !== setPreferenceState) cb(preference);
+    });
+  }, [preference]);
+
+  // Keep this instance in sync with sibling instances and other tabs.
+  useEffect(() => {
+    listeners.add(setPreferenceState);
     const onStorage = (e: StorageEvent): void => {
-      if (e.key !== STORAGE_KEY && e.key !== LEGACY_KEY) return;
-      const next = readSavedPreference();
-      if (next !== null) setDarkMode(next);
+      if (e.key !== STORAGE_KEY) return;
+      setPreferenceState(readPreference());
     };
     window.addEventListener('storage', onStorage);
     return () => {
-      listeners.delete(setDarkMode);
+      listeners.delete(setPreferenceState);
       window.removeEventListener('storage', onStorage);
     };
   }, []);
 
+  // Follow the OS live while in `system` mode.
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = (e: MediaQueryListEvent): void => {
-      if (readSavedPreference() === null) {
-        setDarkMode(e.matches);
-      }
+      setPreferenceState((current) => {
+        if (current === 'system') setDarkMode(e.matches);
+        return current;
+      });
     };
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
+  // Apply the resolved theme to <html>. color-scheme is handled in CSS via the
+  // data-theme attribute (see variables.css).
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light');
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ value: darkMode, timestamp: Date.now() }));
-    localStorage.removeItem(LEGACY_KEY);
-    listeners.forEach((cb) => {
-      if (cb !== setDarkMode) cb(darkMode);
-    });
   }, [darkMode]);
 
+  // Binary toggle (used by ThemeToggleButton): flips to an explicit choice.
   const toggleDarkMode = (): void => {
-    setDarkMode((prev) => !prev);
+    setPreferenceState(resolve(preference) ? 'light' : 'dark');
   };
 
-  return [darkMode, toggleDarkMode];
+  // Cycles Light → Dark → System → Light (used by the account-menu button).
+  const cycleTheme = (): void => {
+    setPreferenceState((current) =>
+      current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light'
+    );
+  };
+
+  return [darkMode, toggleDarkMode, preference, cycleTheme];
 };
 
 export default useDarkMode;

--- a/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
+++ b/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
@@ -16,7 +16,7 @@ import { LogOut } from 'lucide-react';
 import { type MutableRefObject, type ReactNode, memo, useEffect, useState } from 'react';
 import { FaUserCircle } from 'react-icons/fa';
 import { HiCog, HiDotsVertical } from 'react-icons/hi';
-import { PiBell, PiMoon, PiQuestion, PiSun } from 'react-icons/pi';
+import { PiBell, PiDesktop, PiMoon, PiQuestion, PiSun } from 'react-icons/pi';
 
 import { useProfile } from '../../../features/auth/hooks/useProfileData';
 import { getAvatarDisplayProps } from '../../../features/auth/services/profileApiService';
@@ -47,7 +47,7 @@ const SidebarAccount = memo(function SidebarAccount({
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
   const isLoggingOut = useAuthStore((s) => s.isLoggingOut);
-  const [darkMode, toggleDarkMode] = useDarkMode();
+  const [, , themePreference, cycleTheme] = useDarkMode();
   const { data: unreadCount = 0 } = useUnreadCount();
   const { data: profile } = useProfile(user?.id);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -138,12 +138,25 @@ const SidebarAccount = memo(function SidebarAccount({
       <DropdownMenuSeparator />
       <DropdownMenuItem
         onSelect={(e) => {
+          // Keep the menu open so the user can click through Hell → Dunkel → System.
           e.preventDefault();
-          toggleDarkMode();
+          cycleTheme();
         }}
       >
-        {darkMode ? <PiSun className="size-4" /> : <PiMoon className="size-4" />}
-        <span>{darkMode ? 'Heller Modus' : 'Dunkler Modus'}</span>
+        {themePreference === 'light' ? (
+          <PiSun className="size-4" />
+        ) : themePreference === 'dark' ? (
+          <PiMoon className="size-4" />
+        ) : (
+          <PiDesktop className="size-4" />
+        )}
+        <span>
+          {themePreference === 'light'
+            ? 'Heller Modus'
+            : themePreference === 'dark'
+              ? 'Dunkler Modus'
+              : 'System'}
+        </span>
       </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuItem

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -46,7 +46,7 @@ import {
   FiSidebar,
   FiX,
 } from 'react-icons/fi';
-import { PiSun, PiMoon } from 'react-icons/pi';
+import { PiSun, PiMoon, PiDesktop } from 'react-icons/pi';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { z } from 'zod';
 
@@ -159,7 +159,7 @@ function EditorContent() {
   const apiClient = useMemo(() => createDocsApiClient(adapter), [adapter]);
   const { user, isAuthResolved } = useAuth({ lazy: true });
   const isGuest = Boolean(isAuthResolved) && !user;
-  const [darkMode, toggleDarkMode] = useDarkMode();
+  const [, , themePreference, cycleTheme] = useDarkMode();
 
   const guestIdentity = useMemo(() => (isGuest ? getOrCreateGuestIdentity() : null), [isGuest]);
 
@@ -661,12 +661,22 @@ function EditorContent() {
                     <button
                       className="flex items-center gap-2.5 w-full py-2 px-3 text-[0.8125rem] text-foreground bg-transparent border-none rounded-lg cursor-pointer text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 [&_svg]:w-4 [&_svg]:h-4 [&_svg]:text-grey-500"
                       onClick={() => {
-                        setShowActionsMenu(false);
-                        toggleDarkMode();
+                        // Cycle Hell → Dunkel → System; keep the menu open to click through.
+                        cycleTheme();
                       }}
                     >
-                      {darkMode ? <PiSun /> : <PiMoon />}
-                      {darkMode ? 'Heller Modus' : 'Dunkler Modus'}
+                      {themePreference === 'light' ? (
+                        <PiSun />
+                      ) : themePreference === 'dark' ? (
+                        <PiMoon />
+                      ) : (
+                        <PiDesktop />
+                      )}
+                      {themePreference === 'light'
+                        ? 'Heller Modus'
+                        : themePreference === 'dark'
+                          ? 'Dunkler Modus'
+                          : 'System'}
                     </button>
                     <button
                       className="flex items-center gap-2.5 w-full py-2 px-3 text-[0.8125rem] text-foreground bg-transparent border-none rounded-lg cursor-pointer text-left transition-colors hover:bg-black/5 dark:hover:bg-white/10 [&_svg]:w-4 [&_svg]:h-4 [&_svg]:text-grey-500"


### PR DESCRIPTION
## What

Replaces the boolean dark-mode toggle with a **light / dark / system** preference.

- `useDarkMode` now returns `[darkMode, toggleDarkMode, themePreference, cycleTheme]`.
- Account menu (`SidebarAccount`) and the docs editor menu (`DocsEditorPage`) cycle **Hell → Dunkel → System**, with a desktop icon for the system option.
- `system` follows the OS live via `prefers-color-scheme`.

## Storage & migration

- New `themePreference` key; migrates the legacy `darkMode` (timestamped JSON) and `theme` (string) keys, honoring old timestamps.
- An explicit Light/Dark choice lapses back to `system` after **7 days of inactivity** (timestamp refreshes each visit). `system` never expires.

## No-flash

- `color-scheme` is bound to `data-theme` in `variables.css` so native controls (scrollbars, form controls, date pickers) render in the right scheme.
- The `index.html` pre-paint script mirrors the exact same resolution to avoid a flash of the wrong theme.

## Test plan

- [ ] Toggle through Hell → Dunkel → System in both the sidebar account menu and the docs editor menu; icon/label update.
- [ ] In `system`, flip OS appearance — app follows live.
- [ ] Existing users with legacy `darkMode`/`theme` keys migrate without a flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)