### PR TITLE
fix+feat(chat): @sharepic background, confirmation text, and accessibility alt text

### DIFF
--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -730,79 +730,95 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       });
 
       // === Stage 3: Response generation ===
-      sse.send('response_start', { message: PROGRESS_MESSAGES.responseStart });
-
-      const systemMessage = await buildSystemMessage(finalState);
-      const agentConfigForResolve = {
-        provider: finalState.agentConfig.provider as string,
-        model: finalState.agentConfig.model,
-        ...(finalState.agentConfig.defaultModel != null && {
-          defaultModel: finalState.agentConfig.defaultModel,
-        }),
-      };
-      const resolution = await resolveModel(
-        agentConfigForResolve,
-        modelId ?? undefined,
-        requestId,
-        {
-          hasImages: imageAttachments.length > 0,
-          intent: finalState.intent,
-        }
-      );
-
-      const prunedValidMessages = pruneMessages(
-        validMessages as Parameters<typeof pruneMessages>[0]
-      );
-      const finalSystemMessage = actualThreadId
-        ? await applyCompaction(
-            actualThreadId,
-            prunedValidMessages,
-            systemMessage,
-            contextWindowTokens
-          )
-        : systemMessage;
-
-      let messagesForAI = buildMessagesForAI(
-        finalSystemMessage,
-        prunedValidMessages as Parameters<typeof buildMessagesForAI>[1]
-      );
-      // image_edit narrates from BILDVERGLEICH text descriptions; the raw image
-      // would put bytes in front of a non-vision model (since we no longer
-      // force-switch above) and create a redundant grounding source for vision
-      // models — skip injection so the descriptions are the single source.
-      if (finalState.intent !== 'image_edit') {
-        messagesForAI = injectImageAttachments(
-          messagesForAI as Parameters<typeof injectImageAttachments>[0],
-          imageAttachments,
-          requestId
-        );
-      }
-
-      const baseMaxTokens = finalState.agentConfig.params.max_tokens;
-
       let fullText: string | null;
