### PR TITLE
feat(notifications): announce new Pride avatars on login

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -319,6 +319,12 @@ export const auth = betterAuth({
           log.info(
             `[Auth] session-created id=${session.id} user=${session.userId} token=${session.token?.slice(0, 8) ?? 'NONE'}`
           );
+          // Deliver one-off product announcements (e.g. new Pride avatars) on
+          // login — once per user, idempotent, best-effort.
+          const { deliverLoginAnnouncements } = await import(
+            '../services/notifications/loginAnnouncements.js'
+          );
+          await deliverLoginAnnouncements(session.userId);
         },
       },
     },

--- a/apps/api/services/notifications/NotificationService.ts
+++ b/apps/api/services/notifications/NotificationService.ts
@@ -24,6 +24,10 @@ const EMAIL_HANDLED_ELSEWHERE: ReadonlySet<NotificationType> = new Set<Notificat
   'document_shared',
 ]);
 
+// Types delivered exclusively in-app (no push, no email) regardless of importance
+// tier — e.g. one-off product announcements where a mass email/push is unwanted.
+const IN_APP_ONLY: ReadonlySet<NotificationType> = new Set<NotificationType>(['new_avatars']);
+
 type NotificationRow = InferSelectModel<typeof notifications>;
 
 const log = createLogger('NotificationService');
