### PR TITLE
ci(content-sync): stündliche Admin-Digest-Mails abstellen, LV-Mails behalten

### DIFF
--- a/.github/workflows/aggregate-test.yml
+++ b/.github/workflows/aggregate-test.yml
@@ -28,4 +28,8 @@ jobs:
       - run: pnpm install --frozen-lockfile --filter @gruenerator/api...
 
       - name: Run aggregate test
+        # Resolve @gruenerator/* workspace imports to TS source (the package
+        # exports' `development` condition) so the unbuilt dist/ isn't required.
+        env:
+          NODE_OPTIONS: --conditions=development
         run: npx tsx apps/api/test-aggregate.ts

--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -221,8 +221,11 @@ jobs:
 
       - name: Aggregate summaries
         # pnpm --filter sets cwd to apps/api/, so pass an absolute path.
-        run: pnpm --filter @gruenerator/api run sync:aggregate -- --dir "${{ github.workspace }}/summaries/"
+        # Admin digest goes out on the daily run (and manual dispatch) only.
+        # Hourly runs are LV-only and the per-LV jobs send their own mails, so
+        # suppress the admin digest there to avoid hourly inbox spam.
         env:
+          SCHEDULE: ${{ github.event.schedule }}
           BREVO_SMTP_HOST: ${{ secrets.BREVO_SMTP_HOST }}
           BREVO_SMTP_PORT: ${{ secrets.BREVO_SMTP_PORT }}
           BREVO_SMTP_USER: ${{ secrets.BREVO_SMTP_USER }}
@@ -230,6 +233,15 @@ jobs:
           EMAIL_FROM: ${{ vars.EMAIL_FROM || 'Grünerator <info@gruenerator.eu>' }}
           CONTENT_SYNC_EMAIL: ${{ vars.CONTENT_SYNC_EMAIL }}
           SYNC_SUMMARY_PATH: ${{ github.workspace }}/sync-summary.json
+        run: |
+          ARGS="--dir ${{ github.workspace }}/summaries/"
+          # Hourly schedule = any cron other than the daily '0 2 * * *'.
+          # Empty SCHEDULE means manual dispatch → keep the digest.
+          if [ -n "$SCHEDULE" ] && [ "$SCHEDULE" != "0 2 * * *" ]; then
+            ARGS="$ARGS --no-email"
+          fi
+          echo "Running: pnpm --filter @gruenerator/api run sync:aggregate -- $ARGS"
+          pnpm --filter @gruenerator/api run sync:aggregate -- $ARGS
 
       - name: Generate job summary
         if: always()

--- a/apps/api/aggregate-sync-summaries.ts
+++ b/apps/api/aggregate-sync-summaries.ts
@@ -14,21 +14,23 @@ import { env } from './config/env.js';
 import { sendContentSyncEmail } from './services/email/emailService.js';
 import { type SyncSummary } from './types/syncTypes.js';
 
-function parseArgs(): { dir: string } {
+function parseArgs(): { dir: string; noEmail: boolean } {
   const args = process.argv.slice(2);
   let dir = '';
+  let noEmail = false;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--dir') dir = args[++i];
+    else if (args[i] === '--no-email') noEmail = true;
   }
   if (!dir) {
-    console.error('Usage: npx tsx aggregate-sync-summaries.ts --dir <path>');
+    console.error('Usage: npx tsx aggregate-sync-summaries.ts --dir <path> [--no-email]');
     process.exit(1);
   }
-  return { dir };
+  return { dir, noEmail };
 }
 
 async function main() {
-  const { dir } = parseArgs();
+  const { dir, noEmail } = parseArgs();
 
   const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
   if (files.length === 0) {
@@ -73,7 +75,9 @@ async function main() {
   console.log(`Merged summary written to ${summaryPath}`);
 
   const emailTo = env.CONTENT_SYNC_EMAIL;
-  if (emailTo) {
+  if (noEmail) {
+    console.log('Aggregate digest: --no-email set — skipping admin email');
+  } else if (emailTo) {
     // Skip the digest when nothing of interest happened: no new/updated docs,
     // no hard errors, no job failures. Transient fetchErrors don't count —
     // flaky-site retries shouldn't spam the inbox. Mirrors the per-LV gate


### PR DESCRIPTION
## Was

Die stündlichen Content-Sync-Läufe (06–22 Uhr) verschicken bisher **zwei** Arten von Mails:

1. **Per-Landesverband** aus den `sync-lv` Jobs (`update:all --landesverband` schickt selbst eine Mail pro LV) — **die sollen bleiben.**
2. **Admin-Digest** an `CONTENT_SYNC_EMAIL` aus dem `aggregate` Job — lief stündlich *und* täglich und war stündlicher Posteingang-Lärm.

Diese PR stellt den Admin-Digest so um, dass er **nur noch beim täglichen Lauf** (`0 2 * * *`) und bei manuellem Dispatch verschickt wird, stündlich aber nicht.

## Wie

- `aggregate-sync-summaries.ts`: neues `--no-email` Flag. Die Merged-Summary wird weiterhin geschrieben → Job-Summary und Content-Stats-Schritte bleiben unverändert; nur der Mailversand wird übersprungen.
- `content-sync.yml` „Aggregate summaries"-Step: hängt `--no-email` an, wenn `github.event.schedule` gesetzt und ≠ `0 2 * * *` ist (stündlich). Leeres `SCHEDULE` = manueller Dispatch → Digest bleibt.

## Effekt

| Lauf | Per-LV-Mails | Admin-Digest |
|------|:---:|:---:|
| Stündlich (06–22) | ✅ | ❌ (vorher ✅) |
| Täglich (03:00) | ✅ | ✅ |
| Manueller Dispatch | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)