### PR TITLE
feat(vorlagen): Community-Vorlagen kennzeichnen und Urheber:in anzeigen

### DIFF
--- a/apps/api/routes/auth/templates/templateGallery.ts
+++ b/apps/api/routes/auth/templates/templateGallery.ts
@@ -443,6 +443,9 @@ router.get(
           metadata: item.metadata || {},
           created_at: item.created_at,
           updated_at: item.updated_at,
+          // User-submitted templates: lets the gallery mark them as community
+          // contributions and surface their author, distinct from official ones.
+          source: 'community' as const,
         };
       });
 
@@ -518,8 +521,14 @@ router.get(
         }
       }
 
-      // System templates first, then system files, then approved user vorlagen
-      const vorlagen = [...filteredSystemTemplates, ...filteredSystemFiles, ...userVorlagen];
+      // System templates first, then system files, then approved user vorlagen.
+      // Tag the official entries so the frontend can distinguish them from
+      // community contributions.
+      const vorlagen = [
+        ...filteredSystemTemplates.map((t) => ({ ...t, source: 'system' as const })),
+        ...filteredSystemFiles.map((f) => ({ ...f, source: 'system' as const })),
+        ...userVorlagen,
+      ];
 
       res.json({ success: true, vorlagen });
     } catch (error) {

--- a/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
+++ b/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
@@ -1,4 +1,4 @@
-import { Button, Popover, PopoverContent, PopoverTrigger } from '@gruenerator/ui';
+import { Badge, Button, Popover, PopoverContent, PopoverTrigger } from '@gruenerator/ui';
 import { useQuery } from '@tanstack/react-query';
 import { memo, useCallback, useEffect, useMemo, useState, type JSX } from 'react';
 import { HiPlus } from 'react-icons/hi';
@@ -30,6 +30,7 @@ interface VorlageItem {
   external_url?: string;
   content_data?: { originalUrl?: string };
   metadata?: { author_name?: string; contact_email?: string };
+  source?: 'community' | 'system';
   [key: string]: unknown;
 }
 
@@ -250,6 +251,11 @@ const VorlagenGallery = memo((): JSX.Element => {
             const templateType = item.template_type
               ? item.template_type.charAt(0).toUpperCase() + item.template_type.slice(1)
               : '';
+            // Community = user-submitted. Fall back to author presence so cards are
+            // still marked correctly if the API hasn't been redeployed with `source`.
+            const isCommunity = item.source
+              ? item.source === 'community'
+              : Boolean(item.metadata?.author_name);
             return (
               <IndexCard
                 key={String(item.id)}
@@ -263,6 +269,13 @@ const VorlagenGallery = memo((): JSX.Element => {
                 className="vorlagen-card"
                 authorName={item.metadata?.author_name || ''}
                 authorEmail={item.metadata?.contact_email || ''}
+                badge={
+                  isCommunity ? (
+                    <Badge className="border-transparent bg-primary-600 text-white shadow-sm">
+                      Community
+                    </Badge>
+                  ) : null
+                }
               />
             );
           })

--- a/apps/web/src/components/common/IndexCard.tsx
+++ b/apps/web/src/components/common/IndexCard.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@gruenerator/ui';
 import { memo, type JSX, type ReactNode } from 'react';
+import { HiOutlineUser } from 'react-icons/hi2';
 import { IoHeart, IoHeartOutline } from 'react-icons/io5';
 
 import { cn } from '@/utils/cn';
@@ -18,6 +19,8 @@ export interface IndexCardProps {
   imageAlt?: string;
   authorName?: string;
   authorEmail?: string;
+  /** Small pill rendered as an overlay (over the thumbnail) / inline marker, e.g. "Community". */
+  badge?: ReactNode;
   onTagClick?: (tag: string) => void;
   isLiked?: boolean;
   onLikeToggle?: (id: string) => void;
@@ -38,6 +41,7 @@ const IndexCard = memo(
     imageAlt = '',
     authorName,
     authorEmail,
+    badge,
     onTagClick,
     isLiked = false,
     onLikeToggle,
@@ -90,6 +94,7 @@ const IndexCard = memo(
               loading="lazy"
               className="w-full h-full object-contain"
             />
+            {badge != null && <div className="absolute top-sm left-sm">{badge}</div>}
             {onLikeToggle != null && (
               <button
                 type="button"
@@ -108,6 +113,7 @@ const IndexCard = memo(
         )}
 
         <div className={cn('flex flex-col flex-1', hasImage && 'p-lg max-md:p-md')}>
+          {badge != null && !hasImage && <div className="mb-sm">{badge}</div>}
           <div className="flex justify-between items-start mb-md">
             <h3 className="text-xl max-md:text-lg font-semibold text-foreground-heading m-0 flex-1">
               {title}
@@ -145,18 +151,22 @@ const IndexCard = memo(
           )}
 
           {authorName && (
-            <div className="text-sm text-foreground mb-sm">
-              {authorEmail ? (
-                <a
-                  href={`mailto:${authorEmail}`}
-                  className="text-primary-600 no-underline hover:underline"
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                >
-                  {authorName}
-                </a>
-              ) : (
-                <span>{authorName}</span>
-              )}
+            <div className="flex items-center gap-xs text-sm text-grey-600 dark:text-grey-400 mb-sm">
+              <HiOutlineUser className="size-4 shrink-0" aria-hidden="true" />
+              <span>
+                von{' '}
+                {authorEmail ? (
+                  <a
+                    href={`mailto:${authorEmail}`}
+                    className="font-medium text-primary-600 no-underline hover:underline"
+                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  >
+                    {authorName}
+                  </a>
+                ) : (
+                  <span className="font-medium text-foreground">{authorName}</span>
+                )}
+              </span>
             </div>
           )}
 
@@ -180,7 +190,8 @@ const IndexCard = memo(
       prev.id === next.id &&
       prev.variant === next.variant &&
       prev.authorName === next.authorName &&
-      prev.authorEmail === next.authorEmail
+      prev.authorEmail === next.authorEmail &&
+      prev.badge === next.badge
     );
   }
 );


### PR DESCRIPTION
## Was

In der [Vorlagen-Datenbank](https://beta.gruenerator.eu/vorlagen) sind von Nutzer:innen eingereichte Vorlagen jetzt **direkt erkennbar** und es ist sichtbar, **von wem** eine Vorlage stammt.

## Änderungen

- **API** (`/auth/vorlagen`): Jeder Eintrag bekommt ein `source`-Feld — `'community'` für eingereichte `user_templates`, `'system'` für die mitgelieferten offiziellen System-Vorlagen/-Dateien.
- **VorlagenGallery**: Community-Vorlagen erhalten ein **„Community"-Badge** (oben links auf der Karte). Fallback auf das Vorhandensein eines Autors, falls die API noch ohne `source` läuft.
- **IndexCard**: neuer generischer `badge`-Slot (Overlay über dem Thumbnail) und prominentere Urheber-Anzeige — **„von &lt;Name&gt;"** mit Personen-Icon; bei hinterlegter E-Mail als `mailto:`-Link.

## Test

- `pnpm --filter @gruenerator/web typecheck` ✅
- `pnpm --filter @gruenerator/api typecheck` ✅
- ESLint/Prettier der geänderten Dateien sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)