### PR TITLE
feat(canva): direct Canva Connect API integration

### DIFF
--- a/apps/api/config/env.ts
+++ b/apps/api/config/env.ts
@@ -117,6 +117,11 @@ const envSchema = z.object({
   NANGO_SECRET_KEY: z.string().optional(),
   NANGO_SERVER_URL: z.string().default('http://nango:3003'),
 
+  // ── Canva Connect API (direct OAuth2 + PKCE, no Nango) ──────────────────
+  CANVA_CLIENT_ID: z.string().optional(),
+  CANVA_CLIENT_SECRET: z.string().optional(),
+  CANVA_REDIRECT_URI: z.string().optional(),
+
   // ── MCP ────────────────────────────────────────────────────────────────
   MCP_URL: z.string().optional(),
   BUNDESTAG_MCP_URL: z.string().optional(),

--- a/apps/api/database/postgres/migrations/20260607_add_canva_connection.sql
+++ b/apps/api/database/postgres/migrations/20260607_add_canva_connection.sql
@@ -1,0 +1,3 @@
+-- Direct Canva Connect API integration (OAuth2 + PKCE, no Nango).
+-- Stores a single per-user Canva connection (encrypted tokens + metadata) as JSONB.
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS canva_connection JSONB DEFAULT NULL;

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -85,6 +85,7 @@ CREATE TABLE IF NOT EXISTS profiles (
     nextcloud_share_links JSONB DEFAULT '[]',
     wordpress_sites JSONB DEFAULT '[]',
     wordpress_enabled BOOLEAN DEFAULT FALSE,
+    canva_connection JSONB DEFAULT NULL,
     document_mode TEXT DEFAULT 'manual',
     user_defaults JSONB DEFAULT '{}',
     docs BOOLEAN DEFAULT FALSE,

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -264,6 +264,7 @@ export async function setupRoutes(app: Application): Promise<void> {
   const { default: connectionsRouter } =
     await import('./routes/connections/connectionsController.js');
   const { default: wordpressApiRouter } = await import('./routes/wordpress/wordpressApi.js');
+  const { default: canvaApiRouter } = await import('./routes/canva/canvaApi.js');
   const { urlController: crawlUrlRouter } = await import('./routes/crawl/index.js');
   const { default: grueneratorChatRoute } = await import('./routes/chat/grueneratorChat.js');
   const { default: chatServiceRouter } = await import('./routes/chat/index.js');
@@ -701,6 +702,9 @@ export async function setupRoutes(app: Application): Promise<void> {
   app.use('/api/video', requireAuth, standardMutationLimiter, videoRouter);
   app.use('/api/nextcloud', requireAuth, standardMutationLimiter, nextcloudApiRouter);
   app.use('/api/connections', standardMutationLimiter, requireAuth, connectionsRouter);
+  // Direct Canva Connect API (OAuth2 + PKCE). requireAuth is applied per-route
+  // inside the router — the OAuth callback must stay public (cookie-less redirect).
+  app.use('/api/canva', standardMutationLimiter, canvaApiRouter);
   // ts-rest contract router — mount before legacy wordpressApiRouter
   // requireAuth is also inside the legacy router, but we apply it here
   // since the contract router runs first.

--- a/apps/api/routes/canva/canvaApi.ts
+++ b/apps/api/routes/canva/canvaApi.ts
@@ -1,0 +1,196 @@
+/**
+ * Canva Connect API integration routes (direct OAuth2 + PKCE, no Nango).
+ *
+ *   GET    /api/canva/status         → connection status for the current user
+ *   GET    /api/canva/auth/start     → begin OAuth (redirects the popup to Canva)
+ *   GET    /api/canva/auth/callback  → OAuth redirect target; exchanges the code
+ *   DELETE /api/canva                → disconnect
+ *
+ * The OAuth popup is opened same-origin (`/api/canva/auth/start`), so the
+ * session cookie rides along and `requireAuth` can identify the user. The
+ * callback derives the user from the one-time PKCE state in Redis instead of
+ * the cookie, so it works even if the cross-site redirect drops the cookie.
+ */
+
+import { Router, type Request, type Response } from 'express';
+
+import { requireAuth } from '../../middleware/authMiddleware.js';
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForTokens,
+  getProfileDisplayName,
+  listDesigns,
+} from '../../services/api-clients/canvaClient.js';
+import {
+  CanvaConnectionManager,
+  getCanvaCredentials,
+  getCanvaRedirectUri,
+} from '../../services/connections/canva/CanvaConnectionManager.js';
+import {
+  consumePkceState,
+  createPkceState,
+} from '../../services/connections/canva/canvaOAuthState.js';
+import { createLogger } from '../../utils/logger.js';
+
+const log = createLogger('canva');
+const router: Router = Router();
+
+function getUserId(req: Request): string {
+  const userId = req.user?.id;
+  if (!userId) throw Object.assign(new Error('Nicht authentifiziert'), { statusCode: 401 });
+  return userId;
+}
+
+function statusFromError(error: unknown): number {
+  const status = (error as { statusCode?: number }).statusCode;
+  return typeof status === 'number' ? status : 500;
+}
+
+/**
+ * Minimal HTML returned to the OAuth popup. It notifies the opener window and
+ * closes itself; the opener refetches status when it observes the popup close.
+ */
+function popupResultHtml(ok: boolean, message: string): string {
+  const safeMessage = message.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return `<!doctype html>
+<html lang="de"><head><meta charset="utf-8"><title>Canva</title></head>
+<body style="font-family:system-ui,sans-serif;padding:2rem;text-align:center;color:#333">
+<p>${ok ? '✅ Canva verbunden. Dieses Fenster kann geschlossen werden.' : `⚠️ ${safeMessage}`}</p>
+<script>
+  try { window.opener && window.opener.postMessage({ type: 'canva-oauth', ok: ${ok} }, '*'); } catch (e) {}
+  setTimeout(function () { window.close(); }, ${ok ? 800 : 4000});
+</script>
+</body></html>`;
+}
+
+router.get('/status', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    const status = await CanvaConnectionManager.getStatus(userId);
+    res.json(status);
+  } catch (error) {
+    log.error('Failed to get Canva status', { error: (error as Error).message });
+    res.status(statusFromError(error)).json({ error: 'Status konnte nicht abgerufen werden' });
+  }
+});
+
+router.get('/designs', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    const accessToken = await CanvaConnectionManager.getValidAccessToken(userId);
+
+    const query = typeof req.query.query === 'string' ? req.query.query : undefined;
+    const continuation =
+      typeof req.query.continuation === 'string' ? req.query.continuation : undefined;
+    const limitRaw = typeof req.query.limit === 'string' ? parseInt(req.query.limit, 10) : NaN;
+    const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 100) : 50;
+
+    const result = await listDesigns(accessToken, {
+      ...(query ? { query } : {}),
+      ...(continuation ? { continuation } : {}),
+      limit,
+    });
+
+    // Normalize to a flat shape the chat @canva picker consumes directly.
+    const designs = result.items.map((d) => ({
+      id: d.id,
+      title: d.title ?? 'Unbenanntes Design',
+      viewUrl: d.urls.view_url,
+      editUrl: d.urls.edit_url,
+      thumbnailUrl: d.thumbnail?.url ?? null,
+      updatedAt: d.updated_at ?? null,
+    }));
+
+    res.json({ designs, continuation: result.continuation ?? null });
+  } catch (error) {
+    const status = statusFromError(error);
+    log.error('Failed to list Canva designs', { error: (error as Error).message });
+    if (status === 404) {
+      res.status(404).json({ error: 'Keine Canva-Verbindung vorhanden', designs: [] });
+      return;
+    }
+    res.status(status).json({ error: 'Designs konnten nicht geladen werden' });
+  }
+});
+
+router.get('/auth/start', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    const { clientId } = getCanvaCredentials();
+    const redirectUri = getCanvaRedirectUri();
+
+    const { state, codeChallenge } = await createPkceState(userId);
+    const authorizeUrl = buildAuthorizeUrl({ clientId, redirectUri, state, codeChallenge });
+
+    res.redirect(authorizeUrl);
+  } catch (error) {
+    log.error('Failed to start Canva OAuth', { error: (error as Error).message });
+    res
+      .status(statusFromError(error))
+      .send(popupResultHtml(false, 'Canva-Verbindung konnte nicht gestartet werden.'));
+  }
+});
+
+// No requireAuth: the user is resolved from the one-time PKCE state in Redis.
+router.get('/auth/callback', async (req: Request, res: Response): Promise<void> => {
+  const { code, state, error: oauthError } = req.query;
+
+  if (oauthError) {
+    log.warn('Canva OAuth returned an error', { error: String(oauthError) });
+    res.status(400).send(popupResultHtml(false, 'Canva hat die Autorisierung abgelehnt.'));
+    return;
+  }
+
+  if (typeof code !== 'string' || typeof state !== 'string') {
+    res.status(400).send(popupResultHtml(false, 'Ungültige Antwort von Canva.'));
+    return;
+  }
+
+  try {
+    const pkce = await consumePkceState(state);
+    if (!pkce) {
+      res.status(400).send(popupResultHtml(false, 'Sitzung abgelaufen. Bitte erneut verbinden.'));
+      return;
+    }
+
+    const creds = getCanvaCredentials();
+    const redirectUri = getCanvaRedirectUri();
+
+    const tokens = await exchangeCodeForTokens(creds, {
+      code,
+      codeVerifier: pkce.codeVerifier,
+      redirectUri,
+    });
+
+    let displayName: string | null = null;
+    try {
+      displayName = await getProfileDisplayName(tokens.access_token);
+    } catch (profileError) {
+      // Profile is cosmetic — don't fail the whole connection over it.
+      log.warn('Failed to fetch Canva profile', { error: (profileError as Error).message });
+    }
+
+    await CanvaConnectionManager.save(pkce.userId, tokens, displayName);
+    log.info('Canva connection established', { userId: pkce.userId });
+
+    res.status(200).send(popupResultHtml(true, ''));
+  } catch (error) {
+    log.error('Canva OAuth callback failed', { error: (error as Error).message });
+    res
+      .status(500)
+      .send(popupResultHtml(false, 'Verbindung mit Canva fehlgeschlagen. Bitte erneut versuchen.'));
+  }
+});
+
+router.delete('/', requireAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const userId = getUserId(req);
+    await CanvaConnectionManager.disconnect(userId);
+    res.json({ success: true });
+  } catch (error) {
+    log.error('Failed to disconnect Canva', { error: (error as Error).message });
+    res.status(statusFromError(error)).json({ error: 'Verbindung konnte nicht getrennt werden' });
+  }
+});
+
+export default router;

