### PR TITLE
chore: prettier --write notification files (fix Quality Checks)

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -321,9 +321,8 @@ export const auth = betterAuth({
           );
           // Deliver one-off product announcements (e.g. new Pride avatars) on
           // login — once per user, idempotent, best-effort.
-          const { deliverLoginAnnouncements } = await import(
-            '../services/notifications/loginAnnouncements.js'
-          );
+          const { deliverLoginAnnouncements } =
+            await import('../services/notifications/loginAnnouncements.js');
           await deliverLoginAnnouncements(session.userId);
         },
       },

--- a/apps/api/services/notifications/notificationPreferences.ts
+++ b/apps/api/services/notifications/notificationPreferences.ts
@@ -212,7 +212,11 @@ export async function applyLevelForUser(
   level: NotificationLevel
 ): Promise<Record<NotificationType, ChannelPreferences>> {
   const profileService = getProfileService();
-  await profileService.setUserDefaultsGenerator(userId, 'notifications', getPresetPreferences(level));
+  await profileService.setUserDefaultsGenerator(
+    userId,
+    'notifications',
+    getPresetPreferences(level)
+  );
   return getPreferencesForUser(userId);
 }
 

--- a/apps/web/src/features/notifications/components/NotificationPreferences.tsx
+++ b/apps/web/src/features/notifications/components/NotificationPreferences.tsx
@@ -170,7 +170,9 @@ const NotificationPreferences: React.FC<NotificationPreferencesProps> = ({
                       <div className="flex items-center gap-sm grow min-w-0">
                         <Icon className={cn('w-4 h-4 shrink-0 text-grey-400 dark:text-grey-500')} />
                         <div className="min-w-0">
-                          <p className="text-sm font-medium text-foreground truncate">{meta.label}</p>
+                          <p className="text-sm font-medium text-foreground truncate">
+                            {meta.label}
+                          </p>
                           <p className="text-xs text-grey-500 dark:text-grey-400 truncate">
                             {meta.description}
                           </p>

--- a/apps/web/src/features/notifications/notificationPreferenceMeta.ts
+++ b/apps/web/src/features/notifications/notificationPreferenceMeta.ts
@@ -172,7 +172,11 @@ export const RAW_TYPE_META: Record<NotificationType, RawTypeMeta> = {
 const HIDDEN_FROM_PREFS: ReadonlySet<NotificationType> = new Set<NotificationType>(['new_avatars']);
 
 /** Raw types grouped by category, in group order, for the expert table. */
-export function getRawTypesByGroup(): { group: NotificationGroup; label: string; types: NotificationType[] }[] {
+export function getRawTypesByGroup(): {
+  group: NotificationGroup;
+  label: string;
+  types: NotificationType[];
+}[] {
   const byGroup = new Map<NotificationGroup, NotificationType[]>();
   for (const [type, meta] of Object.entries(RAW_TYPE_META) as [NotificationType, RawTypeMeta][]) {
     if (HIDDEN_FROM_PREFS.has(type)) continue;
@@ -182,7 +186,11 @@ export function getRawTypesByGroup(): { group: NotificationGroup; label: string;
   }
   return (Object.keys(NOTIFICATION_GROUPS) as NotificationGroup[])
     .sort((a, b) => NOTIFICATION_GROUPS[a].order - NOTIFICATION_GROUPS[b].order)
-    .map((group) => ({ group, label: NOTIFICATION_GROUPS[group].label, types: byGroup.get(group) ?? [] }))
+    .map((group) => ({
+      group,
+      label: NOTIFICATION_GROUPS[group].label,
+      types: byGroup.get(group) ?? [],
+    }))
     .filter((g) => g.types.length > 0);
 }
 

--- a/apps/web/src/features/notifications/types/index.ts
+++ b/apps/web/src/features/notifications/types/index.ts
@@ -10,7 +10,11 @@ import {
   Users,
 } from 'lucide-react';
 
-import { openLinkAction, setAvatarAction, type NotificationTypeConfig } from '../notificationConfig';
+import {
+  openLinkAction,
+  setAvatarAction,
+  type NotificationTypeConfig,
+} from '../notificationConfig';
 
 export interface Notification {
   id: string;


### PR DESCRIPTION
Fixes the failing **Quality Checks** (Prettier format check) on master caused by the freshly merged notification PRs. Ran `prettier --write` on the 5 affected files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)