### PR TITLE
fix(web): left-align sidebar item labels so "Neu" no longer gaps

### DIFF
--- a/apps/web/src/components/layout/Sidebar/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar/Sidebar.tsx
@@ -149,7 +149,7 @@ const Sidebar = ({ isDesktop = false, onNavigate }: SidebarProps) => {
   }, [close]);
 
   const titleClass = cn(
-    'min-w-0 flex-1 truncate text-sm font-medium leading-tight transition-all duration-150',
+    'min-w-0 flex-1 truncate text-left text-sm font-medium leading-tight transition-all duration-150',
     sidebarExpanded ? 'opacity-100 translate-x-0' : 'hidden'
   );
 
@@ -393,7 +393,7 @@ const SidebarFavourites = memo(function SidebarFavourites({
   if (configItems.length === 0 && agentItems.length === 0) return null;
 
   const titleClass = cn(
-    'min-w-0 flex-1 truncate text-sm font-medium leading-tight transition-all duration-150',
+    'min-w-0 flex-1 truncate text-left text-sm font-medium leading-tight transition-all duration-150',
     expanded ? 'opacity-100 translate-x-0' : 'hidden'
   );
 


### PR DESCRIPTION
## Problem

In the sidebar, the **Neu** item showed a large gap between the `+` icon and the label, while the other items (Workplace, Dokumente und Boards, Notebooks) looked fine.

## Cause

The shared title span uses `flex-1`, so it grows to fill the row width. The regular nav items render as `<Link>` (anchors → `text-align: left`), but the **Neu** dropdown trigger (and favourites) render as `<button>`, which carries the browser default `text-align: center`. Short labels like "Neu" therefore got centered inside the full-width span, producing the gap. Longer labels masked the effect.

## Fix

Add `text-left` to the shared `titleClass` in `Sidebar.tsx` so labels hug the icon regardless of whether the row is an anchor or a button. Applied to both the main nav and favourites title spans for consistency.

One-line Tailwind class change, no behavioural/type impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)