### PR TITLE
feat(groups): Gruppen-Benachrichtigungen über 3-Punkte-Menü stummschalten

### DIFF
--- a/apps/api/database/postgres/migrations/add_group_notification_mute.sql
+++ b/apps/api/database/postgres/migrations/add_group_notification_mute.sql
@@ -1,0 +1,6 @@
+-- Per-member notification mute for groups. When a member toggles "mute" from
+-- the group's 3-dot menu, their email + push notifications for that group are
+-- suppressed (in-app notifications still appear). Defaults to false so existing
+-- members keep receiving notifications unchanged.
+
+ALTER TABLE group_memberships ADD COLUMN IF NOT EXISTS notifications_muted BOOLEAN NOT NULL DEFAULT FALSE;

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -157,6 +157,7 @@ CREATE TABLE IF NOT EXISTS group_memberships (
     role TEXT DEFAULT 'member',
     joined_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     is_active BOOLEAN DEFAULT TRUE,
+    notifications_muted BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE(group_id, user_id)
 );
 

--- a/apps/api/database/schema/groups.ts
+++ b/apps/api/database/schema/groups.ts
@@ -36,6 +36,10 @@ export const group_memberships = pgTable('group_memberships', {
   role: text('role').$type<GroupRole>().default('member'),
   joined_at: timestamp('joined_at', { withTimezone: true }).defaultNow(),
   is_active: boolean('is_active').default(true),
+  // Per-member opt-out: when true, this user's email + push notifications for
+  // this group are suppressed (in-app notifications still appear). Toggled via
+  // the group's 3-dot menu.
+  notifications_muted: boolean('notifications_muted').notNull().default(false),
 });
 
 export const group_join_requests = pgTable('group_join_requests', {

--- a/apps/api/routes/auth/groups/groupsContract/core.ts
+++ b/apps/api/routes/auth/groups/groupsContract/core.ts
@@ -300,7 +300,7 @@ export const coreRoutes = {
       await postgres.ensureInitialized();
 
       const row = (await postgres.queryOne(
-        `SELECT gm.role, gm.joined_at,
+        `SELECT gm.role, gm.joined_at, gm.notifications_muted,
                 g.id, g.name, g.description, g.created_at, g.created_by, g.join_token,
                 g.settings, g.avatar_url, g.links, g.is_public, g.audience, g.slug_suffix
            FROM group_memberships gm
@@ -311,6 +311,7 @@ export const coreRoutes = {
       )) as {
         role: string;
         joined_at: string | Date | null;
+        notifications_muted: boolean | null;
         id: string;
         name: string;
         description: string | null;
@@ -356,6 +357,7 @@ export const coreRoutes = {
             role: row.role,
             joined_at: toIsoOrNull(row.joined_at),
             isAdmin,
+            notifications_muted: row.notifications_muted ?? false,
           },
         },
       };
@@ -662,6 +664,39 @@ export const coreRoutes = {
       return {
         status: 500 as const,
         body: { success: false as const, message: 'Fehler beim Verlassen der Gruppe.' },
+      };
+    }
+  }),
+
+  setGroupMute: s.route(groupsContract.setGroupMute, async (args) => {
+    const { groupId } = args.params;
+    const { muted } = args.body;
+    try {
+      const userId = getUserId(args.req);
+      const postgres = getPostgresInstance();
+      await postgres.ensureInitialized();
+
+      const result = await postgres.exec(
+        'UPDATE group_memberships SET notifications_muted = $1 WHERE group_id = $2 AND user_id = $3',
+        [muted, groupId, userId]
+      );
+
+      if (result.changes === 0) {
+        return {
+          status: 404 as const,
+          body: { success: false as const, message: 'Du bist nicht Mitglied dieser Gruppe.' },
+        };
+      }
+
+      return { status: 200 as const, body: { success: true as const, muted } };
+    } catch (error) {
+      log.error('[groupsContract.setGroupMute] Error:', error);
+      return {
+        status: 500 as const,
+        body: {
+          success: false as const,
+          message: 'Fehler beim Aktualisieren der Benachrichtigungen.',
+        },
       };
     }
   }),

--- a/apps/api/services/notifications/NotificationService.ts
+++ b/apps/api/services/notifications/NotificationService.ts
@@ -1,6 +1,6 @@
 import { and, count, eq, lt, sql, type InferSelectModel } from 'drizzle-orm';
 
-import { notifications } from '../../database/schema/index.js';
+import { group_memberships, notifications } from '../../database/schema/index.js';
 import { getDrizzleInstance } from '../../database/services/DrizzleService.js';
 import { sendNotificationEmail } from '../../services/email/index.js';
 import { sendPushToUser } from '../../services/pushNotificationService.js';
@@ -93,18 +93,64 @@ function fireEmail(
   });
 }
 
