### PR TITLE
Docs/Yjs review: read-only enforcement, data-loss fixes, AI-edit hardening

### DIFF
--- a/apps/api/database/postgres/migrations/yjs_document_updates_one_row_per_doc.sql
+++ b/apps/api/database/postgres/migrations/yjs_document_updates_one_row_per_doc.sql
@@ -1,0 +1,22 @@
+-- One row per document in yjs_document_updates.
+--
+-- The hocuspocus store path writes the FULL document state (not an
+-- incremental delta) on every store tick, so historical rows are redundant
+-- copies of each other: dozens of full gzipped documents accumulate between
+-- snapshots and every connection load has to gunzip and apply all of them.
+-- Keep only the newest row per document and enforce uniqueness so writers
+-- can UPSERT the current state.
+
+DELETE FROM yjs_document_updates u
+USING (
+  SELECT DISTINCT ON (document_id) document_id, id
+  FROM yjs_document_updates
+  ORDER BY document_id, created_at DESC NULLS LAST, id DESC
+) keep
+WHERE u.document_id = keep.document_id
+  AND u.id <> keep.id;
+
+DROP INDEX IF EXISTS idx_yjs_document_updates_document_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_yjs_document_updates_document_id
+  ON yjs_document_updates(document_id);

--- a/apps/api/database/postgres/schema.sql
+++ b/apps/api/database/postgres/schema.sql
@@ -796,7 +796,8 @@ CREATE INDEX IF NOT EXISTS idx_collaborative_document_folders_parent ON collabor
 CREATE INDEX IF NOT EXISTS idx_collaborative_document_folders_created_by ON collaborative_document_folders(created_by);
 
 -- Y.js indexes
-CREATE INDEX IF NOT EXISTS idx_yjs_document_updates_document_id ON yjs_document_updates(document_id);
+-- One full-state row per document (writers UPSERT); see migration yjs_document_updates_one_row_per_doc.sql
+CREATE UNIQUE INDEX IF NOT EXISTS uq_yjs_document_updates_document_id ON yjs_document_updates(document_id);
 CREATE INDEX IF NOT EXISTS idx_yjs_document_updates_created_at ON yjs_document_updates(created_at);
 
 -- Notebook indexes

--- a/apps/api/routes/docs/aiController.ts
+++ b/apps/api/routes/docs/aiController.ts
@@ -33,6 +33,8 @@ import { createLogger } from '../../utils/logger.js';
 import { getModel, isProviderConfigured } from '../chat/agents/providers.js';
 import { type AgentConfig } from '../chat/agents/types.js';
 
+import { checkDocumentWriteAccess } from './documentAccess.js';
+
 const log = createLogger('DocsAI');
 const router = createAuthenticatedRouter();
 
@@ -73,6 +75,10 @@ Do NOT use "replace", "insert", "modify", or any other type value.
 Return ONLY the JSON tool input. No prose, no code fences, no commentary.`;
 
 export const aiRequestBodySchema = z.object({
+  // The document being edited. Auth middleware only proves *who* the caller
+  // is — this id is what lets the handler check they may *edit* the document
+  // (and ties the AI call to a doc for the telemetry log).
+  documentId: z.string().uuid(),
   messages: z.array(z.unknown()),
   toolDefinitions: z.record(z.string(), z.unknown()),
   // Optional: when the docs-chat panel forwards an edit request, the prior
@@ -104,10 +110,19 @@ const DOCS_AI_MODELS: Record<AgentConfig['provider'], string> = {
  */
 export async function handleAiRequest(req: TypedRequest<AiRequestBody>, res: Response) {
   try {
-    const { messages, toolDefinitions, referenceContent } = req.body;
+    const { documentId, messages, toolDefinitions, referenceContent } = req.body;
+
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+    if (!(await checkDocumentWriteAccess(documentId, userId))) {
+      log.warn(`[DocsAI] User ${userId} denied AI edit on document ${documentId}`);
+      return res.status(403).json({ error: 'No edit permission for this document' });
+    }
 
     log.info(
-      `[DocsAI] Request received: ${messages.length} messages, ${Object.keys(toolDefinitions).length} tools, refContentChars: ${referenceContent?.length ?? 0}`
+      `[DocsAI] Request received for doc ${documentId}: ${messages.length} messages, ${Object.keys(toolDefinitions).length} tools, refContentChars: ${referenceContent?.length ?? 0}`
     );
 
     log.info(`[DocsAI] Tool definitions received: ${Object.keys(toolDefinitions).join(', ')}`);
@@ -183,7 +198,7 @@ ${referenceContent.trim()}
       temperature: 0.3,
       onFinish: ({ toolCalls, text, finishReason, usage }) => {
         log.info(
-          `[DocsAI] Stream finished — reason: ${finishReason}, toolCalls: ${toolCalls?.length || 0}, text length: ${text?.length || 0}`
+          `[DocsAI] Stream finished for doc ${documentId} — reason: ${finishReason}, toolCalls: ${toolCalls?.length || 0}, text length: ${text?.length || 0}`
         );
         if (toolCalls?.length) {
           toolCalls.forEach((tc, i) => {

--- a/apps/api/routes/docs/documentAccess.ts
+++ b/apps/api/routes/docs/documentAccess.ts
@@ -62,6 +62,52 @@ export async function checkDocumentAccess(
   return checkGroupAccess(userId, document.id);
 }
 
+/**
+ * Write-access mirror of the Hocuspocus connection check
+ * (services/hocuspocus/src/auth.ts `canEditDocument`): owner → direct
+ * owner/editor permission → editor share link → group share with write.
+ */
+export async function checkDocumentWriteAccess(
+  documentId: string,
+  userId: string
+): Promise<boolean> {
+  const rows = (await db.query(
+    `SELECT created_by, permissions, is_public, share_mode, share_permission
+     FROM collaborative_documents
+     WHERE id = $1 AND is_deleted = false`,
+    [documentId]
+  )) as {
+    created_by: string;
+    permissions: Record<string, { level?: string } | undefined> | null;
+    is_public: boolean;
+    share_mode: string | null;
+    share_permission: string | null;
+  }[];
+
+  if (rows.length === 0) return false;
+  const doc = rows[0];
+
+  if (doc.created_by === userId) return true;
+
+  const level = doc.permissions?.[userId]?.level;
+  if (level === 'owner' || level === 'editor') return true;
+
+  const sharePermission = doc.share_permission || 'editor';
+  if ((doc.share_mode === 'authenticated' || doc.is_public) && sharePermission === 'editor') {
+    return true;
+  }
+
+  const groupAccess = (await db.query(
+    `SELECT gcs.permissions FROM group_content_shares gcs
+     INNER JOIN group_memberships gm ON gm.group_id = gcs.group_id AND gm.user_id = $1 AND gm.is_active = TRUE
+     WHERE gcs.content_type = 'collaborative_documents' AND gcs.content_id = $2
+     LIMIT 1`,
+    [userId, documentId]
+  )) as { permissions: { read?: boolean; write?: boolean } | null }[];
+
+  return groupAccess.length > 0 && groupAccess[0].permissions?.write === true;
+}
+
 export function autoGrantSharePermission(document: CollaborativeDocument, userId: string): void {
   const isLinkShared = document.share_mode === 'authenticated' || document.share_mode === 'public';
   if (

--- a/apps/api/routes/docs/snapshotController.ts
+++ b/apps/api/routes/docs/snapshotController.ts
@@ -311,7 +311,9 @@ router.post(
 
       await db.query(
         `INSERT INTO yjs_document_updates (document_id, update_data, created_at)
