### PR TITLE
fix(boards): async agent writes the real answer + instant "Übernehme." ack

### DIFF
--- a/apps/api/routes/chat/agents/searchTools.ts
+++ b/apps/api/routes/chat/agents/searchTools.ts
@@ -1,0 +1,276 @@
+/**
+ * Shared AI-SDK search/research tools for grounded generation.
+ *
+ * Extracted from chatStreamController so both the (legacy) streaming chat handler
+ * and the async board agent can author with the same grounded tool set. The chat
+ * handler runs these as a router (toolChoice:'required') and needs the
+ * `direct_response` escape hatch; document authoring runs them on-demand
+ * (toolChoice:'auto') and omits it — hence the `includeDirectResponse` option.
+ */
+import { tool, type ToolSet } from 'ai';
+import { z } from 'zod';
+
+import { createLogger } from '../../../utils/logger.js';
+
+import {
+  executeDirectSearch,
+  executeDirectExamplesSearch,
+  executeDirectPressemitteilungExamples,
+  executeDirectWebSearch,
+  executeResearch,
+} from './directSearch.js';
+
+import type { AgentConfig } from './types.js';
+
+const log = createLogger('searchTools');
+
+export const ALL_COLLECTIONS = [
+  'deutschland',
+  'oesterreich',
+  'bundestagsfraktion',
+  'kommunalwiki',
+  'examples',
+  'gruene-de',
+  'gruene-at',
+  'boell-stiftung',
+] as const;
+
+export interface CreateSearchToolsOptions {
+  /**
+   * Add the router-style `direct_response` escape hatch. The chat handler needs
+   * it (it forces a tool call via toolChoice:'required'); document authoring runs
+   * tools on-demand and leaves it out.
+   */
+  includeDirectResponse?: boolean;
+}
+
+/**
+ * Creates search tools dynamically based on agent configuration.
+ * This enables per-agent restrictions on collections (e.g., Austrian agent
+ * can only search Austrian collections).
+ *
+ * Note: Returns ToolSet; type safety is maintained through runtime validation in
+ * execute functions (Zod version conflicts in the monorepo prevent tighter types).
+ */
+export function createSearchTools(
+  agentConfig: AgentConfig,
+  options: CreateSearchToolsOptions = {}
+): ToolSet {
+  const restrictions = agentConfig.toolRestrictions;
+
+  const allowedCollections: readonly string[] = restrictions?.allowedCollections?.length
+    ? restrictions.allowedCollections
+    : ALL_COLLECTIONS;
+
+  const defaultCollection = restrictions?.defaultCollection || allowedCollections[0];
+  const examplesCountry = restrictions?.examplesCountry;
+
+  log.debug(
+    `[Tools] Creating tools for ${agentConfig.identifier}: collections=${allowedCollections.join(',')}, default=${defaultCollection}, personSearch=disabled, examplesCountry=${examplesCountry || 'all'}`
+  );
+
+  const tools: ToolSet = {};
+
+  tools.gruenerator_search = tool({
+    description: `Durchsuche grüne Parteiprogramme, Positionen und Beschlüsse.
+
+NUTZE WENN:
+- Fragen zu grünen Positionen ("Was sagen die Grünen zu...")
+- Politische Standpunkte oder Beschlüsse benötigt
+- Zitate aus Parteiprogrammen gewünscht
+- Grüne Politik/Programmatik gefragt
+
+NICHT FÜR: Aktuelle Nachrichten, Personen-Infos, allgemeine Web-Suche`,
+    inputSchema: z.object({
+      query: z.string().describe('Suchanfrage in deutscher Sprache'),
+      collection: z
+        .enum(allowedCollections as [string, ...string[]])
+        .optional()
+        .default(defaultCollection)
+        .describe(`Sammlung: ${allowedCollections.join(', ')}`),
+      limit: z.number().optional().default(5).describe('Maximale Anzahl Ergebnisse'),
+    }),
+    execute: async ({ query, collection, limit }) => {
+      try {
+        if (!allowedCollections.includes(collection)) {
+          log.warn(`[Tools] Collection "${collection}" not allowed for ${agentConfig.identifier}`);
+          return {
+            error: 'Sammlung nicht verfügbar',
+            results: [],
+            collection,
+            query,
+          };
+        }
+        const results = await executeDirectSearch({ query, collection, limit });
+        return results;
+      } catch (error) {
+        log.error('Direct search error:', error);
+        return { error: 'Suche fehlgeschlagen', results: [], collection, query };
+      }
+    },
+  });
+
+  tools.gruenerator_examples_search = tool({
+    description: `Suche nach Social-Media-Beispielen und Vorlagen.
+
+NUTZE WENN:
+- Beispiele für Social-Media-Posts gesucht
+- Vorlagen für Instagram oder Facebook benötigt
+- Inspiration für grüne Social-Media-Kommunikation
+
+NICHT FÜR: Allgemeine Informationssuche, Fakten, Nachrichten`,
+    inputSchema: z.object({
+      query: z.string().describe('Thema oder Stichwort'),
+      platform: z.enum(['instagram', 'facebook']).optional().describe('Plattform filtern'),
+    }),
+    execute: async ({ query, platform }) => {
+      try {
+        const results = await executeDirectExamplesSearch({
+          query,
+          ...(platform && { platform }),
+          ...(examplesCountry && { country: examplesCountry }),
+        });
+        return results;
+      } catch (error) {
+        log.error('Direct examples search error:', error);
+        return { error: 'Beispielsuche fehlgeschlagen', examples: [], resultsCount: 0 };
+      }
+    },
+  });
+
+  tools.gruenerator_pressemitteilung_examples = tool({
+    description: `Suche nach echten Pressemitteilungen aus Landesverbänden als Inspiration und Vorlage.
+
+NUTZE WENN:
+- Eine Pressemitteilung verfasst werden soll
+- Beispiele für journalistische PM-Sprache und Aufbau gebraucht werden
+- Du sehen willst, wie andere Landesverbände PMs zu ähnlichen Themen formulieren
+
+NICHT FÜR: Social-Media-Posts (nutze gruenerator_examples_search), allgemeine Recherche (nutze gruenerator_search), Anträge oder Reden.`,
+    inputSchema: z.object({
+      query: z.string().describe('Thema der Pressemitteilung'),
+    }),
+    execute: async ({ query }) => {
+      try {
+        const results = await executeDirectPressemitteilungExamples({ query });
+        return results;
+      } catch (error) {
+        log.error('Direct pressemitteilung examples error:', error);
+        return {
+          error: 'Pressemitteilung-Suche fehlgeschlagen',
+          examples: [],
+          resultsCount: 0,
+        };
+      }
+    },
+  });
+
+  tools.web_search = tool({
+    description: `Suche im Internet nach aktuellen Informationen und Nachrichten.
+
+NUTZE WENN:
+- Aktuelle Ereignisse oder Nachrichten gefragt
+- Informationen außerhalb der Grünen-Dokumentation
+- Allgemeine Fakten aus dem Web
+- Externe Quellen benötigt
+
+NICHT FÜR: Grüne Parteiprogramme (nutze gruenerator_search)`,
+    inputSchema: z.object({
+      query: z.string().describe('Suchanfrage in deutscher Sprache'),
+      searchType: z
+        .enum(['general', 'news'])
+        .optional()
+        .default('general')
+        .describe('Suchtyp: general (allgemein) oder news (Nachrichten)'),
+      maxResults: z.number().optional().default(5).describe('Maximale Anzahl Ergebnisse (1-10)'),
+    }),
+    execute: async ({ query, searchType, maxResults }) => {
+      try {
+        const results = await executeDirectWebSearch({ query, searchType, maxResults });
+        return results;
+      } catch (error) {
+        log.error('Direct web search error:', error);
+        return { error: 'Websuche fehlgeschlagen', results: [], resultsCount: 0, query };
+      }
+    },
+  });
+
+  // Research tool: Perplexity-style structured research with planning, multi-source search, and synthesis
+  tools.research = tool({
+    description: `Strukturierte Recherche mit Planung, Suche und Synthese.
+
+NUTZE WENN:
+- Der Benutzer "recherchiere", "suche nach", "finde heraus" sagt
+- Komplexe Fragen mit mehreren Aspekten
+- Vergleiche verschiedener Quellen gewünscht
+- Themen die Kontext aus mehreren Bereichen brauchen
+- Explizite Recherche-Anfragen ("nutze das recherche tool")
+
+Das Tool plant automatisch, sucht in relevanten Quellen, und synthetisiert mit Inline-Zitaten [1], [2].
+
+NICHT FÜR: Einfache Begrüßungen, Dankeschöns, kreative Aufgaben ohne Faktenbedarf`,
+    inputSchema: z.object({
+      question: z.string().describe('Die Frage oder das Thema für die Recherche'),
+      depth: z
+        .enum(['quick', 'thorough'])
+        .optional()
+        .default('quick')
+        .describe(
+          'Recherchetiefe: quick (schnell, 1-2 Quellen) oder thorough (gründlich, mehr Quellen)'
+        ),
+    }),
+    execute: async ({ question, depth }) => {
+      try {
+        log.info(
+          `[Research Tool] Starting research: "${question.slice(0, 50)}..." (depth: ${depth})`
+        );
+        const result = await executeResearch({
+          question,
+          depth,
+          maxSources: depth === 'thorough' ? 10 : 6,
+        });
+        log.info(
+          `[Research Tool] Complete: ${result.citations.length} citations, confidence: ${result.confidence}`
+        );
+        return result;
+      } catch (error) {
+        log.error('Research tool error:', error);
+        return {
+          answer: 'Die Recherche konnte leider nicht durchgeführt werden.',
+          citations: [],
+          followUpQuestions: [],
+          searchSteps: [],
+          confidence: 'low' as const,
+          error: 'Recherche fehlgeschlagen',
+        };
+      }
+    },
+  });
+
+  // Direct response tool: router escape hatch for non-search cases (chat handler only)
+  if (options.includeDirectResponse) {
+    tools.direct_response = tool({
+      description: `Antworte direkt ohne externe Suche.
+
+NUTZE DIESES TOOL WENN:
+- Begrüßungen/Verabschiedungen ("Hallo", "Danke", "Tschüss")
+- Allgemeine Konversation ohne Informationsbedarf
+- Kreative Aufgaben mit bereits gegebenen Infos (z.B. Instagram-Posts, Texte schreiben)
+- Klarstellende Nachfragen
+- Der Benutzer explizit KEINE Suche möchte
+- Einfache Folgefragen zu bereits besprochenen Themen
+
+NICHT NUTZEN wenn Fakten, aktuelle Infos oder Belege gefragt sind.`,
+      inputSchema: z.object({
+        content: z.string().describe('Die vollständige Antwort an den Benutzer'),
+        reason: z.string().optional().describe('Optional: Warum keine Suche nötig war'),
+      }),
+      execute: async ({ content, reason }) => {
+        log.debug(`[Direct Response] Content length: ${content?.length}, Reason: ${reason}`);
+        return { type: 'direct', content, reason };
+      },
+    });
+  }
+
+  return tools;
+}

