### PR TITLE
fix(chat): render thread-list portal inside the runtime to avoid AuiProvider crash

### DIFF
--- a/apps/desktop/azure-trusted-signing-agent-guide.md
+++ b/apps/desktop/azure-trusted-signing-agent-guide.md
@@ -15,47 +15,47 @@ missing rights), and hands **Part B** (repo/CI) to a developer.
 
 ## ⚠️ Read first — two unrelated "signatures" exist
 
-| Thing | What it is | Stops SmartScreen? |
-|---|---|---|
+| Thing                                                                                 | What it is                                                                 | Stops SmartScreen?                     |
+| ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- | -------------------------------------- |
 | `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_KEY_PASSWORD` (already in `desktop-release.yml`) | **minisign** key that signs the **auto-updater manifest** (`latest.json`). | ❌ No — unrelated. **Leave it alone.** |
-| **Azure Trusted Signing** Authenticode cert (this guide) | Microsoft-trusted **code-signing** of the `.exe`/`.msi`. | ✅ Yes — this is the fix. |
+| **Azure Trusted Signing** Authenticode cert (this guide)                              | Microsoft-trusted **code-signing** of the `.exe`/`.msi`.                   | ✅ Yes — this is the fix.              |
 
 ---
 
 ## App facts (use these exact values)
 
-| Field | Value |
-|---|---|
-| Product name | `Grünerator` |
-| Bundle identifier | `de.gruenerator.desktop` |
-| Version | `1.2.0` |
-| Windows artifacts | NSIS `…_x64-setup.exe` and `.msi` |
-| Build pipeline | `.github/workflows/desktop-release.yml` (`tauri-apps/tauri-action@v0`, `windows-latest`, ~line 112) |
-| Tauri config | `apps/desktop/src-tauri/tauri.conf.json` (Windows block has **no** signing config yet) |
-| GitHub repository | `netzbegruenung/Gruenerator` |
-| Release trigger | push of tag `desktop-v*` (plus manual `workflow_dispatch`) |
+| Field             | Value                                                                                               |
+| ----------------- | --------------------------------------------------------------------------------------------------- |
+| Product name      | `Grünerator`                                                                                        |
+| Bundle identifier | `de.gruenerator.desktop`                                                                            |
+| Version           | `1.2.0`                                                                                             |
+| Windows artifacts | NSIS `…_x64-setup.exe` and `.msi`                                                                   |
+| Build pipeline    | `.github/workflows/desktop-release.yml` (`tauri-apps/tauri-action@v0`, `windows-latest`, ~line 112) |
+| Tauri config      | `apps/desktop/src-tauri/tauri.conf.json` (Windows block has **no** signing config yet)              |
+| GitHub repository | `netzbegruenung/Gruenerator`                                                                        |
+| Release trigger   | push of tag `desktop-v*` (plus manual `workflow_dispatch`)                                          |
 
 ## Decisions (prefilled — do not re-ask)
 
-| Decision | Value |
-|---|---|
-| Identity type | **Organization** — validating Moritz Wächter's Einzelunternehmen. *(Individual is NOT offered in the EU — only USA & Canada.)* |
-| Publisher shown in Windows | **Moritz Wächter** (the validated business name) |
-| Region | **West Europe** — endpoint `https://weu.codesigning.azure.net/` |
-| Azure subscription | `cc4836eb-72cc-4145-a8ab-29fbccc7992b` (Pay-As-You-Go) |
-| CI signing method | **`azure/trusted-signing-action`** |
-| The agent also requests the **D-U-N-S number** | yes (Phase 0) |
+| Decision                                       | Value                                                                                                                          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Identity type                                  | **Organization** — validating Moritz Wächter's Einzelunternehmen. _(Individual is NOT offered in the EU — only USA & Canada.)_ |
+| Publisher shown in Windows                     | **Moritz Wächter** (the validated business name)                                                                               |
+| Region                                         | **West Europe** — endpoint `https://weu.codesigning.azure.net/`                                                                |
+| Azure subscription                             | `cc4836eb-72cc-4145-a8ab-29fbccc7992b` (Pay-As-You-Go)                                                                         |
+| CI signing method                              | **`azure/trusted-signing-action`**                                                                                             |
+| The agent also requests the **D-U-N-S number** | yes (Phase 0)                                                                                                                  |
 
 ### Identity / contact values
 
