### PR TITLE
feat: make agent creator available for everyone

### DIFF
--- a/apps/web/src/config/featureFlags.ts
+++ b/apps/web/src/config/featureFlags.ts
@@ -4,10 +4,8 @@
 
 /**
  * Whether the agent creator (conversational creator + manual builder + their
- * sidebar entry) is exposed. Hidden in production by default; shown in dev, or
- * on a deploy that sets `VITE_SHOW_AGENT_CREATOR=true`. Note this only gates the
+ * sidebar entry) is exposed. Available to everyone. Note this only gates the
  * creation/editing surface — `/agents/:slug` (chatting with an existing agent)
  * is always available.
  */
-export const SHOW_AGENT_CREATOR =
-  import.meta.env.DEV || import.meta.env.VITE_SHOW_AGENT_CREATOR === 'true';
+export const SHOW_AGENT_CREATOR = true;

--- a/apps/web/src/config/routes.ts
+++ b/apps/web/src/config/routes.ts
@@ -240,9 +240,8 @@ const standardRoutes: RouteConfig[] = [
   { path: '/texte/*', component: GrueneratorenBundle.Texte, withForm: true },
   { path: '/workplace', component: WorkplacePage },
   // Guided agent creator (default entry: AI brief → pre-filled wizard) + form
-  // editor. Gated behind SHOW_AGENT_CREATOR (dev, or a deploy with
-  // VITE_SHOW_AGENT_CREATOR=true); `/agents/:slug` below stays available so
-  // existing agents remain usable.
+  // editor. Available to everyone via SHOW_AGENT_CREATOR; `/agents/:slug` below
+  // stays available so existing agents remain usable.
   ...(SHOW_AGENT_CREATOR
     ? ([
         { path: '/agents/new', component: AgentCreatorPage },

--- a/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
+++ b/apps/web/src/features/skills/SkillsAndAgentsPage.tsx
@@ -47,6 +47,7 @@ import withAuthRequired from '@/components/common/LoginRequired/withAuthRequired
 import { Markdown } from '@/components/common/Markdown';
 import PageContainer from '@/components/common/PageContainer';
 import { getAgentIcon } from '@/components/layout/Sidebar/sidebarAgentConfig';
+import { SHOW_AGENT_CREATOR } from '@/config/featureFlags';
 import useAgentFavoritesStore from '@/stores/agentFavoritesStore';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -398,7 +399,7 @@ function SkillsAndAgentsPage() {
   const agentFavorites = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
   const toggleAgentFavorite = useAgentFavoritesStore((s) => s.toggle);
 
-  const showCreateAgentCta = import.meta.env.DEV;
+  const showCreateAgentCta = SHOW_AGENT_CREATOR;
 
   const filteredSkills = useMemo(() => {
     // Only "real" skills with their own system prompt (Schnellbefehl-only skills


### PR DESCRIPTION
## Summary

The `/agents` **creation** surface was gated to dev only. This makes it available to all users.

Previously gated by `SHOW_AGENT_CREATOR = import.meta.env.DEV || VITE_SHOW_AGENT_CREATOR === 'true'`, which hid:
- the guided agent creator (`/agents/new`), manual builder (`/agents/new/manual`), and editor (`/agents/:identifier/edit`) routes
- the **Neuer Agent** CTA + edit/delete actions on the Skills & Agents page

Chatting with existing agents (`/agents/:slug`) was always available and is unchanged.

## Changes

- **`featureFlags.ts`** — `SHOW_AGENT_CREATOR = true`
- **`SkillsAndAgentsPage.tsx`** — the create/edit/delete CTA now reads `SHOW_AGENT_CREATOR` instead of `import.meta.env.DEV`, so the flag is the single source of truth (it had its own separate dev-only check before)
- **`routes.ts`** — refreshed the now-stale gating comment

The backend (`POST /api/user-agents`, etc.) never had a dev-only guard — it only requires auth + ownership — so no backend change is needed.

## Test plan

- [x] `pnpm --filter @gruenerator/web typecheck` passes
- [ ] In a production-style build, `/agents` shows the **Neuer Agent** button and `/agents/new` is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)