@@ -101,10 +105,12 @@ export async function createNotification(
   const profile = await getProfileForDelivery(userId);
   const showInApp = await shouldDeliver(userId, type, 'in_app', profile);
   const sendEmailChannel =
-    !EMAIL_HANDLED_ELSEWHERE.has(type) && (await shouldDeliver(userId, type, 'email', profile));
+    !EMAIL_HANDLED_ELSEWHERE.has(type) &&
+    !IN_APP_ONLY.has(type) &&
+    (await shouldDeliver(userId, type, 'email', profile));
 
   if (!showInApp) {
-    const sendPush = await shouldDeliver(userId, type, 'push', profile);
+    const sendPush = !IN_APP_ONLY.has(type) && (await shouldDeliver(userId, type, 'push', profile));
     if (sendPush) firePush(userId, title, body ?? null, type, actionUrl);
     if (sendEmailChannel) fireEmail(userId, profile, title, body ?? null, type, actionUrl);
     return null;
@@ -130,7 +136,8 @@ export async function createNotification(
     log.warn('Failed to publish notification via Redis', { userId, error: err.message });
   });
 
-  const sendPush = await shouldDeliver(userId, type, 'push', profile);
+  const sendPush =
+    !IN_APP_ONLY.has(type) && (await shouldDeliver(userId, type, 'push', profile));
   if (sendPush) firePush(userId, title, body ?? null, type, actionUrl, notification.id);
   if (sendEmailChannel) fireEmail(userId, profile, title, body ?? null, type, actionUrl);
 

--- a/apps/api/services/notifications/loginAnnouncements.ts
+++ b/apps/api/services/notifications/loginAnnouncements.ts
@@ -1,0 +1,74 @@
+/**
+ * One-off product announcements delivered on login.
+ *
+ * Fired from the Better Auth `session.create.after` hook (config/betterAuth.ts),
+ * so every user receives each active announcement exactly once — the next time
+ * they log in. Delivery is:
+ *   - idempotent per user (skips if a notification of that type already exists),
+ *   - bounded by `until` (the per-login check retires itself after the window),
+ *   - best-effort (never throws into the auth flow).
+ *
+ * To retire an announcement, delete its entry here (or let `until` pass).
+ */
+import { and, eq } from 'drizzle-orm';
+
+import { notifications } from '../../database/schema/index.js';
+import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
+import { createLogger } from '../../utils/logger.js';
+
+import { createNotification } from './NotificationService.js';
+
+import type { NotificationType } from './types.js';
+
+const log = createLogger('login-announcements');
+
+interface Announcement {
+  type: NotificationType;
+  title: string;
+  body: string;
+  metadata?: Record<string, unknown>;
+  /** Stop delivering after this instant (ISO). Keeps the check cheap to retire. */
+  until: string;
+}
+
+const ANNOUNCEMENTS: readonly Announcement[] = [
+  {
+    type: 'new_avatars',
+    title: 'Neue Pride-Avatare 🌈',
+    body: 'Es gibt drei neue Pride-Avatare für dein Profil. Tippe auf „Avatar aktivieren" oder wähle deinen Favoriten in deinem Profil.',
+    metadata: { avatarIds: [11, 12, 13] },
+    until: '2026-09-30T23:59:59Z',
+  },
+];
+
+export async function deliverLoginAnnouncements(userId: string): Promise<void> {
+  const now = new Date();
+  const active = ANNOUNCEMENTS.filter((a) => new Date(a.until) > now);
+  if (active.length === 0) return;
+
+  try {
+    const db = getDrizzleInstance();
+    for (const announcement of active) {
+      const existing = await db
+        .select({ id: notifications.id })
+        .from(notifications)
+        .where(and(eq(notifications.user_id, userId), eq(notifications.type, announcement.type)))
+        .limit(1);
+      if (existing.length > 0) continue;
+
+      await createNotification({
+        userId,
+        type: announcement.type,
+        title: announcement.title,
+        body: announcement.body,
+        ...(announcement.metadata ? { metadata: announcement.metadata } : {}),
+      });
+      log.info(`Delivered announcement '${announcement.type}' to user ${userId}`);
+    }
+  } catch (err) {
+    log.warn('Failed to deliver login announcements', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -44,6 +44,7 @@ const TYPE_IMPORTANCE: Record<NotificationType, 1 | 2 | 3> = {
   transfer_downloaded: 3,
   notebook_liked: 3,
   wolke_new_files: 2,
+  new_avatars: 1,
 };
 
 export type NotificationLevel = 'low' | 'medium' | 'high';

--- a/apps/web/src/features/notifications/notificationPreferenceMeta.ts
+++ b/apps/web/src/features/notifications/notificationPreferenceMeta.ts
@@ -23,6 +23,7 @@ import {
   LayoutDashboard,
   MessageSquare,
   Share2,
+  Sparkles,
   UserPlus,
   Users,
 } from 'lucide-react';
@@ -155,12 +156,26 @@ export const RAW_TYPE_META: Record<NotificationType, RawTypeMeta> = {
     icon: CloudDownload,
     group: 'system',
   },
+  new_avatars: {
+    label: 'Neue Avatare',
+    description: 'Wenn neue Profil-Avatare verfügbar sind',
+    icon: Sparkles,
+    group: 'system',
+  },
 };
+
+/**
+ * Raw types excluded from the expert preferences table. One-off announcement
+ * types (e.g. new_avatars) have no meaningful per-user toggle — they fire once
+ * and toggling them afterwards does nothing — so we keep them out of the UI.
+ */
+const HIDDEN_FROM_PREFS: ReadonlySet<NotificationType> = new Set<NotificationType>(['new_avatars']);
 
 /** Raw types grouped by category, in group order, for the expert table. */
 export function getRawTypesByGroup(): { group: NotificationGroup; label: string; types: NotificationType[] }[] {
   const byGroup = new Map<NotificationGroup, NotificationType[]>();
   for (const [type, meta] of Object.entries(RAW_TYPE_META) as [NotificationType, RawTypeMeta][]) {
+    if (HIDDEN_FROM_PREFS.has(type)) continue;
     const existing = byGroup.get(meta.group) ?? [];
     existing.push(type);
     byGroup.set(meta.group, existing);

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -5,11 +5,12 @@ import {
   LayoutDashboard,
   MessageSquare,
   Share2,
+  Sparkles,
   UserPlus,
   Users,
 } from 'lucide-react';
 
-import { openLinkAction, type NotificationTypeConfig } from '../notificationConfig';
+import { openLinkAction, setAvatarAction, type NotificationTypeConfig } from '../notificationConfig';
 
 export interface Notification {
   id: string;
@@ -104,6 +105,14 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
     icon: CloudDownload,
     group: 'system',
     actions: (ctx) => [openLinkAction('Notizbuch öffnen')(ctx)],
+  },
+  new_avatars: {
+    label: 'Neue Avatare',
+    description: 'Wenn neue Profil-Avatare verfügbar sind',
+    icon: Sparkles,
+    image: '/images/profileimages/11.webp',
+    group: 'system',
+    actions: (ctx) => [setAvatarAction(11, 'Avatar aktivieren')(ctx)],
   },
 
   // transfer_downloaded: {

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -37,6 +37,7 @@ export const notificationTypeSchema = z.enum([
   'transfer_downloaded',
   'notebook_liked',
   'wolke_new_files',
+  'new_avatars',
 ]);
 export type NotificationType = z.infer<typeof notificationTypeSchema>;
 


### PR DESCRIPTION
## What

Announce the new Pride-month avatars (IDs 11/12/13) to every user with a one-off in-app notification — delivered **once per user the next time they log in**.

## How

- New notification type `new_avatars` (contracts enum → backend tier → frontend display).
- Delivered from the Better Auth `session.create.after` hook via `deliverLoginAnnouncements()`. Since Better Auth's user model maps to the `profiles` table, `session.userId` is the notification FK.
- **Once per user**: idempotent existence-check skips users who already have it; bounded by an `until` window (2026-09-30) so the per-login check retires itself.
- **In-app only**: new `IN_APP_ONLY` gate in `NotificationService` suppresses push + email regardless of tier.
- CTA reuses the existing `setAvatarAction(11, 'Avatar aktivieren')` helper — same pattern the Wolki avatar used.
- Hidden from the preferences expert table (a one-off announcement has no meaningful toggle).

## Notes

- The one-tap button applies avatar **11**; the body invites users to pick 12/13 in their profile. Change the ID in `types/index.ts` to feature a different one.
- To retire after Pride: delete the entry in `loginAnnouncements.ts` (or let `until` pass).

## Testing

Log in on a dev stack → bell badge appears live (SSE), notification shows Sparkles icon + "Avatar aktivieren"; clicking sets `avatar_robot_id = 11`. Re-login produces no duplicate. Typecheck of the identical changes passed on an equivalent base; CI will re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)