-         VALUES ($1, $2, CURRENT_TIMESTAMP)`,
+         VALUES ($1, $2, CURRENT_TIMESTAMP)
+         ON CONFLICT (document_id) DO UPDATE
+           SET update_data = EXCLUDED.update_data, created_at = EXCLUDED.created_at`,
         [req.params.id, compressedState]
       );
 

--- a/apps/api/services/boards/BoardService.ts
+++ b/apps/api/services/boards/BoardService.ts
@@ -1,5 +1,5 @@
 import { promisify } from 'util';
-import { gunzip } from 'zlib';
+import { gunzip, gzip } from 'zlib';
 
 import * as Y from 'yjs';
 
@@ -7,6 +7,7 @@ import { getPostgresInstance } from '../../database/services/PostgresService/Pos
 import { createLogger } from '../../utils/logger.js';
 
 const gunzipAsync = promisify(gunzip);
+const gzipAsync = promisify(gzip);
 const _log = createLogger('BoardService');
 
 const BOARDS_SUBTYPE = 'boards';
@@ -390,11 +391,15 @@ export async function addRowsToBoard(
   });
 
   const update = Y.encodeStateAsUpdate(doc);
+  const compressed = await gzipAsync(Buffer.from(update));
   const db = getPostgresInstance();
-  await db.query('INSERT INTO yjs_document_updates (document_id, data) VALUES ($1, $2)', [
-    boardId,
-    Buffer.from(update),
-  ]);
+  await db.query(
+    `INSERT INTO yjs_document_updates (document_id, update_data, created_at)
+     VALUES ($1, $2, CURRENT_TIMESTAMP)
+     ON CONFLICT (document_id) DO UPDATE
+       SET update_data = EXCLUDED.update_data, created_at = EXCLUDED.created_at`,
+    [boardId, compressed]
+  );
 
   _log.info(`Added ${rows.length} rows to board ${boardId}`);
   doc.destroy();

--- a/apps/mobile/app/(fullscreen)/doc-editor.tsx
+++ b/apps/mobile/app/(fullscreen)/doc-editor.tsx
@@ -475,6 +475,12 @@ export default function DocumentScreen() {
             }
           }}
           onAiReviewPendingChange={(p) => store.getState().setAiReviewPending(p)}
+          onAiAcceptFailed={() =>
+            Alert.alert(
+              'Änderung nicht synchronisiert',
+              'Die KI-Änderung wurde lokal übernommen, konnte aber nicht an andere Bearbeiter:innen übertragen werden. Bitte lade das Dokument neu und versuche es erneut.'
+            )
+          }
           proxyFetch={handleProxyFetch}
           wsOpen={handleWsOpen}
           wsSend={handleWsSend}