--- a/apps/api/services/api-clients/canvaClient.ts
+++ b/apps/api/services/api-clients/canvaClient.ts
@@ -1,0 +1,180 @@
+/**
+ * Canva Connect API client (direct OAuth2 + PKCE, no Nango).
+ *
+ * Docs: https://www.canva.dev/docs/connect/
+ *  - Authorize (browser):  https://www.canva.com/api/oauth/authorize
+ *  - Token / refresh:      https://api.canva.com/rest/v1/oauth/token
+ *  - Current user profile: https://api.canva.com/rest/v1/users/me/profile
+ *
+ * The token endpoint authenticates the integration with HTTP Basic
+ * (client_id:client_secret) and expects an application/x-www-form-urlencoded body.
+ */
+
+import axios from 'axios';
+import { z } from 'zod';
+
+export const CANVA_AUTHORIZE_URL = 'https://www.canva.com/api/oauth/authorize';
+export const CANVA_TOKEN_URL = 'https://api.canva.com/rest/v1/oauth/token';
+const CANVA_PROFILE_URL = 'https://api.canva.com/rest/v1/users/me/profile';
+const CANVA_DESIGNS_URL = 'https://api.canva.com/rest/v1/designs';
+
+/**
+ * Scopes requested for the integration. Mirrors the Connect quickstart's
+ * recommended set: read/write designs + assets, read brand templates + profile.
+ */
+export const CANVA_SCOPES = [
+  'design:content:read',
+  'design:content:write',
+  'design:meta:read',
+  'asset:read',
+  'asset:write',
+  'brandtemplate:meta:read',
+  'brandtemplate:content:read',
+  'profile:read',
+] as const;
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  token_type: z.string(),
+  expires_in: z.number(),
+  scope: z.string().optional(),
+});
+export type CanvaTokenResponse = z.infer<typeof tokenResponseSchema>;
+
+const profileResponseSchema = z.object({
+  profile: z.object({
+    display_name: z.string().optional(),
+  }),
+});
+
+const designSchema = z.object({
+  id: z.string(),
+  title: z.string().optional(),
+  thumbnail: z
+    .object({
+      width: z.number(),
+      height: z.number(),
+      url: z.string(),
+    })
+    .optional(),
+  urls: z.object({
+    edit_url: z.string(),
+    view_url: z.string(),
+  }),
+  created_at: z.number().optional(),
+  updated_at: z.number().optional(),
+  page_count: z.number().optional(),
+});
+export type CanvaDesign = z.infer<typeof designSchema>;
+
+const listDesignsResponseSchema = z.object({
+  items: z.array(designSchema).default([]),
+  continuation: z.string().optional(),
+});
+export type CanvaListDesignsResult = z.infer<typeof listDesignsResponseSchema>;
+
+function basicAuthHeader(clientId: string, clientSecret: string): string {
+  return `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+}
+
+function tokenHeaders(clientId: string, clientSecret: string) {
+  return {
+    Authorization: basicAuthHeader(clientId, clientSecret),
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+}
+
+interface ClientCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * Build the Canva authorization URL the user's browser is redirected to.
+ */
+export function buildAuthorizeUrl(params: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}): string {
+  const query = new URLSearchParams({
+    response_type: 'code',
+    client_id: params.clientId,
+    redirect_uri: params.redirectUri,
+    scope: CANVA_SCOPES.join(' '),
+    code_challenge: params.codeChallenge,
+    code_challenge_method: 'S256',
+    state: params.state,
+  });
+  return `${CANVA_AUTHORIZE_URL}?${query.toString()}`;
+}
+
+/**
+ * Exchange an authorization code (+ PKCE verifier) for access/refresh tokens.
+ */
+export async function exchangeCodeForTokens(
+  creds: ClientCredentials,
+  params: { code: string; codeVerifier: string; redirectUri: string }
+): Promise<CanvaTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: params.code,
+    code_verifier: params.codeVerifier,
+    redirect_uri: params.redirectUri,
+  });
+  const response = await axios.post(CANVA_TOKEN_URL, body.toString(), {
+    headers: tokenHeaders(creds.clientId, creds.clientSecret),
+  });
+  return tokenResponseSchema.parse(response.data);
+}
+
+/**
+ * Use a refresh token to obtain a fresh access token. Canva rotates refresh
+ * tokens, so the response's refresh_token must be persisted too.
+ */
+export async function refreshTokens(
+  creds: ClientCredentials,
+  refreshToken: string
+): Promise<CanvaTokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  });
+  const response = await axios.post(CANVA_TOKEN_URL, body.toString(), {
+    headers: tokenHeaders(creds.clientId, creds.clientSecret),
+  });
+  return tokenResponseSchema.parse(response.data);
+}
+
+/**
+ * Fetch the connected user's display name (requires the profile:read scope).
+ */
+export async function getProfileDisplayName(accessToken: string): Promise<string | null> {
+  const response = await axios.get(CANVA_PROFILE_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  const parsed = profileResponseSchema.parse(response.data);
+  return parsed.profile.display_name ?? null;
+}
+
+/**
+ * List the user's designs (requires the design:meta:read scope).
+ * https://www.canva.dev/docs/connect/api-reference/designs/list-designs/
+ */
+export async function listDesigns(
+  accessToken: string,
+  params: { query?: string; limit?: number; continuation?: string } = {}
+): Promise<CanvaListDesignsResult> {
+  const search = new URLSearchParams();
+  if (params.query) search.set('query', params.query);
+  if (params.limit) search.set('limit', String(params.limit));
+  if (params.continuation) search.set('continuation', params.continuation);
+  const qs = search.toString();
+
+  const response = await axios.get(`${CANVA_DESIGNS_URL}${qs ? `?${qs}` : ''}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return listDesignsResponseSchema.parse(response.data);
+}