--- a/apps/api/routes/chat/chatStreamController.ts
+++ b/apps/api/routes/chat/chatStreamController.ts
@@ -3,7 +3,7 @@
  * Handles AI chat streaming via Vercel AI SDK
  */
 
-import { streamText, tool, type ModelMessage, stepCountIs, type ToolSet } from 'ai';
+import { streamText, type ModelMessage, stepCountIs, type ToolSet } from 'ai';
 import { z } from 'zod';
 
 import { getPostgresInstance } from '../../database/services/PostgresService.js';
@@ -13,23 +13,14 @@ import { createAuthenticatedRouter } from '../../utils/keycloak/index.js';
 import { createLogger } from '../../utils/logger.js';
 
 import { getDefaultAgentId, getAgentOrCustomPrompt } from './agents/agentLoader.js';
-import {
-  executeDirectSearch,
-  // executeDirectPersonSearch, // DISABLED: Person search not production ready
-  executeDirectExamplesSearch,
-  executeDirectPressemitteilungExamples,
-  executeDirectWebSearch,
-  executeResearch,
-} from './agents/directSearch.js';
 import { getModel, isProviderConfigured } from './agents/providers.js';
+import { createSearchTools } from './agents/searchTools.js';
 import {
   getCompactionState,
   prepareMessagesWithCompaction,
   type CompactionState,
 } from './services/compactionService.js';
 import { getUser } from './services/threadPersistenceService.js';