+/**
+ * Resolve the group a notification belongs to, if any. Group notifications
+ * carry the id in `metadata.groupId` (and mirror it in `groupKey` as
+ * `group:<id>`); non-group notifications have neither.
+ */
+function resolveGroupId(
+  metadata: Record<string, unknown>,
+  groupKey: string | undefined
+): string | null {
+  if (typeof metadata.groupId === 'string' && metadata.groupId) return metadata.groupId;
+  if (groupKey?.startsWith('group:')) return groupKey.slice('group:'.length) || null;
+  return null;
+}
+
+/**
+ * Whether the user has muted notifications for this group (via the group's
+ * 3-dot menu). Fail-open: any error resolves to `false` so notifications are
+ * never silently suppressed by an infra hiccup.
+ */
+async function isGroupMutedForUser(userId: string, groupId: string): Promise<boolean> {
+  try {
+    const db = getDrizzleInstance();
+    const rows = await db
+      .select({ muted: group_memberships.notifications_muted })
+      .from(group_memberships)
+      .where(and(eq(group_memberships.group_id, groupId), eq(group_memberships.user_id, userId)))
+      .limit(1);
+    return rows[0]?.muted === true;
+  } catch (err) {
+    log.warn('Failed to check group mute preference', {
+      userId,
+      groupId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
 export async function createNotification(
   params: CreateNotificationParams
 ): Promise<NotificationRow | null> {
   const { userId, type, title, body, metadata = {}, actionUrl, groupKey } = params;
 
   const profile = await getProfileForDelivery(userId);
+
+  // A muted group suppresses the noisy channels (email + push) for this user;
+  // the in-app notification is still recorded so nothing is lost.
+  const groupId = resolveGroupId(metadata, groupKey);
+  const groupMuted = groupId ? await isGroupMutedForUser(userId, groupId) : false;
+
   const showInApp = await shouldDeliver(userId, type, 'in_app', profile);
   const sendEmailChannel =
-    !EMAIL_HANDLED_ELSEWHERE.has(type) && (await shouldDeliver(userId, type, 'email', profile));
+    !groupMuted &&
+    !EMAIL_HANDLED_ELSEWHERE.has(type) &&
+    (await shouldDeliver(userId, type, 'email', profile));
 
   if (!showInApp) {
-    const sendPush = await shouldDeliver(userId, type, 'push', profile);
+    const sendPush = !groupMuted && (await shouldDeliver(userId, type, 'push', profile));
     if (sendPush) firePush(userId, title, body ?? null, type, actionUrl);
     if (sendEmailChannel) fireEmail(userId, profile, title, body ?? null, type, actionUrl);
     return null;
@@ -130,7 +176,7 @@ export async function createNotification(
     log.warn('Failed to publish notification via Redis', { userId, error: err.message });
   });
 
-  const sendPush = await shouldDeliver(userId, type, 'push', profile);
+  const sendPush = !groupMuted && (await shouldDeliver(userId, type, 'push', profile));
   if (sendPush) firePush(userId, title, body ?? null, type, actionUrl, notification.id);
   if (sendEmailChannel) fireEmail(userId, profile, title, body ?? null, type, actionUrl);
 

--- a/apps/web/src/features/groups/components/GroupInfoSection.tsx
+++ b/apps/web/src/features/groups/components/GroupInfoSection.tsx
@@ -24,6 +24,7 @@ import {
 import { memo, useCallback, useRef, useState } from 'react';
 import {
   HiDotsVertical,
+  HiOutlineBell,
   HiOutlineDocumentText,
   HiOutlineLink,
   HiOutlinePhotograph,
@@ -34,6 +35,7 @@ import {
   HiCheck,
   HiX,
 } from 'react-icons/hi';
+import { HiOutlineBellSlash } from 'react-icons/hi2';
 import { PiSquaresFour } from 'react-icons/pi';
 import { useNavigate } from 'react-router-dom';
 
@@ -43,6 +45,7 @@ import { type GroupAudience } from '../hooks/useGroupRequests';
 import {
   useCloneCanvasTemplate,
   useGroupMembers,
+  useSetGroupMute,
   getGroupInitials,
   type GroupLink,
 } from '../hooks/useGroups';
@@ -68,6 +71,7 @@ export interface GroupData {
   isAdmin?: boolean;
   membership?: {
     role?: string;
+    notifications_muted?: boolean | null;
   };
   groupInfo?: GroupInfo;
   joinToken?: string;
@@ -182,6 +186,21 @@ const GroupInfoSection = memo(
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
     const [showVisibilityDialog, setShowVisibilityDialog] = useState(false);
     const cloneTemplate = useCloneCanvasTemplate();
+
+    const isMuted = data?.membership?.notifications_muted ?? false;
+    const setGroupMute = useSetGroupMute(groupId);
+    const handleToggleMute = useCallback(() => {
+      if (setGroupMute.isPending) return;
+      const next = !isMuted;
+      setGroupMute.mutate(next, {
+        onSuccess: () =>
+          onSuccessMessage?.(
+            next ? 'Gruppe stummgeschaltet.' : 'Benachrichtigungen wieder aktiviert.'
+          ),
+        onError: (err: Error) =>
+          onErrorMessage?.('Fehler beim Aktualisieren der Benachrichtigungen: ' + err.message),
+      });
+    }, [setGroupMute, isMuted, onSuccessMessage, onErrorMessage]);
 
     const handleCloneTemplate = useCallback(
       (templateId: string) => {
@@ -352,53 +371,72 @@ const GroupInfoSection = memo(
                 />
               </PopoverContent>
             </Popover>
-            {data?.isAdmin && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon-xs" aria-label="Gruppenaktionen">
-                    <HiDotsVertical />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={handleStartEditingBoth} disabled={isUpdatingGroupName}>
-                    <HiPencil className="size-4 mr-xs" />
-                    Bearbeiten
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => avatarInputRef.current?.click()}
-                    disabled={isUploadingAvatar}
-                  >
-                    <HiOutlinePhotograph className="size-4 mr-xs" />
-                    Gruppenbild ändern
-                  </DropdownMenuItem>
-                  {data?.groupInfo?.avatar_url && onDeleteAvatar && (
-                    <DropdownMenuItem onClick={onDeleteAvatar} disabled={isUploadingAvatar}>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon-xs" aria-label="Gruppenaktionen">
+                  <HiDotsVertical />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={handleToggleMute} disabled={setGroupMute.isPending}>
+                  {isMuted ? (
+                    <>
+                      <HiOutlineBell className="size-4 mr-xs" />
+                      Stummschaltung aufheben
+                    </>
+                  ) : (
+                    <>
+                      <HiOutlineBellSlash className="size-4 mr-xs" />
+                      Benachrichtigungen stummschalten
+                    </>
+                  )}
+                </DropdownMenuItem>
+                {data?.isAdmin && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={handleStartEditingBoth}
+                      disabled={isUpdatingGroupName}
+                    >
+                      <HiPencil className="size-4 mr-xs" />
+                      Bearbeiten
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => avatarInputRef.current?.click()}
+                      disabled={isUploadingAvatar}
+                    >
+                      <HiOutlinePhotograph className="size-4 mr-xs" />
+                      Gruppenbild ändern
+                    </DropdownMenuItem>
+                    {data?.groupInfo?.avatar_url && onDeleteAvatar && (
+                      <DropdownMenuItem onClick={onDeleteAvatar} disabled={isUploadingAvatar}>
+                        <HiOutlineTrash className="size-4 mr-xs" />
+                        Gruppenbild entfernen
+                      </DropdownMenuItem>
+                    )}
+                    {data?.joinToken && (
+                      <DropdownMenuItem onClick={copyJoinLink}>
+                        <HiOutlineLink className="size-4 mr-xs" />
+                        {joinLinkCopied ? 'Kopiert!' : 'Einladungslink kopieren'}
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem onClick={() => setShowVisibilityDialog(true)}>
+                      <HiOutlineGlobeAlt className="size-4 mr-xs" />
+                      {data?.groupInfo?.is_public ? 'Öffentlich (verwalten)' : 'Öffentlich machen'}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => setShowDeleteConfirm(true)}
+                      disabled={isDeletingGroup || isUpdatingGroupName}
+                      className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400"
+                    >
                       <HiOutlineTrash className="size-4 mr-xs" />
-                      Gruppenbild entfernen
+                      Gruppe löschen
                     </DropdownMenuItem>
-                  )}
-                  {data?.joinToken && (
-                    <DropdownMenuItem onClick={copyJoinLink}>
-                      <HiOutlineLink className="size-4 mr-xs" />
-                      {joinLinkCopied ? 'Kopiert!' : 'Einladungslink kopieren'}
-                    </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem onClick={() => setShowVisibilityDialog(true)}>
-                    <HiOutlineGlobeAlt className="size-4 mr-xs" />
-                    {data?.groupInfo?.is_public ? 'Öffentlich (verwalten)' : 'Öffentlich machen'}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() => setShowDeleteConfirm(true)}
-                    disabled={isDeletingGroup || isUpdatingGroupName}
-                    className="text-red-600 dark:text-red-400 focus:text-red-600 dark:focus:text-red-400"
-                  >
-                    <HiOutlineTrash className="size-4 mr-xs" />
-                    Gruppe löschen
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
 
           <div className="flex items-start gap-md">

--- a/apps/web/src/features/groups/hooks/useGroups.ts
+++ b/apps/web/src/features/groups/hooks/useGroups.ts
@@ -11,6 +11,7 @@ import {
   useGroupMembers as useGroupMembersShared,
   useJoinGroup,
   useLeaveGroup,
+  useSetGroupMute,
   useUpdateGroupLink,
   useUpdateMemberRole as useUpdateMemberRoleShared,
   useUploadGroupAvatar,
@@ -195,9 +196,9 @@ export const useGroups = ({ isActive }: UseGroupsOptions = {}) => {
   };
 };
 
-// Re-exported hook kept for compatibility with existing callers
-// that expect `useLeaveGroup` / `useGroupDetails` in this module.
-export { useLeaveGroup };
+// Re-exported hooks kept for compatibility with existing callers
+// that expect `useLeaveGroup` / `useGroupDetails` / `useSetGroupMute` here.
+export { useLeaveGroup, useSetGroupMute };
 
 export const useGroupMembers = (groupId: string | null, _options: UseGroupsOptions = {}) => {
   const query = useGroupMembersShared(groupId);

--- a/packages/contracts/src/contracts/groupsContract.ts
+++ b/packages/contracts/src/contracts/groupsContract.ts
@@ -22,6 +22,7 @@ import {
   groupLinkBodySchema,
   groupLinkResponseSchema,
   groupMembersResponseSchema,
+  groupMuteResponseSchema,
   groupOkResponseSchema,
   groupResolveResponseSchema,
   groupSuccessResponseSchema,
@@ -33,6 +34,7 @@ import {
   listUserGroupsResponseSchema,
   memberRoleBodySchema,
   requestToJoinResponseSchema,
+  setGroupMuteBodySchema,
   setGroupVisibilityBodySchema,
   shareContentBodySchema,
   unshareContentBodySchema,
@@ -296,6 +298,26 @@ export const groupsContract = c.router({
       500: groupErrorResponseSchema,
     },
     summary: 'Leave a group (non-creator)',
+  },
+
+  /**
+   * PUT /api/auth/groups/:groupId/mute
+   * The caller mutes/unmutes their own email + push notifications for this
+   * group. In-app notifications are unaffected. Operates on the caller's own
+   * membership — no admin rights required.
+   */
+  setGroupMute: {
+    method: 'PUT',
+    path: '/api/auth/groups/:groupId/mute',
+    pathParams: z.object({ groupId: z.string() }),
+    body: setGroupMuteBodySchema,
+    responses: {
+      200: groupMuteResponseSchema,
+      401: groupErrorResponseSchema,
+      404: groupErrorResponseSchema,
+      500: groupErrorResponseSchema,
+    },
+    summary: 'Mute or unmute the caller notifications for a group',
   },
 
   listMembers: {

--- a/packages/contracts/src/schemas/groups.ts
+++ b/packages/contracts/src/schemas/groups.ts
@@ -179,6 +179,8 @@ export const groupMembershipSchema = z.object({
   role: z.string(),
   joined_at: z.string().nullish(),
   isAdmin: z.boolean(),
+  // Whether the caller has muted email + push notifications for this group.
+  notifications_muted: z.boolean().nullish(),
 });
 export type GroupMembershipDto = z.infer<typeof groupMembershipSchema>;
 
@@ -225,6 +227,12 @@ export const memberRoleBodySchema = z.object({
   role: groupRoleSchema,
 });
 export type MemberRoleBody = z.infer<typeof memberRoleBodySchema>;
+
+/** Body for muting/unmuting the caller's own notifications for a group. */
+export const setGroupMuteBodySchema = z.object({
+  muted: z.boolean(),
+});
+export type SetGroupMuteBody = z.infer<typeof setGroupMuteBodySchema>;
 
 export const groupLinkBodySchema = z.object({
   title: z
@@ -288,6 +296,11 @@ export const groupLinkResponseSchema = z.object({
 
 export const groupOkResponseSchema = z.object({
   success: z.literal(true),
+});
+
+export const groupMuteResponseSchema = z.object({
+  success: z.literal(true),
+  muted: z.boolean(),
 });
 
 // ── Content sharing (migrated from the legacy groupContent.ts routes) ──────────

--- a/packages/shared/src/groups/index.ts
+++ b/packages/shared/src/groups/index.ts
@@ -26,6 +26,7 @@ export {
   useGroupMembers,
   useJoinGroup,
   useLeaveGroup,
+  useSetGroupMute,
   useUpdateGroupInfo,
   useUpdateGroupLink,
   useUpdateGroupName,

--- a/packages/shared/src/groups/types.ts
+++ b/packages/shared/src/groups/types.ts
@@ -92,6 +92,8 @@ export interface GroupMembership {
   role: string;
   joined_at?: string;
   isAdmin: boolean;
+  /** Whether the caller muted email + push notifications for this group. */
+  notifications_muted?: boolean | null;
 }
 
 export interface VerifyTokenResult {

--- a/packages/shared/src/groups/useGroups.ts
+++ b/packages/shared/src/groups/useGroups.ts
@@ -203,6 +203,28 @@ export const useUpdateMemberRole = (groupId: string) => {
   });
 };
 
+/**
+ * Mute/unmute the caller's own email + push notifications for a group. In-app
+ * notifications are unaffected. Operates on the caller's membership, so any
+ * member (not just admins) can toggle it.
+ */
+export const useSetGroupMute = (groupId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (muted: boolean) => {
+      const res = await getContractsClient().groups.setGroupMute({
+        params: { groupId },
+        body: { muted },
+      });
+      if (res.status !== 200) throw new Error(errMessage(res.body));
+      return res.body.muted;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: groupDetailsKey(groupId) });
+    },
+  });
+};
+
 export const useAddGroupLink = (groupId: string) => {
   const qc = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Was

Gruppen-Benachrichtigungen – besonders E-Mails – können nervig werden. Diese PR fügt einen **Stummschalten-Schalter pro Mitglied** hinzu, erreichbar über das 3-Punkte-Menü einer Gruppe. Jedes Mitglied (nicht nur Admins) kann damit E-Mail- und Push-Benachrichtigungen einer Gruppe abschalten – In-App-Benachrichtigungen bleiben erhalten, damit nichts verloren geht.

## Änderungen

- **DB:** `group_memberships.notifications_muted` (Migration + `schema.sql` + Drizzle-Schema), Default `false`.
- **Backend:** `createNotification` ermittelt die Gruppe aus `metadata.groupId`/`groupKey`; hat das/die Empfänger:in stummgeschaltet, werden **E-Mail + Push unterdrückt**, die In-App-Notification aber weiterhin angelegt (fail-open bei Lookup-Fehlern).
- **API:** neue `PUT /api/auth/groups/:groupId/mute` Contract-Route + Handler (wirkt auf die eigene Mitgliedschaft, keine Admin-Rechte nötig). `getDetails` liefert jetzt `notifications_muted` mit, damit das UI den Zustand anzeigt.
- **Frontend:** `useSetGroupMute`-Hook; das 3-Punkte-Menü der Gruppe rendert jetzt für **alle Mitglieder** mit einem Stummschalten/Aktivieren-Eintrag; Admin-Aktionen liegen darunter.

## Mute-Semantik

Stummschalten = **E-Mail + Push aus**, In-App bleibt. Entspricht dem Slack-Mute und adressiert die "vor allem per Mail nervig"-Beschwerde direkt.

## Test

- `pnpm --filter @gruenerator/{contracts,shared,web,api} typecheck` – grün
- ESLint/Prettier der geänderten Dateien – grün (nur vorbestehende Warnungen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
