### PR TITLE
feat(boards): AI assistant FAB with full board editing

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -39,6 +39,7 @@ import type {
   SearchResult,
   Citation,
   CurrentDocument,
+  CurrentBoard,
   ImageStyle,
   ImageEditStyle,
   GatherSource,
@@ -145,6 +146,10 @@ const ChatStateAnnotation = Annotation.Root({
   }),
   // Current open document in the docs editor (primary context for docs surface)
   currentDocument: Annotation<CurrentDocument | null>({
+    reducer: (x, y) => y ?? x ?? null,
+  }),
+  // Live board state in the boards editor (primary context for boards surface)
+  currentBoard: Annotation<CurrentBoard | null>({
     reducer: (x, y) => y ?? x ?? null,
   }),
   documentMentionContext: Annotation<string | null>({
@@ -461,6 +466,7 @@ function routeAfterClassification(
     intent === 'save_as_doc' ||
     intent === 'modify_doc' ||
     intent === 'modify_board' ||
+    intent === 'edit_current_board' ||
     intent === 'share_doc' ||
     intent === 'edit_current_doc'
   ) {
@@ -486,6 +492,7 @@ function routeAfterClassification(
     modify_doc: 'modify_doc',
     edit_current_doc: 'edit_current_doc',
     modify_board: 'modify_board',
+    edit_current_board: 'edit_current_board',
     share_doc: 'share_doc',
     direct: 'direct',
   };
@@ -699,6 +706,9 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
 
     // Current open document (docs editor surface)
     currentDocument: input.currentDocument || null,
+
+    // Live board (boards editor surface)
+    currentBoard: input.currentBoard || null,
 
     // Custom system prompt (from thread or user settings)
     customSystemPrompt: input.customSystemPrompt || null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
@@ -30,6 +30,7 @@ export const INTENT_KEYWORDS: Record<
     | 'modify_doc'
     | 'edit_current_doc'
     | 'modify_board'
+    | 'edit_current_board'
     | 'share_doc'
     | 'pressemitteilung_examples'
   >,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -142,6 +142,11 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
     const hasWolkeFiles = state.wolkeFiles && state.wolkeFiles.length > 0;
     const hasConnectFiles = state.connectFiles && state.connectFiles.length > 0;
     const hasBoards = state.boardIds && state.boardIds.length > 0;
+    // Live board open in the boards-editor surface. Primary context, NOT a
+    // retrieval mention — its id is deliberately NOT injected into boardIds, so
+    // `hasBoards` stays false here and the legacy server-side modify_board path
+    // cannot fire on the board page. @board mentions in /chat still hit modify_board.
+    const hasCurrentBoard = !!state.currentBoard;
     // Open document in the docs-editor is primary context, not retrieval scope.
     // Distinct from documentChatIds — we do NOT force-route to search for it.
     const hasCurrentDocument = !!state.currentDocument;
@@ -165,8 +170,33 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
     // to a referenced resource. Must be checked BEFORE passive context checks,
     // otherwise an image attachment or OCR text would shadow the mutation intent.
     const boardModifyPattern =
-      /\b(fuege?\s+(aufgabe|karte|eintrag)|neue\s+(karte|aufgabe)|aktualisiere\s+board|erstelle\s+aufgabe|aender|ergaenz|ueberarbeit|vereinfach|strukturier|umstrukturier|loesch|entfern|verschieb|sortier)/i;
+      /\b(f(?:ü|ue)ge?\s+(aufgabe|karte|eintrag|spalte|feld|kommentar)|neue[rs]?\s+(karte|aufgabe|spalte|feld|ansicht)|aktualisiere\s+board|erstelle\s+(aufgabe|spalte|ansicht|feld)|aender|änder|ergaenz|ergänz|ueberarbeit|überarbeit|vereinfach|strukturier|umstrukturier|loesch|lösch|entfern|verschieb|sortier|kommentier|weise\s+\S.{0,40}?\s+zu|zuweis|label|markier|setze?\s+(f(?:ä|ae)llig|frist|status|zust(?:ä|ae)ndig))/i;
     const docModifyPattern = DOC_MODIFY_PATTERN;
+
+    // Open board in the boards-editor surface + modification keywords → live edit
+    // via the boards assistant (client-side executor on the live Yjs board). Must
+    // fire before any board/doc retrieval branches. Honors the per-board
+    // "AI may edit" toggle (enabledTools.edit_current_board === false).
+    const editCurrentBoardAllowed = state.enabledTools?.edit_current_board !== false;
+    if (
+      hasCurrentBoard &&
+      editCurrentBoardAllowed &&
+      userContent.length > 0 &&
+      boardModifyPattern.test(userContent)
+    ) {
+      const classificationTimeMs = Date.now() - startTime;
+      log.info(`[Classifier] Live board edit (regex fast-path) → edit_current_board`);
+      return {
+        intent: 'edit_current_board',
+        searchSources: [],
+        searchQuery: null,
+        detectedFilters: null,
+        reasoning: 'currentBoard + modification keywords → edit_current_board',
+        hasTemporal: temporal.hasTemporal,
+        complexity,
+        classificationTimeMs,
+      };
+    }
 
     if (hasBoards && userContent.length > 0 && boardModifyPattern.test(userContent)) {
       const classificationTimeMs = Date.now() - startTime;

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -169,8 +169,17 @@ async function classifierNodeImpl(state: ChatGraphState): Promise<Partial<ChatGr
     // These are the most specific signals — a user explicitly requesting a change
     // to a referenced resource. Must be checked BEFORE passive context checks,
     // otherwise an image attachment or OCR text would shadow the mutation intent.
+    // Imperative edit verbs only. Uses `-e`/`-en` imperative/infinitive endings
+    // (NOT bare stems) so participles/nouns in QUESTIONS don't misfire — e.g.
+    // "was wurde geändert/gelöscht/markiert?", "welche Labels gibt es?",
+    // "wie ist es sortiert?" must NOT route to an edit. Noun keywords (label,
+    // status, …) only count when preceded by an edit verb (füge … hinzu /
+    // erstelle / setze … / weise … zu).
+    // Leading `(?<![\p{L}])` (not `\b`) so umlaut-initial verbs (ändere,
+    // überarbeite) match after a space — `\b` fails there since ä/ü aren't ASCII
+    // word chars. `u` flag enables \p{L}.
     const boardModifyPattern =
-      /\b(f(?:ü|ue)ge?\s+(aufgabe|karte|eintrag|spalte|feld|kommentar)|neue[rs]?\s+(karte|aufgabe|spalte|feld|ansicht)|aktualisiere\s+board|erstelle\s+(aufgabe|spalte|ansicht|feld)|aender|änder|ergaenz|ergänz|ueberarbeit|überarbeit|vereinfach|strukturier|umstrukturier|loesch|lösch|entfern|verschieb|sortier|kommentier|weise\s+\S.{0,40}?\s+zu|zuweis|label|markier|setze?\s+(f(?:ä|ae)llig|frist|status|zust(?:ä|ae)ndig))/i;
+      /(?<![\p{L}])(f(?:ü|ue)ge?\s+\S.{0,40}?\s+hinzu|neue[rs]?\s+(karte|aufgabe|spalte|feld|ansicht)|erstelle\s+\S.{0,40}?\s*(aufgabe|karte|spalte|ansicht|feld)|erstelle\s+(aufgabe|karte|spalte|ansicht|feld)|aktualisiere|(?:ä|ae)ndere|erg(?:ä|ae)nze|(?:ü|ue)berarbeite|vereinfache|(?:um)?strukturiere|l(?:ö|oe)sche|entferne|verschiebe|sortiere|kommentiere|markiere|weise\s+\S.{0,40}?\s+zu\b|setze?\s+\S.{0,40}?\s+(?:f(?:ä|ae)llig|frist|status|zust(?:ä|ae)ndig|als|auf|zu\b)|setze?\s+(f(?:ä|ae)llig|frist|status|zust(?:ä|ae)ndig))/iu;
     const docModifyPattern = DOC_MODIFY_PATTERN;
 
     // Open board in the boards-editor surface + modification keywords → live edit

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -200,6 +200,7 @@ async function testExpandedContextWindow() {
     wolkeFiles: [],
     connectFiles: [],
     currentDocument: null,
+    currentBoard: null,
     searchSources: [],
     intent: 'search',
     secondaryIntent: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -241,6 +241,7 @@ async function evaluateBudgetAllocation() {
     wolkeFiles: [],
     connectFiles: [],
     currentDocument: null,
+    currentBoard: null,
     searchSources: [],
     intent: 'search',
     secondaryIntent: null,

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -13,10 +13,10 @@
 import type { SubcategoryFilters } from '../../../config/systemCollectionsConfig.js';
 import type { AgentConfig } from '../../../routes/chat/agents/types.js';
 import type { AIWorkerPool } from '../../../workers/types.js';
-import type { WolkeFileRef, ConnectFileRef } from '@gruenerator/contracts';
+import type { WolkeFileRef, ConnectFileRef, CurrentBoard } from '@gruenerator/contracts';
 import type { ModelMessage } from 'ai';
 
-export type { WolkeFileRef, ConnectFileRef };
+export type { WolkeFileRef, ConnectFileRef, CurrentBoard };
 
 /**
  * Search source backends that can be queried in parallel.
@@ -51,6 +51,7 @@ export type SearchIntent =
   | 'save_as_doc' // Save response as document ("speichere als Dokument")
   | 'modify_doc' // Modify mentioned document ("ändere", "ergänze" with @doc) — for /chat surface
   | 'edit_current_doc' // Live-edit the open document via BlockNote AI — for docs editor surface
+  | 'edit_current_board' // Live-edit the open board via the boards assistant — for boards editor surface
   | 'modify_board' // Modify mentioned board ("füge Aufgabe hinzu" with @board)
   | 'share_doc' // Share document with group ("teile mit Gruppe", "share mit AG")
   | 'direct'; // No search needed (greetings, creative tasks without fact needs)
@@ -320,6 +321,7 @@ export interface ChatGraphInput {
   wolkeFiles?: WolkeFileRef[] | undefined;
   connectFiles?: ConnectFileRef[] | undefined;
   currentDocument?: CurrentDocument | undefined;
+  currentBoard?: CurrentBoard | undefined;
   userLocale?: UserLocale | undefined;
   customSystemPrompt?: string | undefined;
   activeSkillMention?: string | undefined;
@@ -393,6 +395,10 @@ export interface ChatGraphState {
   // Current open document in the docs editor (primary context, not retrieval scope).
   // Set when chat is embedded in a document editor surface.
   currentDocument: CurrentDocument | null;
+
+  // Live board state when chat is embedded in the boards editor surface. Primary
+  // context for board Q&A; presence + edit keywords route to edit_current_board.
+  currentBoard: CurrentBoard | null;
 
   // Custom system prompt (replaces entire agent system prompt when set)
   customSystemPrompt: string | null;

--- a/apps/api/routes/boards/boardAccess.ts
+++ b/apps/api/routes/boards/boardAccess.ts
@@ -5,6 +5,10 @@ const db = getPostgresInstance();
 export interface BoardAccessResult {
   hasAccess: boolean;
   boardTitle: string | null;
+  /** Board owner (collaborative_documents.created_by); null when the board does not exist. */
+  createdBy: string | null;
+  /** True when the user may write to the board (owner, or editor/owner permission). */
+  canEdit: boolean;
 }
 
 export async function checkBoardAccess(
@@ -23,13 +27,20 @@ export async function checkBoardAccess(
     is_public: boolean;
   }>;
 
-  if (rows.length === 0) return { hasAccess: false, boardTitle: null };
+  if (rows.length === 0)
+    return { hasAccess: false, boardTitle: null, createdBy: null, canEdit: false };
 
   const board = rows[0];
-  if (board.created_by === userId || board.is_public || board.permissions?.[userId]) {
-    return { hasAccess: true, boardTitle: board.title };
+  const isOwner = board.created_by === userId;
+  const permLevel = board.permissions?.[userId]?.level;
+  const canEdit = isOwner || permLevel === 'owner' || permLevel === 'editor';
+
+  if (isOwner || board.is_public || board.permissions?.[userId]) {
+    return { hasAccess: true, boardTitle: board.title, createdBy: board.created_by, canEdit };
   }
 
+  // Group shares grant edit access (matches the existing share semantics where a
+  // shared board is editable by group members).
   const groupAccess = (await db.query(
     `SELECT 1 FROM group_content_shares gcs
      INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
@@ -38,5 +49,11 @@ export async function checkBoardAccess(
     [userId, boardId]
   )) as unknown[];
 
-  return { hasAccess: groupAccess.length > 0, boardTitle: board.title };
+  const hasGroupAccess = groupAccess.length > 0;
+  return {
+    hasAccess: hasGroupAccess,
+    boardTitle: board.title,
+    createdBy: board.created_by,
+    canEdit: hasGroupAccess,
+  };
 }

--- a/apps/api/routes/boards/boardAiService.ts
+++ b/apps/api/routes/boards/boardAiService.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-  boardOperationsSchema,
+  boardOperationSchema,
   type BoardOperation,
   type CurrentBoard,
 } from '@gruenerator/contracts';
@@ -64,6 +64,26 @@ RULES:
 - Return ONLY the tool call. No prose.`;
 
 /**
+ * Resolve a row's assignee cell to a human name. The cell is a JSON blob
+ * (`{id,name,avatarRobotId}`); we read `.name` (and resolve `.id` against the
+ * member map when present). Falls back to id-map lookup / raw string for legacy
+ * plain-string cells. Returns null when unassigned.
+ */
+function resolveAssigneeName(raw: unknown, assigneeById: Map<string, string>): string | null {
+  if (typeof raw !== 'string' || !raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { id?: string; name?: string };
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.id && assigneeById.has(parsed.id)) return assigneeById.get(parsed.id)!;
+      if (parsed.name) return parsed.name;
+    }
+  } catch {
+    // Not JSON — legacy plain value below.
+  }
+  return assigneeById.get(raw) ?? raw;
+}
+
+/**
  * Serialize the live board into a compact, model-readable context block.
  * Caps rows so very large boards stay within token limits.
  */
@@ -102,11 +122,10 @@ function serializeBoard(board: CurrentBoard, today: string): string {
     const title = (row.cells[FIELD_IDS.TITLE] as string) || '(kein Titel)';
     const statusId = row.cells[FIELD_IDS.STATUS];
     const statusName = typeof statusId === 'string' ? (statusById.get(statusId) ?? statusId) : '—';
-    const assigneeRaw = row.cells['field-assignee'];
-    const assigneeName =
-      typeof assigneeRaw === 'string' && assigneeRaw
-        ? (assigneeById.get(assigneeRaw) ?? assigneeRaw)
-        : null;
+    // The assignee cell is a JSON blob ({id,name,avatarRobotId}) written by the
+    // card UI / executor — not a bare user id. Parse it to surface the human
+    // name; fall back to id-map lookup then the raw value for legacy cells.
+    const assigneeName = resolveAssigneeName(row.cells['field-assignee'], assigneeById);
     const due = row.cells['field-due-date'];
     let line = `- [${row.id}] "${title}" (Status: ${statusName}`;
     if (assigneeName) line += `, Zuständig: ${assigneeName}`;
@@ -158,7 +177,10 @@ export async function generateBoardOperations(opts: {
     tools: {
       applyBoardOperations: tool({
         description: 'Apply a batch of operations to the board.',
-        inputSchema: z.object({ operations: boardOperationsSchema }),
+        // No `.min(1)` here (unlike boardOperationsSchema): the prompt allows an
+        // empty array to mean "nothing to change", and requiring ≥1 op would make
+        // that legitimate no-op fail tool-input validation / burn a retry.
+        inputSchema: z.object({ operations: z.array(boardOperationSchema).max(50) }),
       }),
     },
     toolChoice: 'required',
@@ -169,11 +191,12 @@ export async function generateBoardOperations(opts: {
 
   for (const tc of result.toolCalls) {
     if (tc.toolName === 'applyBoardOperations') {
-      // Validated against the contract schema; the tool inputSchema already
-      // enforces it, this is the trust-boundary assertion + a typed narrow.
-      const parsed = boardOperationsSchema.safeParse(
-        (tc.input as { operations: unknown }).operations
-      );
+      // Trust-boundary assertion + typed narrow. No `.min(1)` (empty = no-op is
+      // valid); the 50-op cap from boardOperationsSchema still applies.
+      const parsed = z
+        .array(boardOperationSchema)
+        .max(50)
+        .safeParse((tc.input as { operations: unknown }).operations);
       if (parsed.success) {
         captured = parsed.data;
       } else {

--- a/apps/api/routes/boards/boardAiService.ts
+++ b/apps/api/routes/boards/boardAiService.ts
@@ -1,0 +1,187 @@
+/**
+ * Board AI service
+ *
+ * Turns a natural-language board-edit request into a list of structured board
+ * operations (BoardOperation[]). The operations are applied CLIENT-SIDE by the
+ * boards assistant against the live Yjs board — this service only plans them.
+ *
+ * Mirrors the docs AI controller's provider chain + strict tool-call approach,
+ * but returns plain JSON (no streaming) since the executor needs the full op
+ * list, not a token stream.
+ */
+
+import {
+  boardOperationsSchema,
+  type BoardOperation,
+  type CurrentBoard,
+} from '@gruenerator/contracts';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+import { createLogger } from '../../utils/logger.js';
+import { getModel, isProviderConfigured } from '../chat/agents/providers.js';
+import { type AgentConfig } from '../chat/agents/types.js';
+
+const log = createLogger('BoardAI');
+
+// Mirror docs/aiController DOCS_AI_MODELS — these IDs are confirmed to return
+// finish_reason:tool_calls on their respective providers.
+const BOARD_AI_MODELS: Record<AgentConfig['provider'], string> = {
+  litellm: 'gpt-oss:120b',
+  regolo: 'mistral-small-4-119b',
+  mistral: 'mistral-medium-2604',
+  anthropic: 'mistral-medium-2604',
+};
+
+const FIELD_IDS = {
+  TITLE: 'field-title',
+  STATUS: 'field-status',
+} as const;
+
+const BOARD_TOOL_STRICT_PROMPT = `You translate a user's request into board operations by calling the tool applyBoardOperations.
+
+You MUST respond ONLY by calling applyBoardOperations with { "operations": [ ... ] }.
+Each operation has a "type" and the fields documented in the schema. Valid types:
+- create_task { title, status?, description?, dueDate?, assignee?, labels? }
+- update_task { taskId, title?, description?, dueDate? }
+- delete_task { taskId }
+- move_task { taskId, status }
+- add_comment { taskId, text }
+- set_assignee { taskId, assignee? }
+- set_labels { taskId, labels[] }
+- set_due_date { taskId, dueDate? }   // ISO date (YYYY-MM-DD) or null to clear
+- add_column { name, color? }
+- rename_column { columnId, name }
+- add_field { name, fieldType, options? }
+- add_view { name, layout }            // layout: kanban|table|list|calendar|gantt
+
+RULES:
+- Use the EXACT taskId values from the board state for existing tasks.
+- For "status", "assignee" and "labels" use HUMAN NAMES (e.g. "In Arbeit", "Erledigt", a member's name, "Dringend"). The client resolves them to ids and creates a column/label if it does not exist yet.
+- Combine multiple changes into one operations array when the user asks for several things.
+- Dates must be ISO (YYYY-MM-DD). Resolve relative dates ("nächsten Freitag") against today.
+- Only emit operations the user actually asked for. If nothing should change, return an empty operations array.
+- Return ONLY the tool call. No prose.`;
+
+/**
+ * Serialize the live board into a compact, model-readable context block.
+ * Caps rows so very large boards stay within token limits.
+ */
+function serializeBoard(board: CurrentBoard, today: string): string {
+  const statusById = new Map(board.statusOptions.map((o) => [o.id, o.name]));
+  const assigneeById = new Map(board.assignableMembers.map((m) => [m.id, m.name]));
+
+  const lines: string[] = [];
+  lines.push(`Heutiges Datum: ${today}`);
+  lines.push(`Board: ${board.title ?? '(ohne Titel)'}`);
+
+  lines.push('\nSpalten (Status):');
+  if (board.statusOptions.length === 0) lines.push('- (keine)');
+  for (const opt of board.statusOptions) lines.push(`- ${opt.name}`);
+
+  const selectFields = board.fields.filter(
+    (f) => f.id !== FIELD_IDS.STATUS && (f.type === 'singleSelect' || f.type === 'multiSelect')
+  );
+  if (selectFields.length > 0) {
+    lines.push('\nWeitere Auswahlfelder:');
+    for (const f of selectFields) {
+      const opts = (f.typeOptions.options as Array<{ name: string }> | undefined) ?? [];
+      lines.push(`- ${f.name}: ${opts.map((o) => o.name).join(', ') || '(keine Optionen)'}`);
+    }
+  }
+
+  lines.push('\nMitglieder (zuweisbar):');
+  if (board.assignableMembers.length === 0) lines.push('- (keine)');
+  for (const m of board.assignableMembers) lines.push(`- ${m.name}`);
+
+  lines.push('\nAufgaben:');
+  const MAX_ROWS = 300;
+  const rows = board.rows.slice(0, MAX_ROWS);
+  if (rows.length === 0) lines.push('- (keine Aufgaben)');
+  for (const row of rows) {
+    const title = (row.cells[FIELD_IDS.TITLE] as string) || '(kein Titel)';
+    const statusId = row.cells[FIELD_IDS.STATUS];
+    const statusName = typeof statusId === 'string' ? (statusById.get(statusId) ?? statusId) : '—';
+    const assigneeRaw = row.cells['field-assignee'];
+    const assigneeName =
+      typeof assigneeRaw === 'string' && assigneeRaw
+        ? (assigneeById.get(assigneeRaw) ?? assigneeRaw)
+        : null;
+    const due = row.cells['field-due-date'];
+    let line = `- [${row.id}] "${title}" (Status: ${statusName}`;
+    if (assigneeName) line += `, Zuständig: ${assigneeName}`;
+    if (typeof due === 'string' && due) line += `, Fällig: ${due}`;
+    line += ')';
+    lines.push(line);
+  }
+  if (board.rows.length > MAX_ROWS) {
+    lines.push(`- … (${board.rows.length - MAX_ROWS} weitere Aufgaben ausgelassen)`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Plan board operations for a user request. Returns a validated BoardOperation[]
+ * (possibly empty). Throws only on provider/model failure.
+ */
+export async function generateBoardOperations(opts: {
+  userPrompt: string;
+  board: CurrentBoard;
+  referenceContent?: string | null;
+  today: string;
+}): Promise<BoardOperation[]> {
+  const { userPrompt, board, referenceContent, today } = opts;
+
+  const providerChain: AgentConfig['provider'][] = ['mistral', 'regolo', 'litellm'];
+  const provider = providerChain.find((p) => isProviderConfigured(p));
+  if (!provider) {
+    throw new Error('No AI provider configured (tried: mistral, regolo, litellm)');
+  }
+
+  const modelId = BOARD_AI_MODELS[provider];
+  const model = getModel(provider, modelId);
+  log.info(`[BoardAI] Using provider: ${provider}, model: ${modelId}`);
+
+  const referenceSection = referenceContent?.trim()
+    ? `\n\nZUSÄTZLICHER KONTEXT (vorherige Antwort des Assistenten, auf die sich der*die Nutzer*in bezieht):\n<reference_content>\n${referenceContent.trim().slice(0, 8000)}\n</reference_content>`
+    : '';
+
+  const system = `${BOARD_TOOL_STRICT_PROMPT}\n\nAKTUELLER BOARD-ZUSTAND:\n${serializeBoard(board, today)}${referenceSection}`;
+
+  let captured: BoardOperation[] | null = null;
+
+  const result = await generateText({
+    model,
+    system,
+    prompt: userPrompt,
+    tools: {
+      applyBoardOperations: tool({
+        description: 'Apply a batch of operations to the board.',
+        inputSchema: z.object({ operations: boardOperationsSchema }),
+      }),
+    },
+    toolChoice: 'required',
+    maxOutputTokens: 8000,
+    maxRetries: 1,
+    temperature: 0.2,
+  });
+
+  for (const tc of result.toolCalls) {
+    if (tc.toolName === 'applyBoardOperations') {
+      // Validated against the contract schema; the tool inputSchema already
+      // enforces it, this is the trust-boundary assertion + a typed narrow.
+      const parsed = boardOperationsSchema.safeParse(
+        (tc.input as { operations: unknown }).operations
+      );
+      if (parsed.success) {
+        captured = parsed.data;
+      } else {
+        log.warn(`[BoardAI] Operation validation failed: ${parsed.error.message}`);
+      }
+    }
+  }
+
+  log.info(`[BoardAI] Planned ${captured?.length ?? 0} operation(s) for prompt: "${userPrompt}"`);
+  return captured ?? [];
+}

--- a/apps/api/routes/boards/boardsContractRouter.ts
+++ b/apps/api/routes/boards/boardsContractRouter.ts
@@ -34,8 +34,10 @@ import { logContractValidationError } from '../../utils/contractValidationLogger
 import { getAIWorkerPool } from '../../utils/getAIWorkerPool.js';
 import { getAuthedUser } from '../../utils/getAuthedUser.js';
 import { createLogger } from '../../utils/logger.js';
+import { ensureDocChatThread } from '../chat/services/threadPersistenceService.js';
 
 import { checkBoardAccess } from './boardAccess.js';
+import { generateBoardOperations } from './boardAiService.js';
 
 import type { Application } from 'express';
 
@@ -348,6 +350,71 @@ export const boardsContractRouter = s.router(boardsContract, {
         status: 500 as const,
         body: {
           error: 'Failed to create board',
+          details: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  },
+
+  getChatThread: async (args) => {
+    try {
+      const { id } = args.params;
+      const userId = getAuthedUser(args.req).id;
+
+      const { hasAccess, createdBy } = await checkBoardAccess(id, userId);
+      if (!createdBy) {
+        return { status: 404 as const, body: { error: 'Board not found' } };
+      }
+      if (!hasAccess) {
+        return { status: 403 as const, body: { error: 'Access denied' } };
+      }
+
+      // One shared thread per board, keyed by the board id (a collaborative_documents
+      // row) on chat_threads.doc_id. Owner is the thread's user_id, matching docs.
+      const thread = await ensureDocChatThread(id, createdBy, 'gruenerator-boards-editor');
+      return { status: 200 as const, body: { threadId: thread.id } };
+    } catch (error) {
+      log.error('[Boards Contract] Error resolving chat thread:', error);
+      return {
+        status: 500 as const,
+        body: {
+          error: 'Failed to resolve chat thread',
+          details: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  },
+
+  ai: async (args) => {
+    try {
+      const { id } = args.params;
+      const userId = getAuthedUser(args.req).id;
+      const { userPrompt, board, referenceContent } = args.body;
+
+      // Re-enforce write access server-side — never trust the client.
+      const { hasAccess, createdBy, canEdit } = await checkBoardAccess(id, userId);
+      if (!createdBy) {
+        return { status: 404 as const, body: { error: 'Board not found' } };
+      }
+      if (!hasAccess || !canEdit) {
+        return { status: 403 as const, body: { error: 'No write access to this board' } };
+      }
+
+      const today = new Date().toISOString().slice(0, 10);
+      const operations = await generateBoardOperations({
+        userPrompt,
+        board,
+        referenceContent: referenceContent ?? null,
+        today,
+      });
+
+      return { status: 200 as const, body: { operations } };
+    } catch (error) {
+      log.error('[Boards Contract] Error generating board operations:', error);
+      return {
+        status: 500 as const,
+        body: {
+          error: 'Failed to generate board operations',
           details: error instanceof Error ? error.message : String(error),
         },
       };

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -124,6 +124,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         wolkeFiles: rawWolkeFiles,
         connectFiles: rawConnectFiles,
         currentDocument: rawCurrentDocument,
+        currentBoard: rawCurrentBoard,
         customSystemPrompt: rawCustomSystemPrompt,
         roleName: rawRoleName,
         initialAssistantMessage: rawInitialAssistantMessage,
@@ -427,6 +428,9 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
               selectionText: rawCurrentDocument.selectionText ?? null,
             }
           : undefined,
+        // Live board (boards editor surface). Deliberately NOT mirrored into
+        // boardIds — see classifierNode (keeps legacy modify_board from firing).
+        currentBoard: rawCurrentBoard ?? undefined,
         userLocale: user.locale ?? 'de-DE',
         customSystemPrompt: rawCustomSystemPrompt ?? undefined,
         activeSkillMention: rawActiveSkillMention ?? undefined,
@@ -438,6 +442,26 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
       log.info(`[ChatGraph] User ${userId} locale: ${userLocale}`);
 
       initialState.agentConfig.userId = userId;
+
+      // Boards editor surface: surface the live board through the existing
+      // boardContext channel so respondNode can answer read-only questions
+      // ("what's overdue?", "summarize the board"). The edit path is handled
+      // separately via the edit_current_board intent + trigger_board_action SSE.
+      if (rawCurrentBoard) {
+        const { formatBoardAsContext } = await import('../../services/boards/BoardService.js');
+        // Contract board types are structurally compatible with BoardService's
+        // loose BoardState (which casts Yjs toJSON() output); the only mismatch is
+        // exactOptionalPropertyTypes on view fields, so cast at this boundary.
+        initialState.boardContext = formatBoardAsContext({
+          id: rawCurrentBoard.id,
+          title: rawCurrentBoard.title ?? 'Board',
+          boardType: rawCurrentBoard.boardType,
+          fields: rawCurrentBoard.fields,
+          rows: rawCurrentBoard.rows,
+          views: rawCurrentBoard.views,
+        } as Parameters<typeof formatBoardAsContext>[0]);
+      }
+
       if (memoryContext) {
         initialState.memoryContext = memoryContext;
         initialState.memoryRetrieveTimeMs = memoryRetrieveTimeMs;
@@ -973,6 +997,33 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         });
         log.info(
           `[ChatGraph] Emitted trigger_doc_edit for doc ${rawCurrentDocument.id} (selection: ${hasSelection}, refContentChars: ${cappedPrev.length})`
+        );
+      }
+
+      // === Stage 3d: Live board edit trigger (boards editor surface only) ===
+      // For edit_current_board intent, emit a `trigger_board_action` SSE event
+      // with the user's prompt. The boards-editor frontend calls POST
+      // /api/boards/:id/ai to plan operations, then applies them to the live
+      // Yjs board. ChatGraph never edits the board itself — classify + forward.
+      if (finalState.intent === 'edit_current_board' && rawCurrentBoard?.id) {
+        const lastUserText = lastUserMessage ? extractTextContent(lastUserMessage.content) : '';
+        const lastUserIdx = lastUserMessage ? validMessages.indexOf(lastUserMessage) : -1;
+        const priorMessages = lastUserIdx > 0 ? validMessages.slice(0, lastUserIdx) : [];
+        const SUBSTANTIVE_THRESHOLD = 200;
+        const prevAssistantText =
+          [...priorMessages]
+            .reverse()
+            .map((m) => (m.role === 'assistant' ? extractTextContent(m.content) : ''))
+            .find((t) => t.trim().length >= SUBSTANTIVE_THRESHOLD) ?? '';
+        const cappedPrev =
+          prevAssistantText.length > 8000 ? prevAssistantText.slice(0, 8000) : prevAssistantText;
+        sse.send('trigger_board_action', {
+          targetBoardId: rawCurrentBoard.id,
+          userPrompt: lastUserText,
+          ...(cappedPrev.trim() ? { referenceContent: cappedPrev } : {}),
+        });
+        log.info(
+          `[ChatGraph] Emitted trigger_board_action for board ${rawCurrentBoard.id} (refContentChars: ${cappedPrev.length})`
         );
       }
 

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -14,7 +14,11 @@ import type {
   ConfirmActionType,
   ChartData,
 } from '../../../agents/langgraph/ChatGraph/types.js';
-import type { CanvasAiSuggestion, TriggerDocEdit } from '@gruenerator/contracts';
+import type {
+  CanvasAiSuggestion,
+  TriggerDocEdit,
+  TriggerBoardAction,
+} from '@gruenerator/contracts';
 import type { Response } from 'express';
 
 /**
@@ -41,6 +45,7 @@ export type SSEEventType =
   | 'document_indexed'
   | 'document_created'
   | 'trigger_doc_edit'
+  | 'trigger_board_action'
   | 'confirm_action'
   | 'chart_data'
   | 'memory_context'
@@ -164,6 +169,7 @@ export interface SSEEventPayloads {
   document_indexed: { documentId: string; title: string };
   document_created: { documentId: string; title: string; subtype: string; url: string };
   trigger_doc_edit: TriggerDocEdit;
+  trigger_board_action: TriggerBoardAction;
   interrupt: {
     interruptType: 'clarification';
     question: string;
@@ -256,6 +262,7 @@ export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
   modify_doc: ['Bearbeite...', 'Ändere...', 'Überarbeite...'],
   edit_current_doc: ['Passe an...', 'Bearbeite...', 'Ändere...'],
   modify_board: ['Aktualisiere...', 'Ergänze...', 'Pflege...'],
+  edit_current_board: ['Passe Board an...', 'Aktualisiere...', 'Pflege...'],
   share_doc: ['Teile...', 'Sende...', 'Reiche weiter...'],
   direct: ['Antworte...', 'Schreibe...', 'Formuliere...'],
 };

--- a/apps/web/src/features/boards/BoardAiEditToggle.tsx
+++ b/apps/web/src/features/boards/BoardAiEditToggle.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { composerToolbarButtonClass, useChatDensity } from '@gruenerator/chat';
+import { Pencil, PencilOff } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_PREFIX = 'gruenerator.boards.ai-edit.';
+
+function storageKey(boardId: string): string {
+  return `${STORAGE_PREFIX}${boardId}`;
+}
+
+function readInitial(boardId: string): boolean {
+  if (typeof window === 'undefined') return true;
+  const raw = window.localStorage.getItem(storageKey(boardId));
+  if (raw === null) return true;
+  return raw === 'true';
+}
+
+/**
+ * Per-board "AI may edit the board" toggle. When off, the assistant answers
+ * questions but does not mutate the board (the classifier gates on
+ * `enabledTools.edit_current_board`). Mirrors useDocAiEditEnabled.
+ */
+export function useBoardAiEditEnabled(boardId: string): {
+  enabled: boolean;
+  toggle: () => void;
+} {
+  const [enabled, setEnabled] = useState<boolean>(() => readInitial(boardId));
+
+  useEffect(() => {
+    setEnabled(readInitial(boardId));
+  }, [boardId]);
+
+  const toggle = useCallback(() => {
+    setEnabled((prev) => {
+      const next = !prev;
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(storageKey(boardId), String(next));
+      }
+      return next;
+    });
+  }, [boardId]);
+
+  return { enabled, toggle };
+}
+
+interface BoardAiEditToggleProps {
+  enabled: boolean;
+  onToggle: () => void;
+}
+
+export function BoardAiEditToggle({ enabled, onToggle }: BoardAiEditToggleProps) {
+  const isCompact = useChatDensity() === 'compact';
+  const Icon = enabled ? Pencil : PencilOff;
+  const label = isCompact ? (enabled ? 'An' : 'Aus') : enabled ? 'Bearbeiten an' : 'Nur lesen';
+  const title = enabled
+    ? 'KI darf dieses Board bearbeiten. Klicken zum Sperren.'
+    : 'KI ist im Lesemodus. Klicken, damit die KI das Board bearbeiten darf.';
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={composerToolbarButtonClass(isCompact)}
+      aria-pressed={enabled}
+      title={title}
+    >
+      <Icon className={isCompact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/features/boards/BoardAssistantChat.tsx
+++ b/apps/web/src/features/boards/BoardAssistantChat.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { GrueneratorThread } from '@gruenerator/chat';
+
+import { BoardAiEditToggle } from './BoardAiEditToggle';
+import { useBoardChat } from './BoardAssistantProvider';
+
+import type { ReactNode } from 'react';
+
+function BoardChatStatus({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center p-6 text-sm text-foreground-muted">
+      {children}
+    </div>
+  );
+}
+
+export function BoardAssistantChat() {
+  const state = useBoardChat();
+
+  if (state.status === 'guest') {
+    return <BoardChatStatus>Bitte melde dich an, um den KI-Assistenten zu nutzen.</BoardChatStatus>;
+  }
+
+  if (state.status === 'loading') {
+    return <BoardChatStatus>Lade Chat...</BoardChatStatus>;
+  }
+
+  if (state.status === 'error') {
+    return (
+      <BoardChatStatus>Chat konnte nicht geladen werden: {state.error.message}</BoardChatStatus>
+    );
+  }
+
+  return (
+    <GrueneratorThread
+      firstName={state.userName ?? null}
+      density="compact"
+      showToolToggles={false}
+      composerSlots={{
+        sendAdornment: (
+          <BoardAiEditToggle enabled={state.aiEditEnabled} onToggle={state.toggleAiEdit} />
+        ),
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/boards/BoardAssistantPanel.tsx
+++ b/apps/web/src/features/boards/BoardAssistantPanel.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { BoardAssistantChat } from './BoardAssistantChat';
+import { BoardAssistantProvider } from './BoardAssistantProvider';
+
+import type { BoardMutations } from './applyBoardOperations';
+
+interface BoardAssistantPanelProps {
+  boardId: string;
+  userId: string | null;
+  userName: string | null;
+  boardTitle: string | null;
+  /** Live board mutation surface (lifted useBoardState from BoardContent). */
+  boardState: BoardMutations;
+  /**
+   * When true, the chat UI renders. When false the provider stays mounted
+   * (runtime + Hocuspocus + thread alive) but no UI shows — close/reopen is
+   * free, messages and in-flight streams persist.
+   */
+  isOpen: boolean;
+}
+
+export function BoardAssistantPanel({
+  boardId,
+  userId,
+  userName,
+  boardTitle,
+  boardState,
+  isOpen,
+}: BoardAssistantPanelProps) {
+  return (
+    <BoardAssistantProvider
+      boardId={boardId}
+      userId={userId}
+      userName={userName}
+      boardTitle={boardTitle}
+      boardState={boardState}
+    >
+      {isOpen ? <BoardAssistantChat /> : null}
+    </BoardAssistantProvider>
+  );
+}

--- a/apps/web/src/features/boards/BoardAssistantProvider.tsx
+++ b/apps/web/src/features/boards/BoardAssistantProvider.tsx
@@ -1,0 +1,460 @@
+'use client';
+
+import {
+  AssistantRuntimeProvider,
+  AuiProvider,
+  ExportedMessageRepository,
+  useAui,
+  useLocalRuntime,
+  type AssistantRuntime,
+} from '@assistant-ui/react';
+import {
+  AUTO_MODEL_ID,
+  ChatCollaborationProvider,
+  ChatSurfaceProvider,
+  GrueneratorAttachmentAdapter,
+  convertToThreadMessageLike,
+  createChatSurfaceStore,
+  createGrueneratorModelAdapter,
+  resolveAutoModel,
+  useChatCollaboration,
+  useChatConfigStore,
+  type ChatRequestContext,
+  type ChatSurfaceStore,
+  type GrueneratorAdapterConfig,
+} from '@gruenerator/chat';
+import { chatThreadResponseSchema, type ChatThreadResponse } from '@gruenerator/contracts';
+import { getSystemAgent } from '@gruenerator/shared/agents';
+import { getContractsClient } from '@gruenerator/shared/api';
+import { loadedThreadMessagesSchema } from '@gruenerator/shared/chat';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  toast,
+} from '@gruenerator/ui';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { usePeerMessageSync } from '../docs/usePeerMessageSync';
+
+import { applyBoardOperations, type BoardMutations } from './applyBoardOperations';
+import { useBoardAiEditEnabled } from './BoardAiEditToggle';
+import { useAssignableMembers } from './hooks/useAssignableMembers';
+import { serializeBoardForChat } from './utils/serializeBoardContext';
+
+type ChatCollabValue = ReturnType<typeof useChatCollaboration>;
+
+export type BoardChatState =
+  | { status: 'guest' }
+  | { status: 'loading' }
+  | { status: 'error'; error: Error }
+  | {
+      status: 'ready';
+      threadId: string;
+      runtime: AssistantRuntime;
+      collab: ChatCollabValue;
+      aiEditEnabled: boolean;
+      toggleAiEdit: () => void;
+      boardId: string;
+      userName: string | null;
+    };
+
+const BoardChatContext = createContext<BoardChatState | null>(null);
+
+export function useBoardChat(): BoardChatState {
+  const value = useContext(BoardChatContext);
+  if (!value) {
+    throw new Error('useBoardChat must be used inside <BoardAssistantProvider>');
+  }
+  return value;
+}
+
+interface BoardAssistantProviderProps {
+  boardId: string;
+  userId: string | null;
+  userName: string | null;
+  boardTitle: string | null;
+  boardState: BoardMutations;
+  children: ReactNode;
+}
+
+export function BoardAssistantProvider({
+  boardId,
+  userId,
+  userName,
+  boardTitle,
+  boardState,
+  children,
+}: BoardAssistantProviderProps) {
+  if (!userId) {
+    return (
+      <BoardChatContext.Provider value={{ status: 'guest' }}>{children}</BoardChatContext.Provider>
+    );
+  }
+  return (
+    <BoardAuiReset>
+      <BoardAssistantProviderInner
+        boardId={boardId}
+        userId={userId}
+        userName={userName}
+        boardTitle={boardTitle}
+        boardState={boardState}
+      >
+        {children}
+      </BoardAssistantProviderInner>
+    </BoardAuiReset>
+  );
+}
+
+function BoardAuiReset({ children }: { children: ReactNode }) {
+  const freshAui = useAui({}, { parent: null });
+  return <AuiProvider value={freshAui}>{children}</AuiProvider>;
+}
+
+interface InnerProps {
+  boardId: string;
+  userId: string;
+  userName: string | null;
+  boardTitle: string | null;
+  boardState: BoardMutations;
+  children: ReactNode;
+}
+
+function BoardAssistantProviderInner({
+  boardId,
+  userId,
+  userName,
+  boardTitle,
+  boardState,
+  children,
+}: InnerProps) {
+  const {
+    data: threadResp,
+    error: threadError,
+    isLoading: threadLoading,
+  } = useQuery<ChatThreadResponse>({
+    queryKey: ['boards', boardId, 'chat-thread'],
+    queryFn: async () => {
+      const result = await getContractsClient().boards.getChatThread({ params: { id: boardId } });
+      if (result.status !== 200) {
+        throw new Error(`Chat thread lookup failed: ${result.status}`);
+      }
+      return chatThreadResponseSchema.parse(result.body);
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  const threadId = threadResp?.threadId ?? null;
+
+  if (threadError) {
+    return (
+      <BoardChatContext.Provider
+        value={{
+          status: 'error',
+          error: threadError instanceof Error ? threadError : new Error(String(threadError)),
+        }}
+      >
+        {children}
+      </BoardChatContext.Provider>
+    );
+  }
+
+  if (threadLoading || !threadId) {
+    return (
+      <BoardChatContext.Provider value={{ status: 'loading' }}>
+        {children}
+      </BoardChatContext.Provider>
+    );
+  }
+
+  return (
+    <BoardChatReadyHost
+      key={threadId}
+      threadId={threadId}
+      boardId={boardId}
+      userId={userId}
+      userName={userName}
+      boardTitle={boardTitle}
+      boardState={boardState}
+    >
+      {children}
+    </BoardChatReadyHost>
+  );
+}
+
+interface ReadyHostProps {
+  threadId: string;
+  boardId: string;
+  userId: string;
+  userName: string | null;
+  boardTitle: string | null;
+  boardState: BoardMutations;
+  children: ReactNode;
+}
+
+function BoardChatReadyHost({
+  threadId,
+  boardId,
+  userId,
+  userName,
+  boardTitle,
+  boardState,
+  children,
+}: ReadyHostProps) {
+  const fetchFn = useChatConfigStore((s) => s.fetch);
+  const endpoints = useChatConfigStore((s) => s.endpoints);
+  const registerContextProvider = useChatConfigStore((s) => s.registerContextProvider);
+  const registerBoardActionHandler = useChatConfigStore((s) => s.registerBoardActionHandler);
+  const queryClient = useQueryClient();
+
+  const { enabled: aiEditEnabled, toggle: toggleAiEdit } = useBoardAiEditEnabled(boardId);
+  const aiEditEnabledRef = useRef(aiEditEnabled);
+  aiEditEnabledRef.current = aiEditEnabled;
+
+  const { data: assignableMembers } = useAssignableMembers(boardId);
+
+  // Refs so the long-lived context provider + action handler always read fresh
+  // live state without re-registering on every Yjs update.
+  const boardStateRef = useRef(boardState);
+  boardStateRef.current = boardState;
+  const boardTitleRef = useRef(boardTitle);
+  boardTitleRef.current = boardTitle;
+  const membersRef = useRef(assignableMembers ?? []);
+  membersRef.current = assignableMembers ?? [];
+
+  // Promise-based delete confirmation rendered as an AlertDialog.
+  const [pendingDelete, setPendingDelete] = useState<{
+    titles: string[];
+    resolve: (ok: boolean) => void;
+  } | null>(null);
+  const confirmDelete = useCallback((titles: string[]): Promise<boolean> => {
+    return new Promise<boolean>((resolve) => setPendingDelete({ titles, resolve }));
+  }, []);
+  const resolvePendingDelete = useCallback((ok: boolean) => {
+    setPendingDelete((prev) => {
+      prev?.resolve(ok);
+      return null;
+    });
+  }, []);
+
+  const { data: initialMessages } = useQuery({
+    queryKey: ['chat-thread-messages', threadId],
+    queryFn: async () => {
+      const res = await fetchFn(`${endpoints.messages}?threadId=${threadId}`);
+      if (!res.ok) return [];
+      const parsed = loadedThreadMessagesSchema.parse(await res.json());
+      return convertToThreadMessageLike(parsed as Parameters<typeof convertToThreadMessageLike>[0]);
+    },
+    staleTime: 30_000,
+  });
+
+  // Per-thread context provider: feed the live board state each request.
+  useEffect(() => {
+    const provider = (): ChatRequestContext => ({
+      currentBoard: serializeBoardForChat({
+        boardId,
+        boardTitle: boardTitleRef.current,
+        fields: boardStateRef.current.fields,
+        rows: boardStateRef.current.rows,
+        views: boardStateRef.current.views,
+        assignableMembers: membersRef.current,
+      }),
+    });
+    return registerContextProvider(threadId, provider);
+  }, [threadId, boardId, registerContextProvider]);
+
+  // Board-action handler: plan operations via /api/boards/:id/ai, then apply
+  // them to the live board with a client-side executor.
+  useEffect(() => {
+    return registerBoardActionHandler(boardId, async (payload) => {
+      if (payload.targetBoardId !== boardId) return;
+      if (!aiEditEnabledRef.current) return;
+      try {
+        const result = await getContractsClient().boards.ai({
+          params: { id: boardId },
+          body: {
+            userPrompt: payload.userPrompt,
+            board: serializeBoardForChat({
+              boardId,
+              boardTitle: boardTitleRef.current,
+              fields: boardStateRef.current.fields,
+              rows: boardStateRef.current.rows,
+              views: boardStateRef.current.views,
+              assignableMembers: membersRef.current,
+            }),
+            ...(payload.referenceContent ? { referenceContent: payload.referenceContent } : {}),
+          },
+        });
+        if (result.status !== 200) {
+          toast.error('Board-Aktion fehlgeschlagen.');
+          return;
+        }
+        if (result.body.operations.length === 0) return;
+        const { applied, skipped } = await applyBoardOperations(result.body.operations, {
+          boardState: boardStateRef.current,
+          currentUserId: userId,
+          assignableMembers: membersRef.current,
+          addComment: async (taskId, text) => {
+            const res = await getContractsClient().boardComments.createComment({
+              params: { boardId, cardId: taskId },
+              body: { blocks: [{ type: 'text', text }] },
+            });
+            if (res.status !== 201) throw new Error(`Kommentar fehlgeschlagen (${res.status})`);
+            void queryClient.invalidateQueries({ queryKey: ['board-comments', boardId, taskId] });
+          },
+          confirmDelete,
+        });
+        if (applied > 0) {
+          toast.success(`${applied} Änderung${applied === 1 ? '' : 'en'} übernommen.`);
+        }
+        if (skipped.length > 0) {
+          toast.warning(skipped.join(' · '));
+        }
+      } catch (err) {
+        toast.error(
+          `Board-Aktion fehlgeschlagen: ${err instanceof Error ? err.message : 'Unbekannter Fehler'}`
+        );
+      }
+    });
+  }, [boardId, userId, registerBoardActionHandler, confirmDelete, queryClient]);
+
+  const surfaceStore = useMemo<ChatSurfaceStore>(
+    () =>
+      createChatSurfaceStore({
+        selectedAgentId: 'gruenerator-boards-editor',
+        threadMode: 'chat',
+        searchMode: 'web',
+      }),
+    []
+  );
+
+  const threadIdRef = useRef(threadId);
+  threadIdRef.current = threadId;
+
+  const getConfig = useMemo<() => GrueneratorAdapterConfig>(
+    () => () => {
+      const surface = surfaceStore.getState();
+      const resolvedModelId =
+        surface.selectedModel === AUTO_MODEL_ID
+          ? resolveAutoModel({
+              threadMode: surface.threadMode,
+              agent: surface.selectedAgentId
+                ? (getSystemAgent(surface.selectedAgentId) ?? null)
+                : null,
+            })
+          : (surface.selectedModel ?? '');
+      return {
+        agentId: surface.selectedAgentId ?? 'gruenerator-boards-editor',
+        modelId: resolvedModelId,
+        enabledTools: {
+          search: true,
+          web: true,
+          examples: true,
+          pressemitteilung_examples: false,
+          research: true,
+        },
+        customEnabledTools: {
+          summary: true,
+          edit_current_board: aiEditEnabledRef.current,
+        },
+        threadId: threadIdRef.current,
+        threadMode: surface.threadMode,
+        searchMode: surface.searchMode,
+        selectedNotebookId: surface.selectedNotebookId,
+        customSystemPrompt: surface.customSystemPrompt,
+        customRoleName: surface.customRoleName,
+      };
+    },
+    [surfaceStore]
+  );
+
+  const adapter = useMemo(() => createGrueneratorModelAdapter(getConfig, {}), [getConfig]);
+  const attachmentAdapter = useMemo(() => new GrueneratorAttachmentAdapter(), []);
+
+  const runtime = useLocalRuntime(adapter, {
+    initialMessages: initialMessages ?? [],
+    adapters: { attachments: attachmentAdapter },
+  });
+
+  const importedRef = useRef(false);
+  useEffect(() => {
+    if (importedRef.current) return;
+    if (!initialMessages || initialMessages.length === 0) return;
+    if (runtime.thread.getState().isRunning) return;
+    runtime.thread.import(ExportedMessageRepository.fromArray(initialMessages));
+    importedRef.current = true;
+  }, [initialMessages, runtime]);
+
+  const collabUser = useMemo(() => ({ id: userId, name: userName ?? userId }), [userId, userName]);
+  const collab = useChatCollaboration(threadId, collabUser);
+
+  usePeerMessageSync({ threadId, runtime, collab });
+
+  const value = useMemo<BoardChatState>(
+    () => ({
+      status: 'ready',
+      threadId,
+      runtime,
+      collab,
+      aiEditEnabled,
+      toggleAiEdit,
+      boardId,
+      userName,
+    }),
+    [threadId, runtime, collab, aiEditEnabled, toggleAiEdit, boardId, userName]
+  );
+
+  return (
+    <BoardChatContext.Provider value={value}>
+      <ChatSurfaceProvider store={surfaceStore}>
+        <AssistantRuntimeProvider runtime={runtime}>
+          <ChatCollaborationProvider value={collab}>{children}</ChatCollaborationProvider>
+        </AssistantRuntimeProvider>
+      </ChatSurfaceProvider>
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) resolvePendingDelete(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {pendingDelete && pendingDelete.titles.length === 1
+                ? 'Aufgabe löschen?'
+                : `${pendingDelete?.titles.length ?? 0} Aufgaben löschen?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete && pendingDelete.titles.length <= 5
+                ? pendingDelete.titles.map((t) => `„${t}"`).join(', ')
+                : 'Diese Aktion kann nicht rückgängig gemacht werden.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => resolvePendingDelete(false)}>
+              Abbrechen
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={() => resolvePendingDelete(true)}>
+              Löschen
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </BoardChatContext.Provider>
+  );
+}

--- a/apps/web/src/features/boards/BoardAssistantProvider.tsx
+++ b/apps/web/src/features/boards/BoardAssistantProvider.tsx
@@ -283,7 +283,13 @@ function BoardChatReadyHost({
   useEffect(() => {
     return registerBoardActionHandler(boardId, async (payload) => {
       if (payload.targetBoardId !== boardId) return;
-      if (!aiEditEnabledRef.current) return;
+      // The toggle may have been switched off after the request was sent (the
+      // classifier read enabledTools at send time). Don't apply, but tell the
+      // user so the chat's success-sounding reply isn't mistaken for a real edit.
+      if (!aiEditEnabledRef.current) {
+        toast.info('KI-Bearbeitung ist deaktiviert — es wurde nichts am Board geändert.');
+        return;
+      }
       try {
         const result = await getContractsClient().boards.ai({
           params: { id: boardId },

--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -1,6 +1,6 @@
 import { DocsProvider } from '@gruenerator/docs';
 import { Fab } from '@gruenerator/ui';
-import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import { FiMessageSquare, FiX } from 'react-icons/fi';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
@@ -331,16 +331,19 @@ function BoardViewContent({
       {/* AI assistant — only once the board state is synced and a user is present. */}
       {isSynced && userId && (
         <>
-          <Fab
-            icon={<FiMessageSquare />}
-            active={assistantOpen}
-            aria-label="KI-Board-Assistent ein-/ausblenden"
-            title="KI-Board-Assistent"
-            onClick={() => {
-              setAssistantMounted(true);
-              setAssistantOpen((v) => !v);
-            }}
-          />
+          {/* Hidden while the panel is open — the fixed panel overlays the FAB's
+              corner (composer/send button), and the panel has its own close button. */}
+          {!assistantOpen && (
+            <Fab
+              icon={<FiMessageSquare />}
+              aria-label="KI-Board-Assistent öffnen"
+              title="KI-Board-Assistent"
+              onClick={() => {
+                setAssistantMounted(true);
+                setAssistantOpen(true);
+              }}
+            />
+          )}
           {assistantMounted && (
             <aside
               className={

--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -1,5 +1,7 @@
 import { DocsProvider } from '@gruenerator/docs';
+import { Fab } from '@gruenerator/ui';
 import { lazy, Suspense, useCallback, useMemo, useState } from 'react';
+import { FiMessageSquare, FiX } from 'react-icons/fi';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { DottedBackground } from '../../components/common/DottedBackground';
@@ -33,6 +35,10 @@ import type { Doc } from 'yjs';
 
 const LazyExcalidrawBoard = lazy(() =>
   import('./components/ExcalidrawBoard').then((m) => ({ default: m.ExcalidrawBoard }))
+);
+
+const LazyBoardAssistantPanel = lazy(() =>
+  import('./BoardAssistantPanel').then((m) => ({ default: m.BoardAssistantPanel }))
 );
 
 function BoardContent() {
@@ -138,7 +144,10 @@ function BoardContent() {
           provider={provider}
           generatedStructure={generatedStructure}
           currentUserId={String(user?.id || '')}
+          userId={user?.id ? String(user.id) : null}
+          userName={user?.display_name ?? null}
           boardId={board.id}
+          boardTitle={board.title}
           expertMode={expertMode}
         />
       )}
@@ -152,7 +161,10 @@ function BoardViewContent({
   provider,
   generatedStructure,
   currentUserId,
+  userId,
+  userName,
   boardId,
+  boardTitle,
   expertMode,
 }: {
   ydoc: Doc;
@@ -160,13 +172,18 @@ function BoardViewContent({
   provider: HocuspocusProvider | null;
   generatedStructure: BoardInitialStructure | null;
   currentUserId: string;
+  userId: string | null;
+  userName: string | null;
   boardId: string;
+  boardTitle: string;
   expertMode: boolean;
 }) {
   const boardState = useBoardState(ydoc, isSynced, generatedStructure);
   const [activeViewId, setActiveViewId] = useState('view-kanban-default');
   const [selectedRow, setSelectedRow] = useState<Row | null>(null);
   const [detailOpen, setDetailOpen] = useState(false);
+  const [assistantOpen, setAssistantOpen] = useState(false);
+  const [assistantMounted, setAssistantMounted] = useState(false);
 
   const { activeView, fields, filteredRows, groups } = useViewData({
     fields: boardState.fields,
@@ -309,6 +326,53 @@ function BoardViewContent({
           onUpdateField={boardState.updateField}
           boardId={boardId}
         />
+      )}
+
+      {/* AI assistant — only once the board state is synced and a user is present. */}
+      {isSynced && userId && (
+        <>
+          <Fab
+            icon={<FiMessageSquare />}
+            active={assistantOpen}
+            aria-label="KI-Board-Assistent ein-/ausblenden"
+            title="KI-Board-Assistent"
+            onClick={() => {
+              setAssistantMounted(true);
+              setAssistantOpen((v) => !v);
+            }}
+          />
+          {assistantMounted && (
+            <aside
+              className={
+                assistantOpen
+                  ? 'fixed top-0 right-0 bottom-0 w-80 min-w-80 max-w-80 z-[200] flex flex-col border-l border-grey-200 dark:border-grey-700 bg-background dark:bg-grey-900 overflow-hidden shadow-xl max-md:w-full max-md:min-w-full max-md:max-w-full max-md:border-l-0'
+                  : 'hidden'
+              }
+            >
+              <div className="flex items-center justify-end p-2 border-b border-grey-200 dark:border-grey-700 shrink-0">
+                <button
+                  onClick={() => setAssistantOpen(false)}
+                  className="flex h-8 w-8 items-center justify-center rounded-lg text-grey-600 hover:bg-grey-100 hover:text-foreground dark:text-grey-300 dark:hover:bg-grey-700"
+                  aria-label="Assistent schließen"
+                >
+                  <FiX size={18} />
+                </button>
+              </div>
+              <div className="flex-1 min-h-0">
+                <Suspense fallback={null}>
+                  <LazyBoardAssistantPanel
+                    boardId={boardId}
+                    userId={userId}
+                    userName={userName}
+                    boardTitle={boardTitle}
+                    boardState={boardState}
+                    isOpen={assistantOpen}
+                  />
+                </Suspense>
+              </div>
+            </aside>
+          )}
+        </>
       )}
     </>
   );

--- a/apps/web/src/features/boards/applyBoardOperations.ts
+++ b/apps/web/src/features/boards/applyBoardOperations.ts
@@ -1,0 +1,350 @@
+import { type AssignableMember, type BoardOperation } from '@gruenerator/contracts';
+
+import {
+  FIELD_IDS,
+  type BoardView,
+  type CellValue,
+  type Field,
+  type FieldType,
+  type Row,
+  type SelectOption,
+  type ViewLayout,
+} from './types';
+import { COLUMN_COLORS, LABEL_COLORS, createDefaultRow } from './utils/boardDefaults';
+
+/**
+ * Live-board mutation surface the executor needs. Structurally matches the
+ * subset of `useBoardState`'s return value we use, so the hook result can be
+ * passed directly.
+ */
+export interface BoardMutations {
+  fields: Field[];
+  rows: Row[];
+  views: BoardView[];
+  addRow: (row: Row) => void;
+  updateRow: (rowId: string, updates: Partial<Row>) => void;
+  updateRowCell: (rowId: string, fieldId: string, value: CellValue) => void;
+  deleteRow: (rowId: string) => void;
+  addField: (field: Field) => void;
+  updateField: (fieldId: string, updates: Partial<Field>) => void;
+  addView: (view: BoardView) => void;
+}
+
+export interface BoardExecutorCtx {
+  boardState: BoardMutations;
+  currentUserId: string;
+  assignableMembers: AssignableMember[];
+  /** Adds a plain-text comment to a card (REST). */
+  addComment: (taskId: string, text: string) => Promise<void>;
+  /** Confirms a batch of deletions. Resolves true to proceed. */
+  confirmDelete: (titles: string[]) => Promise<boolean>;
+}
+
+export interface ApplyResult {
+  applied: number;
+  skipped: string[];
+}
+
+function rand(): string {
+  return Math.random().toString(36).slice(2, 7);
+}
+
+function slug(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '')
+      .slice(0, 24) || 'x'
+  );
+}
+
+const VIEW_NAMES: Record<ViewLayout, string> = {
+  kanban: 'Kanban',
+  table: 'Tabelle',
+  list: 'Liste',
+  calendar: 'Kalender',
+  gantt: 'Gantt',
+};
+
+/**
+ * Apply a batch of AI-planned board operations to the live Yjs board. Status,
+ * assignee and label values arrive as human names and are resolved here against
+ * the live board (auto-creating missing status columns / labels). Destructive
+ * deletes are batched into a single confirm. Never throws on a single bad op —
+ * unresolved items are reported in `skipped`.
+ */
+export async function applyBoardOperations(
+  ops: BoardOperation[],
+  ctx: BoardExecutorCtx
+): Promise<ApplyResult> {
+  const { boardState } = ctx;
+  const skipped: string[] = [];
+  let applied = 0;
+
+  // Local working copies of select-option sets, seeded from the live board and
+  // mutated as we go — so multiple ops in one batch that create/reference the
+  // same column or label stay consistent (the React snapshot won't update
+  // synchronously between ops within this run).
+  const statusField = boardState.fields.find((f) => f.id === FIELD_IDS.STATUS);
+  let statusOptions: SelectOption[] = [
+    ...((statusField?.typeOptions.options as SelectOption[] | undefined) ?? []),
+  ];
+
+  const labelsField = boardState.fields.find((f) => f.id === FIELD_IDS.LABELS);
+  let labelOptions: SelectOption[] = [
+    ...((labelsField?.typeOptions.options as SelectOption[] | undefined) ?? []),
+  ];
+
+  const rowExists = (taskId: string): boolean => boardState.rows.some((r) => r.id === taskId);
+
+  function resolveStatusId(nameOrId: string | null | undefined): string | null {
+    if (!nameOrId) return null;
+    if (statusOptions.some((o) => o.id === nameOrId)) return nameOrId;
+    const lc = nameOrId.trim().toLowerCase();
+    const byName = statusOptions.find((o) => o.name.trim().toLowerCase() === lc);
+    if (byName) return byName.id;
+    if (!statusField) return null;
+    const id = `status-${slug(nameOrId)}-${rand()}`;
+    const color =
+      COLUMN_COLORS[(statusOptions.length % (COLUMN_COLORS.length - 1)) + 1] ?? '#8da4bf';
+    statusOptions = [...statusOptions, { id, name: nameOrId.trim(), color }];
+    boardState.updateField(FIELD_IDS.STATUS, {
+      typeOptions: { ...statusField.typeOptions, options: statusOptions },
+    });
+    return id;
+  }
+
+  function resolveLabelIds(names: string[]): string[] {
+    if (!labelsField) return [];
+    const ids: string[] = [];
+    let created = false;
+    for (const name of names) {
+      const lc = name.trim().toLowerCase();
+      const existing = labelOptions.find(
+        (o) => o.id === name || o.name.trim().toLowerCase() === lc
+      );
+      if (existing) {
+        ids.push(existing.id);
+        continue;
+      }
+      const id = `label-${slug(name)}-${rand()}`;
+      const color = LABEL_COLORS[labelOptions.length % LABEL_COLORS.length] ?? '#7c9885';
+      labelOptions = [...labelOptions, { id, name: name.trim(), color }];
+      created = true;
+      ids.push(id);
+    }
+    if (created) {
+      boardState.updateField(FIELD_IDS.LABELS, {
+        typeOptions: { ...labelsField.typeOptions, options: labelOptions },
+      });
+    }
+    return ids;
+  }
+
+  function resolveAssigneeCell(name: string | null | undefined): string {
+    if (!name) return '';
+    const lc = name.trim().toLowerCase();
+    const member = ctx.assignableMembers.find((m) => {
+      const display = (m.display_name || m.first_name || '').trim().toLowerCase();
+      return m.user_id === name || display === lc;
+    });
+    if (member) {
+      return JSON.stringify({
+        id: member.user_id,
+        name: member.display_name || member.first_name || name,
+        avatarRobotId: member.avatar_robot_id,
+      });
+    }
+    // Unresolved — store the raw name so it's at least visible, and report it.
+    skipped.push(`Mitglied „${name}" nicht gefunden — als Text gespeichert`);
+    return JSON.stringify({ id: '', name: name.trim(), avatarRobotId: 1 });
+  }
+
+  const fieldTypeFor = (t: FieldType): FieldType => t;
+
+  // Collect deletions to confirm once at the end.
+  const deletes: { taskId: string; title: string }[] = [];
+
+  for (const op of ops) {
+    try {
+      switch (op.type) {
+        case 'create_task': {
+          const statusId = resolveStatusId(op.status) ?? statusOptions[0]?.id ?? 'status-todo';
+          const row = createDefaultRow(statusId, ctx.currentUserId);
+          row.cells[FIELD_IDS.TITLE] = op.title;
+          if (op.description != null) row.cells[FIELD_IDS.DESCRIPTION] = op.description;
+          if (op.dueDate != null) row.cells[FIELD_IDS.DUE_DATE] = op.dueDate;
+          if (op.assignee != null) row.cells[FIELD_IDS.ASSIGNEE] = resolveAssigneeCell(op.assignee);
+          if (op.labels && op.labels.length > 0) {
+            row.cells[FIELD_IDS.LABELS] = resolveLabelIds(op.labels);
+          }
+          boardState.addRow(row);
+          applied++;
+          break;
+        }
+        case 'update_task': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          if (op.title != null) boardState.updateRowCell(op.taskId, FIELD_IDS.TITLE, op.title);
+          if (op.description != null)
+            boardState.updateRowCell(op.taskId, FIELD_IDS.DESCRIPTION, op.description);
+          if (op.dueDate !== undefined)
+            boardState.updateRowCell(op.taskId, FIELD_IDS.DUE_DATE, op.dueDate ?? null);
+          applied++;
+          break;
+        }
+        case 'move_task': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          const statusId = resolveStatusId(op.status);
+          if (!statusId) {
+            skipped.push(`Spalte „${op.status}" konnte nicht aufgelöst werden`);
+            break;
+          }
+          boardState.updateRowCell(op.taskId, FIELD_IDS.STATUS, statusId);
+          applied++;
+          break;
+        }
+        case 'set_assignee': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          boardState.updateRowCell(op.taskId, FIELD_IDS.ASSIGNEE, resolveAssigneeCell(op.assignee));
+          applied++;
+          break;
+        }
+        case 'set_labels': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          boardState.updateRowCell(op.taskId, FIELD_IDS.LABELS, resolveLabelIds(op.labels));
+          applied++;
+          break;
+        }
+        case 'set_due_date': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          boardState.updateRowCell(op.taskId, FIELD_IDS.DUE_DATE, op.dueDate ?? null);
+          applied++;
+          break;
+        }
+        case 'add_comment': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          await ctx.addComment(op.taskId, op.text);
+          applied++;
+          break;
+        }
+        case 'add_column': {
+          // resolveStatusId creates the option when the name doesn't exist.
+          const id = resolveStatusId(op.name);
+          if (id) applied++;
+          else skipped.push(`Spalte „${op.name}" konnte nicht angelegt werden`);
+          break;
+        }
+        case 'rename_column': {
+          if (!statusField) {
+            skipped.push('Kein Status-Feld vorhanden');
+            break;
+          }
+          const idx = statusOptions.findIndex(
+            (o) =>
+              o.id === op.columnId ||
+              o.name.trim().toLowerCase() === op.columnId.trim().toLowerCase()
+          );
+          if (idx === -1) {
+            skipped.push(`Spalte „${op.columnId}" nicht gefunden`);
+            break;
+          }
+          statusOptions = statusOptions.map((o, i) => (i === idx ? { ...o, name: op.name } : o));
+          boardState.updateField(FIELD_IDS.STATUS, {
+            typeOptions: { ...statusField.typeOptions, options: statusOptions },
+          });
+          applied++;
+          break;
+        }
+        case 'add_field': {
+          const isSelect = op.fieldType === 'singleSelect' || op.fieldType === 'multiSelect';
+          const options: SelectOption[] = isSelect
+            ? (op.options ?? []).map((name, i) => ({
+                id: `opt-${slug(name)}-${rand()}`,
+                name,
+                color: LABEL_COLORS[i % LABEL_COLORS.length] ?? '#7c9885',
+              }))
+            : [];
+          const maxOrder = boardState.fields.reduce((m, f) => Math.max(m, f.order), 0);
+          boardState.addField({
+            id: `field-${slug(op.name)}-${rand()}`,
+            name: op.name,
+            type: fieldTypeFor(op.fieldType),
+            typeOptions: isSelect ? { options } : {},
+            order: maxOrder + 1,
+          });
+          applied++;
+          break;
+        }
+        case 'add_view': {
+          const id = `view-${op.layout}-${Date.now()}-${rand()}`;
+          boardState.addView({
+            id,
+            name: op.name || VIEW_NAMES[op.layout],
+            layout: op.layout,
+            ...(op.layout === 'kanban' || op.layout === 'list'
+              ? { groupByFieldId: FIELD_IDS.STATUS }
+              : {}),
+            ...(op.layout === 'calendar' || op.layout === 'gantt'
+              ? { dateFieldId: FIELD_IDS.DUE_DATE }
+              : {}),
+            filters: [],
+            sorts: [],
+            fieldSettings: boardState.fields.map((f) => ({ fieldId: f.id, visible: true })),
+          });
+          applied++;
+          break;
+        }
+        case 'delete_task': {
+          if (!rowExists(op.taskId)) {
+            skipped.push(`Aufgabe ${op.taskId} nicht gefunden`);
+            break;
+          }
+          const title =
+            (boardState.rows.find((r) => r.id === op.taskId)?.cells[FIELD_IDS.TITLE] as string) ||
+            op.taskId;
+          deletes.push({ taskId: op.taskId, title });
+          break;
+        }
+      }
+    } catch (err) {
+      skipped.push(
+        `Operation ${op.type} fehlgeschlagen: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  // Destructive deletes: one confirm for the whole batch.
+  if (deletes.length > 0) {
+    const ok = await ctx.confirmDelete(deletes.map((d) => d.title));
+    if (ok) {
+      for (const d of deletes) {
+        boardState.deleteRow(d.taskId);
+        applied++;
+      }
+    } else {
+      skipped.push(`${deletes.length} Löschung(en) abgebrochen`);
+    }
+  }
+
+  return { applied, skipped };
+}

--- a/apps/web/src/features/boards/utils/serializeBoardContext.ts
+++ b/apps/web/src/features/boards/utils/serializeBoardContext.ts
@@ -1,0 +1,60 @@
+import { type AssignableMember, type CurrentBoard } from '@gruenerator/contracts';
+
+import { FIELD_IDS, type BoardView, type Field, type Row, type SelectOption } from '../types';
+
+import { DEFAULT_STATUS_OPTIONS } from './boardDefaults';
+
+const MAX_ROWS = 300;
+const MAX_DESCRIPTION_CHARS = 500;
+
+/**
+ * Project the live board state into the compact `currentBoard` shape the chat /
+ * AI backend consumes. Drops bulky cells (comments, linked docs) and truncates
+ * long descriptions so the request body stays bounded on large boards.
+ */
+export function serializeBoardForChat(opts: {
+  boardId: string;
+  boardTitle: string | null;
+  fields: Field[];
+  rows: Row[];
+  views: BoardView[];
+  assignableMembers: AssignableMember[];
+}): CurrentBoard {
+  const { boardId, boardTitle, fields, rows, views, assignableMembers } = opts;
+
+  const statusField = fields.find((f) => f.id === FIELD_IDS.STATUS);
+  const statusOptions =
+    ((statusField?.typeOptions.options as SelectOption[] | undefined) ?? DEFAULT_STATUS_OPTIONS) ||
+    [];
+
+  const trimmedRows: Row[] = rows.slice(0, MAX_ROWS).map((row) => {
+    const cells: Row['cells'] = {};
+    for (const [fieldId, value] of Object.entries(row.cells)) {
+      if (fieldId === FIELD_IDS.COMMENTS || fieldId === FIELD_IDS.LINKED_DOCS) continue;
+      if (
+        fieldId === FIELD_IDS.DESCRIPTION &&
+        typeof value === 'string' &&
+        value.length > MAX_DESCRIPTION_CHARS
+      ) {
+        cells[fieldId] = `${value.slice(0, MAX_DESCRIPTION_CHARS)}…`;
+        continue;
+      }
+      cells[fieldId] = value;
+    }
+    return { ...row, cells };
+  });
+
+  return {
+    id: boardId,
+    title: boardTitle,
+    boardType: 'kanban',
+    fields,
+    rows: trimmedRows,
+    views,
+    statusOptions,
+    assignableMembers: assignableMembers.map((m) => ({
+      id: m.user_id,
+      name: m.display_name || m.first_name || 'Unbenannt',
+    })),
+  };
+}

--- a/packages/chat/src/runtime/GrueneratorModelAdapter.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter.ts
@@ -18,7 +18,11 @@ import type {
 } from '../hooks/useChatGraphStream';
 import { useAgentStore, type ToolKey, type ThreadMode, type SearchMode } from '../stores/chatStore';
 import { getSystemAgent } from '@gruenerator/shared/agents';
-import { triggerDocEditSchema } from '@gruenerator/contracts';
+import {
+  triggerDocEditSchema,
+  triggerBoardActionSchema,
+  type CurrentBoard,
+} from '@gruenerator/contracts';
 import { parseAllMentions } from '../lib/mentionParser';
 import { parseSSELine } from '../lib/sseParser';
 import { INTENT_TO_TOOL, DEEP_TOOL_MAP } from '../lib/toolMappings';
@@ -679,6 +683,38 @@ async function* parseSSEStream(
           break;
         }
 
+        case 'trigger_board_action': {
+          // Live board edit (boards editor surface). The chat backend classified
+          // intent=edit_current_board and forwards the user's prompt here so the
+          // boards frontend can plan + apply operations against the live Yjs board.
+          // Handlers are keyed by boardId — one boards surface per board.
+          const parsed = triggerBoardActionSchema.safeParse(data);
+          if (!parsed.success) {
+            console.warn(
+              '[ChatAdapter] trigger_board_action payload failed validation',
+              parsed.error
+            );
+            break;
+          }
+          const payload = parsed.data;
+          const handler = useChatConfigStore
+            .getState()
+            .boardActionHandlers.get(payload.targetBoardId);
+          if (handler) {
+            try {
+              await handler(payload);
+            } catch (err) {
+              console.warn('[ChatAdapter] boardActionHandler threw', err);
+            }
+          } else {
+            console.warn(
+              '[ChatAdapter] trigger_board_action received but no handler registered for board',
+              payload.targetBoardId
+            );
+          }
+          break;
+        }
+
         // ── Search mode events ──
         case 'sources_preview': {
           const { results: previewResults, resultCount } = data as {
@@ -945,7 +981,9 @@ export function createGrueneratorModelAdapter(
       const safeCustomEnabledTools =
         activeAgentForRouting?.routeTo === 'search' && config.customEnabledTools
           ? Object.fromEntries(
-              Object.entries(config.customEnabledTools).filter(([k]) => k !== 'edit_current_doc')
+              Object.entries(config.customEnabledTools).filter(
+                ([k]) => k !== 'edit_current_doc' && k !== 'edit_current_board'
+              )
             )
           : config.customEnabledTools;
 
@@ -1146,6 +1184,7 @@ export function createGrueneratorModelAdapter(
             selectionText?: string | null;
           }
         | undefined;
+      let injectedCurrentBoard: CurrentBoard | undefined;
       if (config.threadId) {
         const provider = contextProviders.get(config.threadId);
         if (provider) {
@@ -1161,6 +1200,7 @@ export function createGrueneratorModelAdapter(
                 selectionText: cd.selectionText ?? null,
               };
             }
+            if (ctx.currentBoard) injectedCurrentBoard = ctx.currentBoard;
             const parts: string[] = [];
             if (ctx.selectionText) parts.push(`## Auswahl:\n${ctx.selectionText}`);
             if (ctx.attachmentContext) parts.push(ctx.attachmentContext);
@@ -1247,6 +1287,7 @@ export function createGrueneratorModelAdapter(
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,
+          currentBoard: injectedCurrentBoard,
           attachmentContext: injectedAttachmentContext,
           defaultNotebookId: config.selectedNotebookId || undefined,
           customSystemPrompt: config.customSystemPrompt || undefined,
@@ -1276,6 +1317,7 @@ export function createGrueneratorModelAdapter(
           documentChatIds: mergedDocChatIds.length > 0 ? mergedDocChatIds : undefined,
           documentChatMode: hasDocumentChat || mergedDocChatIds.length > 0 || undefined,
           currentDocument: injectedCurrentDocument,
+          currentBoard: injectedCurrentBoard,
           attachmentContext: injectedAttachmentContext,
           defaultNotebookId: config.selectedNotebookId || undefined,
           customSystemPrompt: config.customSystemPrompt || undefined,

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 
+import type { CurrentBoard } from '@gruenerator/contracts';
+
 export interface ChatConfig {
   /** Custom fetch function. Default: fetch with credentials:'include' */
   fetch?: (url: string, options?: RequestInit) => Promise<Response>;
@@ -81,6 +83,11 @@ export interface ChatRequestContext {
     markdown: string;
     selectionText?: string | null;
   };
+  /**
+   * The live board the user is editing — primary context when chat is embedded
+   * in the boards editor. Serialized from the live Yjs board each request.
+   */
+  currentBoard?: CurrentBoard;
 }
 
 export type ChatRequestContextProvider = () => Promise<ChatRequestContext> | ChatRequestContext;
@@ -103,6 +110,21 @@ export interface DocumentEditTriggerPayload {
 
 export type DocumentEditTriggerHandler = (
   payload: DocumentEditTriggerPayload
+) => void | Promise<void>;
+
+/**
+ * Handler the boards-editor surface registers to receive `trigger_board_action`
+ * SSE events. The handler calls POST /api/boards/:id/ai to plan operations and
+ * applies them to the live Yjs board via the client-side executor.
+ */
+export interface BoardActionTriggerPayload {
+  targetBoardId: string;
+  userPrompt: string;
+  referenceContent?: string;
+}
+
+export type BoardActionTriggerHandler = (
+  payload: BoardActionTriggerPayload
 ) => void | Promise<void>;
 
 interface ChatConfigStore extends ResolvedChatConfig {
@@ -131,6 +153,10 @@ interface ChatConfigStore extends ResolvedChatConfig {
     threadId: string,
     handler: DocumentEditTriggerHandler
   ) => () => void;
+  /** boardId → board-action dispatcher (boards editor surface only). */
+  boardActionHandlers: Map<string, BoardActionTriggerHandler>;
+  /** Register a board-action handler for a board. Returns the unregister function. */
+  registerBoardActionHandler: (boardId: string, handler: BoardActionTriggerHandler) => () => void;
 }
 
 const DEFAULT_ENDPOINTS: ResolvedEndpoints = {
@@ -188,6 +214,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
   wolkeConnectUrl: undefined,
   contextProviders: new Map(),
   documentEditHandlers: new Map(),
+  boardActionHandlers: new Map(),
 
   configure: (config?: ChatConfig) => {
     set({
@@ -224,6 +251,19 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
       if (after.get(threadId) === handler) {
         after.delete(threadId);
         set({ documentEditHandlers: after });
+      }
+    };
+  },
+
+  registerBoardActionHandler: (boardId, handler) => {
+    const next = new Map(get().boardActionHandlers);
+    next.set(boardId, handler);
+    set({ boardActionHandlers: next });
+    return () => {
+      const after = new Map(get().boardActionHandlers);
+      if (after.get(boardId) === handler) {
+        after.delete(boardId);
+        set({ boardActionHandlers: after });
       }
     };
   },

--- a/packages/contracts/src/contracts/boardsContract.ts
+++ b/packages/contracts/src/contracts/boardsContract.ts
@@ -20,7 +20,10 @@ import {
   boardDocumentSchema,
   boardStateResponseSchema,
   assignableMembersResponseSchema,
+  boardAiRequestBodySchema,
+  boardAiResponseSchema,
 } from '../schemas/boards.js';
+import { chatThreadResponseSchema } from '../schemas/docs.js';
 
 const c = initContract();
 
@@ -143,6 +146,46 @@ export const boardsContract = c.router(
         500: boardErrorResponseSchema,
       },
       summary: 'Create a new board',
+    },
+
+    /**
+     * GET /api/boards/:id/chat-thread
+     * Resolve (idempotently create) the shared chat thread for a board. One
+     * thread per board, shared across collaborators — reuses chat_threads.doc_id
+     * since a board is a collaborative_documents row.
+     */
+    getChatThread: {
+      method: 'GET',
+      path: '/api/boards/:id/chat-thread',
+      pathParams: z.object({ id: z.string() }),
+      responses: {
+        200: chatThreadResponseSchema,
+        401: boardErrorResponseSchema,
+        403: boardErrorResponseSchema,
+        404: boardErrorResponseSchema,
+        500: boardErrorResponseSchema,
+      },
+      summary: 'Resolve the shared chat thread for a board',
+    },
+
+    /**
+     * POST /api/boards/:id/ai
+     * Turn a natural-language board-edit request into a list of board operations
+     * (applied client-side by the boards assistant). Returns operations as JSON.
+     */
+    ai: {
+      method: 'POST',
+      path: '/api/boards/:id/ai',
+      pathParams: z.object({ id: z.string() }),
+      body: boardAiRequestBodySchema,
+      responses: {
+        200: boardAiResponseSchema,
+        401: boardErrorResponseSchema,
+        403: boardErrorResponseSchema,
+        404: boardErrorResponseSchema,
+        500: boardErrorResponseSchema,
+      },
+      summary: 'Generate board operations from a natural-language request',
     },
 
     /**

--- a/packages/contracts/src/schemas/boards.ts
+++ b/packages/contracts/src/schemas/boards.ts
@@ -211,3 +211,111 @@ export type FieldSetting = z.infer<typeof fieldSettingSchema>;
 export type BoardView = z.infer<typeof boardViewSchema>;
 export type BoardState = z.infer<typeof boardStateResponseSchema>;
 export type AssignableMember = z.infer<typeof assignableMemberSchema>;
+
+// ── Board AI assistant ────────────────────────────────────────────────────────
+// Powers the in-board chat assistant (FAB on the boards page). The frontend
+// serializes the LIVE Yjs board state into `currentBoardSchema` and sends it as
+// chat-request context; when the user asks for a change, the chat backend emits
+// the `trigger_board_action` SSE event and the frontend calls POST
+// /api/boards/:id/ai to turn the request into a list of board operations, which
+// a client-side executor applies to the live board.
+
+/**
+ * Compact projection of the live board sent to the chat/AI backend as context.
+ * `assignableMembers` flattens AssignableMember to the id+name the model needs
+ * to resolve human assignee names.
+ */
+export const currentBoardSchema = z.object({
+  id: z.string(),
+  title: z.string().nullish(),
+  boardType: boardTypeSchema,
+  fields: z.array(boardFieldSchema),
+  rows: z.array(boardRowSchema),
+  views: z.array(boardViewSchema),
+  statusOptions: z.array(selectOptionSchema),
+  assignableMembers: z.array(z.object({ id: z.string(), name: z.string() })),
+});
+
+export type CurrentBoard = z.infer<typeof currentBoardSchema>;
+
+/**
+ * Payload of the `trigger_board_action` SSE event. The chat backend (ChatGraph,
+ * intent=edit_current_board) forwards a board-edit instruction to the boards
+ * assistant surface, which calls POST /api/boards/:id/ai and applies the result.
+ * Mirrors triggerDocEditSchema. `.optional()` (not `.nullish()`): SSE payload
+ * field simply omitted when empty, not a request body.
+ */
+export const triggerBoardActionSchema = z.object({
+  targetBoardId: z.string(),
+  userPrompt: z.string(),
+  referenceContent: z.string().optional(),
+});
+
+export type TriggerBoardAction = z.infer<typeof triggerBoardActionSchema>;
+
+/**
+ * A single board mutation the AI proposes. Discriminated union on `type` — per
+ * the repo's type-safety rule, never destructure; switch on `op.type`. The model
+ * emits HUMAN names for status/assignee/labels; the client executor resolves them
+ * to ids against the live board (auto-creating missing status columns / labels).
+ */
+export const boardOperationSchema = z.discriminatedUnion('type', [
+  // ── tasks ──
+  z.object({
+    type: z.literal('create_task'),
+    title: z.string(),
+    status: z.string().nullish(),
+    description: z.string().nullish(),
+    dueDate: z.string().nullish(),
+    assignee: z.string().nullish(),
+    labels: z.array(z.string()).nullish(),
+  }),
+  z.object({
+    type: z.literal('update_task'),
+    taskId: z.string(),
+    title: z.string().nullish(),
+    description: z.string().nullish(),
+    dueDate: z.string().nullish(),
+  }),
+  z.object({ type: z.literal('delete_task'), taskId: z.string() }),
+  z.object({ type: z.literal('move_task'), taskId: z.string(), status: z.string() }),
+  // ── comments ──
+  z.object({ type: z.literal('add_comment'), taskId: z.string(), text: z.string() }),
+  // ── people / fields on a task ──
+  z.object({ type: z.literal('set_assignee'), taskId: z.string(), assignee: z.string().nullish() }),
+  z.object({ type: z.literal('set_labels'), taskId: z.string(), labels: z.array(z.string()) }),
+  z.object({ type: z.literal('set_due_date'), taskId: z.string(), dueDate: z.string().nullish() }),
+  // ── columns (status options) ──
+  z.object({ type: z.literal('add_column'), name: z.string(), color: z.string().nullish() }),
+  z.object({ type: z.literal('rename_column'), columnId: z.string(), name: z.string() }),
+  // ── schema ──
+  z.object({
+    type: z.literal('add_field'),
+    name: z.string(),
+    fieldType: fieldTypeSchema,
+    options: z.array(z.string()).nullish(),
+  }),
+  z.object({ type: z.literal('add_view'), name: z.string(), layout: viewLayoutSchema }),
+]);
+
+export type BoardOperation = z.infer<typeof boardOperationSchema>;
+
+export const boardOperationsSchema = z.array(boardOperationSchema).min(1).max(50);
+
+/**
+ * Request body for POST /api/boards/:id/ai. The model turns `userPrompt` (with
+ * the live `board` as context) into a list of operations.
+ */
+export const boardAiRequestBodySchema = z.object({
+  userPrompt: z.string(),
+  board: currentBoardSchema,
+  referenceContent: z.string().nullish(),
+});
+
+export type BoardAiRequestBody = z.infer<typeof boardAiRequestBodySchema>;
+
+export const boardAiResponseSchema = z.object({
+  operations: z.array(boardOperationSchema),
+});
+
+export type BoardAiResponse = z.infer<typeof boardAiResponseSchema>;

--- a/packages/contracts/src/schemas/chatGraph.ts
+++ b/packages/contracts/src/schemas/chatGraph.ts
@@ -9,6 +9,8 @@
  */
 import { z } from 'zod';
 
+import { currentBoardSchema } from './boards.js';
+
 // ── Shared sub-schemas ──────────────────────────────────────────────────────
 
 /**
@@ -74,6 +76,9 @@ export const chatStreamBodySchema = z.object({
       selectionText: z.string().nullish(),
     })
     .nullish(),
+  // Live board state injected by the boards assistant surface (FAB on the boards
+  // page). Primary context for board Q&A and the edit_current_board intent.
+  currentBoard: currentBoardSchema.nullish(),
   customSystemPrompt: z.string().nullish(),
   roleName: z.string().nullish(),
   // Seed for a brand-new thread: the generated text (Antrag, PM, Social) the

--- a/packages/shared/src/agents/personaAgents.ts
+++ b/packages/shared/src/agents/personaAgents.ts
@@ -402,4 +402,58 @@ Beispielausgabe:
       },
     ],
   },
+  {
+    iconKey: 'layout-grid',
+    identifier: 'gruenerator-boards-editor',
+    title: 'Board-Assistent',
+    description:
+      'Verwaltet das aktuelle Board: erstellt und ändert Aufgaben, verschiebt Karten, kommentiert, pflegt Spalten, Felder und Ansichten — und beantwortet Fragen zum Board.',
+    systemRole:
+      'Du bist ein*e KI-Assistent*in, eingebettet im Board/Planer von {{partyName}}.\n\nDer*die Nutzer*in arbeitet an einem konkreten Board. Das **AKTUELLE BOARD** ist dein Kontext: Spalten sind Status-Werte, Karten sind Aufgaben, dazu kommen Felder (z.B. Zuständig, Labels, Fälligkeit) und Ansichten (Kanban, Tabelle, Kalender, Gantt).\n\n## ARBEITSWEISE\n\n1. **Frage zum Board?** (z.B. „Was ist überfällig?", „Wie viele Aufgaben sind erledigt?", „Fass das Board zusammen") → Antworte direkt aus dem Boardkontext. Erfinde nichts.\n\n2. **Änderungswunsch?** (Aufgabe erstellen, ändern, verschieben oder löschen; kommentieren; Zuständige, Labels oder Fälligkeit setzen; Spalte, Feld oder Ansicht anlegen) → Die Plattform setzt deine Aktion direkt um. Schlage nichts nur als Text vor. Du darfst mehrere Änderungen in einem Schritt kombinieren. Löschungen werden vor der Ausführung kurz bestätigt.\n\n3. **Externe Quellen?** (Bundespartei-Position, aktuelles Ereignis, Faktencheck, erwähntes Notebook) → Nutze search_documents oder web_search.\n\n## SPRACHE\n\n- Klar, knapp, hilfsbereit\n- Du-Form, Genderstern (*innen, *in)\n- Keine ausschweifenden Einleitungen — komm zur Sache. Bestätige Aktionen kurz („Aufgabe erstellt.", „In Erledigt verschoben.").',
+    plugins: ['gruenerator-mcp'],
+    avatar: '📋',
+    backgroundColor: '#316049',
+    tags: ['Boards', 'Planer', 'Aufgaben', 'Projektmanagement'],
+    model: 'mistral-medium-3.5',
+    defaultModel: 'mistral-medium-3.5',
+    provider: 'mistral',
+    params: { max_tokens: 4000, temperature: 0.4 },
+    openingMessage:
+      'Ich helfe dir beim Board — Aufgaben erstellen, verschieben, kommentieren, oder Fragen zum Stand. Was brauchst du?',
+    welcomeQuestion: 'Womit kann ich beim Board helfen?',
+    openingQuestions: [
+      'Erstelle eine Aufgabe „Plakate bestellen" in To-Do',
+      'Was ist überfällig?',
+      'Verschiebe alle erledigten Aufgaben nach Erledigt',
+      'Fass das Board kurz zusammen',
+    ],
+    locale: 'de-DE',
+    audience: 'all',
+    author: 'Grünerator',
+    enabledTools: [
+      'search_documents',
+      'web_search',
+      'research',
+      'summarize',
+      'edit_current_board',
+      'search_examples',
+      'recall_memory',
+      'save_memory',
+    ],
+    fewShotExamples: [
+      {
+        input: 'Erstelle drei Aufgaben für die Wahlkampf-Vorbereitung in To-Do',
+        output: 'Ich lege die Aufgaben direkt in der Spalte To-Do an.',
+        reasoning:
+          'Änderungs-Intent → edit_current_board, mehrere create_task-Operationen in einem Schritt.',
+      },
+      {
+        input: 'Was ist gerade überfällig?',
+        output:
+          'Aktuell überfällig sind: [Aufgaben mit Fälligkeit vor heute aus dem Boardkontext].',
+        reasoning:
+          'Board-bezogene Frage → direkt aus dem Boardkontext beantworten, keine Mutation.',
+      },
+    ],
+  },
 ] as const satisfies readonly Agent[];

--- a/packages/ui/src/components/fab.tsx
+++ b/packages/ui/src/components/fab.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import { cn } from '../lib/cn';
+
+export interface FabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Icon element rendered inside the button (sized to ~22px via CSS). */
+  icon: React.ReactNode;
+  /** Highlighted state, e.g. when the panel the FAB toggles is open. */
+  active?: boolean;
+  /** Renders a small status dot in the top-right corner (e.g. disconnected). */
+  showDot?: boolean;
+}
+
+/**
+ * Floating action button — a fixed, glass-morphism circular button anchored at
+ * the bottom-right. Shared across surfaces (docs editor, boards) so the toggle
+ * affordance stays consistent. Position defaults to `fixed bottom-6 right-6`;
+ * override via `className` if a surface needs a different anchor.
+ */
+export const Fab = React.forwardRef<HTMLButtonElement, FabProps>(function Fab(
+  { icon, active = false, showDot = false, className, ...props },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={cn(
+        'fixed bottom-6 right-6 w-12 h-12 rounded-full flex items-center justify-center',
+        'bg-white/85 dark:bg-grey-900/85 backdrop-blur-xl border border-black/8 dark:border-white/10',
+        'shadow-lg cursor-pointer z-[150] transition-all hover:bg-white/95 dark:hover:bg-grey-800/95',
+        'hover:shadow-xl active:scale-95',
+        '[&_svg]:w-[22px] [&_svg]:h-[22px] [&_svg]:text-grey-700 dark:[&_svg]:text-grey-300',
+        active &&
+          'bg-secondary-100 dark:bg-secondary-600/25 border-secondary-400 dark:border-secondary-600 z-[250] [&_svg]:text-secondary-700 dark:[&_svg]:text-secondary-400',
+        className
+      )}
+      {...props}
+    >
+      {icon}
+      {showDot && (
+        <span className="absolute top-0.5 right-0.5 w-2 h-2 rounded-full border-[1.5px] border-white/90 dark:border-grey-900/90 bg-red-500" />
+      )}
+    </button>
+  );
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -46,6 +46,7 @@ export {
 } from './components/avatar';
 export { Badge, badgeVariants } from './components/badge';
 export { Button, buttonVariants } from './components/button';
+export { Fab, type FabProps } from './components/fab';
 export { Checkbox } from './components/checkbox';
 export {
   Command,


### PR DESCRIPTION
## Context

The Boards feature is a Kanban/Planner backed by a live Yjs document. Until now there was **no in-board assistant** — the only AI path was a limited, server-side `modify_board` intent (add-only, `@board` mention in global `/chat`).

This adds a **floating action button** at the bottom-right of the boards page that opens a chat assistant — mirroring the proven **docs assistant** — covering the **full board surface** and answering read-only questions.

## What it does

- **Full editing:** create/edit/delete/move tasks, add comments, set assignees/labels/due dates, add/rename columns, add fields, create views — and **batch several in one request**.
- **Q&A:** "what's overdue?", "summarize the board" (read-only, from board context).
- **Live + collaborative:** edits apply to the live client Yjs board via a client-side executor reusing `useBoardState` mutations + the board-comments API, so they're instant and sync to other collaborators.
- **Safe deletes:** destructive deletes require **one quick confirm**; everything else applies immediately (Yjs-undoable).

## How it works

Mirrors `edit_current_doc` → `trigger_doc_edit` → client handler:

1. The board page injects the live board as `currentBoard` chat context (also surfaced as `boardContext` for Q&A).
2. A new **`edit_current_board`** classifier intent emits a **`trigger_board_action`** SSE event.
3. The boards surface handles it: calls **`POST /api/boards/:id/ai`** (plans a typed `BoardOperation[]` via tool-calling; server re-enforces write access), then a **client-side executor** applies the ops to the live board (resolving human status/assignee/label names to ids, auto-creating missing columns/labels).

Routing note: `currentBoard.id` is deliberately **not** mirrored into `boardIds`, so the legacy server-side `modify_board` path cannot fire on the board page; `@board` in global `/chat` is unchanged.

Thread reuse: a board is a `collaborative_documents` row, so the shared chat thread reuses `chat_threads.doc_id` via the existing `ensureDocChatThread`.

## Key changes

- **Contracts:** `currentBoardSchema`, `boardOperationSchema` (discriminated union), `triggerBoardActionSchema`, `boardAiRequestBodySchema`; `boards.getChatThread` + `boards.ai` endpoints; `currentBoard` on the chat-stream schema.
- **Backend:** `edit_current_board` intent + SSE wiring (classifier, ChatGraph, router, sseHelpers); `boardAiService` (tool-calling op planner); `boardAccess` now returns `createdBy`/`canEdit`.
- **packages/chat:** `boardActionHandlers` registry + `currentBoard` context injection + `trigger_board_action` SSE handling.
- **packages/shared:** new `gruenerator-boards-editor` agent.
- **packages/ui:** extracted a reusable **`Fab`** component (per request).
- **apps/web:** `BoardAssistant{Panel,Provider,Chat}`, `BoardAiEditToggle`, `applyBoardOperations` executor, `serializeBoardContext`, FAB + drawer in `BoardPage`.

## Verification

- `pnpm typecheck` green across contracts, ui, chat, shared, api, web; prettier + eslint clean (0 errors).
- Manual: open a kanban board → FAB → create/move/update/assignee+labels/delete(confirm)/comment/columns+fields+views/batch/Q&A; multi-tab live sync; backend logs show `edit_current_board` for edits and `direct`/`search` for Q&A (no legacy `modify_board`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)