-
-import type { AgentConfig } from './agents/types.js';
 
 const log = createLogger('ChatStreamController');
 const router = createAuthenticatedRouter();
@@ -154,271 +145,6 @@ const chatStreamRequestSchema = z.object({
 });
 type ChatStreamRequestBody = z.infer<typeof chatStreamRequestSchema>;
 
-const ALL_COLLECTIONS = [
-  'deutschland',
-  'oesterreich',
-  'bundestagsfraktion',
-  'kommunalwiki',
-  'examples',
-  'gruene-de',
-  'gruene-at',
-  'boell-stiftung',
-] as const;
-
-/**
- * Creates search tools dynamically based on agent configuration.
- * This enables per-agent restrictions on collections (e.g., Austrian agent
- * can only search Austrian collections).
- *
- * Note: Returns Record<string, unknown> due to Zod version conflicts in monorepo.
- * Type safety is maintained through runtime validation in execute functions.
- */
-function createSearchTools(agentConfig: AgentConfig): ToolSet {
-  const restrictions = agentConfig.toolRestrictions;
-
-  const allowedCollections: readonly string[] = restrictions?.allowedCollections?.length
-    ? restrictions.allowedCollections
-    : ALL_COLLECTIONS;
-
-  const defaultCollection = restrictions?.defaultCollection || allowedCollections[0];
-  const examplesCountry = restrictions?.examplesCountry;
-  // DISABLED: Person search not production ready
-  // const personSearchEnabled = restrictions?.personSearchEnabled !== false;
-
-  log.debug(
-    `[Tools] Creating tools for ${agentConfig.identifier}: collections=${allowedCollections.join(',')}, default=${defaultCollection}, personSearch=disabled, examplesCountry=${examplesCountry || 'all'}`
-  );
-
-  const tools: ToolSet = {};
-
-  tools.gruenerator_search = tool({
-    description: `Durchsuche grüne Parteiprogramme, Positionen und Beschlüsse.
-
-NUTZE WENN:
-- Fragen zu grünen Positionen ("Was sagen die Grünen zu...")
-- Politische Standpunkte oder Beschlüsse benötigt
-- Zitate aus Parteiprogrammen gewünscht
-- Grüne Politik/Programmatik gefragt
-
-NICHT FÜR: Aktuelle Nachrichten, Personen-Infos, allgemeine Web-Suche`,
-    inputSchema: z.object({
-      query: z.string().describe('Suchanfrage in deutscher Sprache'),
-      collection: z
-        .enum(allowedCollections as [string, ...string[]])
-        .optional()
-        .default(defaultCollection)
-        .describe(`Sammlung: ${allowedCollections.join(', ')}`),
-      limit: z.number().optional().default(5).describe('Maximale Anzahl Ergebnisse'),
-    }),
-    execute: async ({ query, collection, limit }) => {
-      try {
-        if (!allowedCollections.includes(collection)) {
-          log.warn(`[Tools] Collection "${collection}" not allowed for ${agentConfig.identifier}`);
-          return {
-            error: 'Sammlung nicht verfügbar',
-            results: [],
-            collection,
-            query,
-          };
-        }
-        const results = await executeDirectSearch({ query, collection, limit });
-        return results;
-      } catch (error) {
-        log.error('Direct search error:', error);
-        return { error: 'Suche fehlgeschlagen', results: [], collection, query };
-      }
-    },
-  });
-
-  // DISABLED: Person search not production ready
-  // if (personSearchEnabled) {
-  //   tools.gruenerator_person_search = tool({
-  //     description: `Suche nach grünen Politiker*innen und deren Funktionen.
-  //
-  // NUTZE WENN:
-  // - "Wer ist [Name]?" oder "Wer war [Name]?"
-  // - Fragen nach Funktionen/Ämtern von Grünen-Politiker*innen
-  // - Biografie-Informationen über grüne Persönlichkeiten
-  //
-  // NICHT FÜR: Allgemeine Personensuche außerhalb der Grünen`,
-  //     inputSchema: z.object({
-  //       query: z.string().describe('Name oder Funktion der Person'),
-  //     }),
-  //     execute: async ({ query }) => {
-  //       try {
-  //         const results = await executeDirectPersonSearch({ query });
-  //         return results;
-  //       } catch (error) {
-  //         log.error('Direct person search error:', error);
-  //         return { error: 'Personensuche fehlgeschlagen', results: [], isPersonQuery: false };
-  //       }
-  //     },
-  //   });
-  // }
-
-  tools.gruenerator_examples_search = tool({
-    description: `Suche nach Social-Media-Beispielen und Vorlagen.
-
-NUTZE WENN:
-- Beispiele für Social-Media-Posts gesucht
-- Vorlagen für Instagram oder Facebook benötigt
-- Inspiration für grüne Social-Media-Kommunikation
-
-NICHT FÜR: Allgemeine Informationssuche, Fakten, Nachrichten`,
-    inputSchema: z.object({
-      query: z.string().describe('Thema oder Stichwort'),
-      platform: z.enum(['instagram', 'facebook']).optional().describe('Plattform filtern'),
-    }),
-    execute: async ({ query, platform }) => {
-      try {
-        const results = await executeDirectExamplesSearch({
-          query,
-          ...(platform && { platform }),
-          ...(examplesCountry && { country: examplesCountry }),
-        });
-        return results;
-      } catch (error) {
-        log.error('Direct examples search error:', error);
-        return { error: 'Beispielsuche fehlgeschlagen', examples: [], resultsCount: 0 };
-      }
-    },
-  });
-
-  tools.gruenerator_pressemitteilung_examples = tool({
-    description: `Suche nach echten Pressemitteilungen aus Landesverbänden als Inspiration und Vorlage.
-
-NUTZE WENN:
-- Eine Pressemitteilung verfasst werden soll
-- Beispiele für journalistische PM-Sprache und Aufbau gebraucht werden
-- Du sehen willst, wie andere Landesverbände PMs zu ähnlichen Themen formulieren
-
-NICHT FÜR: Social-Media-Posts (nutze gruenerator_examples_search), allgemeine Recherche (nutze gruenerator_search), Anträge oder Reden.`,
-    inputSchema: z.object({
-      query: z.string().describe('Thema der Pressemitteilung'),
-    }),
-    execute: async ({ query }) => {
-      try {
-        const results = await executeDirectPressemitteilungExamples({ query });
-        return results;
-      } catch (error) {
-        log.error('Direct pressemitteilung examples error:', error);
-        return {
-          error: 'Pressemitteilung-Suche fehlgeschlagen',
-          examples: [],
-          resultsCount: 0,
-        };
-      }
-    },
-  });
-
-  tools.web_search = tool({
-    description: `Suche im Internet nach aktuellen Informationen und Nachrichten.
-
-NUTZE WENN:
-- Aktuelle Ereignisse oder Nachrichten gefragt
-- Informationen außerhalb der Grünen-Dokumentation
-- Allgemeine Fakten aus dem Web
-- Externe Quellen benötigt
-
-NICHT FÜR: Grüne Parteiprogramme (nutze gruenerator_search)`,
-    inputSchema: z.object({
-      query: z.string().describe('Suchanfrage in deutscher Sprache'),
-      searchType: z
-        .enum(['general', 'news'])
-        .optional()
-        .default('general')
-        .describe('Suchtyp: general (allgemein) oder news (Nachrichten)'),
-      maxResults: z.number().optional().default(5).describe('Maximale Anzahl Ergebnisse (1-10)'),
-    }),
-    execute: async ({ query, searchType, maxResults }) => {
-      try {
-        const results = await executeDirectWebSearch({ query, searchType, maxResults });
-        return results;
-      } catch (error) {
-        log.error('Direct web search error:', error);
-        return { error: 'Websuche fehlgeschlagen', results: [], resultsCount: 0, query };
-      }
-    },
-  });
-
-  // Research tool: Perplexity-style structured research with planning, multi-source search, and synthesis
-  tools.research = tool({
-    description: `Strukturierte Recherche mit Planung, Suche und Synthese.
-
-NUTZE WENN:
-- Der Benutzer "recherchiere", "suche nach", "finde heraus" sagt
-- Komplexe Fragen mit mehreren Aspekten
-- Vergleiche verschiedener Quellen gewünscht
-- Themen die Kontext aus mehreren Bereichen brauchen
-- Explizite Recherche-Anfragen ("nutze das recherche tool")
-
-Das Tool plant automatisch, sucht in relevanten Quellen, und synthetisiert mit Inline-Zitaten [1], [2].
-
-NICHT FÜR: Einfache Begrüßungen, Dankeschöns, kreative Aufgaben ohne Faktenbedarf`,
-    inputSchema: z.object({
-      question: z.string().describe('Die Frage oder das Thema für die Recherche'),
-      depth: z
-        .enum(['quick', 'thorough'])
-        .optional()
-        .default('quick')
-        .describe(
-          'Recherchetiefe: quick (schnell, 1-2 Quellen) oder thorough (gründlich, mehr Quellen)'
-        ),
-    }),
-    execute: async ({ question, depth }) => {
-      try {
-        log.info(
-          `[Research Tool] Starting research: "${question.slice(0, 50)}..." (depth: ${depth})`
-        );
-        const result = await executeResearch({
-          question,
-          depth,
-          maxSources: depth === 'thorough' ? 10 : 6,
-        });
-        log.info(
-          `[Research Tool] Complete: ${result.citations.length} citations, confidence: ${result.confidence}`
-        );
-        return result;
-      } catch (error) {
-        log.error('Research tool error:', error);
-        return {
-          answer: 'Die Recherche konnte leider nicht durchgeführt werden.',
-          citations: [],
-          followUpQuestions: [],
-          searchSteps: [],
-          confidence: 'low' as const,
-          error: 'Recherche fehlgeschlagen',
-        };
-      }
-    },
-  });
-
-  // Direct response tool: escape hatch for non-search cases
-  tools.direct_response = tool({
-    description: `Antworte direkt ohne externe Suche.
-
-NUTZE DIESES TOOL WENN:
-- Begrüßungen/Verabschiedungen ("Hallo", "Danke", "Tschüss")
-- Allgemeine Konversation ohne Informationsbedarf
-- Kreative Aufgaben mit bereits gegebenen Infos (z.B. Instagram-Posts, Texte schreiben)
-- Klarstellende Nachfragen
-- Der Benutzer explizit KEINE Suche möchte
-- Einfache Folgefragen zu bereits besprochenen Themen
-
-NICHT NUTZEN wenn Fakten, aktuelle Infos oder Belege gefragt sind.`,
-    inputSchema: z.object({
-      content: z.string().describe('Die vollständige Antwort an den Benutzer'),
-      reason: z.string().optional().describe('Optional: Warum keine Suche nötig war'),
-    }),
-    execute: async ({ content, reason }) => {
-      log.debug(`[Direct Response] Content length: ${content?.length}, Reason: ${reason}`);
-      return { type: 'direct', content, reason };
-    },
-  });
-
-  return tools;
-}
-
 async function createThread(
   userId: string,
   agentId: string,
@@ -542,7 +268,7 @@ router.post(
       }
 
       const hasTools = agent.plugins?.includes('gruenerator-mcp');
-      const agentTools = createSearchTools(agent);
+      const agentTools = createSearchTools(agent, { includeDirectResponse: true });
 
       const agentToolKeys: Set<ToolKey> | null = agent.enabledTools
         ? new Set(

--- a/apps/api/services/boards/agentTaskService.ts
+++ b/apps/api/services/boards/agentTaskService.ts
@@ -44,6 +44,20 @@ export async function enqueueAgentTask(params: EnqueueAgentTaskParams): Promise<
     ]
   );
   log.info(`Enqueued agent task ${rows[0].id} for board ${params.boardId} card ${params.cardId}`);
