### PR TITLE
fix(chat): route sharepic requests by text and honor requested variant

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
@@ -257,11 +257,28 @@ export function heuristicClassify(userContent: string): HeuristicResult {
     };
   }
 
+  // High confidence (0.93): Sharepic requests — a branded social graphic, NOT a
+  // free-form AI image. Checked BEFORE the generic image heuristic below, which
+  // would otherwise swallow "sharepic" into the AI-image path. Matches the noun
+  // anywhere ("mach mir ein zitat sharepic", "sharepic über X") plus the German
+  // spelling variants ("spruchbild", "zitatbild"). The specific variant
+  // (zitat/dreizeilen/info) is resolved later in the execution path from the same
+  // text — here we only need to route to the sharepic intent.
+  const sharepicKeywords = /\b(share[\s-]?pics?|sharepics?|spruchbild\w*|zitatbild\w*)\b/i;
+  if (sharepicKeywords.test(q)) {
+    return {
+      intent: 'sharepic',
+      searchQuery: null,
+      reasoning: 'Sharepic request detected',
+      confidence: 0.93,
+    };
+  }
+
   // High confidence (0.92): Image generation requests - very explicit patterns
   const imageKeywords =
-    /\b(erstell|generier|visualisier|zeichne|male|illustrier).{0,20}(bild|grafik|illustration|foto|image|poster|sharepic)\b/i;
+    /\b(erstell|generier|visualisier|zeichne|male|illustrier).{0,20}(bild|grafik|illustration|foto|image|poster)\b/i;
   const imageKeywordsAlt =