-| Field | Value |
-|---|---|
-| Business name (must match D-U-N-S **exactly**) | `Moritz Wächter` |
-| Business address (must match D-U-N-S exactly) | `Villestr. 6-8, 53347 Alfter` |
-| Country | `Germany` |
-| Contact email | `moritz-waechter@outlook.de` |
-| Contact phone | `+49 162 9830496` (national `0162 9830496`) |
-| D-U-N-S number | `<FILL: D-U-N-S>` — obtained in Phase 0 |
+| Field                                          | Value                                       |
+| ---------------------------------------------- | ------------------------------------------- |
+| Business name (must match D-U-N-S **exactly**) | `Moritz Wächter`                            |
+| Business address (must match D-U-N-S exactly)  | `Villestr. 6-8, 53347 Alfter`               |
+| Country                                        | `Germany`                                   |
+| Contact email                                  | `moritz-waechter@outlook.de`                |
+| Contact phone                                  | `+49 162 9830496` (national `0162 9830496`) |
+| D-U-N-S number                                 | `<FILL: D-U-N-S>` — obtained in Phase 0     |
 
 ### Status so far (done — do not redo)
 
@@ -84,7 +84,7 @@ in parallel.
 
 1. Open the free **Apple D-U-N-S lookup tool** (works for any business, no Apple account needed):
    `https://developer.apple.com/enroll/duns-lookup/`.
-   *(Fallback if unavailable: Dun & Bradstreet Germany `https://www.dnb.com/de-de/` → "D-U-N-S-Nummer".)*
+   _(Fallback if unavailable: Dun & Bradstreet Germany `https://www.dnb.com/de-de/` → "D-U-N-S-Nummer".)_
 2. Enter and **search**:
    - **Legal entity name:** `Moritz Wächter`
    - **Country/region:** `Germany`
@@ -101,6 +101,7 @@ in parallel.
    personal verification on their behalf.
 
 > **Known traps on the Apple D-U-N-S form (learned in practice — the operator must finish these):**
+>
 > 1. **Umlauts get stripped** by the form-fill tooling — "Wächter" saves as "Wchter". The operator
 >    must manually correct **Legal Entity Name → `Moritz Wächter`** and **Family Name → `Wächter`**.
 >    A mismatch here makes the Phase 3 D-U-N-S match fail.
@@ -121,7 +122,7 @@ No D-U-N-S needed for this — do it immediately while Phase 0 is pending.
 
 1. Go to `https://portal.azure.com`. If a sign-in/MFA screen appears, **stop** and let the human
    authenticate (never type credentials).
-2. Search **`gruenerator-signing`** and open it. *(The account already exists — do not create one.)*
+2. Search **`gruenerator-signing`** and open it. _(The account already exists — do not create one.)_
 3. Left menu → **Access control (IAM)** → **+ Add** → **Add role assignment**.
 4. Role: **`Artifact Signing Identity Verifier`** (search by name).
    - **Members:** user `moritz-waechter@outlook.de`. → **Review + assign**.
@@ -172,7 +173,7 @@ registration in the task — for CI auth, not user login.
      **Register**.
    - Copy **Application (client) ID** and **Directory (tenant) ID**.
 2. App → **Certificates & secrets** → **Federated credentials** → **+ Add credential**, scenario
-   *GitHub Actions deploying Azure resources*, **Organization** `netzbegruenung`, **Repository**
+   _GitHub Actions deploying Azure resources_, **Organization** `netzbegruenung`, **Repository**
    `Gruenerator`. Add **two** credentials:
    - Entity type **Tag**, value `desktop-v*`, name `release-tag` (releases are tag-triggered).
    - Entity type **Branch**, value `master`, name `manual-dispatch` (covers `workflow_dispatch`).
