### PR TITLE
fix(image-studio): mint-failure, non-mintable types, and missing required image (follow-up to #1163)

### DIFF
--- a/apps/web/src/features/image-studio/components/StepFlow.tsx
+++ b/apps/web/src/features/image-studio/components/StepFlow.tsx
@@ -10,6 +10,7 @@ import { useStepFlow } from '../hooks/useStepFlow';
 import ImageSizeSelectStep from '../steps/ImageSizeSelectStep';
 import ImageUploadStep from '../steps/ImageUploadStep';
 import InputStep from '../steps/InputStep';
+import { isMintableCanvasType } from '../utils/canvasTypeFields';
 
 // Types (Keep StepFlowProps, but maybe move others if needed by steps)
 
@@ -59,6 +60,7 @@ const StepFlow: React.FC<StepFlowProps> = ({
 }) => {
   const handleChange = useImageStudioStore((s) => s.handleChange);
   const updateFormData = useImageStudioStore((s) => s.updateFormData);
+  const type = useImageStudioStore((s) => s.type);
   const user = useAuthStore((s) => s.user);
 
   const { direction, currentStep, isFirstStep, loading, error, goNext, goBack, bgRemovalProgress } =
@@ -146,18 +148,38 @@ const StepFlow: React.FC<StepFlowProps> = ({
             />
           )}
 
-          {currentStep.type === 'canvas_edit' && (
-            // Canvas editing has moved to the collaborative `/studio/canvas/:id`
-            // route. Reaching this step hands off via the store (see useStepFlow);
-            // this brief loader shows until TemplateStudioFlow mints and navigates.
-            <div
-              key={currentStep.id}
-              className="flex items-center justify-center gap-sm py-2xl text-foreground"
-            >
-              <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
-              <span className="text-sm">Leinwand wird vorbereitet…</span>
-            </div>
-          )}
+          {currentStep.type === 'canvas_edit' &&
+            (isMintableCanvasType(type ?? '') ? (
+              // Canvas editing has moved to the collaborative `/studio/canvas/:id`
+              // route. Reaching this step hands off via the store (see useStepFlow);
+              // this brief loader shows until TemplateStudioFlow mints and navigates.
+              <div
+                key={currentStep.id}
+                className="flex items-center justify-center gap-sm py-2xl text-foreground"
+              >
+                <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />
+                <span className="text-sm">Leinwand wird vorbereitet…</span>
+              </div>
+            ) : (
+              // Non-mintable types (e.g. presentation, a multi-slide pres-* config)
+              // have no single-document canvas route, so there is no handoff — show
+              // an explicit message instead of a loader that would never resolve.
+              <div
+                key={currentStep.id}
+                className="flex flex-col items-center justify-center gap-md py-2xl text-center text-foreground"
+              >
+                <p className="text-sm text-grey-600 dark:text-grey-300">
+                  Dieser Vorlagentyp kann hier nicht bearbeitet werden.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleBack}
+                  className="rounded-md border border-grey-200 px-4 py-2 text-sm hover:bg-grey-100 dark:border-grey-700 dark:hover:bg-grey-800"
+                >
+                  Zurück
+                </button>
+              </div>
+            ))}
         </AnimatePresence>
 
         {imageLimitData && imageLimitData.count >= 8 && (

--- a/apps/web/src/features/image-studio/flows/TemplateStudioFlow.tsx
+++ b/apps/web/src/features/image-studio/flows/TemplateStudioFlow.tsx
@@ -38,7 +38,7 @@ const TemplateStudioFlow = ({ onBack }: TemplateStudioFlowProps) => {
     previousStep === FORM_STEPS.IMAGE_UPLOAD && currentStep === FORM_STEPS.INPUT;
 
   const [isWideStep, setIsWideStep] = useState(false);
-  const [isMintingCanvas, setIsMintingCanvas] = useState(false);
+  const [mintError, setMintError] = useState(false);
 
   const handleStepChange = useCallback((stepType: string) => {
     setIsWideStep(stepType === 'image_upload');
@@ -47,30 +47,33 @@ const TemplateStudioFlow = ({ onBack }: TemplateStudioFlowProps) => {
   const navigate = useNavigate();
   const mintingRef = useRef(false);
 
-  useEffect(() => {
-    if (currentStep !== FORM_STEPS.CANVAS_EDIT) return;
+  // Reaching CANVAS_EDIT mints a canvas document and navigates to the
+  // collaborative /studio/canvas/:id route. Extracted so the failure UI can
+  // retry it. mintingRef guards against concurrent/duplicate mints.
+  const runMint = useCallback(async () => {
     if (mintingRef.current) return;
     if (!type) return;
 
     mintingRef.current = true;
-    setIsMintingCanvas(true);
+    setMintError(false);
+    try {
+      const state = useImageStudioStore.getState();
+      const { id } = await mintCanvasFromStudioStore(state);
+      void navigate(`/studio/canvas/${id}`, { replace: true });
+    } catch (err) {
+      console.error('[TemplateStudioFlow] Canvas mint failed:', err);
+      void import('sonner').then(({ toast }) =>
+        toast.error('Leinwand konnte nicht gespeichert werden. Bitte erneut versuchen.')
+      );
+      mintingRef.current = false;
+      setMintError(true);
+    }
+  }, [type, navigate]);
 
-    const run = async () => {
-      try {
-        const state = useImageStudioStore.getState();
-        const { id } = await mintCanvasFromStudioStore(state);
-        void navigate(`/studio/canvas/${id}`, { replace: true });
-      } catch (err) {
-        console.error('[TemplateStudioFlow] Canvas mint failed:', err);
-        void import('sonner').then(({ toast }) =>
-          toast.error('Leinwand konnte nicht gespeichert werden. Bitte erneut versuchen.')
-        );
-        mintingRef.current = false;
-        setIsMintingCanvas(false);
-      }
-    };
-    void run();
-  }, [currentStep, type, navigate]);
+  useEffect(() => {
+    if (currentStep !== FORM_STEPS.CANVAS_EDIT) return;
+    void runMint();
+  }, [currentStep, runMint]);
 
   const handleAnimationStart = useCallback(() => {
     useImageStudioStore.getState().setIsAnimating(true);
@@ -165,7 +168,35 @@ const TemplateStudioFlow = ({ onBack }: TemplateStudioFlowProps) => {
     return <div className="error-message">Konfiguration für diesen Typ nicht gefunden.</div>;
   }
 
-  if (isMintingCanvas) {
+  // CANVAS_EDIT is the mint→navigate handoff. While minting (or in the brief
+  // window before the effect runs) show a loader; on failure show an explicit
+  // retry/back instead of a dead-end blank screen.
+  if (currentStep === FORM_STEPS.CANVAS_EDIT) {
+    if (mintError) {
+      return (
+        <div className="flex h-[60vh] flex-col items-center justify-center gap-md text-center text-foreground">
+          <p className="text-sm text-grey-600 dark:text-grey-300">
+            Leinwand konnte nicht vorbereitet werden.
+          </p>
+          <div className="flex items-center gap-sm">
+            <button
+              type="button"
+              onClick={() => void runMint()}
+              className="rounded-md bg-primary-500 px-4 py-2 text-sm text-white hover:bg-primary-600"
+            >
+              Erneut versuchen
+            </button>
+            <button
+              type="button"
+              onClick={onBack}
+              className="rounded-md border border-grey-200 px-4 py-2 text-sm hover:bg-grey-100 dark:border-grey-700 dark:hover:bg-grey-800"
+            >
+              Zurück
+            </button>
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="flex h-[60vh] items-center justify-center gap-sm text-foreground">
         <div className="size-4 animate-spin rounded-full border-2 border-grey-200 border-t-primary-500" />

--- a/apps/web/src/features/image-studio/services/canvasMintService.ts
+++ b/apps/web/src/features/image-studio/services/canvasMintService.ts
@@ -89,7 +89,13 @@ async function buildInitialState(
 
   if (config.image) {
     const imageUrl = await resolveImageUrl(state, config.image.source);
-    if (imageUrl) initial[config.image.key] = imageUrl;
+    if (imageUrl) {
+      initial[config.image.key] = imageUrl;
+    } else if (config.image.required) {
+      // Fail loudly rather than mint a broken, imageless canvas — the caller
+      // surfaces this as a retry prompt (see TemplateStudioFlow).
+      throw new Error(`Cannot mint canvas: required image for "${type}" could not be resolved`);
+    }
   }
 
   return initial;


### PR DESCRIPTION
Follow-up to #1163 (single-route collaborative canvas), addressing three issues found in code review of that PR.

## 1. Mint failure left a dead-end blank screen
#1163 removed `FORM_STEPS.CANVAS_EDIT` from `shouldRenderStepFlow`, so when `mintCanvasFromStudioStore` failed (non-201 from `canvas.create`, network error, etc.) the store stayed at `CANVAS_EDIT` and `TemplateStudioFlow` rendered nothing — a blank page with only a transient toast and no way back. Mint is now a retryable `runMint` callback; the `CANVAS_EDIT` branch renders a loader while minting and an explicit **"Erneut versuchen" / "Zurück"** UI on failure.

## 2. Non-mintable types showed an infinite loader
Types that still produce a `canvas_edit` step but aren't in `CANVAS_TYPE_FIELDS` (e.g. `presentation`, a multi-slide `pres-*` config) never hand off, so the new loader spun forever. They now render a clear **"Dieser Vorlagentyp kann hier nicht bearbeitet werden"** message with a back action.

## 3. Missing required image silently minted a broken canvas
If a required image failed to resolve (e.g. profilbild's transparent re-upload failing, or a media-upload error), the canvas was minted imageless with no error. `buildInitialState` now honors the previously-unused `CanvasImageConfig.required` flag and throws, surfacing the failure through the retry UI above.

## Verification
- `pnpm --filter @gruenerator/web typecheck` — passes (verified on identical content).
- `prettier --check` — clean on all three files.
- `eslint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)