### PR TITLE
fix(chat): resolve user-created agents in ChatGraph init

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -14,7 +14,11 @@
 import { StateGraph, Annotation } from '@langchain/langgraph';
 
 import { resolveNotebookCollections } from '../../../config/notebookCollectionMap.js';
-import { getAgent, getDefaultAgentId } from '../../../routes/chat/agents/agentLoader.js';
+import {
+  getAgent,
+  getAgentForUser,
+  getDefaultAgentId,
+} from '../../../routes/chat/agents/agentLoader.js';
 import { createLogger } from '../../../utils/logger.js';
 
 import { briefGeneratorNode } from './nodes/briefGeneratorNode.js';
@@ -629,7 +633,13 @@ export const chatGraph = createChatGraph();
  * Loads agent configuration and sets up initial state.
  */
 export async function initializeChatState(input: ChatGraphInput): Promise<ChatState> {
-  const agentConfig = await getAgent(input.agentId || getDefaultAgentId());
+  const agentId = input.agentId || getDefaultAgentId();
+  // User-created agents (`user_agents`) and custom-generator agents (`cg-*`) are
+  // keyed by userId, so resolve through the user-aware loader when we have one.
+  // Without a userId (tests, non-HTTP callers) only system agents resolve.
+  const agentConfig = input.userId
+    ? await getAgentForUser(agentId, input.userId)
+    : await getAgent(agentId);
 
   if (!agentConfig) {
     throw new Error(`Agent not found: ${input.agentId}`);

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -287,6 +287,12 @@ export interface ChatGraphInput {
   messages: ModelMessage[];
   threadId?: string | undefined;
   agentId: string;
+  /**
+   * Owner of the request. Required to resolve user-created agents (the
+   * `user_agents` table) and custom-generator agents (`cg-*`), which are keyed
+   * by `(user_id, identifier)`. When omitted, only system agents resolve.
+   */
+  userId?: string | undefined;
   enabledTools: Record<string, boolean>;
   aiWorkerPool: AIWorkerPool;
   attachmentContext?: string | undefined;

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -376,6 +376,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         messages: validMessages,
         threadId: actualThreadId,
         agentId: agentId ?? 'gruenerator-universal',
+        userId,
         enabledTools: enabledTools ?? {
           search: true,
           web: true,

--- a/apps/api/routes/chat/chatGraphController.ts
+++ b/apps/api/routes/chat/chatGraphController.ts
@@ -380,6 +380,7 @@ router.post(
         messages: validMessages,
         threadId: actualThreadId,
         agentId: agentId || 'gruenerator-universal',
+        userId,
         enabledTools: enabledTools || {
           search: true,
           web: true,


### PR DESCRIPTION
## Problem

Chatting with a **user-created** agent (stored in the `user_agents` table, e.g. `mobilitaets-recherchebot-8bsx4p`) failed with:

```
ERROR [chatGraphContractRouter] [ChatGraph] Controller error: Agent not found: mobilitaets-recherchebot-8bsx4p
    at initializeChatState (apps/api/agents/langgraph/ChatGraph/ChatGraph.ts:635)
```

`initializeChatState` resolved agents only against the **static system registry** via `getAgent` (`getSystemAgent`). User-created agents and `cg-*` custom-generator agents are keyed by `(user_id, identifier)` and require a `userId` to resolve — but `ChatGraphInput` never carried one. The controller set `agentConfig.userId` only *after* init, too late.

## Fix

- Add optional `userId` to `ChatGraphInput`.
- In `initializeChatState`, resolve via the existing `getAgentForUser(agentId, userId)` when a `userId` is present (system → `user_agents` → `cg-*`), falling back to `getAgent` for callers without one (tests, non-HTTP).
- Pass `userId` from both chat controllers (contract router + legacy controller).

No new resolution logic — reuses `getAgentForUser`. System agents continue to work unchanged.

## Verification

- `pnpm --filter @gruenerator/api typecheck` passes.
- Manually confirmed: chatting with a custom user agent now runs the normal classifier→respond flow instead of throwing; system agents (`gruenerator-universal`) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)