### PR TITLE
feat(skills): canonical /agents route + 2-line card titles

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -73,11 +73,11 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
 
   items.agents = {
     id: 'agents',
-    path: '/skills',
+    path: '/agents',
     title: 'Skills & Agents',
     description: 'KI-Assistent*innen und Schnellbefehle für deine Aufgaben',
     icon: RiSpyLine,
-    activePaths: ['/skills', '/agents'],
+    activePaths: ['/agents', '/skills'],
   };
 
   if (import.meta.env.DEV) {

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -249,6 +249,10 @@ const standardRoutes: RouteConfig[] = [
         { path: '/agents/:identifier/edit', component: AgentSettingsPage },
       ] satisfies RouteConfig[])
     : []),
+  // Skills & Agents library — canonical at /agents (exact match ranks ahead of
+  // the `/agents/:slug` chat route below in React Router). `/skills` redirects
+  // here for old links.
+  { path: '/agents', component: SkillsAndAgentsPage },
   // Chat with a specific system agent at /agents/<slug>. Slug is the agent
   // identifier with the `gruenerator-` prefix stripped (see `getAgentSlug`
   // in @gruenerator/shared/agents). ChatPage handles both this path-based
@@ -263,7 +267,10 @@ const standardRoutes: RouteConfig[] = [
     path: '/recherche',
     component: lazy(() => Promise.resolve({ default: createRedirect('/notebooks') })),
   },
-  { path: '/skills', component: SkillsAndAgentsPage },
+  {
+    path: '/skills',
+    component: lazy(() => Promise.resolve({ default: createRedirect('/agents') })),
+  },
   { path: '/gruppen', component: GruppenPage },
   { path: '/gruppen/:idOrSlug', component: GruppenPage },
   { path: '/gruen-o-mat', component: GruenOMatDemoPage },

--- a/apps/web/src/features/agents/AgentBuilderForm.tsx
+++ b/apps/web/src/features/agents/AgentBuilderForm.tsx
@@ -341,7 +341,7 @@ function AgentBuilderForm({ initialState, onCancel }: AgentBuilderFormProps) {
         <Button
           type="button"
           variant="brand-outline"
-          onClick={() => (onCancel ? onCancel() : navigate('/skills'))}
+          onClick={() => (onCancel ? onCancel() : navigate('/agents'))}
         >
           Abbrechen
         </Button>

--- a/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
+++ b/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
@@ -158,8 +158,8 @@ function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardP
         </div>
         <div className="flex flex-col flex-1 p-md min-w-0">
           <div className="flex justify-between items-start gap-sm mb-xs">
-            <div className="flex min-w-0 items-center gap-xs">
-              <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+            <div className="flex min-w-0 items-start gap-xs">
+              <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
                 {skill.title}
               </h3>
               <TypeBadge kind="skill" />
@@ -253,8 +253,8 @@ function AgentCard({
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <div className="flex justify-between items-start gap-sm mb-xs">
-          <div className="flex min-w-0 items-center gap-xs">
-            <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+          <div className="flex min-w-0 items-start gap-xs">
+            <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
               {agent.title}
             </h3>
             <TypeBadge kind="agent" />
@@ -344,8 +344,8 @@ function SharedAgentCard({ entry, onSelect, isFavorite, onToggleFavorite }: Shar
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <div className="flex justify-between items-start gap-sm mb-xs">
-          <div className="flex min-w-0 items-center gap-xs">
-            <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+          <div className="flex min-w-0 items-start gap-xs">
+            <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
               {agent.title}
             </h3>
             <TypeBadge kind="agent" />

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -642,7 +642,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
                 onInsertMention={handleSelect}
                 onOpenFileBrowser={handlePlusMenuOpenFileBrowser}
                 onUploadFile={handlePlusMenuUpload}
-                {...(onNavigate ? { onOpenSkillsPage: () => onNavigate('/skills') } : {})}
+                {...(onNavigate ? { onOpenSkillsPage: () => onNavigate('/agents') } : {})}
               />
             )}
             {showToolToggles && (


### PR DESCRIPTION
## Was

Verbessert die **Skills & Agents** Bibliothek an zwei Punkten:

### 1. Kanonische URL `/agents` statt nur `/skills`
Die Seite heißt „Skills & Agents", lag aber nur unter `/skills`. Sie ist jetzt kanonisch unter **`/agents`** erreichbar (exakter Match rankt in React Router vor der `/agents/:slug` Chat-Route). `/skills` bleibt als **Redirect** auf `/agents` erhalten, damit alte Links weiter funktionieren. Interne Navigation (AgentBuilder „Abbrechen", Composer Plus-Menü) zeigt direkt auf `/agents`. Menü-`path`/`activePaths` aktualisiert.

### 2. Card-Titel dürfen 2 Zeilen sein
Agent- und Skill-Titel wurden mit `truncate` schon nach einer Zeile abgeschnitten. Längere Agent-Namen waren dadurch früh unleserlich. Titel nutzen jetzt `line-clamp-2` (max. 2 Zeilen), der Typ-Badge richtet sich oben an der ersten Zeile aus (`items-start`).

## Geändert
- `apps/web/src/config/routes.ts` — `/agents` Route + `/skills` Redirect
- `apps/web/src/components/layout/Header/menuData.tsx` — Menü-Pfad
- `apps/web/src/features/skills/SkillsAndAgentsPage.tsx` — `line-clamp-2` in allen 3 Cards
- `apps/web/src/features/agents/AgentBuilderForm.tsx` — Cancel-Navigation
- `packages/chat/src/components/thread/GrueneratorComposer.tsx` — Plus-Menü-Navigation

## Test
- `pnpm --filter @gruenerator/web typecheck` ✅
- `pnpm --filter @gruenerator/chat typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)