### PR TITLE
chore: 5-Jahre-Datenfenster für Sachsen-Anhalt-Quellen

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -103,6 +103,7 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       type: 'landesverband',
       baseUrl: 'https://www.gruene-lsa.de',
       cms: 'wordpress',
+      maxAgeYears: 5,
       contentPaths: [
         {
           // Site relaunched in Dec 2025 and changed permalinks from
@@ -168,6 +169,7 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       // pagination is /pressemitteilungen~p2 (no .html), ~77 pages; dates DD.MM.YY.
       baseUrl: 'https://gruene-fraktion-sachsen-anhalt.de',
       cms: 'neos',
+      maxAgeYears: 5,
       contentPaths: [
         {
           type: 'presse',


### PR DESCRIPTION
## Was

Beide Sachsen-Anhalt-Scraper-Quellen (`sachsen-anhalt-lv`, `sachsen-anhalt-fraktion`) in `apps/api/config/landesverbaendeConfig.ts` hatten kein `maxAgeYears` gesetzt und fielen damit auf den Default von **10 Jahren** zurück. Alle anderen Landesverbände setzen das Feld explizit (überwiegend `5`).

Dieser PR setzt `maxAgeYears: 5` für beide Quellen, sodass der Daten-Gap des Sachsen-Anhalt-Notebooks wie bei den übrigen LVs **5 Jahre** beträgt.

## Hinweis

Greift beim nächsten Scrape-Lauf. Wurden die Quellen bereits mit dem 10-Jahres-Fenster eingelesen, ist ein erneuter Scrape nötig, damit Inhalte zwischen 5 und 10 Jahren wegfallen.

Der PDF-Pfad (`extractDateFromPdfInfo`) nutzt weiterhin ein fest verdrahtetes 10-Jahres-Limit, betrifft Sachsen-Anhalt aber nicht (einzige PDF-Quelle ist das Landtagswahlprogramm 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)