### PR TITLE
feat(skills): canonical /agents route + 2-line card titles

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -73,11 +73,11 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
 
   items.agents = {
     id: 'agents',
-    path: '/skills',
+    path: '/agents',
     title: 'Skills & Agents',
     description: 'KI-Assistent*innen und Schnellbefehle für deine Aufgaben',
     icon: RiSpyLine,
-    activePaths: ['/skills', '/agents'],
+    activePaths: ['/agents', '/skills'],
   };
 
   if (import.meta.env.DEV) {

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -249,6 +249,10 @@ const standardRoutes: RouteConfig[] = [
         { path: '/agents/:identifier/edit', component: AgentSettingsPage },
       ] satisfies RouteConfig[])
     : []),
+  // Skills & Agents library — canonical at /agents (exact match ranks ahead of
+  // the `/agents/:slug` chat route below in React Router). `/skills` redirects
+  // here for old links.
+  { path: '/agents', component: SkillsAndAgentsPage },
   // Chat with a specific system agent at /agents/<slug>. Slug is the agent
   // identifier with the `gruenerator-` prefix stripped (see `getAgentSlug`
   // in @gruenerator/shared/agents). ChatPage handles both this path-based
@@ -263,7 +267,10 @@ const standardRoutes: RouteConfig[] = [
     path: '/recherche',
     component: lazy(() => Promise.resolve({ default: createRedirect('/notebooks') })),
   },
-  { path: '/skills', component: SkillsAndAgentsPage },
+  {
+    path: '/skills',
+    component: lazy(() => Promise.resolve({ default: createRedirect('/agents') })),
+  },
   { path: '/gruppen', component: GruppenPage },
   { path: '/gruppen/:idOrSlug', component: GruppenPage },
   { path: '/gruen-o-mat', component: GruenOMatDemoPage },

--- a/apps/web/src/features/agents/AgentBuilderForm.tsx
+++ b/apps/web/src/features/agents/AgentBuilderForm.tsx
@@ -341,7 +341,7 @@ function AgentBuilderForm({ initialState, onCancel }: AgentBuilderFormProps) {
         <Button
           type="button"
           variant="brand-outline"
-          onClick={() => (onCancel ? onCancel() : navigate('/skills'))}
+          onClick={() => (onCancel ? onCancel() : navigate('/agents'))}
         >
           Abbrechen
         </Button>

--- a/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
+++ b/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
@@ -158,8 +158,8 @@ function SkillCard({ skill, isFavorite, onToggleFavorite, onSelect }: SkillCardP
         </div>
         <div className="flex flex-col flex-1 p-md min-w-0">
           <div className="flex justify-between items-start gap-sm mb-xs">
-            <div className="flex min-w-0 items-center gap-xs">
-              <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+            <div className="flex min-w-0 items-start gap-xs">
+              <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
                 {skill.title}
               </h3>
               <TypeBadge kind="skill" />
@@ -253,8 +253,8 @@ function AgentCard({
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <div className="flex justify-between items-start gap-sm mb-xs">
-          <div className="flex min-w-0 items-center gap-xs">
-            <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+          <div className="flex min-w-0 items-start gap-xs">
+            <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
               {agent.title}
             </h3>
             <TypeBadge kind="agent" />
@@ -344,8 +344,8 @@ function SharedAgentCard({ entry, onSelect, isFavorite, onToggleFavorite }: Shar
       </div>
       <div className="flex flex-col flex-1 p-md min-w-0">
         <div className="flex justify-between items-start gap-sm mb-xs">
-          <div className="flex min-w-0 items-center gap-xs">
-            <h3 className="text-base font-semibold text-foreground-heading m-0 truncate">
+          <div className="flex min-w-0 items-start gap-xs">
+            <h3 className="text-base font-semibold text-foreground-heading m-0 line-clamp-2">
               {agent.title}
             </h3>
             <TypeBadge kind="agent" />

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -642,7 +642,7 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
                 onInsertMention={handleSelect}
                 onOpenFileBrowser={handlePlusMenuOpenFileBrowser}
                 onUploadFile={handlePlusMenuUpload}
-                {...(onNavigate ? { onOpenSkillsPage: () => onNavigate('/skills') } : {})}
+                {...(onNavigate ? { onOpenSkillsPage: () => onNavigate('/agents') } : {})}
               />
             )}
             {showToolToggles && (


### PR DESCRIPTION
Test-Branch-Variante von #1153 (gleiche Änderung, cherry-picked auf `test-branch`).

## Was
1. **Kanonische URL `/agents`** für die Skills & Agents Bibliothek (statt nur `/skills`). `/skills` bleibt als Redirect. Interne Nav + Menü aktualisiert.
2. **Card-Titel 2 Zeilen** (`line-clamp-2` statt `truncate`), Typ-Badge oben ausgerichtet — längere Agent-Namen bleiben lesbar.

## Test
- `pnpm --filter @gruenerator/web typecheck` ✅
- `pnpm --filter @gruenerator/chat typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)