--- a/apps/mobile/components/docs/DocEditorDOM.tsx
+++ b/apps/mobile/components/docs/DocEditorDOM.tsx
@@ -242,6 +242,7 @@ interface DocEditorDOMProps {
   onDocSnapshotChange?: (markdown: string, selectionText: string) => void;
   onSlashChange?: (json: string) => void;
   onAiReviewPendingChange?: (pending: boolean) => void;
+  onAiAcceptFailed?: () => void;
   proxyFetch?: (url: string, options?: string) => Promise<string>;
   wsOpen?: (url: string, protocols?: string) => Promise<string>;
   wsSend?: (b64: string) => Promise<void>;
@@ -626,6 +627,8 @@ export default function DocEditorDOM(props: DocEditorDOMProps) {
   wsCloseRef.current = props.wsClose;
   const onAiReviewPendingChangeRef = useRef(props.onAiReviewPendingChange);
   onAiReviewPendingChangeRef.current = props.onAiReviewPendingChange;
+  const onAiAcceptFailedRef = useRef(props.onAiAcceptFailed);
+  onAiAcceptFailedRef.current = props.onAiAcceptFailed;
 
   const hasWsBridge = !!(props.wsOpen && props.wsSend && props.wsReceive && props.wsClose);
 
@@ -708,7 +711,8 @@ export default function DocEditorDOM(props: DocEditorDOMProps) {
       // NOTE: since the AI menu is never opened, the doc stays editable during
       // review (xl-ai normally locks isEditable via openAIMenuAtBlock). Accepted
       // as-is for now — no native editable-locking.
-      acceptDocumentAI(props.documentId);
+      const result = acceptDocumentAI(props.documentId);
+      if (result === 'not-broadcast') onAiAcceptFailedRef.current?.();
       onAiReviewPendingChangeRef.current?.(false);
     } else if (props.pendingAction.type === 'reject-ai') {
       rejectDocumentAI(props.documentId);

--- a/packages/collab/src/hooks/useCollaboration.ts
+++ b/packages/collab/src/hooks/useCollaboration.ts
@@ -86,7 +86,7 @@ export const useCollaboration = ({
     if (!isGuest && !userRef.current) return;
 
     let ignore = false;
-    let corruptionTimeout: ReturnType<typeof setTimeout> | null = null;
+    let idbTimeout: ReturnType<typeof setTimeout> | null = null;
     const ydoc = new Y.Doc();
 
     const markLocalLoaded = () =>
@@ -102,12 +102,28 @@ export const useCollaboration = ({
           console.info('[Collab] Local cache loaded | doc:', documentId);
           markLocalLoaded();
         });
-        corruptionTimeout = setTimeout(() => {
+        // A slow IDB open is NOT corruption — slow disks/mobile/large docs hit
+        // this regularly, and the cache may be the user's only copy while
+        // offline. On timeout just proceed without the local cache for this
+        // session (server state arrives over the websocket; IDB may still
+        // finish syncing in the background).
+        idbTimeout = setTimeout(() => {
           if (ignore || idbProvider.synced) return;
           console.warn(
-            '[Collab] IndexedDB sync timeout — clearing corrupted cache | doc:',
+            '[Collab] IndexedDB sync timeout — proceeding without local cache | doc:',
             documentId
           );
+          markLocalLoaded();
+        }, 10000);
+        idbProvider.whenSynced.then(() => {
+          if (idbTimeout) clearTimeout(idbTimeout);
+        });
+        // Only an actual IDB open error means the cache is unusable — drop it
+        // so the next visit starts clean. (whenSynced never rejects; the
+        // underlying openDB promise is `_db`.)
+        idbProvider._db.catch(() => {
+          if (ignore) return;
+          console.warn('[Collab] IndexedDB error — clearing local cache | doc:', documentId);
           idbProvider.destroy();
           idbProviderRef.current = null;
           try {
@@ -116,9 +132,6 @@ export const useCollaboration = ({
             /* best-effort */
           }
           markLocalLoaded();
-        }, 5000);
-        idbProvider.whenSynced.then(() => {
-          if (corruptionTimeout) clearTimeout(corruptionTimeout);
         });
         registerDocAccess(documentId);
       } catch (err) {
@@ -220,7 +233,7 @@ export const useCollaboration = ({
     return () => {
       console.info('[Collab] Cleanup | doc:', documentId);
       ignore = true;
-      if (corruptionTimeout) clearTimeout(corruptionTimeout);
+      if (idbTimeout) clearTimeout(idbTimeout);
       providerRef.current?.awareness?.setLocalState(null);
       providerRef.current?.destroy();
       providerRef.current = null;

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -248,6 +248,9 @@ const BlockNoteEditorInner = ({
         transport: new DefaultChatTransport({
           api: aiApiUrl,
           credentials: 'include',
+          // The backend verifies edit permission against this id before
+          // generating operations (aiController.ts).
+          body: { documentId },
           // Route through the DocsAdapter's fetch so the mobile DOM WebView reaches
           // the API via the native proxy (CORS/auth). On web this is platformFetch
           // — identical to the default — so web behavior is unchanged.
@@ -275,7 +278,7 @@ const BlockNoteEditorInner = ({
     }
 
     return exts;
-  }, [showComments, threadStore, resolveUsers, aiApiUrl, collaborationOptions]);
+  }, [showComments, threadStore, resolveUsers, aiApiUrl, documentId, collaborationOptions]);
 
   const editor = useCreateBlockNote(
     {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -82,7 +82,11 @@ export {
 } from './lib/blockNoteUtils';
 export { defaultDocumentContent } from './lib/defaultContent';
 export { invokeDocumentAI } from './lib/invokeDocumentAI';
-export { acceptDocumentAI, rejectDocumentAI } from './lib/reviewDocumentAI';
+export {
+  acceptDocumentAI,
+  rejectDocumentAI,
+  type AcceptDocumentAIResult,
+} from './lib/reviewDocumentAI';
 
 // Utils
 export { lazyWithRetry } from './utils/lazyWithRetry';

--- a/packages/docs/src/lib/reviewDocumentAI.ts
+++ b/packages/docs/src/lib/reviewDocumentAI.ts
@@ -2,11 +2,20 @@ import { useEditorStore } from '../stores/editorStore';
 import { getDocAIExtension, isDocAIForked } from './aiExtension';
 
 /**
+ * - 'merged': accepted and (as far as detectable) broadcast to collaborators
+ * - 'not-broadcast': accepted locally, but the merge never landed on the live
+ *   doc the provider syncs — collaborators will NOT see the change; callers
+ *   must surface this to the user instead of silently closing the review UI
+ * - 'no-extension': no editor/AI extension mounted for this document
+ */
+export type AcceptDocumentAIResult = 'merged' | 'not-broadcast' | 'no-extension';
+
+/**
  * Accept the pending AI suggestions for a document. Public counterpart to the
  * web AI popover's Accept button — used by the native review bar on mobile,
  * where the web popover is suppressed. `acceptChanges` self-contains cleanup
  * (it calls closeAIMenu internally) and works even though the menu was never
- * opened. Returns false if no editor/extension is mounted (defensive).
+ * opened.
  *
  * The reported bug — "I merge an AI change, I see it, but collaborators don't" —
  * is a broadcast failure: BlockNote's `acceptChanges()` merges the AI fork back
@@ -16,9 +25,9 @@ import { getDocAIExtension, isDocAIForked } from './aiExtension';
  * broadcastable update on it, and (2) force a sync so any locally-applied but
  * unsent update is pushed before the user can navigate away.
  */
-export function acceptDocumentAI(documentId: string): boolean {
+export function acceptDocumentAI(documentId: string): AcceptDocumentAIResult {
   const ext = getDocAIExtension(documentId);
-  if (!ext) return false;
+  if (!ext) return 'no-extension';
 
   const { provider, ydoc } = useEditorStore.getState().getDocContext(documentId) ?? {
     provider: null,
@@ -45,8 +54,9 @@ export function acceptDocumentAI(documentId: string): boolean {
 
   const stillForked = isDocAIForked(documentId);
   const sameDoc = provider && ydoc ? provider.document === ydoc : null;
+  const notBroadcast = Boolean(wasForked && ydoc && provider && !liveDocUpdated);
 
-  if (wasForked && ydoc && provider && !liveDocUpdated) {
+  if (notBroadcast) {
     // eslint-disable-next-line no-console
     console.error(
       '[acceptDocumentAI] merge produced no update on the live doc — accepted change will NOT sync to collaborators',
@@ -72,7 +82,7 @@ export function acceptDocumentAI(documentId: string): boolean {
     synced: provider?.synced ?? null,
   });
 
-  return true;
+  return notBroadcast ? 'not-broadcast' : 'merged';
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1753,6 +1753,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@26.1.0(canvas@3.2.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   services/mcp:
     dependencies:
@@ -35408,7 +35411,7 @@ snapshots:
       cosmiconfig: 7.1.0
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.57.1)
@@ -38794,7 +38797,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       debug: 4.4.3
       eslint: 8.57.1
@@ -38817,7 +38820,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 

--- a/services/hocuspocus/package.json
+++ b/services/hocuspocus/package.json
@@ -18,6 +18,7 @@
     "dev": "NODE_OPTIONS=--conditions=development tsx watch src/main.ts",
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -43,7 +44,8 @@
     "@types/pg": "^8.20.0",
     "eslint": "^9.39.4",
     "tsx": "^4.22.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/services/hocuspocus/src/auth.ts
+++ b/services/hocuspocus/src/auth.ts
@@ -15,6 +15,7 @@ import type {
 const log = createLogger('HocuspocusAuth');
 
 const GRANTED_BY_SHARE_LINK = 'auto:share_link';
+const SESSION_CHECK_TIMEOUT_MS = 5000;
 
 export class AuthService {
   private readonly db: DbQueryFn;
@@ -365,16 +366,23 @@ export class AuthService {
         },
       });
 
-      this.db(
-        `UPDATE collaborative_documents
-         SET permissions = COALESCE(permissions, '{}')::jsonb || $1::jsonb
-         WHERE id = $2
-           AND NOT (COALESCE(permissions, '{}')::jsonb ? $3)`,
-        [permissionEntry, documentName, userId]
-      ).catch((err: unknown) => {
+      // Awaited so a failed grant is at least visible at error level with the
+      // ids needed for follow-up: the user keeps this live session either way,
+      // but without the persisted entry they lose access on reconnect.
+      try {
+        await this.db(
+          `UPDATE collaborative_documents
+           SET permissions = COALESCE(permissions, '{}')::jsonb || $1::jsonb
+           WHERE id = $2
+             AND NOT (COALESCE(permissions, '{}')::jsonb ? $3)`,
+          [permissionEntry, documentName, userId]
+        );
+      } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
-        log.error(`[Auth] Error auto-adding user to permissions: ${error.message}`);
-      });
+        log.error(
+          `[Auth] Error auto-adding user ${userId} to permissions of ${documentName}: ${error.message}`
+        );
+      }
     }
 
     const permissionLevel = userPermission?.level;
@@ -443,6 +451,9 @@ export class AuthService {
     try {
       const response = await fetch(`${apiBase}/api/auth/v2/get-session`, {
         headers: { authorization: `Bearer ${token}` },
+        // Fail the handshake fast instead of stalling every connection for
+        // Node's default fetch timeout when the API hangs.
+        signal: AbortSignal.timeout(SESSION_CHECK_TIMEOUT_MS),
       });
 
       if (!response.ok) {
@@ -489,6 +500,7 @@ export class AuthService {
     try {
       const response = await fetch(`${apiBase}/api/auth/v2/get-session`, {
         headers: { cookie: cookieHeader },
+        signal: AbortSignal.timeout(SESSION_CHECK_TIMEOUT_MS),
       });
 
       if (!response.ok) {

--- a/services/hocuspocus/src/persistence.ts
+++ b/services/hocuspocus/src/persistence.ts
@@ -70,13 +70,13 @@ function extractAutoTitle(html: string): string | null {
  * PostgreSQL Persistence Adapter for Y.js Documents
  *
  * Stores Y.js documents in PostgreSQL using existing tables:
- * - yjs_document_updates: Incremental updates
- * - yjs_document_snapshots: Periodic snapshots for fast loading
+ * - yjs_document_updates: one full-state row per document (UPSERT on store)
+ * - yjs_document_snapshots: periodic snapshots for version history
  */
 export class PostgresPersistence {
-  private readonly UPDATE_BATCH_SIZE = 100;
   private readonly SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
   private readonly SNAPSHOT_RETENTION_DAYS = 90;
+  private readonly MAX_SNAPSHOT_SIZE_ENTRIES = 10_000;
   private readonly db: DbQueryFn;
   private lastSnapshotSizes = new Map<string, number>();
   private snapshotCounter = 0;
@@ -85,99 +85,109 @@ export class PostgresPersistence {
     this.db = db;
   }
 
-  /** Throws on DB error — callers must handle. Returns null only for genuinely new documents. */
+  /**
+   * Throws on DB error, and when stored rows exist but none of them can be
+   * decoded — serving an empty doc in that case would let the caller inject
+   * the template and the next store would overwrite the (still recoverable)
+   * real bytes in Postgres. Returns null only for genuinely new documents.
+   */
   async loadDocument(documentId: string): Promise<Uint8Array | null> {
-    const snapshotResult = await this.db(
-      `SELECT snapshot_data, version, created_at
-       FROM yjs_document_snapshots
-       WHERE document_id = $1
-       ORDER BY version DESC
-       LIMIT 1`,
-      [documentId]
-    );
+    const ydoc = new Y.Doc();
 
-    if (snapshotResult.length > 0) {
-      const snapshot = snapshotResult[0];
-      log.debug(`[Load] Found snapshot for ${documentId}, version ${snapshot.version}`);
+    // Walk snapshots newest-first until one decompresses and applies cleanly.
+    let appliedSnapshot: { version: number; created_at: unknown } | null = null;
+    let snapshotRowsSeen = 0;
+    for (let offset = 0; ; offset++) {
+      const rows = await this.db(
+        `SELECT snapshot_data, version, created_at
+         FROM yjs_document_snapshots
+         WHERE document_id = $1
+         ORDER BY version DESC
+         LIMIT 1 OFFSET $2`,
+        [documentId, offset]
+      );
+      if (rows.length === 0) break;
+      snapshotRowsSeen++;
 
-      const ydoc = new Y.Doc();
-
+      const snapshot = rows[0];
       try {
         const decompressed = await gunzipAsync(snapshot.snapshot_data as Buffer);
         Y.applyUpdate(ydoc, decompressed);
-        log.debug(`[Load] Applied snapshot (${decompressed.length} bytes)`);
-      } catch (error) {
-        log.error(`[Load] Failed to decompress/apply snapshot: ${error}`);
-      }
-
-      const updatesResult = await this.db(
-        `SELECT update_data
-         FROM yjs_document_updates
-         WHERE document_id = $1
-           AND created_at > $2
-         ORDER BY created_at ASC`,
-        [documentId, snapshot.created_at]
-      );
-
-      log.debug(`[Load] Found ${updatesResult.length} updates after snapshot`);
-
-      for (const row of updatesResult) {
-        try {
-          const decompressed = await gunzipAsync(row.update_data as Buffer);
-          Y.applyUpdate(ydoc, decompressed);
-        } catch (error) {
-          log.error(`[Load] Failed to apply update: ${error}`);
+        appliedSnapshot = snapshot as { version: number; created_at: unknown };
+        if (offset > 0) {
+          log.warn(
+            `[Load] Recovered ${documentId} from older snapshot v${appliedSnapshot.version} (${offset} newer snapshot(s) unreadable)`
+          );
         }
+        break;
+      } catch (error) {
+        log.error(
+          `[Load] Snapshot v${snapshot.version} for ${documentId} unreadable, trying older: ${error}`
+        );
       }
+    }
 
+    // Current-state rows (at most one post-migration; the ordered loop also
+    // covers pre-migration leftovers). Each row holds a full state, so a row
+    // applied on top of an older fallback snapshot self-heals the document.
+    const updatesResult = appliedSnapshot
+      ? await this.db(
+          `SELECT update_data
+           FROM yjs_document_updates
+           WHERE document_id = $1
+             AND created_at > $2
+           ORDER BY created_at ASC`,
+          [documentId, appliedSnapshot.created_at]
+        )
+      : await this.db(
+          `SELECT update_data
+           FROM yjs_document_updates
+           WHERE document_id = $1
+           ORDER BY created_at ASC`,
+          [documentId]
+        );
+
+    let appliedUpdates = 0;
+    let failedUpdates = 0;
+    for (const row of updatesResult) {
+      try {
+        const decompressed = await gunzipAsync(row.update_data as Buffer);
+        Y.applyUpdate(ydoc, decompressed);
+        appliedUpdates++;
+      } catch (error) {
+        failedUpdates++;
+        log.error(`[Load] Failed to apply update for ${documentId}: ${error}`);
+      }
+    }
+
+    if (appliedSnapshot || appliedUpdates > 0) {
       const state = Y.encodeStateAsUpdate(ydoc);
       log.info(`[Load] Document ${documentId} loaded (${state.length} bytes)`);
       return state;
     }
 
-    const updatesResult = await this.db(
-      `SELECT update_data
-       FROM yjs_document_updates
-       WHERE document_id = $1
-       ORDER BY created_at ASC`,
+    if (snapshotRowsSeen > 0 || failedUpdates > 0) {
+      throw new Error(
+        `Stored state for ${documentId} exists but is unreadable (${snapshotRowsSeen} snapshot(s), ${failedUpdates} update(s) failed to decode)`
+      );
+    }
+
+    // Third tier: API-seeded init_data. Live Yjs state takes precedence;
+    // this only fires on first connection after a server-side doc creation.
+    const initResult = await this.db(
+      'SELECT init_data FROM collaborative_documents_init WHERE document_id = $1',
       [documentId]
     );
-
-    if (updatesResult.length === 0) {
-      // Third tier: API-seeded init_data. Live Yjs state takes precedence;
-      // this only fires on first connection after a server-side doc creation.
-      const initResult = await this.db(
-        'SELECT init_data FROM collaborative_documents_init WHERE document_id = $1',
-        [documentId]
+    if (initResult.length > 0 && initResult[0].init_data) {
+      const decompressed = await gunzipAsync(initResult[0].init_data as Buffer);
+      log.info(
+        `[Load] Document ${documentId} hydrated from init_data (${decompressed.length} bytes)`
       );
-      if (initResult.length > 0 && initResult[0].init_data) {
-        const decompressed = await gunzipAsync(initResult[0].init_data as Buffer);
-        log.info(
-          `[Load] Document ${documentId} hydrated from init_data (${decompressed.length} bytes)`
-        );
-        return decompressed;
-      }
-
-      log.info(`[Load] No stored state for ${documentId}`);
-      return null;
+      return decompressed;
     }
 
-    log.debug(`[Load] Found ${updatesResult.length} total updates (no snapshot)`);
-
-    const ydoc = new Y.Doc();
-
-    for (const row of updatesResult) {
-      try {
-        const decompressed = await gunzipAsync(row.update_data as Buffer);
-        Y.applyUpdate(ydoc, decompressed);
-      } catch (error) {
-        log.error(`[Load] Failed to apply update: ${error}`);
-      }
-    }
-
-    const state = Y.encodeStateAsUpdate(ydoc);
-    log.info(`[Load] Document ${documentId} loaded (${state.length} bytes)`);
-    return state;
+    log.info(`[Load] No stored state for ${documentId}`);
+    return null;
   }
 
   async initializeWithTemplate(documentId: string, ydoc: Y.Doc): Promise<void> {
@@ -241,16 +251,19 @@ export class PostgresPersistence {
     try {
       const compressed = await gzipAsync(state);
 
+      // `state` is the full document, so a single row per document suffices —
+      // appending would pile up redundant full copies between snapshots.
       await this.db(
         `INSERT INTO yjs_document_updates (document_id, update_data, created_at)
-         VALUES ($1, $2, CURRENT_TIMESTAMP)`,
+         VALUES ($1, $2, CURRENT_TIMESTAMP)
+         ON CONFLICT (document_id) DO UPDATE
+           SET update_data = EXCLUDED.update_data, created_at = EXCLUDED.created_at`,
         [documentId, compressed]
       );
 
       log.debug(`[Store] Stored update for ${documentId} (${compressed.length} bytes compressed)`);
 
       await this.maybeCreateSnapshot(documentId, state);
-      await this.cleanupOldUpdates(documentId);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log.error(`[Store] Error storing document ${documentId}: ${err.message}`);
@@ -289,6 +302,10 @@ export class PostgresPersistence {
           [documentId, compressed, nextVersion]
         );
 
+        // Crude bound so the map can't grow with every doc ever touched.
+        if (this.lastSnapshotSizes.size >= this.MAX_SNAPSHOT_SIZE_ENTRIES) {
+          this.lastSnapshotSizes.clear();
+        }
         this.lastSnapshotSizes.set(documentId, state.length);
         log.info(`[Snapshot] Created snapshot for ${documentId}, version ${nextVersion}`);
 
@@ -323,36 +340,6 @@ export class PostgresPersistence {
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log.error(`[Cleanup] Error cleaning old snapshots: ${err.message}`);
-    }
-  }
-
-  private async cleanupOldUpdates(documentId: string): Promise<void> {
-    try {
-      const snapshotResult = await this.db(
-        `SELECT created_at
-         FROM yjs_document_snapshots
-         WHERE document_id = $1
-         ORDER BY version DESC
-         LIMIT 1`,
-        [documentId]
-      );
-
-      if (snapshotResult.length > 0) {
-        const deleteResult = await this.db(
-          `DELETE FROM yjs_document_updates
-           WHERE document_id = $1
-             AND created_at < $2
-           RETURNING id`,
-          [documentId, snapshotResult[0].created_at]
-        );
-
-        if (deleteResult.length > 0) {
-          log.debug(`[Cleanup] Deleted ${deleteResult.length} old updates for ${documentId}`);
-        }
-      }
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      log.error(`[Cleanup] Error cleaning up old updates: ${err.message}`);
     }
   }
 

--- a/services/hocuspocus/src/persistence.vitest.ts
+++ b/services/hocuspocus/src/persistence.vitest.ts
@@ -1,0 +1,120 @@
+import { gzipSync } from 'zlib';
+
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+
+import { PostgresPersistence } from './persistence.js';
+
+import type { DbQueryFn } from './types.js';
+
+const DOC_ID = '00000000-0000-0000-0000-000000000001';
+
+function encodeState(text: string): Buffer {
+  const ydoc = new Y.Doc();
+  ydoc.getMap('test').set('content', text);
+  return Buffer.from(Y.encodeStateAsUpdate(ydoc));
+}
+
+function gzippedState(text: string): Buffer {
+  return gzipSync(encodeState(text));
+}
+
+function decodeContent(state: Uint8Array): string {
+  const ydoc = new Y.Doc();
+  Y.applyUpdate(ydoc, state);
+  return ydoc.getMap('test').get('content') as string;
+}
+
+interface MockRows {
+  snapshots?: { snapshot_data: Buffer; version: number; created_at: string }[];
+  updates?: { update_data: Buffer }[];
+  init?: { init_data: Buffer }[];
+}
+
+/** Minimal DbQueryFn double dispatching on the table referenced in the SQL. */
+function mockDb(rows: MockRows): DbQueryFn {
+  return async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM yjs_document_snapshots')) {
+      const offset = (params?.[1] as number) ?? 0;
+      const row = (rows.snapshots ?? [])[offset];
+      return row ? [row as unknown as Record<string, unknown>] : [];
+    }
+    if (sql.includes('FROM yjs_document_updates')) {
+      return (rows.updates ?? []) as unknown as Record<string, unknown>[];
+    }
+    if (sql.includes('collaborative_documents_init')) {
+      return (rows.init ?? []) as unknown as Record<string, unknown>[];
+    }
+    return [];
+  };
+}
+
+describe('PostgresPersistence.loadDocument', () => {
+  it('returns null for a genuinely new document (no rows anywhere)', async () => {
+    const persistence = new PostgresPersistence(mockDb({}));
+    await expect(persistence.loadDocument(DOC_ID)).resolves.toBeNull();
+  });
+
+  it('loads the latest snapshot plus the current-state row', async () => {
+    const persistence = new PostgresPersistence(
+      mockDb({
+        snapshots: [
+          { snapshot_data: gzippedState('snapshot-v2'), version: 2, created_at: '2026-01-02' },
+        ],
+        updates: [{ update_data: gzippedState('live-state') }],
+      })
+    );
+    const state = await persistence.loadDocument(DOC_ID);
+    expect(state).not.toBeNull();
+    expect(decodeContent(state!)).toBe('live-state');
+  });
+
+  it('falls back to an older snapshot when the latest one is corrupted', async () => {
+    const persistence = new PostgresPersistence(
+      mockDb({
+        snapshots: [
+          { snapshot_data: Buffer.from('not gzip'), version: 2, created_at: '2026-01-02' },
+          { snapshot_data: gzippedState('snapshot-v1'), version: 1, created_at: '2026-01-01' },
+        ],
+      })
+    );
+    const state = await persistence.loadDocument(DOC_ID);
+    expect(state).not.toBeNull();
+    expect(decodeContent(state!)).toBe('snapshot-v1');
+  });
+
+  it('recovers from the full-state update row when all snapshots are corrupted', async () => {
+    const persistence = new PostgresPersistence(
+      mockDb({
+        snapshots: [
+          { snapshot_data: Buffer.from('not gzip'), version: 1, created_at: '2026-01-01' },
+        ],
+        updates: [{ update_data: gzippedState('live-state') }],
+      })
+    );
+    const state = await persistence.loadDocument(DOC_ID);
+    expect(state).not.toBeNull();
+    expect(decodeContent(state!)).toBe('live-state');
+  });
+
+  it('throws when stored rows exist but none are readable (never serves an empty doc)', async () => {
+    const persistence = new PostgresPersistence(
+      mockDb({
+        snapshots: [
+          { snapshot_data: Buffer.from('not gzip'), version: 1, created_at: '2026-01-01' },
+        ],
+        updates: [{ update_data: Buffer.from('also not gzip') }],
+      })
+    );
+    await expect(persistence.loadDocument(DOC_ID)).rejects.toThrow(/unreadable/);
+  });
+
+  it('hydrates from init_data when no snapshots or updates exist', async () => {
+    const persistence = new PostgresPersistence(
+      mockDb({ init: [{ init_data: gzippedState('seeded') }] })
+    );
+    const state = await persistence.loadDocument(DOC_ID);
+    expect(state).not.toBeNull();
+    expect(decodeContent(state!)).toBe('seeded');
+  });
+});

--- a/services/hocuspocus/src/server.ts
+++ b/services/hocuspocus/src/server.ts
@@ -31,7 +31,6 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
     async onAuthenticate(data) {
       try {
         const { documentName, requestHeaders, requestParameters, token } = data;
-        const connection = (data as unknown as { connection: unknown }).connection;
 
         log.info(
           `[Auth-Hook] onAuthenticate called for document: ${documentName}, hasToken: ${!!token}`
@@ -41,7 +40,6 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
           documentName,
           requestHeaders,
           requestParameters,
-          connection,
           token,
         });
 
@@ -53,6 +51,11 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
         }
 
         log.info(`[Auth] User ${authResult.userId} authenticated for document ${documentName}`);
+
+        // Server-side write enforcement: Hocuspocus only blocks incoming sync
+        // writes when connectionConfig.readOnly is set — the context flag below
+        // is informational and never consulted by the framework.
+        data.connectionConfig.readOnly = authResult.readOnly || false;
 
         return {
           user: {
@@ -163,10 +166,13 @@ export function createHocuspocusServer(config: HocuspocusConfig): Server {
       log.info(`Hocuspocus server listening on ${host}:${port}`);
       log.info('WebSocket endpoint: ws://' + host + ':' + port);
 
-      // One-time backfill: regenerate previews with fixed heading conversion
-      persistence.backfillAllPreviews().catch((err) => {
-        log.error(`[Backfill] Error during startup backfill: ${err}`);
-      });
+      // Full preview backfill loads every document from Postgres — opt-in only,
+      // for one-off repairs. Previews stay fresh via updateContentPreview on store.
+      if (process.env.HOCUSPOCUS_BACKFILL_PREVIEWS === 'true') {
+        persistence.backfillAllPreviews().catch((err) => {
+          log.error(`[Backfill] Error during startup backfill: ${err}`);
+        });
+      }
     },
 
     async onStateless(_data) {},

--- a/services/hocuspocus/src/types.ts
+++ b/services/hocuspocus/src/types.ts
@@ -18,7 +18,6 @@ export interface AuthenticationData {
   documentName: string;
   requestHeaders: Record<string, string | string[] | undefined>;
   requestParameters: URLSearchParams;
-  connection: unknown;
   token?: string;
 }
 

--- a/services/hocuspocus/tsconfig.build.json
+++ b/services/hocuspocus/tsconfig.build.json
@@ -6,5 +6,7 @@
     "noEmit": false,
     "declaration": true,
     "sourceMap": true
-  }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.vitest.ts"]
 }

--- a/services/hocuspocus/tsconfig.json
+++ b/services/hocuspocus/tsconfig.json
@@ -15,6 +15,6 @@
 
     "noEmit": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/services/hocuspocus/vitest.config.ts
+++ b/services/hocuspocus/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    // Resolve workspace packages (@gruenerator/shared) to their TS sources.
+    conditions: ['development'],
+  },
+  test: {
+    include: ['**/*.vitest.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary

Review of the collaborative docs stack (Hocuspocus, Yjs persistence, client provider) and the AI features built on it surfaced 8 verified issues, plus one bonus runtime bug. All fixed here.

### Security / correctness
1. **Read-only was never enforced server-side** — `onAuthenticate` only put `readOnly` into `context`, which Hocuspocus ignores; viewer-link guests and viewer collaborators could write to (and persist into) any document they could open. Now sets `connectionConfig.readOnly`, which gates sync writes. Awareness (chat typing, presence) is unaffected, so live chat rooms keep working for non-owners.
2. **Corrupted snapshot → silent data loss** — an unreadable latest snapshot loaded as an empty doc, triggering template injection that the next store persisted over the user's real content. `loadDocument` now falls back to older snapshots, recovers from the full-state update row, and throws (rejecting the connection) when rows exist but none decode. Covered by a new vitest suite in the hocuspocus service.
3. **AI accept merge failure was invisible** — `acceptDocumentAI` detected "merged locally but never reached collaborators" yet reported success. It now returns a result; the mobile review bar alerts on `not-broadcast`.
4. **`/api/docs/ai` had no document identity** — authenticated users could drive it for any document. The request now carries `documentId` and the handler verifies edit permission (`checkDocumentWriteAccess`, mirroring the hocuspocus connection check incl. editor share-links and group write shares).

### Performance / storage
5. **`yjs_document_updates` stored the FULL doc state per store tick** — dozens of redundant gzipped copies between snapshots, all decoded on every load. Now a single UPSERTed current-state row per document (migration dedupes and adds the unique index).
6. **`backfillAllPreviews()` fully loaded every document on every boot** — now opt-in via `HOCUSPOCUS_BACKFILL_PREVIEWS=true`.

### Reliability / UX
7. **Hocuspocus auth**: 5s timeout on session checks (a hung API stalled every handshake); share-link auto-grant is awaited so failures are visible.
8. **IndexedDB cache no longer deleted on slow sync** — the 5s "corruption" timeout destroyed the user's offline copy on slow devices; deletion is now reserved for actual IDB open errors.

### Bonus fix
`addRowsToBoard` (AI add-board-rows via chat confirm) inserted into a non-existent `data` column with uncompressed bytes — failed at runtime; now gzips and UPSERTs `update_data`.

## Deploy notes
- Migration `yjs_document_updates_one_row_per_doc.sql` must run (API startup does this) before the new hocuspocus `ON CONFLICT` writes work; both ship together and the API runs migrations on boot before hocuspocus spawns. Until then a store failure logs an error but doesn't crash; clients retry on the next store tick.
- `aiRequestBodySchema` now requires `documentId`: stale frontend bundles get a 400 on docs-AI requests until refreshed.

## Verification
- New `pnpm --filter @gruenerator/hocuspocus test` suite (6 tests) covering snapshot fallback, update-row recovery, throw-on-unreadable, init_data tier — all green.
- `pnpm typecheck` (20/20), `pnpm lint` (0 errors), hocuspocus `build`, prettier check on changed files — all green.
- Manual checks recommended on test env: viewer share link cannot edit; docs AI still streams; board AI row-add works; doc reload after editing session shows a single `yjs_document_updates` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)