-    /\b(bild|grafik|illustration|foto|poster|sharepic).{0,20}(erstell|generier|erzeug|mach)\b/i;
+    /\b(bild|grafik|illustration|foto|poster).{0,20}(erstell|generier|erzeug|mach)\b/i;
   if (imageKeywords.test(q) || imageKeywordsAlt.test(q)) {
     return {
       intent: 'image',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierParsing.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierParsing.ts
@@ -31,6 +31,7 @@ export function parseClassifierResponse(
     'search',
     'web',
     'examples',
+    'sharepic',
     'image',
     'image_edit',
     'summary',
@@ -216,6 +217,13 @@ export function parseClassifierResponse(
   const intentFieldPattern = (intent: string) =>
     new RegExp(`["']?intent["']?\\s*[:=]\\s*["']?${intent}\\b`, 'i');
 
+  // sharepic before image: it's the more specific intent and must not be shadowed.
+  if (intentFieldPattern('sharepic').test(content))
+    return {
+      intent: 'sharepic',
+      searchQuery: null,
+      reasoning: 'Fallback: sharepic detected in response',
+    };
   if (intentFieldPattern('image').test(content))
     return {
       intent: 'image',

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierPrompt.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierPrompt.ts
@@ -13,7 +13,8 @@
 export const CLASSIFIER_PROMPT = `Du analysierst Benutzeranfragen und entscheidest welches Tool benötigt wird.
 
 VERFÜGBARE TOOLS:
-- image: Bildgenerierung - "erstelle Bild", "generiere Bild", "visualisiere", "zeichne", "male"
+- sharepic: Sharepic-Erstellung (gebrandete Social-Media-Grafik der Grünen) - "erstelle ein Sharepic", "Zitat-Sharepic", "Spruchbild", "Dreizeiler", "Info-Sharepic". NICHT mit "image" verwechseln: ein Sharepic ist eine Vorlagen-Grafik mit Text, kein frei generiertes KI-Bild.
+- image: Bildgenerierung (freies KI-Bild) - "erstelle Bild", "generiere Bild", "visualisiere", "zeichne", "male"
 - image_edit: Bildbearbeitung eines angehängten Bildes - "bearbeite das Bild", "ändere dieses Foto", "mach mehr Bäume rein", "editiere", "transformiere das Bild". Nur wenn ein Bild angehängt ist ODER der Nutzer explizit Bild/Foto erwähnt.
 - research: NUR bei EXPLIZITER Recherche-Anforderung ("recherchiere", "finde Fakten zu", "belege für")
 - search: NUR bei expliziten FRAGEN zu Grünen Parteiprogrammen, Positionen, Beschlüssen
@@ -58,7 +59,8 @@ RECHERCHE NUR WENN:
 - Nutzer NICHT alle Informationen mitliefert UND Fakten benötigt werden
 
 SCHRITT 3 - TOOL WÄHLEN:
-1. Bildgenerierung? → image
+0. Sharepic/Spruchbild/Zitat-Sharepic/Dreizeiler/Info-Sharepic? → sharepic (VOR image prüfen!)
+1. Bildgenerierung (freies KI-Bild)? → image
 1b. Bildbearbeitung (Bearbeitungsverb + Bild/Foto-Bezug oder Bild-Anhang)? → image_edit
 2. EXPLIZITE Web-Suche ("suche im netz")? → web
 3. Zusammenfassung eines angehängten/referenzierten Dokuments? → summary
@@ -153,7 +155,7 @@ Antworte NUR mit JSON:
   "typoAnalysis": {"original": "...", "corrected": "..."} | null,
   "contentType": "pressemitteilung" | "artikel" | "rede" | "argumentation" | "tweet" | "slogan" | null,
   "needsResearch": true | false,
-  "intent": "image" | "image_edit" | "research" | "search" | "web" | "examples" | "summary" | "chart" | "save_as_doc" | "modify_doc" | "modify_board" | "share_doc" | "direct",
+  "intent": "sharepic" | "image" | "image_edit" | "research" | "search" | "web" | "examples" | "summary" | "chart" | "save_as_doc" | "modify_doc" | "modify_board" | "share_doc" | "direct",
   "secondaryIntent": "image" | "examples" | "chart" | "save_as_doc" | null,
   "documentSubtype": "antrag" | "pressemitteilung" | "protokoll" | "notizen" | "redaktionsplan" | "checkliste" | "einladung" | "tabelle" | null,
   "searchQuery": "ORIGINALTEXT des Benutzers (KEINE Korrekturen an Eigennamen!)" | null,
@@ -175,7 +177,7 @@ Antworte NUR mit JSON:
   "reasoning": "..."
 }
 
-Bei "direct", "image" und "image_edit" setze searchQuery, optimizedSearchQuery, subQueries, searchSources und filters auf null/[].
+Bei "direct", "sharepic", "image" und "image_edit" setze searchQuery, optimizedSearchQuery, subQueries, searchSources und filters auf null/[].
 Bei "save_as_doc" setze documentSubtype auf den passenden Dokumenttyp:
 - "checkliste" für Aufgabenlisten, Todo-Listen, Checklisten, Aufgaben zum Abhaken
 - "protokoll" für Sitzungsprotokolle, Versammlungsprotokolle
@@ -194,6 +196,7 @@ Bei "share_doc" setze targetGroupName auf den im Text genannten Gruppennamen (z.
  */
 export const NON_SEARCH_INTENTS = new Set([
   'direct',
+  'sharepic',
   'image',
   'image_edit',
   'chart',

--- a/apps/api/routes/chat/services/intentExecutionService.ts
+++ b/apps/api/routes/chat/services/intentExecutionService.ts
@@ -23,7 +23,11 @@ import { createLogger } from '../../../utils/logger.js';
 import { CONFIRM_ACTION_CONFIG } from './confirmActionService.js';
 import { extractTextContent } from './messageHelpers.js';
 import { pendingActionStore } from './pendingActionStore.js';
-import { generateSharepicVariants, type SharepicVariant } from './sharepicVariantHelpers.js';
+import {
+  detectPreferredVariant,
+  generateSharepicVariants,
+  type SharepicVariant,
+} from './sharepicVariantHelpers.js';
 import { PROGRESS_MESSAGES } from './sseHelpers.js';
 import { createMessage, touchThread } from './threadPersistenceService.js';
 
@@ -502,12 +506,16 @@ export async function executeIntentPipeline(opts: {
         const lastMsg = finalState.messages?.[finalState.messages.length - 1];
         const rawText = lastMsg ? extractTextContent(lastMsg.content) : '';
         const messageText = rawText.replace(/@sharepic\b/gi, '').trim();
-        log.info(`[ChatGraph] Sharepic topic: "${messageText.slice(0, 100)}"`);
+        const preferredVariant = detectPreferredVariant(messageText);
+        log.info(
+          `[ChatGraph] Sharepic topic: "${messageText.slice(0, 100)}", preferredVariant: ${preferredVariant ?? 'all'}`
+        );
 
         if (!opts.req) throw new Error('Express request required for sharepic generation');
         const variants = await generateSharepicVariants({
           req: opts.req as SharepicExpressRequest,
           text: messageText,
+          ...(preferredVariant && { preferredVariant }),
         });
 
         if (variants.length === 0) {

--- a/apps/api/routes/chat/services/sharepicVariantHelpers.ts
+++ b/apps/api/routes/chat/services/sharepicVariantHelpers.ts
@@ -11,11 +11,52 @@ const log = createLogger('SharepicVariants');
 export const SHAREPIC_VARIANT_TYPES = ['dreizeilen', 'zitat', 'info'] as const;
 export type SharepicVariantType = (typeof SHAREPIC_VARIANT_TYPES)[number];
 
+/**
+ * Keyword patterns that pin a sharepic request to a SPECIFIC variant.
+ *
+ * Order matters: the first match wins. `zitat` is checked first so
+ * "zitat sharepic" / "zitat-sharepic" resolves to the quote layout instead of
+ * falling through to the dreizeilen default. The `dreizeilen` synonyms include
+ * "balken" because users call that layout the "3-Balken-Bild".
+ *
+ * These are only consulted AFTER the message is already classified as a sharepic
+ * request, so chart terms like "balkendiagramm" never reach this map.
+ */
+const VARIANT_KEYWORDS: ReadonlyArray<{ type: SharepicVariantType; pattern: RegExp }> = [
+  {
+    type: 'zitat',
+    pattern: /\b(zitat\w*|quotes?|spruch\w*|spruchbild|zitatbild|aussage|statement)\b/i,
+  },
+  {
+    type: 'info',
+    pattern: /\b(info\w*|fakten|faktencheck|information\w*|erklär\w*|erklaer\w*)\b/i,
+  },
+  {
+    type: 'dreizeilen',
+    pattern:
+      /\b(dreizeiler|dreizeilen|drei[\s-]?zeilen|3[\s-]?zeilen|slogan|dreibalken|drei[\s-]?balken|balken)\b/i,
+  },
+];
+
+/**
+ * Detect whether the user explicitly asked for a particular sharepic variant.
+ * Returns null when the request is generic ("erstelle ein sharepic"), in which
+ * case all variants are generated so the user can choose.
+ */
+export function detectPreferredVariant(text: string): SharepicVariantType | null {
+  for (const { type, pattern } of VARIANT_KEYWORDS) {
+    if (pattern.test(text)) return type;
+  }
+  return null;
+}
+
 export interface SharepicVariant {
   id: string;
   canvasType: string;
   initialProps: Record<string, unknown>;
   label?: string;
+  /** Accessibility description generated alongside the sharepic text (for screen readers / social posts). */
+  altText?: string;
 }
 
 const CANVAS_TYPE_BY_SHAREPIC: Record<string, string> = {
@@ -45,6 +86,7 @@ interface SharepicResponseShape {
   subheader?: string;
   body?: string;
   selectedImage?: string;
+  altText?: string;
 }
 
 function buildInitialPropsForType(
@@ -87,13 +129,23 @@ function buildInitialPropsForType(
 interface GenerateVariantsArgs {
   req: SharepicExpressRequest;
   text: string;
+  /**
+   * When set, only this variant is generated (the user explicitly asked for it,
+   * e.g. "zitat sharepic"). When omitted, all variants are generated so the user
+   * can choose.
+   */
+  preferredVariant?: SharepicVariantType | null;
 }
 
 export async function generateSharepicVariants(
   args: GenerateVariantsArgs
 ): Promise<SharepicVariant[]> {
+  const typesToGenerate: ReadonlyArray<SharepicVariantType> = args.preferredVariant
+    ? [args.preferredVariant]
+    : SHAREPIC_VARIANT_TYPES;
+
   const settled = await Promise.allSettled(
-    SHAREPIC_VARIANT_TYPES.map((type) =>
+    typesToGenerate.map((type) =>
       generateSharepicForChat(args.req, type, {
         text: args.text,
         subject: args.text,
@@ -104,7 +156,7 @@ export async function generateSharepicVariants(
 
   const variants: SharepicVariant[] = [];
   settled.forEach((result, idx) => {
-    const requestedType = SHAREPIC_VARIANT_TYPES[idx];
+    const requestedType = typesToGenerate[idx];
     if (result.status !== 'fulfilled') {
       log.warn(`[SharepicVariants] ${requestedType} variant rejected:`, result.reason);
       return;
@@ -120,6 +172,7 @@ export async function generateSharepicVariants(
       canvasType,
       initialProps: buildInitialPropsForType(sharepic, canvasType),
       label: VARIANT_LABEL_BY_CANVAS_TYPE[canvasType] ?? canvasType,
+      ...(sharepic.altText && { altText: sharepic.altText }),
     });
   });
 


### PR DESCRIPTION
## Problem

Sharepic-Erstellung im Chat war ohne die `@sharepic`-Erwähnung unzuverlässig:

1. **Ohne `@sharepic` → KI-Bild statt Sharepic.** Das Wort „sharepic" steckte in der Bildgenerierungs-Heuristik (`classifierHeuristics.ts`) und wurde als Intent `image` (freies KI-Bild) klassifiziert. Ein `sharepic`-Intent entstand textseitig nie – nur über die `@sharepic`-Erwähnung (forcedTool).
2. **„zitat sharepic" → 3-Balken-Bild.** `generateSharepicVariants` erzeugte **immer alle drei** Varianten (`dreizeilen`, `zitat`, `info`); die `dreizeilen`-Karte („3-Balken-Bild") stand oben. Die gewünschte Variante wurde nie ausgewertet.

## Fix

- **Sharepic aus Text erkennen:** dedizierte High-Confidence-Heuristik (0.93) für `sharepic`/`spruchbild`/`zitatbild`, **vor** der Bild-Heuristik; „sharepic" aus den Bild-Regexes entfernt.
- **Gewünschte Variante respektieren:** neue `detectPreferredVariant()`. Nennt der/die Nutzer:in eine konkrete Variante (zitat/info/dreizeilen), wird **nur diese** generiert. Generisches „erstelle ein sharepic" liefert weiterhin alle drei zur Auswahl.
- **LLM-Tier ergänzt:** `sharepic` als Intent im Classifier-Prompt, in `validIntents`, `NON_SEARCH_INTENTS` und im Text-Fallback – für implizite Anfragen ohne das Wort „sharepic".

## Varianten & Auswahl

| Variante | Canvas | Trigger-Keywords |
|---|---|---|
| `zitat` (Spruchbild) | `zitat-pure` | zitat, quote, spruch, aussage, statement |
| `info` (Faktenkachel) | `info` | info, fakten, faktencheck, erklär… |
| `dreizeilen` (3 Zeilen + Bild) | `dreizeilen` | dreizeiler, slogan, 3 zeilen, balken |

Reihenfolge: zitat → info → dreizeilen (erster Treffer gewinnt), damit „zitat sharepic" sicher das Zitat ergibt.

## Test

- ✅ `pnpm --filter @gruenerator/api typecheck`
- ✅ Prettier + ESLint auf den geänderten Dateien
- ⚠️ Nicht live im laufenden Chat verifiziert (nur statisch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)