-      try {
-        fullText = await streamWithFallback({
-          primary: resolution,
-          sse,
-          logPrefix: '[ChatGraph]',
-          buildStream: async (r) => {
-            const isReasoning = isRegoloReasoningModel(r.provider, r.modelName);
-            return streamForResolution({
-              resolution: r,
-              messages: messagesForAI as Parameters<typeof streamForResolution>[0]['messages'],
-              maxTokens: isReasoning ? Math.max(baseMaxTokens, 9000) : baseMaxTokens,
-              temperature: finalState.agentConfig.params.temperature,
-              sse,
-              logPrefix: '[ChatGraph]',
-            });
-          },
-        });
-      } finally {
-        if (resolution.releaseSlot) await resolution.releaseSlot();
-      }
+      if (finalState.intent === 'sharepic') {
+        // Sharepic variants were already produced + streamed in Stage 2 (sharepic_complete).
+        // Skip the LLM — with the still-vague topic it asks clarifying questions over the
+        // already-finished sharepic. Emit a fixed confirmation instead so the user sees the
+        // assistant knows the sharepic exists. Also covers the all-variants-failed case.
+        const n = sharepicVariants.length;
+        fullText =
+          n > 0
+            ? `Ich habe dir ${n} Sharepic-${n === 1 ? 'Variante' : 'Varianten'} erstellt. ` +
+              `Wähle eine aus oder sag mir, was ich am Text oder Bild anpassen soll.`
+            : `Die Sharepic-Erstellung hat leider nicht geklappt. Magst du es mit einem ` +
+              `anderen Thema noch einmal versuchen?`;
+        sse.send('response_start', { message: PROGRESS_MESSAGES.responseStart });
+        sse.send('text_delta', { text: fullText });
+      } else {
+        sse.send('response_start', { message: PROGRESS_MESSAGES.responseStart });
 
-      if (fullText === null) return { status: 200 as const, body: undefined };
+        const systemMessage = await buildSystemMessage(finalState);
+        const agentConfigForResolve = {
+          provider: finalState.agentConfig.provider as string,
+          model: finalState.agentConfig.model,
+          ...(finalState.agentConfig.defaultModel != null && {
+            defaultModel: finalState.agentConfig.defaultModel,
+          }),
+        };
+        const resolution = await resolveModel(
+          agentConfigForResolve,
+          modelId ?? undefined,
+          requestId,
+          {
+            hasImages: imageAttachments.length > 0,
+            intent: finalState.intent,
+          }
+        );
+
+        const prunedValidMessages = pruneMessages(
+          validMessages as Parameters<typeof pruneMessages>[0]
+        );
+        const finalSystemMessage = actualThreadId
+          ? await applyCompaction(
+              actualThreadId,
+              prunedValidMessages,
+              systemMessage,
+              contextWindowTokens
+            )
+          : systemMessage;
+
+        let messagesForAI = buildMessagesForAI(
+          finalSystemMessage,
+          prunedValidMessages as Parameters<typeof buildMessagesForAI>[1]
+        );
+        // image_edit narrates from BILDVERGLEICH text descriptions; the raw image
+        // would put bytes in front of a non-vision model (since we no longer
+        // force-switch above) and create a redundant grounding source for vision
+        // models — skip injection so the descriptions are the single source.
+        if (finalState.intent !== 'image_edit') {
+          messagesForAI = injectImageAttachments(
+            messagesForAI as Parameters<typeof injectImageAttachments>[0],
+            imageAttachments,
+            requestId
+          );
+        }
+
+        const baseMaxTokens = finalState.agentConfig.params.max_tokens;
+
+        try {
+          fullText = await streamWithFallback({
+            primary: resolution,
+            sse,
+            logPrefix: '[ChatGraph]',
+            buildStream: async (r) => {
+              const isReasoning = isRegoloReasoningModel(r.provider, r.modelName);
+              return streamForResolution({
+                resolution: r,
+                messages: messagesForAI as Parameters<typeof streamForResolution>[0]['messages'],
+                maxTokens: isReasoning ? Math.max(baseMaxTokens, 9000) : baseMaxTokens,
+                temperature: finalState.agentConfig.params.temperature,
+                sse,
+                logPrefix: '[ChatGraph]',
+              });
+            },
+          });
+        } finally {
+          if (resolution.releaseSlot) await resolution.releaseSlot();
+        }
+
+        if (fullText === null) return { status: 200 as const, body: undefined };
+      }
 
       // === Stage 3b: Extract chart data from response (if chart intent) ===
       if (finalState.intent === 'chart') {

--- a/apps/api/routes/chat/services/sharepicVariantHelpers.ts
+++ b/apps/api/routes/chat/services/sharepicVariantHelpers.ts
@@ -44,6 +44,7 @@ interface SharepicResponseShape {
   header?: string;
   subheader?: string;
   body?: string;
+  selectedImage?: string;
 }
 
 function buildInitialPropsForType(
@@ -57,6 +58,12 @@ function buildInitialPropsForType(
         line1: slogan.line1 ?? '',
         line2: slogan.line2 ?? '',
         line3: slogan.line3 ?? '',
+        // Carry the AI-selected stock background so the frontend canvas renders it.
+        // `hasBackgroundImage` is derived from `currentImageSrc` in the dreizeilen
+        // config's createInitialState — passing this key alone shows the layer.
+        ...(sharepic.selectedImage && {
+          currentImageSrc: `/api/image-picker/stock-image/${encodeURIComponent(sharepic.selectedImage)}`,
+        }),
       };
     }
     case 'zitat-pure':


### PR DESCRIPTION
Improves the chat `@sharepic` flow with two bug fixes and one accessibility feature.

## 1. Fix: blank background on the Dreizeiler variant
The backend AI-selects a stock background and returns its filename, but `buildInitialPropsForType()` dropped it, so the canvas had no `currentImageSrc`. Now carried through as `/api/image-picker/stock-image/<filename>`; the dreizeilen config derives `hasBackgroundImage` from it. (`zitat` = solid color, `info` = fixed color-mapped background — unaffected.)

## 2. Fix: spurious clarifying questions after a sharepic
`@sharepic` forces `intent = 'sharepic'`, but Stage 3 still ran the LLM, which asked *"Um den Text optimal…"* questions over the finished sharepic. Stage 3 is now guarded: for `sharepic` intent it skips the LLM and emits a short synthetic confirmation via `text_delta`, so the assistant clearly acknowledges the result.

## 3. Feature: accessibility alt text generated in the same run
The sharepic LLM now produces a screen-reader alt text **in the same generation call** (no extra round-trip):

- **Prompts** (dreizeilen / info / zitat_pure): added an `ALTTEXT:` output line (one-sentence accessible description, ~200 chars) + raised single-item `max_tokens`.
- **unifiedHandler**: `alttext` is an **optional** labeled field per type — extracted if present, never fails generation if the model omits it — surfaced as top-level `response.altText`.
- **Service + variants**: the three chat-reachable generators carry `altText` into `content.sharepic`; threaded onto the typed `SharepicVariant` (backend + frontend) — no `Record<string, unknown>` hole.
- **SharepicVariantCard**: uses `altText` as the `<img alt>` and shows a copy-to-clipboard caption so users can paste it when posting.

## Verification
- ✅ `pnpm --filter @gruenerator/api typecheck` and `pnpm --filter @gruenerator/chat typecheck` both pass.
- Manual: `@sharepic Mehr Klimaschutz` in `/chat` →
  - Dreizeiler shows a stock background (not blank).
  - Assistant bubble shows only the short confirmation — no clarifying questions.
  - Each variant card shows an "Alt-Text:" caption (copyable); the rendered `<img>` carries it as `alt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)