+
+  // Immediate, short acknowledgement so the user sees the agent picked up the
+  // task the moment it's tagged — the result/failure reply follows from the worker.
+  await postBotComment({
+    boardId: params.boardId,
+    cardId: params.cardId,
+    parentId: params.triggerCommentId,
+    blocks: [{ type: 'text', text: 'Übernehme.' }],
+  }).catch((err: unknown) => {
+    log.warn('Failed to post acknowledgement comment', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
   return rows[0];
 }
 

--- a/apps/api/services/boards/agentTaskService.ts
+++ b/apps/api/services/boards/agentTaskService.ts
@@ -84,7 +84,7 @@ export async function claimNextAgentTask(): Promise<AgentTask | null> {
   return rows[0] ?? null;
 }
 
-export async function completeAgentTask(taskId: string, documentId: string): Promise<void> {
+export async function completeAgentTask(taskId: string, documentId: string | null): Promise<void> {
   await db.query(
     `UPDATE agent_tasks
         SET status = 'completed', result_document_id = $2, error = NULL,

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -3,15 +3,15 @@
  *
  * Started once per process from server.ts (startWorker). Each tick claims
  * claimable tasks one at a time (FOR UPDATE SKIP LOCKED → safe across cluster
- * workers), runs the existing headless ChatGraph, writes the result to a
- * collaborative document, then notifies the requester (in-app + push + email via
- * createNotification) and replies on the originating card as the bot.
+ * workers), classifies the request, generates a document (with live search/
+ * research tools), writes it, then notifies the requester (in-app + push + email
+ * via createNotification) and replies on the originating card as the bot.
  */
 import { generateText, stepCountIs, type ModelMessage } from 'ai';
 
 import {
   buildSystemMessage,
-  chatGraph,
+  classifierNode,
   initializeChatState,
 } from '../../agents/langgraph/ChatGraph/index.js';
 import { PRIMARY_URL } from '../../config/domains.js';
@@ -97,11 +97,10 @@ async function processTask(task: AgentTask): Promise<void> {
     const userLocale = task.locale === 'de-AT' ? 'de-AT' : 'de-DE';
     const userMessage: ModelMessage = { role: 'user', content: task.task_text };
 
-    // Run the ChatGraph for classification + retrieval/context, then generate the
-    // answer. The graph's respondNode only *prepares* the system message
-    // (state.responseText) — the chat controller normally streams the completion
-    // itself, so a headless caller must do the model call too. (Using the graph's
-    // responseText directly would put the system prompt into the document.)
+    // Classify only — the model does its own retrieval via the search/research
+    // tools during authoring, so we skip the graph's search/rerank/qualityGate
+    // stages to avoid double retrieval. The classifier still gives us the intent
+    // (for the unsupported-artifact guard) and a locale/intent-aware system prompt.
     const initialState = await initializeChatState({
       messages: [userMessage],
       agentId: '', // falsy → ChatGraph resolves the default universal agent
@@ -109,7 +108,8 @@ async function processTask(task: AgentTask): Promise<void> {
       aiWorkerPool: getAIService(),
       userLocale,
     });
-    const finalState = await chatGraph.invoke(initialState);
+    const classification = await classifierNode(initialState);
+    const finalState = { ...initialState, ...classification };
     if (finalState.error) {
       throw new Error(finalState.error);
     }
@@ -136,10 +136,10 @@ async function processTask(task: AgentTask): Promise<void> {
       return;
     }
 
-    // Build the chat context (search results, locale, citations) but author a full
-    // document: the universal agent's ANTWORT-REGELN constrain output to a short
-    // chat reply, so a document-mode directive (appended last, so it wins) lifts
-    // the length cap. A generous token floor prevents truncation of long-form docs.
+    // Build the agent's system prompt (systemRole, locale, intent guidance) but
+    // author a full document: the universal agent's ANTWORT-REGELN constrain output
+    // to a short chat reply, so a document-mode directive (appended last, so it
+    // wins) lifts the length cap. A generous token floor prevents truncation.
     const baseSystemMessage = await buildSystemMessage(finalState);
     const systemMessage = `${baseSystemMessage}
 

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -16,7 +16,7 @@ import {
 } from '../../agents/langgraph/ChatGraph/index.js';
 import { PRIMARY_URL } from '../../config/domains.js';
 import { type AgentTask } from '../../database/schema/agentTasks.js';
-import { getModel } from '../../routes/chat/agents/providers.js';
+import { resolveModel } from '../../routes/chat/services/responseStreamingService.js';
 import { createLogger } from '../../utils/logger.js';
 import { getAIService } from '../ai/aiService.js';
 import { createDocumentWithContent } from '../docs/DocGenerationService.js';
@@ -29,9 +29,23 @@ import {
   postBotComment,
 } from './agentTaskService.js';
 
+import type { SearchIntent } from '../../agents/langgraph/ChatGraph/index.js';
+
 const log = createLogger('boardAgentWorker');
 
 const POLL_INTERVAL_MS = 5_000;
+
+// Hard ceiling on a single generation so one hung model call can't stall the
+// whole drain loop (which processes tasks sequentially).
+const GENERATION_TIMEOUT_MS = 180_000;
+
+// Documents can be long-form; never let a chat-tuned agent's small token budget
+// truncate the result below this floor.
+const MIN_DOCUMENT_TOKENS = 4000;
+
+// Intents that produce a non-text artifact (image/sharepic/chart) the board
+// agent can't deliver as a document — answered with a short explanation instead.
+const UNSUPPORTED_INTENTS = new Set<SearchIntent>(['image', 'image_edit', 'sharepic', 'chart']);
 
 let intervalId: ReturnType<typeof setInterval> | null = null;
 let initialized = false;
@@ -96,17 +110,68 @@ async function processTask(task: AgentTask): Promise<void> {
       throw new Error(finalState.error);
     }
 
-    const systemMessage = await buildSystemMessage(finalState);
-    const { agentConfig } = finalState;
-    const generated = await generateText({
-      model: getModel(agentConfig.provider as string, agentConfig.model),
-      system: systemMessage,
-      messages: [userMessage],
-      maxOutputTokens: agentConfig.params.max_tokens,
-      temperature: agentConfig.params.temperature,
-    });
+    // The board agent only delivers text documents. For image/sharepic/chart
+    // intents the graph would burn work producing an artifact we can't attach, so
+    // answer with a short explanation and finish the task cleanly (no document).
+    if (UNSUPPORTED_INTENTS.has(finalState.intent)) {
+      await completeAgentTask(task.id, null);
+      await postBotComment({
+        boardId: task.board_id,
+        cardId: task.card_id,
+        parentId: task.trigger_comment_id,
+        blocks: [
+          {
+            type: 'text',
+            text: 'Ich kann auf Boards aktuell nur Text-Dokumente erstellen (keine Bilder, Sharepics oder Diagramme). Formuliere die Aufgabe gerne als Textauftrag.',
+          },
+        ],
+      }).catch((e: unknown) =>
+        log.warn('Failed to post unsupported-intent comment', { error: errMsg(e) })
+      );
+      log.info(`Agent task ${task.id} completed without document (intent: ${finalState.intent})`);
+      return;
+    }
 
-    const content = generated.text.trim();
+    // Build the chat context (search results, locale, citations) but author a full
+    // document: the universal agent's ANTWORT-REGELN constrain output to a short
+    // chat reply, so a document-mode directive (appended last, so it wins) lifts
+    // the length cap. A generous token floor prevents truncation of long-form docs.
+    const baseSystemMessage = await buildSystemMessage(finalState);
+    const systemMessage = `${baseSystemMessage}
+
+## DOKUMENT-MODUS (vorrangig)
+Du erstellst ein eigenständiges, vollständiges Dokument — KEINE kurze Chat-Antwort. Die Längen- und Knappheitsregeln aus den ANTWORT-REGELN gelten hier NICHT. Schreibe so ausführlich und strukturiert, wie die Aufgabe es verlangt: mit aussagekräftiger Überschrift (#), sinnvollen Zwischenüberschriften und vollständig ausformulierten Absätzen. Gib AUSSCHLIESSLICH den Dokumentinhalt als Markdown aus — keine Meta-Kommentare, keine Rückfragen.`;
+
+    const { agentConfig } = finalState;
+    // Resolve via the same path as the chat controller so overflow-lane slots and
+    // provider fallback are handled; release any acquired slot afterwards.
+    const resolution = await resolveModel(
+      {
+        provider: agentConfig.provider as string,
+        model: agentConfig.model,
+        ...(agentConfig.defaultModel != null && { defaultModel: agentConfig.defaultModel }),
+      },
+      undefined,
+      `board-agent-${task.id}`,
+      { intent: finalState.intent }
+    );
+
+    let generatedText: string;
+    try {
+      const generated = await generateText({
+        model: resolution.model,
+        system: systemMessage,
+        messages: [userMessage],
+        maxOutputTokens: Math.max(agentConfig.params.max_tokens, MIN_DOCUMENT_TOKENS),
+        temperature: agentConfig.params.temperature,
+        abortSignal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),
+      });
+      generatedText = generated.text;
+    } finally {
+      if (resolution.releaseSlot) await resolution.releaseSlot();
+    }
+
+    const content = generatedText.trim();
     if (!content) {
       throw new Error('Der Agent lieferte kein Ergebnis');
     }

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -20,6 +20,7 @@ import { createSearchTools } from '../../routes/chat/agents/searchTools.js';
 import { resolveModel } from '../../routes/chat/services/responseStreamingService.js';
 import { createLogger } from '../../utils/logger.js';
 import { getAIService } from '../ai/aiService.js';
+import { INTERMEDIATE_MODEL } from '../ai/providers.js';
 import { createDocumentWithContent } from '../docs/DocGenerationService.js';
 import { createNotification } from '../notifications/NotificationService.js';
 
@@ -46,6 +47,17 @@ const MIN_DOCUMENT_TOKENS = 4000;
 
 // Max model<->tool round-trips while authoring (search/research then write).
 const MAX_TOOL_STEPS = 5;
+
+// Decides whether a tagged comment wants a short answer (posted back as a comment)
+// or a created text artifact (a document).
+const DELIVERABLE_PROMPT = `Du entscheidest, wie der Grünerator auf eine Aufgabe in einem Board-Kommentar reagieren soll.
+
+Antworte NUR mit einem JSON-Objekt: {"format":"comment"} ODER {"format":"document"}.
+
+"comment" = der Nutzer stellt eine Frage oder will eine kurze Auskunft/Einschätzung, die als Antwort im Kommentar-Thread passt.
+"document" = der Nutzer möchte, dass ein eigenständiger Text erstellt wird (z. B. Pressemitteilung, Rede, Antrag, Brief, Konzept oder längerer Entwurf; "schreib/erstelle/verfasse …").
+
+Im Zweifel: eine Frage → "comment"; ein Auftrag, einen Text zu erstellen → "document".`;
 
 // Intents that produce a non-text artifact (image/sharepic/chart) the board
 // agent can't deliver as a document — answered with a short explanation instead.
@@ -136,17 +148,25 @@ async function processTask(task: AgentTask): Promise<void> {
       return;
     }
 
-    // Build the agent's system prompt (systemRole, locale, intent guidance) but
-    // author a full document: the universal agent's ANTWORT-REGELN constrain output
-    // to a short chat reply, so a document-mode directive (appended last, so it
-    // wins) lifts the length cap. A generous token floor prevents truncation.
+    // Decide the deliverable: a quick question is answered in the comment thread;
+    // a "create a text" request becomes a document.
+    const isDocument = (await classifyDeliverable(task.task_text)) === 'document';
+
+    // Build the agent's system prompt (systemRole, locale, intent guidance), then
+    // steer the format: a full document (overriding the universal agent's short
+    // ANTWORT-REGELN), or a concise comment answer (where those rules fit as-is).
     const baseSystemMessage = await buildSystemMessage(finalState);
-    const systemMessage = `${baseSystemMessage}
+    const systemMessage = isDocument
+      ? `${baseSystemMessage}
 
 ## DOKUMENT-MODUS (vorrangig)
 Du erstellst ein eigenständiges, vollständiges Dokument — KEINE kurze Chat-Antwort. Die Längen- und Knappheitsregeln aus den ANTWORT-REGELN gelten hier NICHT. Schreibe so ausführlich und strukturiert, wie die Aufgabe es verlangt: mit aussagekräftiger Überschrift (#), sinnvollen Zwischenüberschriften und vollständig ausformulierten Absätzen.
 
-Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze sie aktiv, um Fakten und grüne Positionen zu belegen, bevor du schreibst — verlasse dich nicht nur auf vorhandenen Kontext. Gib am Ende AUSSCHLIESSLICH den Dokumentinhalt als Markdown aus — keine Meta-Kommentare, keine Rückfragen.`;
+Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze sie aktiv, um Fakten und grüne Positionen zu belegen, bevor du schreibst — verlasse dich nicht nur auf vorhandenen Kontext. Gib am Ende AUSSCHLIESSLICH den Dokumentinhalt als Markdown aus — keine Meta-Kommentare, keine Rückfragen.`
+      : `${baseSystemMessage}
+
+## KOMMENTAR-MODUS
+Du antwortest direkt in einem Board-Kommentar-Thread. Antworte knapp und konkret auf die Frage (folge den ANTWORT-REGELN oben). Nutze bei Faktenbedarf zuerst die Recherche-Tools. Gib NUR die Antwort aus — keine Anrede, keine Meta-Kommentare, keine Überschrift.`;
 
     const { agentConfig } = finalState;
     // Resolve via the same path as the chat controller so overflow-lane slots and
@@ -173,7 +193,9 @@ Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze s
         messages: [userMessage],
         tools: createSearchTools(agentConfig),
         stopWhen: stepCountIs(MAX_TOOL_STEPS),
-        maxOutputTokens: Math.max(agentConfig.params.max_tokens, MIN_DOCUMENT_TOKENS),
+        maxOutputTokens: isDocument
+          ? Math.max(agentConfig.params.max_tokens, MIN_DOCUMENT_TOKENS)
+          : agentConfig.params.max_tokens,
         temperature: agentConfig.params.temperature,
         abortSignal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),
       });
@@ -185,6 +207,28 @@ Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze s
     const content = generatedText.trim();
     if (!content) {
       throw new Error('Der Agent lieferte kein Ergebnis');
+    }
+
+    // Question → answer directly in the comment thread, no document.
+    if (!isDocument) {
+      await completeAgentTask(task.id, null);
+      await postBotComment({
+        boardId: task.board_id,
+        cardId: task.card_id,
+        parentId: task.trigger_comment_id,
+        blocks: [{ type: 'text', text: content }],
+      });
+      await createNotification({
+        userId: task.requested_by,
+        type: 'agent_task_completed',
+        title: 'Der Grünerator hat geantwortet',
+        body: content.length > 140 ? content.slice(0, 139) + '…' : content,
+        actionUrl: `/boards/${task.board_id}?card=${task.card_id}`,
+        metadata: { boardId: task.board_id, cardId: task.card_id, taskId: task.id },
+        groupKey: `agent-task-${task.id}`,
+      });
+      log.info(`Agent task ${task.id} answered in comment (no document)`);
+      return;
     }
 
     const title = deriveTitle(task.task_text, content);
@@ -250,6 +294,34 @@ Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze s
         ],
       }).catch((e: unknown) => log.warn('Failed to post failure comment', { error: errMsg(e) }));
     }
