### PR TITLE
feat(web): move Skills & Agents from nav into Tools section

### DIFF
--- a/apps/web/src/components/layout/Header/menuData.tsx
+++ b/apps/web/src/components/layout/Header/menuData.tsx
@@ -1,5 +1,4 @@
 import { PiGlobe } from 'react-icons/pi';
-import { RiSpyLine } from 'react-icons/ri';
 import { SlNotebook } from 'react-icons/sl';
 
 import { getIcon, getIconById as getIconFromRegistry } from '../../../config/icons';
@@ -69,15 +68,6 @@ export const getDirectMenuItems = (_flags: MenuFlags = {}): DirectMenuItemsResul
     description: 'Suche, Wissensmanagement & Dokumentenrecherche',
     icon: SlNotebook,
     activePaths: ['/notebooks', '/notebook'],
-  };
-
-  items.agents = {
-    id: 'agents',
-    path: '/agents',
-    title: 'Skills & Agents',
-    description: 'KI-Assistent*innen und Schnellbefehle für deine Aufgaben',
-    icon: RiSpyLine,
-    activePaths: ['/agents', '/skills'],
   };
 
   if (import.meta.env.DEV) {

--- a/apps/web/src/features/workplace/components/ToolsSection.tsx
+++ b/apps/web/src/features/workplace/components/ToolsSection.tsx
@@ -1,5 +1,6 @@
 import { IconButton } from '@gruenerator/ui';
 import React from 'react';
+import { RiSpyLine } from 'react-icons/ri';
 import { useNavigate } from 'react-router-dom';
 
 import { getIcon } from '../../../config/icons';
@@ -22,6 +23,12 @@ interface FavoriteItem {
 }
 
 const MAIN_TOOLS: ToolItem[] = [
+  {
+    id: 'agents',
+    title: 'Skills & Agents',
+    path: '/agents',
+    icon: RiSpyLine,
+  },
   {
     id: 'gruen-veraendern',
     title: 'Bild mit KI begrünen',


### PR DESCRIPTION
## What

Moves the **Skills & Agents** entry out of the primary navigation and into the **Weitere Tools** section on the Workplace page.

## Why

Consolidates Skills & Agents alongside the other tools rather than occupying a top-level nav slot.

## Changes

- `menuData.tsx` — remove the `items.agents` entry from `getDirectMenuItems()` (the single source feeding the sidebar, mobile nav menu, and desktop home), plus its now-unused `RiSpyLine` import.
- `ToolsSection.tsx` — add a `Skills & Agents` item (→ `/agents`, `RiSpyLine` icon) at the top of `MAIN_TOOLS`.

The `/agents` route and the `SkillsAndAgentsPage` component are untouched, so existing links still resolve.

## Notes

- Verified with `pnpm --filter @gruenerator/web typecheck` (passes).
- Placed first in the tools grid since it was a prominent nav item — easy to reorder if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)