--- a/apps/api/services/connections/canva/CanvaConnectionManager.ts
+++ b/apps/api/services/connections/canva/CanvaConnectionManager.ts
@@ -1,0 +1,166 @@
+/**
+ * Per-user Canva connection store.
+ *
+ * One Canva connection per user, persisted as the `canva_connection` JSONB
+ * column on `profiles`. Tokens are encrypted at rest with the shared credential
+ * encryption helper (same scheme as WordPress app passwords).
+ */
+
+import { env } from '../../../config/env.js';
+import { getPostgresInstance } from '../../../database/services/PostgresService.js';
+import { createLogger } from '../../../utils/logger.js';
+import { decryptCredential, encryptCredential } from '../../../utils/validation/encryption.js';
+import { refreshTokens, type CanvaTokenResponse } from '../../api-clients/canvaClient.js';
+
+const log = createLogger('canva-connection');
+
+// Refresh a little before actual expiry to avoid racing the deadline mid-request.
+const EXPIRY_SKEW_MS = 60_000;
+
+interface CanvaConnectionRecord {
+  access_token_encrypted: string;
+  refresh_token_encrypted: string;
+  expires_at: string; // ISO timestamp
+  scope: string | null;
+  display_name: string | null;
+  connected_at: string; // ISO timestamp
+}
+
+export interface CanvaConnectionStatus {
+  connected: boolean;
+  displayName: string | null;
+  connectedAt: string | null;
+}
+
+export interface CanvaCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * Read the integration's client credentials from the environment.
+ * Throws (HTTP 503-ish) when the integration is not configured on this server.
+ */
+export function getCanvaCredentials(): CanvaCredentials {
+  const clientId = env.CANVA_CLIENT_ID;
+  const clientSecret = env.CANVA_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw Object.assign(new Error('Canva-Integration ist auf diesem Server nicht konfiguriert'), {
+      statusCode: 503,
+    });
+  }
+  return { clientId, clientSecret };
+}
+
+export function getCanvaRedirectUri(): string {
+  const redirectUri = env.CANVA_REDIRECT_URI;
+  if (!redirectUri) {
+    throw Object.assign(new Error('CANVA_REDIRECT_URI ist nicht konfiguriert'), {
+      statusCode: 503,
+    });
+  }
+  return redirectUri;
+}
+
+export class CanvaConnectionManager {
+  private static async getPostgres() {
+    const postgres = getPostgresInstance();
+    await postgres.ensureInitialized();
+    return postgres;
+  }
+
+  private static async getRecord(userId: string): Promise<CanvaConnectionRecord | null> {
+    const postgres = await this.getPostgres();
+    const profile = await postgres.queryOne<{ canva_connection: CanvaConnectionRecord | null }>(
+      'SELECT canva_connection FROM profiles WHERE id = $1',
+      [userId],
+      { table: 'profiles' }
+    );
+    return profile?.canva_connection ?? null;
+  }
+
+  private static async writeRecord(
+    userId: string,
+    record: CanvaConnectionRecord | null
+  ): Promise<void> {
+    const postgres = await this.getPostgres();
+    const result = await postgres.update(
+      'profiles',
+      { canva_connection: record ? JSON.stringify(record) : null },
+      { id: userId }
+    );
+    if (!result.data || result.data.length === 0) {
+      throw new Error('Profile not found');
+    }
+  }
+
+  private static toRecord(
+    tokens: CanvaTokenResponse,
+    displayName: string | null,
+    connectedAt: string
+  ): CanvaConnectionRecord {
+    return {
+      access_token_encrypted: encryptCredential(tokens.access_token),
+      refresh_token_encrypted: encryptCredential(tokens.refresh_token),
+      expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+      scope: tokens.scope ?? null,
+      display_name: displayName,
+      connected_at: connectedAt,
+    };
+  }
+
+  /** Persist a freshly authorized connection. */
+  static async save(
+    userId: string,
+    tokens: CanvaTokenResponse,
+    displayName: string | null
+  ): Promise<void> {
+    await this.writeRecord(userId, this.toRecord(tokens, displayName, new Date().toISOString()));
+    log.info('Canva connection saved', { userId });
+  }
+
+  static async getStatus(userId: string): Promise<CanvaConnectionStatus> {
+    const record = await this.getRecord(userId);
+    if (!record) {
+      return { connected: false, displayName: null, connectedAt: null };
+    }
+    return {
+      connected: true,
+      displayName: record.display_name,
+      connectedAt: record.connected_at,
+    };
+  }
+
+  static async disconnect(userId: string): Promise<void> {
+    const record = await this.getRecord(userId);
+    if (!record) return;
+    await this.writeRecord(userId, null);
+    log.info('Canva connection removed', { userId });
+  }
+
+  /**
+   * Return a currently-valid access token, transparently refreshing (and
+   * persisting the rotated refresh token) when the stored one is near expiry.
+   * Throws if the user has no connection.
+   */
+  static async getValidAccessToken(userId: string): Promise<string> {
+    const record = await this.getRecord(userId);
+    if (!record) {
+      throw Object.assign(new Error('Keine Canva-Verbindung vorhanden'), { statusCode: 404 });
+    }
+
+    const expiresAt = new Date(record.expires_at).getTime();
+    if (Date.now() < expiresAt - EXPIRY_SKEW_MS) {
+      return decryptCredential(record.access_token_encrypted);
+    }
+
+    // Token expired/expiring — refresh using the rotated refresh token.
+    const creds = getCanvaCredentials();
+    const refreshToken = decryptCredential(record.refresh_token_encrypted);
+    const tokens = await refreshTokens(creds, refreshToken);
+    await this.writeRecord(userId, this.toRecord(tokens, record.display_name, record.connected_at));
+    return tokens.access_token;
+  }
+}
+
+export default CanvaConnectionManager;

