### PR TITLE
feat(boards): asynchronous Grünerator agent for delegated board tasks

### DIFF
--- a/apps/api/database/postgres/migrations/create_async_agent.sql
+++ b/apps/api/database/postgres/migrations/create_async_agent.sql
@@ -1,0 +1,38 @@
+-- Asynchronous Grünerator board agent: bot identity + durable task queue.
+--
+-- A user delegates work by writing a comment "@gruenerator <task>" on a board
+-- card. The comment-mention path enqueues a row here; the boardAgentWorker
+-- poller drains it (FOR UPDATE SKIP LOCKED → cluster-safe), runs the ChatGraph,
+-- writes a document and notifies the requester.
+--
+-- The bot is a sentinel profiles row so it can appear in the @-mention list and
+-- author its own reply comments. Its id matches GRUENERATOR_BOT_USER_ID in
+-- apps/api/services/boards/grueneratorBot.ts. All other profile columns rely on
+-- their schema defaults.
+
+INSERT INTO profiles (id, display_name, first_name, username, avatar_robot_id)
+VALUES ('00000000-0000-0000-0000-000000000010', 'Grünerator', 'Grünerator', 'gruenerator', 1)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS agent_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  board_id UUID NOT NULL,
+  card_id TEXT NOT NULL,
+  trigger_comment_id UUID,
+  requested_by UUID NOT NULL,
+  task_text TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 3,
+  result_document_id UUID,
+  error TEXT,
+  locale TEXT NOT NULL DEFAULT 'de-DE',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+
+-- The poller claims the oldest claimable task; this index serves the
+-- WHERE status / ORDER BY created_at scan.
+CREATE INDEX IF NOT EXISTS idx_agent_tasks_status_created ON agent_tasks (status, created_at);

--- a/apps/api/database/schema/agentTasks.ts
+++ b/apps/api/database/schema/agentTasks.ts
@@ -1,0 +1,32 @@
+import { type InferSelectModel } from 'drizzle-orm';
+import { integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/**
+ * Type source for the asynchronous board-agent task queue. Runtime DDL lives in
+ * database/postgres/migrations/create_async_agent.sql (auto-run on startup); this
+ * schema exists so the service layer derives its row type via InferSelectModel
+ * instead of a hand-written interface.
+ */
+
+export type AgentTaskStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export const agent_tasks = pgTable('agent_tasks', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  board_id: uuid('board_id').notNull(),
+  card_id: text('card_id').notNull(),
+  trigger_comment_id: uuid('trigger_comment_id'),
+  requested_by: uuid('requested_by').notNull(),
+  task_text: text('task_text').notNull(),
+  status: text('status').$type<AgentTaskStatus>().notNull().default('pending'),
+  attempts: integer('attempts').notNull().default(0),
+  max_attempts: integer('max_attempts').notNull().default(3),
+  result_document_id: uuid('result_document_id'),
+  error: text('error'),
+  locale: text('locale').notNull().default('de-DE'),
+  created_at: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updated_at: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  started_at: timestamp('started_at', { withTimezone: true }),
+  completed_at: timestamp('completed_at', { withTimezone: true }),
+});
+
+export type AgentTask = InferSelectModel<typeof agent_tasks>;

--- a/apps/api/database/schema/index.ts
+++ b/apps/api/database/schema/index.ts
@@ -15,6 +15,7 @@ export * from './notebooks.js';
 export * from './collaborative.js';
 export * from './canvas.js';
 export * from './boards.js';
+export * from './agentTasks.js';
 export * from './yjs.js';
 export * from './sites.js';
 export * from './apiKeys.js';

