### PR TITLE
feat(profile): Experten-Schalter für Benachrichtigungen + Aufräumen

### DIFF
--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/ProfileView.tsx
@@ -9,7 +9,8 @@ import MemoriesSection from '../../../../../../components/profile/MemoriesSectio
 import { useAuthStore, type SupportedLocale } from '../../../../../../stores/authStore';
 import { cn } from '../../../../../../utils/cn';
 
-import ImageModelSettingsSection from './ImageModelSettingsSection';
+// Bildmodellauswahl vorübergehend auskommentiert
+// import ImageModelSettingsSection from './ImageModelSettingsSection';
 import ModelSettingsSection from './ModelSettingsSection';
 import RolesSection from './RolesSection';
 import SettingsSection from './SettingsSection';
@@ -208,7 +209,8 @@ const ProfileView = ({
 
       <ModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
 
-      <ImageModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} />
+      {/* Bildmodellauswahl vorübergehend auskommentiert
+      <ImageModelSettingsSection onSuccessMessage={onSuccessMessage} onErrorMessage={() => {}} /> */}
 
       <MemoriesSection />
 

--- a/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/ProfileInfo/SettingsSection.tsx
@@ -45,8 +45,10 @@ const SettingsSection: React.FC<SettingsSectionProps> = memo(
         <NotificationPreferences
           onSuccessMessage={onSuccessMessage}
           onErrorMessage={onErrorMessage}
+          expertExtras={
+            <TestEmailRow onSuccessMessage={onSuccessMessage} onErrorMessage={onErrorMessage} />
+          }
         />
-        <TestEmailRow onSuccessMessage={onSuccessMessage} onErrorMessage={onErrorMessage} />
       </div>
     );
   }

--- a/apps/web/src/features/notifications/components/NotificationPreferences.tsx
+++ b/apps/web/src/features/notifications/components/NotificationPreferences.tsx
@@ -14,6 +14,8 @@ import { cn } from '@/utils/cn';
 interface NotificationPreferencesProps {
   onSuccessMessage: (message: string) => void;
   onErrorMessage: (message: string) => void;
+  /** Nur im Experten-Modus angezeigt (z. B. Test-E-Mail). */
+  expertExtras?: React.ReactNode;
 }
 
 const CHANNEL_ICONS: Record<NotificationChannel, React.ComponentType<{ className?: string }>> = {
@@ -33,6 +35,7 @@ const RAW_GROUPS = getRawTypesByGroup();
 const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
   onSuccessMessage,
   onErrorMessage,
+  expertExtras,
 }) => {
   const { level, preferences, isLoading, applyLevel, isApplyingLevel, toggleChannel } =
     useNotificationPreferences();
@@ -194,6 +197,7 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
               </div>
             </div>
           ))}
+          {expertExtras}
         </div>
       )}
     </div>

--- a/apps/web/src/features/notifications/components/NotificationPreferences.tsx
+++ b/apps/web/src/features/notifications/components/NotificationPreferences.tsx
@@ -1,5 +1,5 @@
-import { CollapsibleSection, SelectCard, Switch } from '@gruenerator/ui';
-import { Bell, Info, Mail, Settings2, Smartphone } from 'lucide-react';
+import { SelectCard, Switch } from '@gruenerator/ui';
+import { Bell, Mail, Settings2, Smartphone } from 'lucide-react';
 import React from 'react';
 
 import { useNotificationPreferences } from '../hooks/useNotificationPreferences';
