### PR TITLE
fix(workplace): make Pride greeting render full rainbow gradient

### DIFF
--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -250,7 +250,9 @@ const WorkplacePage = () => {
         <div className="text-center mb-lg pt-md">
           <h1
             className={`text-4xl max-md:text-2xl font-semibold mb-xs ${
-              pride ? 'bg-clip-text text-transparent' : 'text-foreground-heading'
+              pride
+                ? 'inline-block w-fit bg-clip-text text-transparent'
+                : 'text-foreground-heading'
             }`}
             style={
               pride

--- a/apps/web/src/features/workplace/WorkplacePage.tsx
+++ b/apps/web/src/features/workplace/WorkplacePage.tsx
@@ -250,9 +250,7 @@ const WorkplacePage = () => {
         <div className="text-center mb-lg pt-md">
           <h1
             className={`text-4xl max-md:text-2xl font-semibold mb-xs ${
-              pride
-                ? 'inline-block w-fit bg-clip-text text-transparent'
-                : 'text-foreground-heading'
+              pride ? 'inline-block w-fit bg-clip-text text-transparent' : 'text-foreground-heading'
             }`}
             style={
               pride


### PR DESCRIPTION
## Problem

The Pride-month greeting on the workplace page was not fully rainbow — it only showed the middle colors (roughly yellow→green), never the red or purple ends.

## Root cause

The `<h1>` is a block element spanning the full container width. `bg-clip-text` clips the full-width 6-stop gradient to the text glyphs — but since the text is centered, it only sits in the **middle slice** of that gradient. The red (`#E40303`) on the far left and purple (`#750787`) on the far right never landed on any letters.

## Fix

Add `inline-block w-fit` to the `<h1>` in pride mode so its box hugs the text. The full red→orange→yellow→green→blue→purple spread now maps across the actual glyphs. It stays horizontally centered because the parent keeps `text-center`. Non-pride heading is untouched.

Typechecked locally (`pnpm --filter @gruenerator/web typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)