+  }
+}
+
+/**
+ * Decide whether the tagged comment wants a short answer (posted back as a
+ * comment) or a created document. Cheap intermediate-model call; defaults to
+ * 'document' on any failure (preserves the prior always-a-document behaviour).
+ */
+async function classifyDeliverable(taskText: string): Promise<'comment' | 'document'> {
+  try {
+    const response = await getAIService().processRequest({
+      type: 'chat_intent_classification',
+      provider: INTERMEDIATE_MODEL.provider,
+      systemPrompt: DELIVERABLE_PROMPT,
+      messages: [{ role: 'user', content: taskText }],
+      options: {
+        model: INTERMEDIATE_MODEL.model,
+        max_tokens: 20,
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      },
+    });
+    const match = (response.content || '').match(/\{[\s\S]*\}/);
+    const parsed = JSON.parse(match?.[0] || '{}') as { format?: unknown };
+    return parsed.format === 'comment' ? 'comment' : 'document';
+  } catch (err) {
+    log.warn('Deliverable classification failed, defaulting to document', { error: errMsg(err) });
+    return 'document';
   }
 }
 

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -7,11 +7,16 @@
  * collaborative document, then notifies the requester (in-app + push + email via
  * createNotification) and replies on the originating card as the bot.
  */
-import { type ModelMessage } from 'ai';
+import { generateText, type ModelMessage } from 'ai';
 
