### PR TITLE
fix(canvas-editor): exclude marks from Logos category

### DIFF
--- a/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
@@ -3,7 +3,7 @@ import { FaPuzzlePiece, FaSearch, FaShapes } from 'react-icons/fa';
 import { HiSparkles } from 'react-icons/hi2';
 import { PiFrameCornersFill, PiSmileyWink, PiTagFill } from 'react-icons/pi';
 
-import { ALL_ASSETS, type AssetInstance } from '../../../utils/canvasAssets';
+import { LOGO_ASSETS, type AssetInstance } from '../../../utils/canvasAssets';
 import { getIconsSync, loadAllIcons } from '../../../utils/canvasIcons';
 import { ALL_ILLUSTRATIONS, UNDRAW_FEATURED } from '../../../utils/illustrations/registry';
 import { prefetchBackground } from '../../../utils/illustrations/svgCache';
@@ -207,8 +207,8 @@ function MobileView({
   const effectiveIllustrationsExpanded = bridge.active || illustrationenExpanded;
 
   const sortedAssets = useMemo(() => {
-    const recommended = ALL_ASSETS.filter((a) => recommendedAssetIds.includes(a.id));
-    const others = ALL_ASSETS.filter((a) => !recommendedAssetIds.includes(a.id));
+    const recommended = LOGO_ASSETS.filter((a) => recommendedAssetIds.includes(a.id));
+    const others = LOGO_ASSETS.filter((a) => !recommendedAssetIds.includes(a.id));
     return [...recommended, ...others];
   }, [recommendedAssetIds]);
 

--- a/packages/canvas-editor/src/sidebar/sections/assets/BrowseView.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/BrowseView.tsx
@@ -3,7 +3,7 @@ import { PiArrowLeft } from 'react-icons/pi';
 
 import useDebounce from '../../../hooks/useDebounce';
 import { useCanvasEditorServices } from '../../../CanvasEditorProvider';
-import { ALL_ASSETS, type UniversalAsset } from '../../../utils/canvasAssets';
+import { ALL_ASSETS, LOGO_ASSETS, type UniversalAsset } from '../../../utils/canvasAssets';
 import { filterIllustrations, matchesQuery } from '../../../utils/filterUtils';
 import {
   ALL_ILLUSTRATIONS,
@@ -495,8 +495,8 @@ function GrafiksSectionContent({
   searchQuery?: string;
 }) {
   const sortedAssets = useMemo(() => {
-    const recommended = ALL_ASSETS.filter((a) => recommendedAssetIds.includes(a.id));
-    const others = ALL_ASSETS.filter((a) => !recommendedAssetIds.includes(a.id));
+    const recommended = LOGO_ASSETS.filter((a) => recommendedAssetIds.includes(a.id));
+    const others = LOGO_ASSETS.filter((a) => !recommendedAssetIds.includes(a.id));
     const all = [...recommended, ...others];
     if (!searchQuery.trim()) return all;
     return all.filter((a) => matchesQuery(searchQuery, a.label, a.tags));

--- a/packages/canvas-editor/src/utils/canvasAssets.ts
+++ b/packages/canvas-editor/src/utils/canvasAssets.ts
@@ -119,6 +119,14 @@ export const ALL_ASSETS: UniversalAsset[] = [
 ];
 
 /**
+ * Logo assets shown in the "Logos" (grafiken) category.
+ * Only true logos (decoration) — marks like Anführungszeichen/Pfeil are excluded.
+ */
+export const LOGO_ASSETS: UniversalAsset[] = ALL_ASSETS.filter(
+  (a) => a.category === 'decoration'
+);
+
+/**
  * Mapping of canvas types to their recommended (default) assets
  * These appear in the "Empfohlen" section at the top
  */

--- a/packages/canvas-editor/src/utils/canvasAssets.ts
+++ b/packages/canvas-editor/src/utils/canvasAssets.ts
@@ -122,9 +122,7 @@ export const ALL_ASSETS: UniversalAsset[] = [
  * Logo assets shown in the "Logos" (grafiken) category.
  * Only true logos (decoration) — marks like Anführungszeichen/Pfeil are excluded.
  */
-export const LOGO_ASSETS: UniversalAsset[] = ALL_ASSETS.filter(
-  (a) => a.category === 'decoration'
-);
+export const LOGO_ASSETS: UniversalAsset[] = ALL_ASSETS.filter((a) => a.category === 'decoration');
 
 /**
  * Mapping of canvas types to their recommended (default) assets


### PR DESCRIPTION
## Summary
In the canvas editor's **Logos** category, the Anführungszeichen (quote) and Pfeil-rechts (arrow) appeared alongside the sunflower logos — but these are marks, not logos.

The "Logos" (grafiken) view rendered the full `ALL_ASSETS` list, which mixes `category: 'decoration'` (sunflowers = real logos) with `category: 'mark'` (quote, arrow).

## Changes
- Add `LOGO_ASSETS` in `canvasAssets.ts` — `ALL_ASSETS` filtered to `category === 'decoration'`.
- Use it in both render paths: the desktop drill-down (`BrowseView.tsx` `GrafiksSectionContent`) and the mobile "Grafiken" subsection (`AssetsSection.tsx`).

The marks stay defined in `ALL_ASSETS`, so they remain available via search and as recommended/auto-placed assets for the `zitat`/`info` canvas types — they just no longer show under "Logos".

## Testing
- `pnpm --filter @gruenerator/canvas-editor typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)