### PR TITLE
fix(canvas-editor): mobile subsection panels (Elemente, Hintergrund) render empty

### DIFF
--- a/packages/canvas-editor/src/components/CanvasEditor.tsx
+++ b/packages/canvas-editor/src/components/CanvasEditor.tsx
@@ -852,17 +852,26 @@ function CanvasEditorInner({
     mobileBridge.callbacks.onActiveTabChange(activeTab);
   }, [mobileBridge, activeTab]);
 
-  // Clear stale subsections when active tab changes (new section will report its own)
+  // Reset mobile-web subsection state DURING render when the tab changes — before the
+  // new section's SubsectionTabBar mounts and reports. A post-commit effect would run
+  // after the child's report/auto-select (child effects fire before parent effects) and
+  // clobber them, leaving the panel empty.
+  const webSubsectionResetTabRef = useRef(activeTab);
+  if (isMobileWeb && !isExternalSidebar && webSubsectionResetTabRef.current !== activeTab) {
+    webSubsectionResetTabRef.current = activeTab;
+    setMobileWebSubsections([]);
+    setMobileWebActiveSubsection(null);
+  }
+
+  // Clear stale subsections when active tab changes (new section will report its own).
+  // The mobile-web path is handled above during render; native + external stay here
+  // because they invoke external callbacks/store updates that can't run during render.
   const prevActiveTabRef = useRef(activeTab);
   useEffect(() => {
     if (prevActiveTabRef.current !== activeTab) {
       prevActiveTabRef.current = activeTab;
       if (mobileBridge) {
         mobileBridge.callbacks.onSubsectionsChange([]);
-      }
-      if (isMobileWeb) {
-        setMobileWebSubsections([]);
-        setMobileWebActiveSubsection(null);
       }
       if (isExternalSidebar && externalMobileMode) {
         setMobileWebSubsections([]);
@@ -873,7 +882,7 @@ function CanvasEditorInner({
         });
       }
     }
-  }, [mobileBridge, isMobileWeb, isExternalSidebar, externalMobileMode, activeTab]);
+  }, [mobileBridge, isExternalSidebar, externalMobileMode, activeTab]);
 
   // External sidebar store: lifecycle (activate on mount, deactivate on unmount)
   useEffect(() => {

--- a/packages/canvas-editor/src/sidebar/SubsectionTabBar.tsx
+++ b/packages/canvas-editor/src/sidebar/SubsectionTabBar.tsx
@@ -32,31 +32,17 @@ export function SubsectionTabBar({ subsections, defaultSubsection }: SubsectionT
     }
   }, [bridge, subsections]);
 
-  // Auto-select first subsection when bridge becomes active and none is selected
-  const hasAutoSelectedRef = useRef(false);
+  // Auto-select first subsection whenever the bridge is active and none is selected.
+  // In bridge/mobile mode the bottom sheet always shows exactly one subsection, so
+  // "nothing selected" is never a valid user state — re-select unconditionally rather
+  // than latching, which made recovery impossible if the active subsection was cleared
+  // externally.
   useEffect(() => {
-    if (!bridge.active || hasAutoSelectedRef.current) return;
+    if (!bridge.active) return;
     if (!bridge.activeSubsection && subsections.length > 0) {
-      hasAutoSelectedRef.current = true;
       bridge.onActiveSubsectionChange(defaultSubsection || subsections[0].id);
     }
   }, [bridge, subsections, defaultSubsection]);
-
-  // Reset auto-select flag when bridge deactivates
-  useEffect(() => {
-    if (!bridge.active) {
-      hasAutoSelectedRef.current = false;
-    }
-  }, [bridge.active]);
-
-  // Reset auto-select when subsections change (new tab was selected)
-  const prevSubsectionsRef = useRef(subsections);
-  useEffect(() => {
-    if (prevSubsectionsRef.current !== subsections) {
-      prevSubsectionsRef.current = subsections;
-      hasAutoSelectedRef.current = false;
-    }
-  }, [subsections]);
 
   // Standard web state (always called to satisfy hooks rules)
   const [isMobile, setIsMobile] = useState(


### PR DESCRIPTION
## Problem

Im Canvas-Editor (Web, mobile Ansicht < 900px) öffnete sich beim Tippen auf **Elemente** oder **Hintergrund** ein leeres Bottom-Sheet-Panel — keine Subsection-Leiste, kein Inhalt. **Text** und **Tools** funktionierten, weil sie keine `SubsectionTabBar` nutzen.

## Root Cause — Effect-Ordering-Clobber

Auf mobile-web meldet das Kind `SubsectionTabBar` in seinen Mount-Effekten seine Subsections nach oben und auto-selektiert die erste. Der Eltern-Effekt „Clear stale subsections when active tab changes" läuft aber **danach** (React führt Kind-Effekte vor Eltern-Effekten aus) und überschrieb `mobileWebSubsections=[]` / `mobileWebActiveSubsection=null`.

Im Folge-Render konnte sich das Kind nicht erholen, weil seine Idempotenz-Guards griffen:
- `prevSerializedRef` dedupliziert die Subsection-Meldung nach Inhalt → keine erneute Meldung.
- `hasAutoSelectedRef` war noch `true`; der Reset-Effekt flippte ihn erst nach dem Auto-Select im selben Commit → zu spät.

→ Subsection-Leiste wird nicht gerendert, `SubsectionTabBar` gibt im Bridge-Modus `null` zurück → leeres Panel.

## Fix

1. **`CanvasEditor.tsx`**: Den mobile-web Subsection-Reset aus dem Post-Commit-`useEffect` in die **Render-Phase** verschoben (Reacts „adjust state during render when a value changes"-Muster, guarded per Ref auf `activeTab`). Da der Elternteil top-down rendert, wird der State geleert *bevor* das Kind mountet — kein Clobber mehr. Native + external Pfade bleiben im Effekt (externe Callbacks/Store-Updates sind nicht render-phase-tauglich).

2. **`SubsectionTabBar.tsx`** (Defense-in-depth): `hasAutoSelectedRef`-Latch + zwei Reset-Effekte durch eine einfache Auto-Select-Bedingung ersetzt — im Bridge-/Mobile-Modus soll immer genau eine Subsection aktiv sein, sodass sich der Auto-Select auch bei externem Leeren erholt.

## Verification

- `pnpm --filter @gruenerator/canvas-editor typecheck` ✅
- `pnpm --filter @gruenerator/web typecheck` ✅
- Manuell: Mobil-Viewport < 900px → Image Studio → Canvas-Editor → Elemente/Hintergrund antippen zeigt Subsection-Leiste + Inhalt; Wechsel zwischen Text/Elemente/Hintergrund/Tools ohne leere Panels. Desktop (≥ 900px) unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)