-import { runChatGraph } from '../../agents/langgraph/ChatGraph/index.js';
+import {
+  buildSystemMessage,
+  chatGraph,
+  initializeChatState,
+} from '../../agents/langgraph/ChatGraph/index.js';
 import { PRIMARY_URL } from '../../config/domains.js';
 import { type AgentTask } from '../../database/schema/agentTasks.js';
+import { getModel } from '../../routes/chat/agents/providers.js';
 import { createLogger } from '../../utils/logger.js';
 import { getAIService } from '../ai/aiService.js';
 import { createDocumentWithContent } from '../docs/DocGenerationService.js';
@@ -68,46 +73,46 @@ async function drain(): Promise<void> {
 async function processTask(task: AgentTask): Promise<void> {
   log.info(`Processing agent task ${task.id} (attempt ${task.attempts}/${task.max_attempts})`);
 
-  // Acknowledge on the card on the first attempt only.
-  if (task.attempts <= 1) {
-    await postBotComment({
-      boardId: task.board_id,
-      cardId: task.card_id,
-      parentId: task.trigger_comment_id,
-      blocks: [
-        {
-          type: 'text',
-          text: '🤖 Ich arbeite an deiner Aufgabe … du bekommst Bescheid, sobald das Dokument fertig ist.',
-        },
-      ],
-    }).catch((err: unknown) => {
-      log.warn(`Failed to post ack comment for task ${task.id}`, { error: errMsg(err) });
-    });
-  }
-
+  // The "Übernehme." acknowledgement is posted at enqueue time (agentTaskService),
+  // so the worker goes straight to producing the result.
   try {
     const userLocale = task.locale === 'de-AT' ? 'de-AT' : 'de-DE';
-    const messages: ModelMessage[] = [{ role: 'user', content: task.task_text }];
+    const userMessage: ModelMessage = { role: 'user', content: task.task_text };
 
-    const result = await runChatGraph({
-      messages,
+    // Run the ChatGraph for classification + retrieval/context, then generate the
+    // answer. The graph's respondNode only *prepares* the system message
+    // (state.responseText) — the chat controller normally streams the completion
+    // itself, so a headless caller must do the model call too. (Using the graph's
+    // responseText directly would put the system prompt into the document.)
+    const initialState = await initializeChatState({
+      messages: [userMessage],
       agentId: '', // falsy → ChatGraph resolves the default universal agent
       enabledTools: { search: true, web: true, person: true, examples: true, research: true },
       aiWorkerPool: getAIService(),
       userLocale,
     });
-
-    if (!result.success || !result.responseText.trim()) {
-      throw new Error(result.error || 'Der Agent lieferte kein Ergebnis');
+    const finalState = await chatGraph.invoke(initialState);
+    if (finalState.error) {
+      throw new Error(finalState.error);
     }
 
-    const title = deriveTitle(task.task_text, result.responseText);
-    const doc = await createDocumentWithContent(
-      title,
-      result.responseText,
-      'blank',
-      task.requested_by
-    );
+    const systemMessage = await buildSystemMessage(finalState);
+    const { agentConfig } = finalState;
+    const generated = await generateText({
+      model: getModel(agentConfig.provider as string, agentConfig.model),
+      system: systemMessage,
+      messages: [userMessage],
+      maxOutputTokens: agentConfig.params.max_tokens,
+      temperature: agentConfig.params.temperature,
+    });
+
+    const content = generated.text.trim();
+    if (!content) {
+      throw new Error('Der Agent lieferte kein Ergebnis');
+    }
+
+    const title = deriveTitle(task.task_text, content);
+    const doc = await createDocumentWithContent(title, content, 'blank', task.requested_by);
     const relativeUrl = `/docs/${doc.id}`;
 
     await completeAgentTask(task.id, doc.id);

--- a/apps/api/services/boards/boardAgentWorker.ts
+++ b/apps/api/services/boards/boardAgentWorker.ts
@@ -7,7 +7,7 @@
  * collaborative document, then notifies the requester (in-app + push + email via
  * createNotification) and replies on the originating card as the bot.
  */
-import { generateText, type ModelMessage } from 'ai';
+import { generateText, stepCountIs, type ModelMessage } from 'ai';
 
 import {
   buildSystemMessage,
@@ -16,6 +16,7 @@ import {
 } from '../../agents/langgraph/ChatGraph/index.js';
 import { PRIMARY_URL } from '../../config/domains.js';
 import { type AgentTask } from '../../database/schema/agentTasks.js';
+import { createSearchTools } from '../../routes/chat/agents/searchTools.js';
 import { resolveModel } from '../../routes/chat/services/responseStreamingService.js';
 import { createLogger } from '../../utils/logger.js';
 import { getAIService } from '../ai/aiService.js';
@@ -42,6 +43,9 @@ const GENERATION_TIMEOUT_MS = 180_000;
 // Documents can be long-form; never let a chat-tuned agent's small token budget
 // truncate the result below this floor.
 const MIN_DOCUMENT_TOKENS = 4000;
+
+// Max model<->tool round-trips while authoring (search/research then write).
+const MAX_TOOL_STEPS = 5;
 
 // Intents that produce a non-text artifact (image/sharepic/chart) the board
 // agent can't deliver as a document — answered with a short explanation instead.
@@ -140,7 +144,9 @@ async function processTask(task: AgentTask): Promise<void> {
     const systemMessage = `${baseSystemMessage}
 
 ## DOKUMENT-MODUS (vorrangig)
-Du erstellst ein eigenständiges, vollständiges Dokument — KEINE kurze Chat-Antwort. Die Längen- und Knappheitsregeln aus den ANTWORT-REGELN gelten hier NICHT. Schreibe so ausführlich und strukturiert, wie die Aufgabe es verlangt: mit aussagekräftiger Überschrift (#), sinnvollen Zwischenüberschriften und vollständig ausformulierten Absätzen. Gib AUSSCHLIESSLICH den Dokumentinhalt als Markdown aus — keine Meta-Kommentare, keine Rückfragen.`;
+Du erstellst ein eigenständiges, vollständiges Dokument — KEINE kurze Chat-Antwort. Die Längen- und Knappheitsregeln aus den ANTWORT-REGELN gelten hier NICHT. Schreibe so ausführlich und strukturiert, wie die Aufgabe es verlangt: mit aussagekräftiger Überschrift (#), sinnvollen Zwischenüberschriften und vollständig ausformulierten Absätzen.
+
+Du hast Recherche-Tools (gruenerator_search, web_search, research, …). Nutze sie aktiv, um Fakten und grüne Positionen zu belegen, bevor du schreibst — verlasse dich nicht nur auf vorhandenen Kontext. Gib am Ende AUSSCHLIESSLICH den Dokumentinhalt als Markdown aus — keine Meta-Kommentare, keine Rückfragen.`;
 
     const { agentConfig } = finalState;
     // Resolve via the same path as the chat controller so overflow-lane slots and
@@ -158,10 +164,15 @@ Du erstellst ein eigenständiges, vollständiges Dokument — KEINE kurze Chat-A
 
     let generatedText: string;
     try {
+      // Give the model live retrieval (search/research) while authoring, so it can
+      // ground facts on demand rather than only from the graph's pre-fetched
+      // context. toolChoice defaults to 'auto'; stepCountIs caps tool round-trips.
       const generated = await generateText({
         model: resolution.model,
         system: systemMessage,
         messages: [userMessage],
+        tools: createSearchTools(agentConfig),
+        stopWhen: stepCountIs(MAX_TOOL_STEPS),
         maxOutputTokens: Math.max(agentConfig.params.max_tokens, MIN_DOCUMENT_TOKENS),
         temperature: agentConfig.params.temperature,
         abortSignal: AbortSignal.timeout(GENERATION_TIMEOUT_MS),


### PR DESCRIPTION
Follow-up to #1161 (async Grünerator board agent). Two fixes:

### 1. Document contained the system prompt, not the answer
`runChatGraph()`'s `responseText` is only the **prepared system message** — `respondNode` builds the context, and the chat controller normally streams the actual completion itself. The headless worker was writing that system prompt straight into the document.

Now the worker runs the graph for classification + retrieval/context, then performs the model call itself — mirroring the controller: `buildSystemMessage(finalState)` → `generateText({ model: getModel(provider, model), system, messages, maxOutputTokens, temperature })` — and writes the generated text.

### 2. Instant acknowledgement
A short **"Übernehme."** comment is now posted at enqueue time (the moment `@gruenerator` is tagged), instead of the worker's delayed ack ~5s later. The detailed worker ack was removed to avoid a duplicate; the result/failure reply still follows.

## Verification
- `pnpm --filter @gruenerator/api typecheck` — clean
- ESLint on changed files — clean
- Cherry-picked cleanly onto current `master`; 2 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)