--- a/apps/api/services/connections/canva/canvaOAuthState.ts
+++ b/apps/api/services/connections/canva/canvaOAuthState.ts
@@ -1,0 +1,69 @@
+/**
+ * Canva OAuth PKCE state (Redis)
+ *
+ * The Canva Connect API requires PKCE. We generate a code_verifier when the
+ * user starts the flow, hand Canva the derived code_challenge, and must hand
+ * the verifier back at the token-exchange step. The verifier (plus the user it
+ * belongs to) is parked in Redis under a one-time `state` key with a short TTL.
+ */
+
+import crypto from 'node:crypto';
+
+import { createLogger } from '../../../utils/logger.js';
+import { ensureConnected, redisClient } from '../../../utils/redis/client.js';
+
+const log = createLogger('canva-oauth');
+
+const STATE_TTL_SECONDS = 600; // 10 minutes — covers the user completing Canva's consent screen
+
+interface CanvaOAuthState {
+  userId: string;
+  codeVerifier: string;
+  createdAt: number;
+}
+
+function key(state: string): string {
+  return `oauth:canva:pkce:${state}`;
+}
+
+function base64Url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export interface PkceChallenge {
+  state: string;
+  codeChallenge: string;
+}
+
+/**
+ * Generate a PKCE verifier/challenge pair + opaque state, and persist the
+ * verifier (bound to userId) for the later callback.
+ */
+export async function createPkceState(userId: string): Promise<PkceChallenge> {
+  const codeVerifier = base64Url(crypto.randomBytes(64)); // 86 chars, within the 43–128 spec range
+  const codeChallenge = base64Url(crypto.createHash('sha256').update(codeVerifier).digest());
+  const state = base64Url(crypto.randomBytes(24));
+
+  const payload: CanvaOAuthState = { userId, codeVerifier, createdAt: Date.now() };
+
+  await ensureConnected();
+  await redisClient.setEx(key(state), STATE_TTL_SECONDS, JSON.stringify(payload));
+
+  log.debug('Stored Canva PKCE state', { userId, statePrefix: state.slice(0, 8) });
+
+  return { state, codeChallenge };
+}
+
+/**
+ * Retrieve-and-delete the verifier for a state (one-time use). Returns null if
+ * the state is unknown or expired.
+ */
+export async function consumePkceState(state: string): Promise<CanvaOAuthState | null> {
+  await ensureConnected();
+  const raw = await redisClient.getDel(key(state));
+  if (!raw || typeof raw !== 'string') {
+    log.warn('Canva PKCE state not found / already used', { statePrefix: state.slice(0, 8) });
+    return null;
+  }
+  return JSON.parse(raw) as CanvaOAuthState;
+}

--- a/apps/web/src/features/auth/components/profile/tabs/WolkeManagement/WolkeManagementView.tsx
+++ b/apps/web/src/features/auth/components/profile/tabs/WolkeManagement/WolkeManagementView.tsx
@@ -20,6 +20,7 @@ import {
 const ConnectedAccountsSection = lazy(
   () => import('../../../../../connections/components/ConnectedAccountsSection')
 );
+const CanvaSection = lazy(() => import('../../../../../canva/components/CanvaSection'));
 
 import { cn } from '@/utils/cn';
 import './clouds.css';
@@ -233,6 +234,7 @@ const WolkeManagementView = memo(
         </CloudCard>
         {import.meta.env.DEV && <WordPressSection />}
         <ConnectedAccountsSection onSuccess={onSuccessMessage} onError={onErrorMessage} />
+        <CanvaSection onSuccess={onSuccessMessage} onError={onErrorMessage} />
       </motion.div>
     );
   }