@@ -36,6 +36,10 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
 }) => {
   const { level, preferences, isLoading, applyLevel, isApplyingLevel, toggleChannel } =
     useNotificationPreferences();
+
+  // Experten-Modus: ersetzt die Stufenauswahl durch die erweiterten Einstellungen
+  // (nie beides gleichzeitig). Standardmäßig an, wenn bereits individuell konfiguriert.
+  const [expertMode, setExpertMode] = React.useState(level === 'custom');
 
   const handleSelectLevel = async (value: 'low' | 'medium' | 'high') => {
     if (level === value) return;
@@ -78,59 +82,49 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
 
   return (
     <div className="space-y-lg">
-      <div>
-        <div className="text-sm font-medium text-foreground mb-xs">Benachrichtigungen</div>
-        <p className="text-xs text-grey-500 dark:text-grey-400">
-          Wähle, wie viele Benachrichtigungen du erhalten möchtest.
-          {level === 'custom' && (
-            <span className="ml-xs font-medium text-secondary-600 dark:text-secondary-400">
-              Aktuell: Individuell
-            </span>
-          )}
-        </p>
-      </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-md">
-        {LEVEL_OPTIONS.map((opt) => {
-          const Icon = opt.icon;
-          return (
-            <SelectCard
-              key={opt.value}
-              label={opt.label}
-              description={opt.description}
-              icon={<Icon className="w-5 h-5" />}
-              selected={level === opt.value}
-              onClick={() => {
-                if (!isApplyingLevel) void handleSelectLevel(opt.value);
-              }}
-            />
-          );
-        })}
-      </div>
-
-      <div className="flex items-start gap-sm p-md rounded-lg bg-primary-50 dark:bg-primary-950/30 border border-primary-200 dark:border-primary-800">
-        <Info className="w-4 h-4 mt-0.5 text-primary-600 dark:text-primary-400 shrink-0" />
-        <p className="text-sm text-primary-700 dark:text-primary-300">
-          Stufe Mittel ist empfohlen. Push-Benachrichtigungen erfordern die mobile App;
-          In-App-Benachrichtigungen erscheinen in der Glocke oben rechts.
-        </p>
-      </div>
-
-      <CollapsibleSection
-        bordered
-        title={
-          <span className="flex items-center gap-xs">
-            <Settings2 className="w-4 h-4" />
-            Erweiterte Einstellungen
-          </span>
-        }
-      >
-        <div className="space-y-lg pt-sm">
+      <div className="flex items-start justify-between gap-md">
+        <div>
+          <div className="text-sm font-medium text-foreground mb-xs">Benachrichtigungen</div>
           <p className="text-xs text-grey-500 dark:text-grey-400">
-            Stelle einzelne Benachrichtigungen pro Kanal ein. Eigene Anpassungen setzen die Stufe auf
-            Individuell.
+            {expertMode
+              ? 'Stelle einzelne Benachrichtigungen pro Kanal ein.'
+              : 'Wähle, wie viele Benachrichtigungen du erhalten möchtest.'}
           </p>
+        </div>
+        <label className="flex items-center gap-xs shrink-0 cursor-pointer select-none">
+          <span className="flex items-center gap-xs text-xs text-grey-500 dark:text-grey-400">
+            <Settings2 className="w-3.5 h-3.5" />
+            Experten
+          </span>
+          <Switch
+            className="h-[20px] w-[40px] data-[state=checked]:bg-secondary-600 data-[state=unchecked]:bg-grey-200 dark:data-[state=unchecked]:bg-grey-700"
+            checked={expertMode}
+            onCheckedChange={setExpertMode}
+            aria-label="Experteneinstellungen"
+          />
+        </label>
+      </div>
 
+      {!expertMode ? (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-md">
+          {LEVEL_OPTIONS.map((opt) => {
+            const Icon = opt.icon;
+            return (
+              <SelectCard
+                key={opt.value}
+                label={opt.label}
+                description={opt.description}
+                icon={<Icon className="w-5 h-5" />}
+                selected={level === opt.value}
+                onClick={() => {
+                  if (!isApplyingLevel) void handleSelectLevel(opt.value);
+                }}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="space-y-lg">
           {RAW_GROUPS.map(({ group, label, types }) => (
             <div
               key={group}
@@ -201,7 +195,7 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
             </div>
           ))}
         </div>
-      </CollapsibleSection>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Was

Räumt den Benachrichtigungs-Bereich auf der Profilseite (`/profile`) auf:

- **Experten-Schalter** rechts neben der Überschrift „Benachrichtigungen". Ist er aktiv, ersetzt er die Stufenauswahl (Wenig/Mittel/Viele) durch die erweiterten Einstellungen pro Kanal — **nie beides gleichzeitig**, um UI zu sparen. Standardmäßig an, wenn bereits eine individuelle Konfiguration besteht.
- **Info-Box entfernt** („Stufe Mittel ist empfohlen. Push-Benachrichtigungen erfordern die mobile App; In-App-Benachrichtigungen erscheinen in der Glocke oben rechts.").
- **Bildmodellauswahl** auf der Profilseite **vorübergehend auskommentiert**.

## Dateien

- `apps/web/.../notifications/components/NotificationPreferences.tsx`
- `apps/web/.../profile/tabs/ProfileInfo/ProfileView.tsx`

Typecheck (`pnpm --filter @gruenerator/web typecheck`) grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)