@@ -220,7 +221,7 @@ upload:
 
 1. `azure/login@v2` with `client-id`/`tenant-id`/`subscription-id` (OIDC).
 2. `azure/trusted-signing-action@v0` with `endpoint`, `trusted-signing-account-name:
-   gruenerator-signing`, `certificate-profile-name: gruenerator-public-trust`, and a glob over
+gruenerator-signing`, `certificate-profile-name: gruenerator-public-trust`, and a glob over
    `apps/desktop/src-tauri/target/**/release/bundle/{nsis,msi}` filtering `*.exe,*.msi`.
 
 The job needs `permissions: { id-token: write, contents: write }`.

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -1,24 +1,12 @@
-import { GrueneratorChatProvider, TooltipProvider, type SharepicVariant } from '@gruenerator/chat';
-import { useQuery } from '@tanstack/react-query';
 import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
-import { createPortal } from 'react-dom';
+  GrueneratorChatProvider,
+  TooltipProvider,
+  preloadChatRuntime,
+  type SharepicVariant,
+} from '@gruenerator/chat';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-
-// The thread list is built on assistant-ui (~heavy). It only renders for
-// authenticated users (the portal below is gated on userId), so lazy-loading it
-// keeps assistant-ui out of the initial bundle for logged-out visitors.
-const ChatThreadList = lazy(() =>
-  import('@gruenerator/chat').then((m) => ({ default: m.ChatThreadList }))
-);
 
 import { renderSharepicToImage } from '../features/image-studio/renderSharepicToImage';
 import { useModelPreferences } from '../features/models/hooks/useModelPreferences';
@@ -28,38 +16,10 @@ import { resolveNotebookChatEntries } from '../features/notebook/utils/notebookC
 import { useAuthStore } from '../stores/authStore';
 import { buildLoginUrl, isPublicPage } from '../utils/authRedirect';
 
+// DOM id of the sidebar slot the global thread list renders into. The slot
+// element lives in the layout Sidebar; the chat runtime renders the thread list
+// into it (see GrueneratorChatRuntimeProvider's threadListPortalSlotId).
 const PORTAL_SLOT_ID = 'chat-thread-portal-slot';
-
-function ChatThreadPortal() {
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    const sync = () => setPortalTarget(document.getElementById(PORTAL_SLOT_ID));
-    sync();
-    const observer = new MutationObserver(sync);
-    observer.observe(document.body, { childList: true, subtree: true });
-    return () => observer.disconnect();
-  }, []);
-
-  const handleClick = () => {
-    if (!location.pathname.startsWith('/chat')) {
-      void navigate('/chat');
-    }
-  };
-
-  if (!portalTarget) return null;
-
-  return createPortal(
-    <div onClick={handleClick} className="contents">
-      <Suspense fallback={null}>
-        <ChatThreadList noScroll />
-      </Suspense>
-    </div>,
-    portalTarget
-  );
-}
 
 interface GlobalChatProviderProps {
   children: ReactNode;
@@ -135,6 +95,17 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
     [navigate]
   );
 
+  // Clicking the global thread-list portal opens the chat surface.
+  const openChat = useCallback(() => {
+    if (!location.pathname.startsWith('/chat')) void navigate('/chat');
+  }, [location.pathname, navigate]);
+
+  // Warm the chat-runtime chunk as soon as the user is authenticated so per-route
+  // chat surfaces (and the thread-list portal) render against a loaded runtime.
+  useEffect(() => {
+    if (userId) preloadChatRuntime();
+  }, [userId]);
+
   const chatConfig = useMemo(
     () => ({
       onUnauthorized: () => {
@@ -201,11 +172,10 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
       onExternalThreadClick={handleExternalClick}
       activePath={location.pathname}
       enabledModelIds={enabledModelIds}
+      threadListPortalSlotId={PORTAL_SLOT_ID}
+      onRequestOpenChat={openChat}
     >
-      <TooltipProvider>
-        {children}
-        {userId && <ChatThreadPortal />}
-      </TooltipProvider>
+      <TooltipProvider>{children}</TooltipProvider>
     </GrueneratorChatProvider>
   );
 }

--- a/packages/chat/src/components/ChatThreadListPortal.tsx
+++ b/packages/chat/src/components/ChatThreadListPortal.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChatThreadList } from './ChatThreadList';
+
+interface ChatThreadListPortalProps {
+  /** DOM id of the slot to render the thread list into (owned by the host layout). */
+  slotId: string;
+  /** Invoked when the user clicks the thread list (e.g. navigate to /chat). */
+  onRequestOpen?: () => void;
+}
+
+/**
+ * Renders the global thread-list sidebar into a host-provided DOM slot.
+ *
+ * This lives inside the assistant-ui runtime tree (rendered by
+ * GrueneratorChatRuntimeProvider, inside AssistantRuntimeProvider), so
+ * ChatThreadList is always mounted with a runtime in scope and co-bundles with
+ * the runtime chunk — it can never render in the Suspense fallback before the
+ * runtime exists. The host (app) supplies only the slot id and an open callback.
+ */
+export function ChatThreadListPortal({ slotId, onRequestOpen }: ChatThreadListPortalProps) {
+  const [target, setTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const sync = () => setTarget(document.getElementById(slotId));
+    sync();
+    // The slot mounts/unmounts with the sidebar (layout mode, expand/collapse),
+    // so track it rather than reading it once.
+    const observer = new MutationObserver(sync);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [slotId]);
+
+  if (!target) return null;
+
+  return createPortal(
+    <div onClick={onRequestOpen} className="contents">
+      <ChatThreadList noScroll />
+    </div>,
+    target
+  );
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -69,7 +69,7 @@ export {
 } from './stores/chatConfigStore';
 
 // Runtime
-export { GrueneratorChatProvider } from './runtime/GrueneratorChatProvider';
+export { GrueneratorChatProvider, preloadChatRuntime } from './runtime/GrueneratorChatProvider';
 export { convertToThreadMessageLike } from './runtime/threadMessageConversion';
 export { GrueneratorAttachmentAdapter } from './runtime/GrueneratorAttachmentAdapter';
 export {

--- a/packages/chat/src/runtime/GrueneratorChatProvider.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatProvider.tsx
@@ -12,11 +12,23 @@ import { type ExternalThreadEntry } from './GrueneratorThreadListAdapter';
 // logged-out visitors on public pages never download it. The unauthenticated
 // branch below never references this lazy component, so the chunk is fetched
 // only once a logged-in user mounts a page. See GrueneratorChatRuntime.tsx.
+const importRuntime = () => import('./GrueneratorChatRuntime');
+
 const GrueneratorChatRuntimeProvider = lazy(() =>
-  import('./GrueneratorChatRuntime').then((m) => ({
+  importRuntime().then((m) => ({
     default: m.GrueneratorChatRuntimeProvider,
   }))
 );
+
+/**
+ * Warm the chat-runtime chunk ahead of first use. Call once a user is known to be
+ * authenticated so per-route chat surfaces (and the global thread-list portal) hit
+ * an already-loaded runtime instead of a cold lazy import. React's `lazy` dedupes
+ * the underlying import promise, so this shares the same module fetch.
+ */
+export const preloadChatRuntime = () => {
+  void importRuntime();
+};
 
 interface GrueneratorChatProviderProps {
   children: ReactNode;
@@ -27,6 +39,14 @@ interface GrueneratorChatProviderProps {
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
   enabledModelIds?: ReadonlySet<TextModelId> | null;
+  /**
+   * DOM id of the slot the global thread-list portal renders into. When set, the
+   * runtime renders the thread list itself (inside AssistantRuntimeProvider), so
+   * the app never injects runtime-dependent UI into the Suspense fallback.
+   */
+  threadListPortalSlotId?: string;
+  /** Invoked when the user clicks the global thread-list portal (e.g. navigate to /chat). */
+  onRequestOpenChat?: () => void;
 }
 
 export function GrueneratorChatProvider({
@@ -38,6 +58,8 @@ export function GrueneratorChatProvider({
   onExternalThreadClick,
   activePath,
   enabledModelIds,
+  threadListPortalSlotId,
+  onRequestOpenChat,
 }: GrueneratorChatProviderProps) {
   // Sync config store during render (before any hooks read from it).
   // useEffect runs AFTER render, which creates a race: providerApiClient
@@ -78,7 +100,8 @@ export function GrueneratorChatProvider({
   // fallback={children} renders the page unwrapped while the runtime chunk
   // loads — identical to the unauthenticated branch above, so it is safe by
   // construction. The chunk caches after first load, so navigation never
-  // re-suspends.
+  // re-suspends. Runtime-dependent chrome (the thread-list portal) is rendered
+  // INSIDE the runtime via threadListPortalSlotId, never as fallback children.
   return (
     <ModelPreferencesProvider enabledModelIds={enabledModelIds}>
       <Suspense fallback={children}>
@@ -88,6 +111,8 @@ export function GrueneratorChatProvider({
           getExternalThreads={getExternalThreads}
           onExternalThreadClick={onExternalThreadClick}
           activePath={activePath}
+          threadListPortalSlotId={threadListPortalSlotId}
+          onRequestOpenChat={onRequestOpenChat}
         >
           {children}
         </GrueneratorChatRuntimeProvider>

--- a/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
@@ -42,6 +42,7 @@ import {
 } from './GrueneratorThreadListAdapter';
 import { ExternalThreadProvider } from '../context/ExternalThreadContext';
 import { grueneratorToolkit } from '../components/tool-ui/GrueneratorToolUIs';
+import { ChatThreadListPortal } from '../components/ChatThreadListPortal';
 import { chatSuggestions } from '../lib/suggestions';
 import type { StreamMetadata } from '../hooks/useChatGraphStream';
 import { convertToThreadMessageLike, type LoadedMessage } from './threadMessageConversion';
@@ -304,6 +305,8 @@ export function GrueneratorChatRuntimeProvider({
   getExternalThreads,
   onExternalThreadClick,
   activePath,
+  threadListPortalSlotId,
+  onRequestOpenChat,
 }: {
   children: ReactNode;
   userId: string;
@@ -311,6 +314,8 @@ export function GrueneratorChatRuntimeProvider({
   getExternalThreads?: () => ExternalThreadEntry[];
   onExternalThreadClick?: (externalId: string) => void;
   activePath?: string;
+  threadListPortalSlotId?: string;
+  onRequestOpenChat?: () => void;
 }) {
   const fetchFn = useChatConfigStore((s) => s.fetch);
   const onUnauthorized = useChatConfigStore((s) => s.onUnauthorized);
@@ -362,6 +367,12 @@ export function GrueneratorChatRuntimeProvider({
       <ExternalThreadProvider value={externalCtx}>
         <ThreadTitleEffect />
         <AgentSwitchListener />
+        {threadListPortalSlotId && (
+          <ChatThreadListPortal
+            slotId={threadListPortalSlotId}
+            onRequestOpen={onRequestOpenChat}
+          />
+        )}
         <ChatCollaborationBridge userId={userId} userName={userName}>
           {children}
         </ChatCollaborationBridge>

--- a/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
+++ b/packages/chat/src/runtime/GrueneratorChatRuntime.tsx
@@ -368,10 +368,7 @@ export function GrueneratorChatRuntimeProvider({
         <ThreadTitleEffect />
         <AgentSwitchListener />
         {threadListPortalSlotId && (
-          <ChatThreadListPortal
-            slotId={threadListPortalSlotId}
-            onRequestOpen={onRequestOpenChat}
-          />
+          <ChatThreadListPortal slotId={threadListPortalSlotId} onRequestOpen={onRequestOpenChat} />
         )}
         <ChatCollaborationBridge userId={userId} userName={userName}>
           {children}


### PR DESCRIPTION
## Problem

On localhost (Vite dev) the app crashes with **"You are using a component or hook that requires an AuiProvider"**, with the stack inside a React *Suspense Fallback*.

Root cause — a dev-only chunk-load race rooted in an architectural smell:
- `GrueneratorChatProvider` renders `<Suspense fallback={children}>` while the lazy `GrueneratorChatRuntime` chunk (which mounts `AssistantRuntimeProvider`) loads.
- Those `children` included the app's `{userId && <ChatThreadPortal />}`, which renders `ChatThreadList` → `ThreadListPrimitive.Items` / `useAui()` — all requiring the runtime that isn't mounted yet.
- `ChatThreadList` (barrel chunk) and `GrueneratorChatRuntime` (relative-import chunk) were **separate** lazy chunks. In dev, Vite serves each as its own HTTP request, so `ChatThreadList` can render *before* the runtime → crash. In prod (`codeSplitting: false`) they bundle together, so it can't — hence "only on localhost".

## Fix — the runtime owns its own chrome

Rather than guard the symptom, this removes the bug class by construction:
- **New `ChatThreadListPortal`** (`packages/chat`) renders the thread-list sidebar into a host-provided DOM slot, **inside `AssistantRuntimeProvider`**. It imports `ChatThreadList` directly, so the list **co-bundles with the runtime chunk** — no separate-chunk race — and can never appear in the Suspense fallback.
- The app (`GlobalChatProvider`) no longer renders a runtime-dependent component; it passes only `threadListPortalSlotId` + an `onRequestOpenChat` callback. The DOM slot stays in the layout `Sidebar`.
- **`preloadChatRuntime()`** warms the runtime chunk the moment a user is authenticated, so per-route chat surfaces (`/chat`, `/agents/:slug`, …) — which still render as routed `children` — hit an already-loaded runtime.

This also consolidates chat/runtime ownership in `packages/chat`, matching the repo's "chat UI defined once in packages/chat, rendered per-platform" principle.

## Files
- `packages/chat/src/components/ChatThreadListPortal.tsx` (new)
- `packages/chat/src/runtime/GrueneratorChatRuntime.tsx` — render portal inside the runtime
- `packages/chat/src/runtime/GrueneratorChatProvider.tsx` — thread props + `preloadChatRuntime`
- `packages/chat/src/index.ts` — export `preloadChatRuntime`
- `apps/web/src/providers/GlobalChatProvider.tsx` — drop local portal, pass slot id + callback, preload on auth

## Verification
- ✅ `pnpm --filter @gruenerator/chat typecheck` + `pnpm --filter @gruenerator/web typecheck`
- ✅ ESLint clean on changed files
- Manual: hard-reload several times on a non-`/chat` page (DevTools throttled to Slow 3G to widen the race window) — no crash; sidebar thread list appears shortly after load; click still navigates to `/chat`.

### Known residual (cheap follow-up)
A cold **direct deep-link to `/chat`** could still briefly render the chat page in the fallback before the preload resolves. The reported global-portal crash is fully fixed; if this surfaces, the follow-up is hoisting `preloadChatRuntime()` into `AuthBootstrap`/`RequireAuth` or adding a `/chat` skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)