--- a/apps/api/routes/boards/boardCommentsContractRouter.ts
+++ b/apps/api/routes/boards/boardCommentsContractRouter.ts
@@ -16,6 +16,8 @@ import {
 import { createExpressEndpoints, initServer } from '@ts-rest/express';
 
 import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+import { enqueueAgentTask } from '../../services/boards/agentTaskService.js';
+import { GRUENERATOR_BOT_USER_ID } from '../../services/boards/grueneratorBot.js';
 import { createNotification } from '../../services/notifications/NotificationService.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
 import { getAuthedUser } from '../../utils/getAuthedUser.js';
@@ -400,6 +402,28 @@ async function fireCommentNotifications(params: CommentNotificationParams): Prom
 
   for (const mentionedId of mentionedUserIds) {
     if (mentionedId === authorId) continue;
+
+    // Mentioning the bot delegates the comment as an async task instead of
+    // sending a notification (the bot has no inbox). Fire-and-forget like the
+    // surrounding notification dispatch.
+    if (mentionedId === GRUENERATOR_BOT_USER_ID) {
+      const localeRows = await db.query<{ locale: string }>(
+        `SELECT locale FROM profiles WHERE id = $1`,
+        [authorId]
+      );
+      void enqueueAgentTask({
+        boardId,
+        cardId,
+        triggerCommentId: commentId,
+        requestedBy: authorId,
+        taskText: content,
+        locale: localeRows[0]?.locale ?? 'de-DE',
+      }).catch((err: unknown) => {
+        log.warn('Failed to enqueue agent task', { error: errMsg(err) });
+      });
+      continue;
+    }
+
     notifiedUserIds.add(mentionedId);
 
     await createNotification({
@@ -420,7 +444,12 @@ async function fireCommentNotifications(params: CommentNotificationParams): Prom
     );
 
     const parentAuthorId = parentRows[0]?.user_id;
-    if (parentAuthorId && parentAuthorId !== authorId && !notifiedUserIds.has(parentAuthorId)) {
+    if (
+      parentAuthorId &&
+      parentAuthorId !== authorId &&
+      parentAuthorId !== GRUENERATOR_BOT_USER_ID &&
+      !notifiedUserIds.has(parentAuthorId)
+    ) {
       notifiedUserIds.add(parentAuthorId);
 
       await createNotification({
@@ -444,6 +473,7 @@ async function fireCommentNotifications(params: CommentNotificationParams): Prom
   );
 
   for (const row of cardCreatorRows) {
+    if (row.user_id === GRUENERATOR_BOT_USER_ID) continue;
     if (notifiedUserIds.has(row.user_id)) continue;
     notifiedUserIds.add(row.user_id);
 

--- a/apps/api/routes/boards/boardsContractRouter.ts
+++ b/apps/api/routes/boards/boardsContractRouter.ts
@@ -26,6 +26,10 @@ import {
   parseBoardStructure,
   postProcessBoardStructure,
 } from '../../services/boards/BoardService.js';
+import {
+  GRUENERATOR_BOT_USER_ID,
+  GRUENERATOR_BOT_DISPLAY_NAME,
+} from '../../services/boards/grueneratorBot.js';
 import { logContractValidationError } from '../../utils/contractValidationLogger.js';
 import { getAIWorkerPool } from '../../utils/getAIWorkerPool.js';
 import { getAuthedUser } from '../../utils/getAuthedUser.js';
@@ -37,6 +41,16 @@ import type { Application } from 'express';
 
 const log = createLogger('boardsContract');
 const BOARDS_SUBTYPE = 'boards';
+
+// The async board agent is always assignable/mentionable on every board, so the
+// @-mention popover can delegate tasks to it without per-board permission setup.
+const GRUENERATOR_BOT_MEMBER: AssignableMember = {
+  user_id: GRUENERATOR_BOT_USER_ID,
+  source: 'bot',
+  first_name: GRUENERATOR_BOT_DISPLAY_NAME,
+  display_name: GRUENERATOR_BOT_DISPLAY_NAME,
+  avatar_robot_id: 1,
+};
 
 const db = getPostgresInstance();
 
@@ -207,7 +221,13 @@ export const boardsContractRouter = s.router(boardsContract, {
         [id, BOARDS_SUBTYPE]
       );
 
-      return { status: 200 as const, body: members };
+      // Surface the async agent first so it's easy to delegate a task to it.
+      const withBot = [
+        GRUENERATOR_BOT_MEMBER,
+        ...members.filter((m) => m.user_id !== GRUENERATOR_BOT_USER_ID),
+      ];
+
+      return { status: 200 as const, body: withBot };
     } catch (error) {
       log.error('[Boards Contract] Error listing assignable members:', error);
       return {

--- a/apps/api/server.ts
+++ b/apps/api/server.ts
@@ -30,6 +30,7 @@ import { shouldSkipBodyParser } from './middleware/bodyParserConfig.js';
 import { createCacheMiddleware } from './middleware/cacheMiddleware.js';
 import { setupRoutes } from './routes.js';
 import { createAIService, type AIService } from './services/ai/aiService.js';
+import { startBoardAgentWorker } from './services/boards/boardAgentWorker.js';
 import { startUploadsCleanup } from './services/cleanup/uploadsCleanupService.js';
 import { startNotificationCleanup } from './services/notifications/notificationCleanupService.js';
 import { startCleanupScheduler as startExportCleanup } from './services/subtitler/exportCleanupService.js';
@@ -269,6 +270,10 @@ async function startWorker(): Promise<void> {
     const err = error instanceof Error ? error : new Error(String(error));
     log.warn(`ProfileService init failed: ${err.message}`);
   }
+
+  // Async board agent: drains the agent_tasks queue (@gruenerator delegations).
+  // Safe to run in every cluster worker — claiming uses FOR UPDATE SKIP LOCKED.
+  startBoardAgentWorker();
 
   // TUS Upload Handler — registered before compression middleware.
   // TUS uploads are binary streams that don't benefit from compression

--- a/apps/api/services/boards/agentTaskService.ts
+++ b/apps/api/services/boards/agentTaskService.ts
@@ -1,0 +1,145 @@
+/**
+ * Durable task queue for the asynchronous Grünerator board agent.
+ *
+ * Tasks are enqueued from the comment-mention path (boardCommentsContractRouter)
+ * and drained by boardAgentWorker. Claiming uses `FOR UPDATE SKIP LOCKED` so the
+ * poller is safe to run in every cluster worker without double-processing.
+ */
+import { type CommentBlock } from '@gruenerator/contracts';
+
+import { type AgentTask } from '../../database/schema/agentTasks.js';
+import { getPostgresInstance } from '../../database/services/PostgresService/PostgresService.js';
+import { createLogger } from '../../utils/logger.js';
+
+import { GRUENERATOR_BOT_USER_ID } from './grueneratorBot.js';
+
+const db = getPostgresInstance();
+const log = createLogger('agentTaskService');
+
+// A task left in 'running' longer than this is assumed to belong to a crashed
+// worker and becomes claimable again (the attempt was already counted at claim).
+const STALE_RUNNING_MINUTES = 10;
+
+export interface EnqueueAgentTaskParams {
+  boardId: string;
+  cardId: string;
+  triggerCommentId: string | null;
+  requestedBy: string;
+  taskText: string;
+  locale: string;
+}
+
+export async function enqueueAgentTask(params: EnqueueAgentTaskParams): Promise<AgentTask> {
+  const rows = await db.query<AgentTask>(
+    `INSERT INTO agent_tasks (board_id, card_id, trigger_comment_id, requested_by, task_text, locale)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *`,
+    [
+      params.boardId,
+      params.cardId,
+      params.triggerCommentId,
+      params.requestedBy,
+      params.taskText,
+      params.locale,
+    ]
+  );
+  log.info(`Enqueued agent task ${rows[0].id} for board ${params.boardId} card ${params.cardId}`);
+  return rows[0];
+}
+
+/**
+ * Atomically claim the oldest claimable task (pending, or a stale 'running' task
+ * from a crashed worker), marking it 'running' and incrementing its attempt
+ * count. Returns null when there is nothing to do.
+ */
+export async function claimNextAgentTask(): Promise<AgentTask | null> {
+  const rows = await db.query<AgentTask>(
+    `UPDATE agent_tasks
+        SET status = 'running', started_at = now(), updated_at = now(), attempts = attempts + 1
+      WHERE id = (
+        SELECT id FROM agent_tasks
+         WHERE status = 'pending'
+            OR (status = 'running' AND started_at < now() - make_interval(mins => $1))
+         ORDER BY created_at
+         FOR UPDATE SKIP LOCKED
+         LIMIT 1
+      )
+      RETURNING *`,
+    [STALE_RUNNING_MINUTES]
+  );
+  return rows[0] ?? null;
+}
+
+export async function completeAgentTask(taskId: string, documentId: string): Promise<void> {
+  await db.query(
+    `UPDATE agent_tasks
+        SET status = 'completed', result_document_id = $2, error = NULL,
+            completed_at = now(), updated_at = now()
+      WHERE id = $1`,
+    [taskId, documentId]
+  );
+}
+
+/**
+ * Record a failed attempt. Resets to 'pending' for another try while attempts
+ * remain, otherwise marks the task permanently 'failed'.
+ */
+export async function failOrRetryAgentTask(
+  task: AgentTask,
+  errorMessage: string
+): Promise<{ willRetry: boolean }> {
+  if (task.attempts < task.max_attempts) {
+    await db.query(
+      `UPDATE agent_tasks SET status = 'pending', error = $2, updated_at = now() WHERE id = $1`,
+      [task.id, errorMessage]
+    );
+    return { willRetry: true };
+  }
+  await db.query(
+    `UPDATE agent_tasks
+        SET status = 'failed', error = $2, completed_at = now(), updated_at = now()
+      WHERE id = $1`,
+    [task.id, errorMessage]
+  );
+  return { willRetry: false };
+}
+
+export interface PostBotCommentParams {
+  boardId: string;
+  cardId: string;
+  /** Reply under this comment when it is top-level; otherwise post a new top-level comment. */
+  parentId: string | null;
+  blocks: CommentBlock[];
+}
+
+/** Author a comment on a card as the Grünerator bot (used for ack/result replies). */
+export async function postBotComment(params: PostBotCommentParams): Promise<void> {
+  const content = params.blocks
+    .map((b) => (b.type === 'mention' ? `@${b.displayName ?? ''}` : (b.text ?? '')))
+    .join('')
+    .trim();
+
+  // Only one reply level is allowed (see boardCommentsContractRouter.createComment).
+  // If the trigger comment is itself a reply, fall back to a top-level comment.
+  let parentId = params.parentId;
+  if (parentId) {
+    const parent = await db.query<{ parent_id: string | null }>(
+      `SELECT parent_id FROM board_comments WHERE id = $1`,
+      [parentId]
+    );
+    if (parent.length === 0 || parent[0].parent_id) parentId = null;
+  }
+
+  await db.query(
+    `INSERT INTO board_comments (board_id, card_id, parent_id, user_id, content, blocks, mentioned_user_ids)
+     VALUES ($1, $2, $3, $4, $5, $6, '{}')`,
+    [
+      params.boardId,
+      params.cardId,
+      parentId,
+      GRUENERATOR_BOT_USER_ID,
+      content,
+      JSON.stringify(params.blocks),
+    ]
+  );
+}

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -1,0 +1,191 @@
+/**
+ * Background poller that drains the agent_tasks queue.
+ *
+ * Started once per process from server.ts (startWorker). Each tick claims
+ * claimable tasks one at a time (FOR UPDATE SKIP LOCKED → safe across cluster
+ * workers), runs the existing headless ChatGraph, writes the result to a
+ * collaborative document, then notifies the requester (in-app + push + email via
+ * createNotification) and replies on the originating card as the bot.
+ */
+import { type ModelMessage } from 'ai';
+
+import { runChatGraph } from '../../agents/langgraph/ChatGraph/index.js';
+import { PRIMARY_URL } from '../../config/domains.js';
+import { type AgentTask } from '../../database/schema/agentTasks.js';
+import { createLogger } from '../../utils/logger.js';
+import { getAIService } from '../ai/aiService.js';
+import { createDocumentWithContent } from '../docs/DocGenerationService.js';
+import { createNotification } from '../notifications/NotificationService.js';
+
+import {
+  claimNextAgentTask,
+  completeAgentTask,
+  failOrRetryAgentTask,
+  postBotComment,
+} from './agentTaskService.js';
+
+const log = createLogger('boardAgentWorker');
+
+const POLL_INTERVAL_MS = 5_000;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let initialized = false;
+let draining = false;
+
+export function startBoardAgentWorker(): void {
+  if (initialized) return;
+  intervalId = setInterval(() => {
+    void drain();
+  }, POLL_INTERVAL_MS);
+  initialized = true;
+  log.info('Board agent worker started (interval: 5s)');
+}
+
+export function stopBoardAgentWorker(): void {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+    initialized = false;
+  }
+}
+
+/** Claim and process tasks until the queue is drained for this tick. */
+async function drain(): Promise<void> {
+  if (draining) return;
+  draining = true;
+  try {
+    let task: AgentTask | null;
+    while ((task = await claimNextAgentTask())) {
+      await processTask(task);
+    }
+  } catch (err) {
+    log.error(`Drain loop error: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    draining = false;
+  }
+}
+
+async function processTask(task: AgentTask): Promise<void> {
+  log.info(`Processing agent task ${task.id} (attempt ${task.attempts}/${task.max_attempts})`);
+
+  // Acknowledge on the card on the first attempt only.
+  if (task.attempts <= 1) {
+    await postBotComment({
+      boardId: task.board_id,
+      cardId: task.card_id,
+      parentId: task.trigger_comment_id,
+      blocks: [
+        {
+          type: 'text',
+          text: '🤖 Ich arbeite an deiner Aufgabe … du bekommst Bescheid, sobald das Dokument fertig ist.',
+        },
+      ],
+    }).catch((err: unknown) => {
+      log.warn(`Failed to post ack comment for task ${task.id}`, { error: errMsg(err) });
+    });
+  }
+
+  try {
+    const userLocale = task.locale === 'de-AT' ? 'de-AT' : 'de-DE';
+    const messages: ModelMessage[] = [{ role: 'user', content: task.task_text }];
+
+    const result = await runChatGraph({
+      messages,
+      agentId: '', // falsy → ChatGraph resolves the default universal agent
+      enabledTools: { search: true, web: true, person: true, examples: true, research: true },
+      aiWorkerPool: getAIService(),
+      userLocale,
+    });
+
+    if (!result.success || !result.responseText.trim()) {
+      throw new Error(result.error || 'Der Agent lieferte kein Ergebnis');
+    }
+
+    const title = deriveTitle(task.task_text, result.responseText);
+    const doc = await createDocumentWithContent(
+      title,
+      result.responseText,
+      'blank',
+      task.requested_by
+    );
+    const relativeUrl = `/docs/${doc.id}`;
+
+    await completeAgentTask(task.id, doc.id);
+
+    // In-app + push + email (createNotification fans out per the user's prefs).
+    await createNotification({
+      userId: task.requested_by,
+      type: 'agent_task_completed',
+      title: `Dein Dokument ist fertig: ${title}`,
+      body: 'Der Grünerator hat deine Aufgabe erledigt. Öffne das Dokument, um das Ergebnis zu sehen.',
+      actionUrl: relativeUrl,
+      metadata: {
+        boardId: task.board_id,
+        cardId: task.card_id,
+        documentId: doc.id,
+        taskId: task.id,
+      },
+      groupKey: `agent-task-${task.id}`,
+    });
+
+    await postBotComment({
+      boardId: task.board_id,
+      cardId: task.card_id,
+      parentId: task.trigger_comment_id,
+      blocks: [
+        { type: 'text', text: '✅ Fertig! Ich habe ein Dokument erstellt: ' },
+        { type: 'link', text: title, url: `${PRIMARY_URL}${relativeUrl}` },
+      ],
+    });
+
+    log.info(`Agent task ${task.id} completed → document ${doc.id}`);
+  } catch (err) {
+    const message = errMsg(err);
+    log.error(`Agent task ${task.id} failed: ${message}`);
+    const { willRetry } = await failOrRetryAgentTask(task, message);
+
+    if (!willRetry) {
+      await createNotification({
+        userId: task.requested_by,
+        type: 'agent_task_failed',
+        title: 'Aufgabe konnte nicht erledigt werden',
+        body: 'Der Grünerator konnte deine Aufgabe leider nicht abschließen. Bitte versuche es erneut.',
+        actionUrl: `/boards/${task.board_id}?card=${task.card_id}`,
+        metadata: { boardId: task.board_id, cardId: task.card_id, taskId: task.id },
+        groupKey: `agent-task-${task.id}`,
+      }).catch((e: unknown) =>
+        log.warn('Failed to post failure notification', { error: errMsg(e) })
+      );
+
+      await postBotComment({
+        boardId: task.board_id,
+        cardId: task.card_id,
+        parentId: task.trigger_comment_id,
+        blocks: [
+          {
+            type: 'text',
+            text: `⚠️ Ich konnte die Aufgabe leider nicht abschließen (${message}). Bitte formuliere sie ggf. neu und erwähne mich erneut.`,
+          },
+        ],
+      }).catch((e: unknown) => log.warn('Failed to post failure comment', { error: errMsg(e) }));
+    }
+  }
+}
+
+/**
+ * Derive a document title: prefer a leading heading from the generated content,
+ * otherwise fall back to the (mention-stripped) task text.
+ */
+function deriveTitle(taskText: string, responseText: string): string {
+  const mdHeading = responseText.match(/^\s{0,3}#{1,3}\s+(.+)$/m);
+  const htmlHeading = responseText.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  const heading = (mdHeading?.[1] ?? htmlHeading?.[1] ?? '').replace(/<[^>]+>/g, '').trim();
+  if (heading) return heading.slice(0, 120);
+
+  const cleaned = taskText.replace(/@\S+/g, '').replace(/\s+/g, ' ').trim();
+  return cleaned.slice(0, 80) || 'Neues Dokument';
+}
+
+function errMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/api/services/boards/grueneratorBot.ts
+++ b/apps/api/services/boards/grueneratorBot.ts
@@ -1,0 +1,11 @@
+/**
+ * Identity of the asynchronous Grünerator board agent.
+ *
+ * The bot is a sentinel `profiles` row (seeded by the create_async_agent.sql
+ * migration) so it can be @mentioned/assigned on board cards via the normal
+ * mention machinery, and authored as the comment author when it replies with
+ * results. The UUID is hardcoded and must match the migration.
+ */
+export const GRUENERATOR_BOT_USER_ID = '00000000-0000-0000-0000-000000000010';
+
+export const GRUENERATOR_BOT_DISPLAY_NAME = 'Grünerator';

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -44,6 +44,10 @@ const TYPE_IMPORTANCE: Record<NotificationType, 1 | 2 | 3> = {
   transfer_downloaded: 3,
   notebook_liked: 3,
   wolke_new_files: 2,
+  // Tier 1: the user explicitly delegated work and is waiting on the result —
+  // always deliver (incl. email) regardless of notification level.
+  agent_task_completed: 1,
+  agent_task_failed: 1,
 };
 
 export type NotificationLevel = 'low' | 'medium' | 'high';
@@ -211,7 +215,11 @@ export async function applyLevelForUser(
   level: NotificationLevel
 ): Promise<Record<NotificationType, ChannelPreferences>> {
   const profileService = getProfileService();
-  await profileService.setUserDefaultsGenerator(userId, 'notifications', getPresetPreferences(level));
+  await profileService.setUserDefaultsGenerator(
+    userId,
+    'notifications',
+    getPresetPreferences(level)
+  );
   return getPreferencesForUser(userId);
 }
 

--- a/apps/web/src/features/notifications/notificationPreferenceMeta.ts
+++ b/apps/web/src/features/notifications/notificationPreferenceMeta.ts
@@ -23,6 +23,7 @@ import {
   LayoutDashboard,
   MessageSquare,
   Share2,
+  Sparkles,
   UserPlus,
   Users,
 } from 'lucide-react';
@@ -83,6 +84,18 @@ export const RAW_TYPE_META: Record<NotificationType, RawTypeMeta> = {
     label: 'Erwähnungen',
     description: 'Wenn du in einem Kommentar erwähnt wirst',
     icon: AtSign,
+    group: 'board',
+  },
+  agent_task_completed: {
+    label: 'Agent-Aufgabe fertig',
+    description: 'Wenn der Grünerator eine an ihn delegierte Aufgabe erledigt hat',
+    icon: Sparkles,
+    group: 'board',
+  },
+  agent_task_failed: {
+    label: 'Agent-Aufgabe fehlgeschlagen',
+    description: 'Wenn der Grünerator eine delegierte Aufgabe nicht erledigen konnte',
+    icon: Sparkles,
     group: 'board',
   },
 
@@ -158,7 +171,11 @@ export const RAW_TYPE_META: Record<NotificationType, RawTypeMeta> = {
 };
 
 /** Raw types grouped by category, in group order, for the expert table. */
-export function getRawTypesByGroup(): { group: NotificationGroup; label: string; types: NotificationType[] }[] {
+export function getRawTypesByGroup(): {
+  group: NotificationGroup;
+  label: string;
+  types: NotificationType[];
+}[] {
   const byGroup = new Map<NotificationGroup, NotificationType[]>();
   for (const [type, meta] of Object.entries(RAW_TYPE_META) as [NotificationType, RawTypeMeta][]) {
     const existing = byGroup.get(meta.group) ?? [];
@@ -167,7 +184,11 @@ export function getRawTypesByGroup(): { group: NotificationGroup; label: string;
   }
   return (Object.keys(NOTIFICATION_GROUPS) as NotificationGroup[])
     .sort((a, b) => NOTIFICATION_GROUPS[a].order - NOTIFICATION_GROUPS[b].order)
-    .map((group) => ({ group, label: NOTIFICATION_GROUPS[group].label, types: byGroup.get(group) ?? [] }))
+    .map((group) => ({
+      group,
+      label: NOTIFICATION_GROUPS[group].label,
+      types: byGroup.get(group) ?? [],
+    }))
     .filter((g) => g.types.length > 0);
 }
 

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -5,6 +5,7 @@ import {
   LayoutDashboard,
   MessageSquare,
   Share2,
+  Sparkles,
   UserPlus,
   Users,
 } from 'lucide-react';
@@ -58,6 +59,14 @@ export const NOTIFICATION_TYPES: Record<string, NotificationTypeConfig> = {
     group: 'board',
     subtypes: ['board_comment_added', 'board_comment_reply', 'board_user_mentioned'],
     actions: (ctx) => [openLinkAction('Karte öffnen')(ctx)],
+  },
+  agent_task_completed: {
+    label: 'Grünerator-Agent',
+    description: 'Wenn der Grünerator eine an ihn delegierte Aufgabe erledigt hat',
+    icon: Sparkles,
+    group: 'board',
+    subtypes: ['agent_task_completed', 'agent_task_failed'],
+    actions: (ctx) => [openLinkAction('Dokument öffnen')(ctx)],
   },
 
   group_member_joined: {

--- a/packages/contracts/src/schemas/boards.ts
+++ b/packages/contracts/src/schemas/boards.ts
@@ -73,7 +73,7 @@ export const deleteBoardResponseSchema = z.object({
 
 export const assignableMemberSchema = z.object({
   user_id: z.string(),
-  source: z.enum(['owner', 'direct', 'group']),
+  source: z.enum(['owner', 'direct', 'group', 'bot']),
   first_name: z.string().nullable(),
   display_name: z.string().nullable(),
   avatar_robot_id: z.number(),

--- a/packages/contracts/src/schemas/notifications.ts
+++ b/packages/contracts/src/schemas/notifications.ts
@@ -37,6 +37,8 @@ export const notificationTypeSchema = z.enum([
   'transfer_downloaded',
   'notebook_liked',
   'wolke_new_files',
+  'agent_task_completed',
+  'agent_task_failed',
 ]);
 export type NotificationType = z.infer<typeof notificationTypeSchema>;
 


### PR DESCRIPTION
## What

Lets users **delegate a task to the Grünerator asynchronously from a kanban board**: write a comment `@gruenerator <task>` on a card, and a background agent runs the existing ChatGraph, writes a document with the result, and reports back — no chat session required.

## Flow

```
Comment "@gruenerator <task>" on a card
  → fireCommentNotifications enqueues an agent_tasks row
  → boardAgentWorker (poll, FOR UPDATE SKIP LOCKED) claims it
     → posts a "🤖 arbeite daran" ack comment
     → runChatGraph(default universal agent, locale-aware)
     → createDocumentWithContent → /docs/{id}
     → createNotification (in-app + push + email)  +  result comment with link
  → on error: retry up to max_attempts, then mark failed + notify/comment
```

## Changes

- **Bot identity** — sentinel `profiles` row (`GRUENERATOR_BOT_USER_ID`), seeded by migration; appended to `getAssignableMembers` so it shows up in the `@`-mention popover on every board (no frontend change needed). New `source: 'bot'` in `assignableMemberSchema`.
- **Durable queue** — `agent_tasks` table + Drizzle schema. Claimed with `FOR UPDATE SKIP LOCKED` (safe in every cluster worker), with retry and stale-`running` reclaim for crashed workers.
- **Trigger** — `fireCommentNotifications` enqueues when the bot is mentioned, and the bot is excluded from the normal comment-notification fan-out.
- **Worker** — `boardAgentWorker` started in `startWorker()`; reuses `runChatGraph`, `createDocumentWithContent`, `createNotification`. Locale-aware (de-AT/de-DE).
- **Notifications** — new `agent_task_completed` / `agent_task_failed` types wired through contracts, backend importance tiers, and frontend display/preference metadata.

## Reuse

Built entirely on existing infrastructure — headless `runChatGraph`, the docs service, the notification fan-out (which already does in-app + push + email), and the board comment/mention machinery. Net new code is the orchestration glue + queue.

## Verification

- `pnpm --filter @gruenerator/{contracts,api,web} typecheck` — clean
- ESLint on all changed files — clean
- Manual E2E (reviewer): comment `@gruenerator …` on a card → ack comment → document created at `/docs/{id}` → notification + email + result comment with link. Failure path retries then reports.

## Notes

- DB migration runs automatically on startup (`PostgresService.init()`).
- Branched off `origin/master` to keep the diff scoped to this feature (13 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)