--- a/apps/web/src/features/canva/components/CanvaSection.tsx
+++ b/apps/web/src/features/canva/components/CanvaSection.tsx
@@ -1,0 +1,149 @@
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { FiCheck, FiLoader } from 'react-icons/fi';
+import { SiCanva } from 'react-icons/si';
+
+import { useCanvaStatus, useDisconnectCanva, useInvalidateCanvaStatus } from '../hooks/useCanva';
+import { CANVA_AUTH_START_URL } from '../lib/canvaApi';
+
+import { cn } from '@/utils/cn';
+
+interface CanvaSectionProps {
+  onSuccess?: (message: string) => void;
+  onError?: (message: string) => void;
+}
+
+const CanvaSection = memo(({ onSuccess, onError }: CanvaSectionProps) => {
+  const { data: status, isLoading } = useCanvaStatus();
+  const disconnect = useDisconnectCanva();
+  const invalidateStatus = useInvalidateCanvaStatus();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const popupRef = useRef<Window | null>(null);
+
+  // Refetch status when the OAuth popup posts back (success/failure) or is closed.
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as { type?: string; ok?: boolean } | null;
+      if (data?.type !== 'canva-oauth') return;
+      void invalidateStatus();
+      setIsConnecting(false);
+      if (data.ok) {
+        onSuccess?.('Canva verbunden');
+      } else {
+        onError?.('Canva-Verbindung fehlgeschlagen');
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [invalidateStatus, onSuccess, onError]);
+
+  const handleConnect = useCallback(() => {
+    setIsConnecting(true);
+    const popup = window.open(CANVA_AUTH_START_URL, '_blank', 'width=600,height=700');
+    popupRef.current = popup;
+
+    if (!popup) {
+      setIsConnecting(false);
+      onError?.('Popup wurde blockiert. Bitte Popups für diese Seite erlauben.');
+      return;
+    }
+
+    // Fallback: if the popup is closed without postMessage, refetch on close.
+    const interval = setInterval(() => {
+      if (popup.closed) {
+        clearInterval(interval);
+        setIsConnecting(false);
+        void invalidateStatus();
+      }
+    }, 1000);
+  }, [invalidateStatus, onError]);
+
+  const handleDisconnect = useCallback(async () => {
+    try {
+      await disconnect.mutateAsync();
+      onSuccess?.('Canva-Verbindung getrennt');
+    } catch {
+      onError?.('Verbindung konnte nicht getrennt werden');
+    }
+  }, [disconnect, onSuccess, onError]);
+
+  const connected = status?.connected ?? false;
+  const isBusy = isConnecting || disconnect.isPending;
+
+  return (
+    <div className="mt-xl">
+      <div className="flex items-center gap-sm mb-md">
+        <SiCanva className="w-6 h-6 text-[#00C4CC]" />
+        <h2 className="text-xl font-semibold text-foreground-heading m-0">Canva</h2>
+        <span className="text-xs bg-secondary-100 text-secondary-700 px-sm py-0.5 rounded-full font-medium">
+          Experimentell
+        </span>
+      </div>
+
+      {isLoading && <p className="text-sm text-grey-400 text-center py-sm">Lade Verbindung...</p>}
+
+      {!isLoading && (
+        <div
+          className={cn(
+            'flex items-center justify-between p-md rounded-lg border bg-background-pure transition-colors',
+            connected
+              ? 'border-primary-300 dark:border-primary-700'
+              : 'border-grey-200 dark:border-grey-700'
+          )}
+        >
+          <div className="flex items-center gap-md">
+            <SiCanva className="w-5 h-5 text-[#00C4CC]" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground-heading">Canva</span>
+              <span className="text-xs text-grey-400">
+                {connected && status?.displayName
+                  ? status.displayName
+                  : 'Designs, Brand-Vorlagen, Assets'}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-sm">
+            {connected && (
+              <span className="flex items-center gap-1 text-xs text-primary-600 dark:text-primary-400">
+                <FiCheck size={12} />
+                Verbunden
+              </span>
+            )}
+
+            {connected ? (
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                disabled={isBusy}
+                className={cn(
+                  'text-xs px-sm py-1 rounded-md cursor-pointer transition-colors',
+                  'bg-transparent border border-grey-300 dark:border-grey-600',
+                  'text-grey-500 hover:text-[var(--error-red)] hover:border-[var(--error-red)]',
+                  isBusy && 'opacity-50 cursor-not-allowed'
+                )}
+              >
+                {disconnect.isPending ? <FiLoader className="animate-spin" size={12} /> : 'Trennen'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={handleConnect}
+                disabled={isBusy}
+                className={cn(
+                  'text-xs px-md py-1 rounded-md cursor-pointer transition-colors font-medium',
+                  'bg-primary-500 text-white hover:bg-primary-600 border-none',
+                  isBusy && 'opacity-50 cursor-not-allowed'
+                )}
+              >
+                {isConnecting ? <FiLoader className="animate-spin" size={12} /> : 'Verbinden'}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+CanvaSection.displayName = 'CanvaSection';
+
+export default CanvaSection;

--- a/apps/web/src/features/canva/hooks/useCanva.ts
+++ b/apps/web/src/features/canva/hooks/useCanva.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { disconnectCanva, fetchCanvaStatus, type CanvaStatus } from '../lib/canvaApi';
+
+const CANVA_STATUS_KEY = ['canva', 'status'] as const;
+
+export function useCanvaStatus() {
+  return useQuery<CanvaStatus>({
+    queryKey: CANVA_STATUS_KEY,
+    queryFn: fetchCanvaStatus,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useInvalidateCanvaStatus() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: CANVA_STATUS_KEY });
+}
+
+export function useDisconnectCanva() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: disconnectCanva,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: CANVA_STATUS_KEY });
+    },
+  });
+}

--- a/apps/web/src/features/canva/lib/canvaApi.ts
+++ b/apps/web/src/features/canva/lib/canvaApi.ts
@@ -1,0 +1,22 @@
+import apiClient from '@/components/utils/apiClient';
+
+export interface CanvaStatus {
+  connected: boolean;
+  displayName: string | null;
+  connectedAt: string | null;
+}
+
+const API_BASE = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '/api';
+
+// Opened in a popup as a top-level browser navigation (not via apiClient) so the
+// session cookie is sent and the backend can redirect on to Canva.
+export const CANVA_AUTH_START_URL = `${API_BASE}/canva/auth/start`;
+
+export async function fetchCanvaStatus(): Promise<CanvaStatus> {
+  const response = await apiClient.get<CanvaStatus>('/canva/status');
+  return response.data;
+}
+
+export async function disconnectCanva(): Promise<void> {
+  await apiClient.delete('/canva');
+}

--- a/packages/chat/src/components/thread/CanvaMentionPopover.tsx
+++ b/packages/chat/src/components/thread/CanvaMentionPopover.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useCanvaDesignsQuery, type ChatCanvaDesign } from '../../hooks/useMentionablesQuery';
+import { type CanvaDesignToken } from '../../lib/mentionables';
+import { MentionFloatingPanel } from './MentionFloatingPanel';
+
+interface CanvaMentionPopoverProps {
+  visible: boolean;
+  onSelect: (designs: CanvaDesignToken[]) => void;
+  onDismiss: () => void;
+}
+
+export function CanvaMentionPopover({ visible, onSelect, onDismiss }: CanvaMentionPopoverProps) {
+  const [filter, setFilter] = useState('');
+  const [debouncedFilter, setDebouncedFilter] = useState('');
+  const [selection, setSelection] = useState<Map<string, ChatCanvaDesign>>(new Map());
+
+  // Debounce the search term — Canva's list endpoint accepts a server-side query.
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedFilter(filter.trim()), 300);
+    return () => clearTimeout(id);
+  }, [filter]);
+
+  useEffect(() => {
+    if (!visible) {
+      setSelection(new Map());
+      setFilter('');
+      setDebouncedFilter('');
+    }
+  }, [visible]);
+
+  const { data, isLoading, isError } = useCanvaDesignsQuery(debouncedFilter, visible);
+  const designs = useMemo(() => data?.designs ?? [], [data]);
+  const notConnected = !isLoading && data?.connected === false;
+  const selectionList = [...selection.values()];
+
+  const toggle = (design: ChatCanvaDesign) => {
+    setSelection((prev) => {
+      const next = new Map(prev);
+      if (next.has(design.id)) next.delete(design.id);
+      else next.set(design.id, design);
+      return next;
+    });
+  };
+
+  const handleConfirm = () => {
+    if (selectionList.length === 0) return;
+    onSelect(
+      selectionList.map((d) => ({
+        id: d.id,
+        title: d.title,
+        viewUrl: d.viewUrl,
+        ...(d.thumbnailUrl ? { thumbnailUrl: d.thumbnailUrl } : {}),
+      }))
+    );
+  };
+
+  return (
+    <MentionFloatingPanel
+      open={visible}
+      onDismiss={onDismiss}
+      width="w-[360px]"
+      role="dialog"
+      ariaLabel="Canva-Designs auswählen"
+    >
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onDismiss();
+          }
+        }}
+      >
+        <div className="border-b border-border px-3 py-2">
+          <span className="text-xs font-semibold uppercase tracking-wider text-foreground-muted/70">
+            Canva-Designs
+          </span>
+          {!notConnected && (
+            <div className="mt-2">
+              <input
+                type="text"
+                autoFocus
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Designs durchsuchen…"
+                className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary/40"
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {notConnected ? (
+            <div className="flex flex-col items-start gap-2 px-3 py-4">
+              <p className="text-sm font-medium text-foreground">Canva nicht verbunden</p>
+              <p className="text-xs text-foreground-muted">
+                Verbinde zuerst dein Canva-Konto unter Profil → Wolke, damit du Designs per @canva
+                einfügen kannst.
+              </p>
+            </div>
+          ) : isLoading ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">Lade Designs…</div>
+          ) : isError ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">
+              Fehler beim Laden der Designs.
+            </div>
+          ) : designs.length === 0 ? (
+            <div className="px-3 py-4 text-sm text-foreground-muted">
+              {debouncedFilter ? 'Keine Treffer.' : 'Keine Designs gefunden.'}
+            </div>
+          ) : (
+            designs.map((design) => {
+              const isSelected = selection.has(design.id);
+              return (
+                <button
+                  key={design.id}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    toggle(design);
+                  }}
+                  className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                    isSelected
+                      ? 'bg-primary/10 text-foreground'
+                      : 'text-foreground-muted hover:bg-primary/5'
+                  }`}
+                >
+                  {design.thumbnailUrl ? (
+                    <img
+                      src={design.thumbnailUrl}
+                      alt=""
+                      className="h-9 w-9 flex-shrink-0 rounded object-cover"
+                    />
+                  ) : (
+                    <span
+                      aria-hidden
+                      className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded bg-primary/5 text-base"
+                    >
+                      🎨
+                    </span>
+                  )}
+                  <span className="flex-1 truncate">{design.title}</span>
+                  <span aria-hidden className="text-base">
+                    {isSelected ? '☑️' : ''}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex items-center justify-between border-t border-border px-3 py-2">
+          <span className="text-xs text-foreground-muted">{selectionList.length} ausgewählt</span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onDismiss();
+              }}
+              className="rounded-md px-2 py-1 text-xs text-foreground-muted hover:bg-primary/5"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="button"
+              disabled={selectionList.length === 0 || notConnected}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleConfirm();
+              }}
+              className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-white hover:bg-primary/90 disabled:opacity-50"
+            >
+              Einfügen
+            </button>
+          </div>
+        </div>
+      </div>
+    </MentionFloatingPanel>
+  );
+}

--- a/packages/chat/src/components/thread/GrueneratorComposer.tsx
+++ b/packages/chat/src/components/thread/GrueneratorComposer.tsx
@@ -26,8 +26,9 @@ import { computeMentionInsertion } from '../../lib/mentionInsertion';
 import { FileMentionPopover } from './FileMentionPopover';
 import { WolkeMentionPopover } from './WolkeMentionPopover';
 import { ConnectMentionPopover } from './ConnectMentionPopover';
+import { CanvaMentionPopover } from './CanvaMentionPopover';
 import type { CollabDocSelection } from '../../lib/documentMentionables';
-import type { WolkeFileToken, ConnectFileToken } from '../../lib/mentionables';
+import type { WolkeFileToken, ConnectFileToken, CanvaDesignToken } from '../../lib/mentionables';
 import { PlusMenu } from './PlusMenu';
 import { ModelPicker } from './ModelPicker';
 import { getCaretCoords } from '../../lib/caretPosition';
@@ -197,7 +198,7 @@ function ComposerButtons({
 
 interface MentionState {
   visible: boolean;
-  mode: 'functions' | 'skills' | 'datei' | 'wolke' | 'connect';
+  mode: 'functions' | 'skills' | 'datei' | 'wolke' | 'connect' | 'canva';
   query: string;
   selectedIndex: number;
   anchorRect: { x: number; y: number } | null;
@@ -301,6 +302,24 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
           });
         }
         setMention((prev) => ({ ...prev, mode: 'connect', visible: true, mentionStart: -1 }));
+        return;
+      }
+
+      // When user selects the @canva trigger, swap to the Canva design picker
+      if (mentionable.type === 'canva') {
+        // Strip the in-progress "@canv…" trigger from the textarea — the picker
+        // inserts a markdown link per chosen design via handleCanvaSelect.
+        if (mention.mentionStart >= 0) {
+          const currentText = composerRuntime.getState().text;
+          const before = currentText.slice(0, mention.mentionStart);
+          const after = currentText.slice(textarea.selectionStart);
+          composerRuntime.setText(`${before}${after}`);
+          requestAnimationFrame(() => {
+            const pos = before.length;
+            textarea.setSelectionRange(pos, pos);
+          });
+        }
+        setMention((prev) => ({ ...prev, mode: 'canva', visible: true, mentionStart: -1 }));
         return;
       }
 
@@ -455,10 +474,37 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
     [composerRuntime, dismissPopover]
   );
 
+  const handleCanvaSelect = useCallback(
+    (designs: CanvaDesignToken[]) => {
+      if (designs.length === 0) return;
+      // Insert each chosen design as a markdown link — a direct, durable
+      // reference (view URLs are valid 30 days) the user/agent can act on.
+      const links = designs.map((d) => `[🎨 ${d.title}](${d.viewUrl})`).join(' ');
+      const currentText = composerRuntime.getState().text;
+      const needsSpace = currentText.length > 0 && !currentText.endsWith(' ');
+      const newText = `${currentText}${needsSpace ? ' ' : ''}${links} `;
+      composerRuntime.setText(newText);
+      dismissPopover();
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          textarea.setSelectionRange(newText.length, newText.length);
+          textarea.focus();
+        }
+      });
+    },
+    [composerRuntime, dismissPopover]
+  );
+
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      // Don't interfere when file/doc browser, wolke, or connect picker is open
-      if (mention.mode === 'datei' || mention.mode === 'wolke' || mention.mode === 'connect')
+      // Don't interfere when file/doc browser, wolke, connect, or canva picker is open
+      if (
+        mention.mode === 'datei' ||
+        mention.mode === 'wolke' ||
+        mention.mode === 'connect' ||
+        mention.mode === 'canva'
+      )
         return;
 
       const textarea = e.target;
@@ -491,7 +537,12 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
       // In datei/docs mode, only handle Escape (cmdk handles arrow keys internally).
       // Enter is swallowed so the textarea doesn't submit the form while the picker
       // is open — the user must select via the picker or dismiss with Escape first.
-      if (mention.mode === 'datei' || mention.mode === 'wolke' || mention.mode === 'connect') {
+      if (
+        mention.mode === 'datei' ||
+        mention.mode === 'wolke' ||
+        mention.mode === 'connect' ||
+        mention.mode === 'canva'
+      ) {
         if (e.key === 'Escape') {
           e.preventDefault();
           dismissPopover();
@@ -593,6 +644,12 @@ export const GrueneratorComposer = memo(function GrueneratorComposer({
             <ConnectMentionPopover
               visible={mention.visible}
               onSelect={handleConnectSelect}
+              onDismiss={dismissPopover}
+            />
+          ) : mention.mode === 'canva' ? (
+            <CanvaMentionPopover
+              visible={mention.visible}
+              onSelect={handleCanvaSelect}
               onDismiss={dismissPopover}
             />
           ) : mention.mode === 'skills' ? (

--- a/packages/chat/src/components/thread/MentionPopover.tsx
+++ b/packages/chat/src/components/thread/MentionPopover.tsx
@@ -29,7 +29,7 @@ export function MentionPopover({
   anchorRect,
 }: MentionPopoverProps) {
   const listRef = useRef<HTMLDivElement>(null);
-  const { notebooks, userNotebooks, tools, boards, docs, documents, wolke, connect } =
+  const { notebooks, userNotebooks, tools, boards, docs, documents, wolke, connect, canva } =
     filterMentionables(query);
 
   const sections: MentionSection[] = useMemo(() => {
@@ -48,6 +48,7 @@ export function MentionPopover({
       { kind: 'flat', label: 'Dateien', items: documents },
       { kind: 'flat', label: 'Wolke', items: wolke },
       { kind: 'flat', label: 'Verbundene Accounts', items: connect },
+      { kind: 'flat', label: 'Canva', items: canva },
       ...(notebookGroups.length > 0
         ? [{ kind: 'grouped' as const, label: 'Notizbücher', groups: notebookGroups }]
         : []),
@@ -56,7 +57,7 @@ export function MentionPopover({
     return all.filter((s) =>
       s.kind === 'flat' ? s.items.length > 0 : s.groups.some((g) => g.items.length > 0)
     );
-  }, [tools, boards, docs, documents, wolke, connect, notebooks, userNotebooks]);
+  }, [tools, boards, docs, documents, wolke, connect, canva, notebooks, userNotebooks]);
 
   const totalItems = sections.reduce(
     (sum, s) =>

--- a/packages/chat/src/hooks/useMentionablesQuery.ts
+++ b/packages/chat/src/hooks/useMentionablesQuery.ts
@@ -311,6 +311,51 @@ export function useConnectBrowseQuery(
   });
 }
 
+// ── @canva (direct Canva Connect API designs) ────────────────────────────────
+//
+// Unlike @connect/@wolke (Nango / Nextcloud), Canva is a direct OAuth
+// integration. The picker lists the user's designs live; selecting designs
+// inserts a markdown link per design into the composer.
+
+export interface ChatCanvaDesign {
+  id: string;
+  title: string;
+  viewUrl: string;
+  editUrl: string;
+  thumbnailUrl: string | null;
+  updatedAt: number | null;
+}
+
+/**
+ * The user's Canva designs. Disabled until the picker opens (`enabled`), and
+ * re-fetched on open so newly created designs show up. Returns an empty list
+ * (not an error) when the user hasn't connected Canva yet — the picker renders
+ * an empty-state in that case.
+ */
+export function useCanvaDesignsQuery(query: string, enabled = true) {
+  const apiClient = useApiClient();
+  return useQuery<{ designs: ChatCanvaDesign[]; connected: boolean }>({
+    queryKey: ['mention-canva-designs', query],
+    queryFn: async () => {
+      try {
+        const qs = query ? `?query=${encodeURIComponent(query)}` : '';
+        const res = await apiClient.get<{ designs?: ChatCanvaDesign[]; error?: string }>(
+          `/api/canva/designs${qs}`
+        );
+        return { designs: Array.isArray(res?.designs) ? res.designs : [], connected: true };
+      } catch {
+        // 404 (not connected) or any failure → treat as "not connected" so the
+        // picker shows the connect-first empty-state instead of an error.
+        return { designs: [], connected: false };
+      }
+    },
+    staleTime: 0,
+    refetchOnMount: 'always',
+    enabled,
+    retry: 1,
+  });
+}
+
 /**
  * Convenience hook that triggers all dynamic-mentionable queries — call from
  * the chat composer so dynamic mentionables are warm by the time @-popovers

--- a/packages/chat/src/lib/mentionDetection.ts
+++ b/packages/chat/src/lib/mentionDetection.ts
@@ -51,8 +51,9 @@ export function detectMention(text: string, caretPosition: number): MentionDetec
 }
 
 export function getFilteredFunctions(query: string): Mentionable[] {
-  const { notebooks, tools, boards, docs, documents, wolke, connect } = filterMentionables(query);
-  return [...tools, ...boards, ...docs, ...documents, ...wolke, ...connect, ...notebooks];
+  const { notebooks, tools, boards, docs, documents, wolke, connect, canva } =
+    filterMentionables(query);
+  return [...tools, ...boards, ...docs, ...documents, ...wolke, ...connect, ...canva, ...notebooks];
 }
 
 export function getFilteredSkills(query: string): Mentionable[] {

--- a/packages/chat/src/lib/mentionParser.ts
+++ b/packages/chat/src/lib/mentionParser.ts
@@ -159,6 +159,15 @@ export function parseAllMentions(text: string): ParsedMentions {
       continue;
     }
 
+    // Handle bare @canva trigger (popover hint — strip, no payload). Picked
+    // designs are inserted as plain markdown links, not @canva: tokens, so
+    // there's no payload form to decode here.
+    if (trigger === '@' && alias === 'canva') {
+      const triggerIndex = match.index + match[0].indexOf('@');
+      mentionSpans.push([triggerIndex, triggerIndex + alias.length + 1]);
+      continue;
+    }
+
     const mentionable = resolveMentionable(alias);
     if (!mentionable) {
       if (trigger === '@') {
@@ -274,7 +283,11 @@ export function extractMentionPreviews(text: string): MentionPreview[] {
 
     if (
       trigger === '@' &&
-      (alias === 'datei' || alias === 'dokumentchat' || alias === 'wolke' || alias === 'connect')
+      (alias === 'datei' ||
+        alias === 'dokumentchat' ||
+        alias === 'wolke' ||
+        alias === 'connect' ||
+        alias === 'canva')
     ) {
       continue;
     }

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -29,7 +29,8 @@ export type MentionableType =
   | 'board'
   | 'doc'
   | 'wolke'
-  | 'connect';
+  | 'connect'
+  | 'canva';
 export type MentionableCategory = 'skill' | 'function';
 
 export interface Mentionable {
@@ -552,6 +553,33 @@ export function decodeConnectToken(token: string): ConnectFileToken | null {
   }
 }
 
+// @canva opens a sub-popover that lists the user's Canva designs (fetched live
+// from the Connect API via React Query). Picking designs inserts a markdown
+// link per design into the composer — a direct "insert the design" reference,
+// not a RAG document source (designs are visual, not text). Mirrors the
+// trigger-then-picker UX of @wolke/@connect.
+export const canvaMentionables: Mentionable[] = [
+  {
+    type: 'canva',
+    category: 'function',
+    trigger: '@',
+    identifier: 'canva-trigger',
+    title: 'Canva',
+    description: 'Eigene Canva-Designs einfügen',
+    avatar: '🎨',
+    icon: PiPaintBrush,
+    backgroundColor: '#00C4CC',
+    mention: 'canva',
+  },
+];
+
+export interface CanvaDesignToken {
+  id: string;
+  title: string;
+  viewUrl: string;
+  thumbnailUrl?: string;
+}
+
 export function getAllMentionables(): Mentionable[] {
   return [
     ...getAgentMentionables(),
@@ -566,6 +594,7 @@ export function getAllMentionables(): Mentionable[] {
     ...documentMentionables,
     ...wolkeMentionables,
     ...connectMentionables,
+    ...canvaMentionables,
   ];
 }
 
@@ -586,6 +615,7 @@ function rebuildMentionableMap(): void {
     documentMentionables,
     wolkeMentionables,
     connectMentionables,
+    canvaMentionables,
   ];
   for (const source of orderedSources) {
     for (const m of source) {
@@ -615,6 +645,7 @@ export function filterMentionables(query: string): {
   documents: Mentionable[];
   wolke: Mentionable[];
   connect: Mentionable[];
+  canva: Mentionable[];
 } {
   const allBoards = [...boardToolMentionables, ...dynamicBoardMentionables];
   const allDocs = [...docToolMentionables, ...dynamicDocMentionables];
@@ -630,6 +661,7 @@ export function filterMentionables(query: string): {
       documents: documentMentionables,
       wolke: wolkeMentionables,
       connect: connectMentionables,
+      canva: canvaMentionables,
     };
   }
   const q = query.toLowerCase();
@@ -661,6 +693,7 @@ export function filterMentionables(query: string): {
     documents: documentMentionables.filter(matchFn),
     wolke: wolkeMentionables.filter(matchFn),
     connect: connectMentionables.filter(matchFn),
+    canva: canvaMentionables.filter(matchFn),
   };
 }
 
@@ -679,6 +712,7 @@ export function filterMentionablesByCategory(
     ...all.documents,
     ...all.wolke,
     ...all.connect,
+    ...all.canva,
     ...all.userNotebooks,
     ...all.notebooks,
   ];


### PR DESCRIPTION
## Was

Direkte **Canva Connect API**-Integration (OAuth2 + PKCE) — bewusst **nicht** über Nango (anders als Google/Microsoft/Jira/Confluence).

### 1. Wolke-Seite: Canva verbinden
Eigene Canva-Sektion neben „Verbundene Konten". Verbinden öffnet ein Popup auf `/api/canva/auth/start`, das per PKCE zu Canva weiterleitet; der Callback speichert die Tokens verschlüsselt.

- `apps/api/services/api-clients/canvaClient.ts` — Authorize-URL, Token-Exchange/Refresh (Basic-Auth), Profil, `listDesigns`, Scopes
- `apps/api/services/connections/canva/CanvaConnectionManager.ts` — eine Verbindung/User, verschlüsselte Tokens in `profiles.canva_connection` (JSONB), Auto-Refresh
- `apps/api/services/connections/canva/canvaOAuthState.ts` — PKCE-State in Redis (einmalig, 10 min TTL)
- `apps/api/routes/canva/canvaApi.ts` — `GET /status` · `GET /designs` · `GET /auth/start` · `GET /auth/callback` (öffentlich, User aus State) · `DELETE /`; gemountet unter `/api/canva`
- Migration `20260607_add_canva_connection.sql` + `schema.sql`
- Frontend: `apps/web/src/features/canva/*` + `CanvaSection` in `WolkeManagementView`

### 2. Chat: `@canva`-Mention
Wie `@docs`/`@boards`: `@canva` öffnet einen Picker, der die Designs live per **React Query** (`/api/canva/designs`) listet (Thumbnails, Suche, Mehrfachauswahl). Ausgewählte Designs werden als Markdown-Link `[🎨 Titel](view_url)` in den Composer eingefügt.

> **Warum Markdown-Link statt RAG-Attachment** (wie @connect/@wolke): Canva-Designs sind visuell, nicht text-durchsuchbar; der ModelAdapter verwirft unbekannte Attachment-Kinds. Der Link (view_url 30 Tage gültig) ist der robuste, sofort funktionierende „Einfügen"-Weg ohne Backend-Plumbing.

## Setup nötig (kein Code)
- `CANVA_CLIENT_ID` / `CANVA_CLIENT_SECRET` / `CANVA_REDIRECT_URI` in der env (liegen bereits auf dem Server)
- Im Canva Developer Portal: Redirect-URL = `CANVA_REDIRECT_URI` je Umgebung + Scopes aus `CANVA_SCOPES` aktivieren

## Test
- `pnpm --filter @gruenerator/{api,web,chat} typecheck` — alle grün
- Geänderte Dateien lint-sauber (husky pre-commit bestanden)
- DB-Migration läuft beim Backend-Start automatisch

🤖 Generated with [Claude Code](https://claude.com/claude-code)