### PR TITLE
Docs frontend review: rename cache sync, AI/export failure feedback, comments auth hardening

### DIFF
--- a/apps/mobile/components/docs/DocEditorDOM.tsx
+++ b/apps/mobile/components/docs/DocEditorDOM.tsx
@@ -701,9 +701,14 @@ export default function DocEditorDOM(props: DocEditorDOMProps) {
         documentId: props.documentId,
         userPrompt: prompt,
         useSelection,
-      }).then((ok) => {
-        if (ok) onAiReviewPendingChangeRef.current?.(true);
-      });
+      })
+        .then((ok) => {
+          if (ok) onAiReviewPendingChangeRef.current?.(true);
+        })
+        .catch((err) => {
+          console.error('[DocEditorDOM] AI invoke failed:', err);
+          onAiReviewPendingChangeRef.current?.(false);
+        });
     } else if (props.pendingAction.type === 'accept-ai') {
       // NOTE: since the AI menu is never opened, the doc stays editable during
       // review (xl-ai normally locks isEditable via openAIMenuAtBlock). Accepted

--- a/apps/web/src/features/docs/DocsChatProvider.tsx
+++ b/apps/web/src/features/docs/DocsChatProvider.tsx
@@ -24,8 +24,8 @@ import {
   type GrueneratorAdapterConfig,
 } from '@gruenerator/chat';
 import { chatThreadResponseSchema, type ChatThreadResponse } from '@gruenerator/contracts';
-import { getSystemAgent } from '@gruenerator/shared/agents';
 import { invokeDocumentAI, useEditorStore } from '@gruenerator/docs';
+import { getSystemAgent } from '@gruenerator/shared/agents';
 import { getContractsClient } from '@gruenerator/shared/api';
 import { loadedThreadMessagesSchema } from '@gruenerator/shared/chat';
 import { useQuery } from '@tanstack/react-query';
@@ -244,12 +244,23 @@ function DocsChatReadyHost({
     return registerDocumentEditHandler(documentId, async (payload) => {
       if (payload.targetDocumentId !== documentId) return;
       if (!aiEditEnabledRef.current) return;
-      await invokeDocumentAI({
-        documentId,
-        userPrompt: payload.userPrompt,
-        useSelection: payload.useSelection,
-        ...(payload.referenceContent ? { referenceContent: payload.referenceContent } : {}),
-      });
+      // The SSE dispatcher only console.warns on handler errors — without a
+      // toast here, the chat announces the edit and then silently nothing
+      // happens (e.g. network failure or missing edit permission).
+      try {
+        const invoked = await invokeDocumentAI({
+          documentId,
+          userPrompt: payload.userPrompt,
+          useSelection: payload.useSelection,
+          ...(payload.referenceContent ? { referenceContent: payload.referenceContent } : {}),
+        });
+        if (!invoked) throw new Error('no editor mounted for document');
+      } catch (err) {
+        console.error('[DocsChat] AI document edit failed:', err);
+        void import('sonner').then(({ toast }) =>
+          toast.error('Die KI-Bearbeitung konnte nicht gestartet werden.')
+        );
+      }
     });
   }, [documentId, registerDocumentEditHandler]);
 

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -8,6 +8,7 @@ import {
   useVersionHistoryShortcut,
   useDocsAdapter,
   createDocsApiClient,
+  useUpdateDocument,
   lazyWithRetry,
   ErrorBoundary,
   type Document,
@@ -192,6 +193,7 @@ function EditorContent() {
   }, [docData, isGuest, user]);
 
   const queryClient = useQueryClient();
+  const { mutateAsync: updateDocument } = useUpdateDocument();
 
   const handleTitleChange = useCallback(
     async (newTitle: string) => {
@@ -201,12 +203,16 @@ function EditorContent() {
         old ? { ...old, title: newTitle } : old
       );
       try {
-        await apiClient.put(`/docs/${id}`, { title: newTitle });
+        // useUpdateDocument also syncs the documents-list cache on success,
+        // so the rename shows up on the list page immediately.
+        await updateDocument({ id, updates: { title: newTitle } });
       } catch {
-        queryClient.setQueryData(activeKey, docData);
+        // Refetch the canonical state instead of writing back the closure's
+        // possibly outdated docData snapshot.
+        await queryClient.invalidateQueries({ queryKey: activeKey });
       }
     },
-    [id, apiClient, queryClient, docData]
+    [id, queryClient, updateDocument]
   );
 
   const [showShareModal, setShowShareModal] = useState(false);
@@ -327,6 +333,7 @@ function EditorContent() {
       setShowActionsMenu(false);
     } catch (error) {
       console.error('Export failed:', error);
+      void import('sonner').then(({ toast }) => toast.error('Export fehlgeschlagen'));
     }
   }, [docData, editor]);
 
@@ -351,6 +358,7 @@ function EditorContent() {
       setShowActionsMenu(false);
     } catch (error) {
       console.error('PDF export failed:', error);
+      void import('sonner').then(({ toast }) => toast.error('PDF-Export fehlgeschlagen'));
     }
   }, [docData, editor]);
 
@@ -369,6 +377,7 @@ function EditorContent() {
       setShowActionsMenu(false);
     } catch (error) {
       console.error('ODT export failed:', error);
+      void import('sonner').then(({ toast }) => toast.error('ODT-Export fehlgeschlagen'));
     }
   }, [docData, editor]);
 

--- a/packages/docs/src/components/editor/BlockNoteEditor.tsx
+++ b/packages/docs/src/components/editor/BlockNoteEditor.tsx
@@ -295,7 +295,14 @@ const BlockNoteEditorInner = ({
       collaboration: collaborationOptions,
       domAttributes: EDITOR_DOM_ATTRIBUTES,
     },
-    [collaborationOptions]
+    // `extensions` is frozen into the editor at creation — anything inside it
+    // that can change identity at runtime must appear here, or the live editor
+    // keeps the stale instance. threadStore carries the comments auth role
+    // (DefaultThreadStoreAuth), which changes when `editable` flips
+    // mid-session; recreating the editor then is safe (content lives in Yjs).
+    // Gated on showComments so surfaces without comments (mobile) never churn.
+    // aiApiUrl/documentId/resolveUsers are creation-stable by construction.
+    [collaborationOptions, showComments ? threadStore : null]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Follow-up review of the docs frontend (`apps/web/src/features/docs/` + `packages/docs/`), companion to #1201 (backend/Yjs). The frontend held up well under review — several suspected leaks turned out to be correctly guarded (editor store cleanup runs on document switch, Yjs observers are effect-scoped, list mutations maintain their caches). Five real issues fixed:

1. **Rename from the editor page didn't reach the documents list** — the title PUT bypassed `useUpdateDocument`, so the list kept the old title for up to 5 min; the error path also reverted to a stale closure snapshot. Now saves via the mutation (which syncs the list cache) and recovers by invalidating the per-document query.
2. **Chat-triggered AI edits failed silently** — `trigger_doc_edit` handler errors ended in a `console.warn`; the chat announced the edit, then nothing happened. Failures (including no editor mounted) now show an error toast.
3. **Mobile AI invoke had no `.catch`** — a rejected `invokeDocumentAI` was an unhandled promise rejection in the DOM component; now logged with the review bar kept hidden.
4. **DOCX/PDF/ODT export failures were silent** — each now shows a sonner error toast.
5. **Comments auth role frozen at editor creation (latent)** — `useCreateBlockNote` freezes `extensions`; a mid-session `editable` flip rebuilt the `YjsThreadStore` (new `DefaultThreadStoreAuth` role) but the live `CommentsExtension` kept the stale one, so comment moderation rights never updated until reload. Editor recreation is now keyed on `showComments ? threadStore : null` — fires exactly on a genuine role change on web, never on mobile (comments disabled there). The frozen-extensions invariant is documented at the deps array.

## Verification
- `pnpm typecheck` (20/20), `pnpm lint` (0 errors), prettier on changed files — all green.
- Manual checks recommended: rename a doc in the editor → list shows the new title immediately; trigger "in Dokument einfügen" from chat with the backend unreachable → error toast instead of silence.

Independent of #1201 (branched off current master); both can merge in either order — the only shared files are `DocEditorDOM.tsx`/`BlockNoteEditor.tsx` with non-overlapping hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)