### PR TITLE
fix: Reel/Subtitler bug fixes across web, API, shared and mobile

### DIFF
--- a/apps/api/routes/subtitler/processingController.ts
+++ b/apps/api/routes/subtitler/processingController.ts
@@ -160,7 +160,12 @@ router.post(
           await redisClient.set(jobKey, JSON.stringify({ status: 'error', data: error.message }), {
             EX: 86400,
           });
-        });
+        })
+        // Terminal catch: if the error handler itself fails (e.g. Redis
+        // down), the job would silently stay "processing" for 24h.
+        .catch((handlerError: unknown) =>
+          log.error('[subtitler-transcription] error handler failed:', handlerError)
+        );
 
       res.status(202).json({ success: true, status: 'processing', uploadId });
     } catch (error: unknown) {
@@ -578,9 +583,17 @@ router.post(
         projectId,
         userId,
         textOverlays: toAssTextOverlays(textOverlays),
-      }).catch((e: Error) =>
-        reportBackgroundError(e, { job: 'subtitler-export', exportToken, uploadId: uploadId || '' })
-      );
+      })
+        .catch((e: Error) =>
+          reportBackgroundError(e, {
+            job: 'subtitler-export',
+            exportToken,
+            uploadId: uploadId || '',
+          })
+        )
+        .catch((handlerError: unknown) =>
+          log.error('[subtitler-export] error handler failed:', handlerError)
+        );
     } catch (e: unknown) {
       if (!res.headersSent)
         res.status(500).json({ error: e instanceof Error ? e.message : String(e) });

--- a/apps/api/services/subtitler/__tests__/subtitleSegmentValidation.vitest.ts
+++ b/apps/api/services/subtitler/__tests__/subtitleSegmentValidation.vitest.ts
@@ -1,0 +1,85 @@
+import {
+  findActiveSegment,
+  findActiveSegmentIndex,
+  validateSubtitleSegments,
+} from '@gruenerator/shared/subtitle-editor';
+import { describe, expect, it } from 'vitest';
+
+const segment = (id: number, startTime: number, endTime: number, text = `Text ${id}`) => ({
+  id,
+  startTime,
+  endTime,
+  text,
+});
+
+describe('findActiveSegment boundary semantics', () => {
+  const segments = [segment(0, 0, 5), segment(1, 5, 10)];
+
+  it('matches exactly one segment at an adjacent boundary', () => {
+    expect(findActiveSegment(segments, 5)?.id).toBe(1);
+    expect(findActiveSegmentIndex(segments, 5)).toBe(1);
+  });
+
+  it('matches the segment containing the time', () => {
+    expect(findActiveSegment(segments, 2.5)?.id).toBe(0);
+    expect(findActiveSegment(segments, 9.99)?.id).toBe(1);
+  });
+
+  it('returns null/-1 outside all segments', () => {
+    expect(findActiveSegment(segments, 10)).toBeNull();
+    expect(findActiveSegment(segments, -1)).toBeNull();
+    expect(findActiveSegmentIndex(segments, 10)).toBe(-1);
+  });
+});
+
+describe('validateSubtitleSegments', () => {
+  it('returns no issues for a clean segment list', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 2), segment(1, 2, 4)], 10);
+    expect(result.issues).toEqual([]);
+    expect(result.allEmpty).toBe(false);
+  });
+
+  it('flags empty text and reports allEmpty when every text is blank', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 2, '  '), segment(1, 2, 4, '')]);
+    expect(result.allEmpty).toBe(true);
+    expect(result.issues.filter((i) => i.type === 'empty-text')).toHaveLength(2);
+  });
+
+  it('does not report allEmpty when at least one segment has text', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 2, ''), segment(1, 2, 4, 'Hallo')]);
+    expect(result.allEmpty).toBe(false);
+    expect(result.issues.filter((i) => i.type === 'empty-text')).toHaveLength(1);
+  });
+
+  it('flags non-positive durations and negative start times', () => {
+    const result = validateSubtitleSegments([segment(0, 3, 3), segment(1, -1, 2)]);
+    const types = result.issues.map((i) => i.type);
+    expect(types.filter((t) => t === 'invalid-times')).toHaveLength(2);
+  });
+
+  it('flags overlapping neighbours regardless of input order', () => {
+    const result = validateSubtitleSegments([segment(1, 4, 8), segment(0, 0, 5)]);
+    expect(result.issues.some((i) => i.type === 'overlap')).toBe(true);
+  });
+
+  it('does not flag back-to-back segments as overlapping', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 5), segment(1, 5, 10)]);
+    expect(result.issues.some((i) => i.type === 'overlap')).toBe(false);
+  });
+
+  it('flags segments ending past the video duration', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 12)], 10);
+    expect(result.issues.some((i) => i.type === 'exceeds-duration')).toBe(true);
+  });
+
+  it('skips the duration check when duration is unknown', () => {
+    const result = validateSubtitleSegments([segment(0, 0, 12)], null);
+    expect(result.issues.some((i) => i.type === 'exceeds-duration')).toBe(false);
+  });
+
+  it('returns allEmpty=false for an empty list', () => {
+    const result = validateSubtitleSegments([]);
+    expect(result.allEmpty).toBe(false);
+    expect(result.issues).toEqual([]);
+  });
+});

--- a/apps/api/services/subtitler/backgroundExportService.ts
+++ b/apps/api/services/subtitler/backgroundExportService.ts
@@ -212,15 +212,25 @@ export async function processVideoExportInBackground(
           command.videoFilters(videoFilters);
         }
 
+        // Throttle progress writes (ffmpeg can emit >10 events/sec) and
+        // stop them entirely once the job is finished so no stale
+        // "exporting" write can overwrite the terminal status.
+        let lastProgressWrite = 0;
+        let exportFinished = false;
+
         command
           .on('start', () => {
             log.debug('FFmpeg processing started');
           })
-          .on('progress', async (progress: { percent?: number; timemark?: string }) => {
+          .on('progress', (progress: { percent?: number; timemark?: string }) => {
             const progressPercent = progress.percent ? Math.round(progress.percent) : 0;
 
-            try {
-              await redisClient.set(
+            const now = Date.now();
+            if (exportFinished || now - lastProgressWrite < 500) return;
+            lastProgressWrite = now;
+
+            redisClient
+              .set(
                 `export:${exportToken}`,
                 JSON.stringify({
                   status: 'exporting',
@@ -228,14 +238,15 @@ export async function processVideoExportInBackground(
                   timeRemaining: progress.timemark,
                 }),
                 { EX: 60 * 60 }
+              )
+              .catch((redisError: unknown) =>
+                log.warn(
+                  `Redis progress update error: ${redisError instanceof Error ? redisError.message : String(redisError)}`
+                )
               );
-            } catch (redisError: unknown) {
-              log.warn(
-                `Redis progress update error: ${redisError instanceof Error ? redisError.message : String(redisError)}`
-              );
-            }
           })
           .on('error', async (err: Error) => {
+            exportFinished = true;
             log.error(`FFmpeg error: ${err.message}`);
             redisClient
               .set(
@@ -254,6 +265,7 @@ export async function processVideoExportInBackground(
             reject(err);
           })
           .on('end', async () => {
+            exportFinished = true;
             log.info(`FFmpeg processing complete for ${exportToken}`);
 
             if (projectId && userId) {

--- a/apps/api/services/subtitler/downloadUtils.ts
+++ b/apps/api/services/subtitler/downloadUtils.ts
@@ -348,67 +348,84 @@ async function processVideoWithSubtitles(
       log.debug(`[FFmpeg] Applied VAAPI filter chain with subtitles`);
     } else if (assFilePath) {
       const fontDir = path.dirname(tempFontPath || assFilePath);
-      command.videoFilters([`subtitles=${assFilePath}:fontsdir=${fontDir}`]);
+      command.videoFilters([hwaccel.buildSubtitlesFilter(assFilePath, fontDir)]);
       log.debug(
         `[FFmpeg] Applied ASS filter with font directory: ${assFilePath}:fontsdir=${fontDir}`
       );
     }
 
+    // ffmpeg fires progress events many times per second; unserialized
+    // Redis writes can land after the terminal del/complete write and
+    // resurrect the key as "exporting". Throttle and stop writing once
+    // the job is finished.
+    let lastProgressWrite = 0;
+    let exportFinished = false;
+
     command
       .on('start', (_cmd: string) => {
         log.debug('[FFmpeg] Processing started');
       })
-      .on('progress', async (progress: { percent?: number; timemark?: string }) => {
+      .on('progress', (progress: { percent?: number; timemark?: string }) => {
         const progressPercent = progress.percent ? Math.round(progress.percent) : 0;
         log.debug('Fortschritt:', `${progressPercent}%`);
+
+        const now = Date.now();
+        if (exportFinished || now - lastProgressWrite < 500) return;
+        lastProgressWrite = now;
 
         const progressData = {
           status: 'exporting',
           progress: progressPercent,
           timeRemaining: progress.timemark,
         };
-        try {
-          await redisClient.set(`export:${exportToken}`, JSON.stringify(progressData), {
-            EX: 60 * 60,
-          });
-        } catch (redisError: unknown) {
-          log.warn(
-            'Redis Progress Update Fehler:',
-            redisError instanceof Error ? redisError.message : redisError
+        redisClient
+          .set(`export:${exportToken}`, JSON.stringify(progressData), { EX: 60 * 60 })
+          .catch((redisError: unknown) =>
+            log.warn(
+              'Redis Progress Update Fehler:',
+              redisError instanceof Error ? redisError.message : redisError
+            )
           );
-        }
       })
       .on('error', (err: Error) => {
+        exportFinished = true;
         log.error('FFmpeg Fehler:', err);
-        redisClient
-          .del(`export:${exportToken}`)
-          .catch((delErr: unknown) =>
+
+        // Await all cleanup before rejecting so temp ASS/font files are
+        // not orphaned when the surrounding promise chain unwinds.
+        void (async () => {
+          try {
+            await redisClient.del(`export:${exportToken}`);
+          } catch (delErr: unknown) {
             log.warn(
               `[FFmpeg Error Cleanup] Failed to delete progress key export:${exportToken}`,
               delErr
-            )
-          );
-
-        if (assFilePath) {
-          assService
-            .cleanupTempFile(assFilePath)
-            .catch((cleanupErr: unknown) =>
-              log.warn('[FFmpeg Error] ASS cleanup failed:', cleanupErr)
             );
-          if (tempFontPath) {
-            fsPromises
-              .unlink(tempFontPath)
-              .catch((fontErr: unknown) =>
+          }
+
+          if (assFilePath) {
+            try {
+              await assService.cleanupTempFile(assFilePath);
+            } catch (cleanupErr: unknown) {
+              log.warn('[FFmpeg Error] ASS cleanup failed:', cleanupErr);
+            }
+            if (tempFontPath) {
+              try {
+                await fsPromises.unlink(tempFontPath);
+              } catch (fontErr: unknown) {
                 log.warn(
                   '[FFmpeg Error] Font cleanup failed:',
                   fontErr instanceof Error ? fontErr.message : fontErr
-                )
-              );
+                );
+              }
+            }
           }
-        }
-        reject(err);
+
+          reject(err);
+        })();
       })
       .on('end', async () => {
+        exportFinished = true;
         log.debug('FFmpeg Verarbeitung abgeschlossen');
 
         try {

--- a/apps/api/services/subtitler/hwaccelUtils.ts
+++ b/apps/api/services/subtitler/hwaccelUtils.ts
@@ -153,6 +153,17 @@ export function getVaapiOutputOptions(qp: number, encoder: string): string[] {
   return ['-c:v', encoder, '-qp', qp.toString(), '-profile:v', profile];
 }
 
+/**
+ * Build a `subtitles=` video filter with paths escaped for ffmpeg filter
+ * syntax (`:` is the option separator, `'` the quote char). Unescaped
+ * paths containing either character break the filter graph.
+ */
+export function buildSubtitlesFilter(assFilePath: string, fontDir: string): string {
+  const escapedAssPath = assFilePath.replace(/:/g, '\\:').replace(/'/g, "\\'");
+  const escapedFontDir = fontDir.replace(/:/g, '\\:').replace(/'/g, "\\'");
+  return `subtitles='${escapedAssPath}':fontsdir='${escapedFontDir}'`;
+}
+
 export function getSubtitleFilterChain(
   assFilePath: string | null,
   fontDir: string | null,
@@ -161,9 +172,7 @@ export function getSubtitleFilterChain(
   const cpuFilters: string[] = [];
 
   if (assFilePath && fontDir) {
-    const escapedAssPath = assFilePath.replace(/:/g, '\\:').replace(/'/g, "\\'");
-    const escapedFontDir = fontDir.replace(/:/g, '\\:').replace(/'/g, "\\'");
-    cpuFilters.push(`subtitles='${escapedAssPath}':fontsdir='${escapedFontDir}'`);
+    cpuFilters.push(buildSubtitlesFilter(assFilePath, fontDir));
   }
 
   if (scaleFilter) cpuFilters.push(scaleFilter);

--- a/apps/api/services/subtitler/hwaccelUtils.ts
+++ b/apps/api/services/subtitler/hwaccelUtils.ts
@@ -159,8 +159,11 @@ export function getVaapiOutputOptions(qp: number, encoder: string): string[] {
  * paths containing either character break the filter graph.
  */
 export function buildSubtitlesFilter(assFilePath: string, fontDir: string): string {
-  const escapedAssPath = assFilePath.replace(/:/g, '\\:').replace(/'/g, "\\'");
-  const escapedFontDir = fontDir.replace(/:/g, '\\:').replace(/'/g, "\\'");
+  // Escape backslash first so the `\:` / `\'` sequences we add below aren't re-escaped.
+  const escapeFilterPath = (p: string): string =>
+    p.replace(/\\/g, '\\\\').replace(/:/g, '\\:').replace(/'/g, "\\'");
+  const escapedAssPath = escapeFilterPath(assFilePath);
+  const escapedFontDir = escapeFilterPath(fontDir);
   return `subtitles='${escapedAssPath}':fontsdir='${escapedFontDir}'`;
 }
 

--- a/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
+++ b/apps/api/services/subtitler/manualSubtitleGeneratorService.ts
@@ -110,6 +110,13 @@ function detectPunctuation(word: string): PunctuationResult {
   };
 }
 
+// Emits the wire format "M:SS.F" with exactly ONE fractional digit
+// (tenths). All consumers parse this strictly — shared parseTimestamp
+// (packages/shared/src/subtitle-editor/subtitle-utils.ts) rejects frac > 9,
+// web parseSubtitleTime and downloadUtils' processSubtitleSegments match
+// a single \d — and deployed mobile clients ship the strict parser.
+// Widening to centiseconds requires changing all parsers first and
+// waiting out old app versions.
 function formatTime(timeInSeconds: number): string {
   const minutes = Math.floor(timeInSeconds / 60);
   const wholeSeconds = Math.floor(timeInSeconds % 60);

--- a/apps/api/services/subtitler/projectSavingService.ts
+++ b/apps/api/services/subtitler/projectSavingService.ts
@@ -80,8 +80,21 @@ async function saveSubtitledVideo(
   await fsPromises.mkdir(projectDir, { recursive: true });
 
   if (existingSubtitledPath) {
-    const oldPath = path.join(PROJECTS_DIR, existingSubtitledPath);
-    await fsPromises.unlink(oldPath).catch(() => {});
+    // Defense in depth: the path comes from the DB and is written by this
+    // service, but never unlink outside PROJECTS_DIR even if a row was
+    // tampered with.
+    const oldPath = path.resolve(PROJECTS_DIR, existingSubtitledPath);
+    if (!oldPath.startsWith(path.resolve(PROJECTS_DIR) + path.sep)) {
+      log.error(`Refusing to delete path outside projects dir: ${existingSubtitledPath}`);
+    } else {
+      await fsPromises
+        .unlink(oldPath)
+        .catch((err: unknown) =>
+          log.debug(
+            `Old subtitled video cleanup skipped: ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+    }
   }
 
   await fsPromises.copyFile(outputPath, persistentPath);

--- a/apps/mobile/app/(fullscreen)/subtitle-editor.tsx
+++ b/apps/mobile/app/(fullscreen)/subtitle-editor.tsx
@@ -1,10 +1,12 @@
 import { Ionicons } from '@react-native-vector-icons/ionicons';
 import { router, useLocalSearchParams } from 'expo-router';
+import { useEffect } from 'react';
 import { View, Pressable, StyleSheet, useColorScheme } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ErrorBoundary } from '../../components/common/ErrorBoundary';
 import { SubtitleEditorScreen } from '../../components/subtitle-editor';
+import { useSubtitleEditorStore } from '../../stores/subtitleEditorStore';
 import { lightTheme, darkTheme, colors } from '../../theme';
 
 import type { Project } from '@gruenerator/shared';
@@ -14,6 +16,14 @@ export default function FullscreenSubtitleEditor() {
   const theme = colorScheme === 'dark' ? darkTheme : lightTheme;
   const insets = useSafeAreaInsets();
   const params = useLocalSearchParams<{ projectId: string; projectData: string }>();
+
+  // Clear editor state on unmount so a later session can't observe a
+  // previous project's state if its load path skips loadProject().
+  useEffect(() => {
+    return () => {
+      useSubtitleEditorStore.getState().reset();
+    };
+  }, []);
 
   const project: Project | null = params.projectData
     ? (JSON.parse(params.projectData) as Project)

--- a/apps/mobile/hooks/useSubtitleEditor.ts
+++ b/apps/mobile/hooks/useSubtitleEditor.ts
@@ -121,18 +121,25 @@ export function useSubtitleEditor({ player, timelineRef }: UseSubtitleEditorOpti
       clearTimeout(autoSaveTimeoutRef.current);
     }
 
-    // Set new timeout for auto-save
+    // Set new timeout for auto-save. Read ALL state from the store at
+    // fire time — mixing closure-captured values with getState() reads
+    // is how a stale (e.g. temp-) projectId sneaks into the save.
     autoSaveTimeoutRef.current = setTimeout(async () => {
       try {
         const state = useSubtitleEditorStore.getState();
-        if (!state.hasUnsavedChanges || state.isSaving) {
+        if (
+          !state.hasUnsavedChanges ||
+          state.isSaving ||
+          !state.projectId ||
+          state.projectId.startsWith('temp-')
+        ) {
           return;
         }
 
         useSubtitleEditorStore.setState({ isSaving: true, error: null });
 
         const subtitlesText = formatSubtitlesToText(state.segments);
-        await updateProject(state.projectId!, {
+        await updateProject(state.projectId, {
           subtitles: subtitlesText,
           stylePreference: state.stylePreference,
           heightPreference: state.heightPreference,

--- a/apps/mobile/hooks/useSubtitleExport.ts
+++ b/apps/mobile/hooks/useSubtitleExport.ts
@@ -1,3 +1,4 @@
+import { validateSubtitleSegments } from '@gruenerator/shared';
 import { useAuthStore } from '@gruenerator/shared/stores';
 import * as Notifications from 'expo-notifications';
 import { useState, useCallback, useRef, useEffect } from 'react';
@@ -84,6 +85,22 @@ export function useSubtitleExport(saveChanges: () => Promise<boolean>) {
         error: 'Keine Untertitel zum Exportieren vorhanden',
       });
       return;
+    }
+
+    const validation = validateSubtitleSegments(segments);
+    if (validation.allEmpty) {
+      setState({
+        ...initialState,
+        status: 'error',
+        error: 'Alle Untertitel sind leer — bitte füge Text hinzu, bevor du exportierst.',
+      });
+      return;
+    }
+    if (validation.issues.length > 0) {
+      console.warn(
+        '[useSubtitleExport] Exporting despite subtitle issues:',
+        validation.issues.map((issue) => issue.message)
+      );
     }
 
     setState((prev) => ({ ...prev, status: 'exporting', progress: 0 }));

--- a/apps/mobile/stores/subtitleEditorStore.ts
+++ b/apps/mobile/stores/subtitleEditorStore.ts
@@ -150,9 +150,12 @@ export const useSubtitleEditorStore = create<SubtitleEditorStore>()((set, get) =
  * Selector for the active segment at current time
  */
 export const selectActiveSegment = (state: SubtitleEditorStore): SubtitleSegment | null => {
+  // End boundary exclusive, mirroring findActiveSegment in
+  // @gruenerator/shared — adjacent segments would otherwise both match
+  // at the exact boundary time.
   return (
     state.segments.find(
-      (segment) => state.currentTime >= segment.startTime && state.currentTime <= segment.endTime
+      (segment) => state.currentTime >= segment.startTime && state.currentTime < segment.endTime
     ) || null
   );
 };
@@ -162,7 +165,7 @@ export const selectActiveSegment = (state: SubtitleEditorStore): SubtitleSegment
  */
 export const selectActiveSegmentId = (state: SubtitleEditorStore): number | null => {
   const segment = state.segments.find(
-    (s) => state.currentTime >= s.startTime && state.currentTime <= s.endTime
+    (s) => state.currentTime >= s.startTime && state.currentTime < s.endTime
   );
   return segment?.id ?? null;
 };

--- a/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitleEditor.tsx
@@ -1,4 +1,4 @@
-import { useProjectsStore } from '@gruenerator/shared';
+import { useProjectsStore, validateSubtitleSegments } from '@gruenerator/shared';
 import { Button } from '@gruenerator/ui';
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { FaSave, FaCheck, FaDownload, FaPlay, FaPause } from 'react-icons/fa';
@@ -210,6 +210,7 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
     error: exportError,
     exportToken,
     startExport,
+    retryExport,
     resetExport,
     subscribe,
   } = exportStore;
@@ -339,8 +340,13 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
     if (!videoRef.current) return;
 
     const video = videoRef.current;
-    video.currentTime = timeInSeconds;
-    setCurrentTimeInSeconds(timeInSeconds);
+    // Segments can end past the actual video duration (transcription
+    // drift); the browser clamps silently, so clamp ourselves to keep
+    // currentTimeInSeconds in sync with the real playback position.
+    const maxTime = Number.isFinite(video.duration) ? video.duration : timeInSeconds;
+    const clampedTime = Math.min(Math.max(0, timeInSeconds), maxTime);
+    video.currentTime = clampedTime;
+    setCurrentTimeInSeconds(clampedTime);
 
     if (scrubTimeoutRef.current) {
       clearTimeout(scrubTimeoutRef.current);
@@ -404,6 +410,22 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
     if (!uploadId || !segments.length) {
       setError('Fehlende Upload-ID oder keine Untertitel zum Exportieren.');
       return;
+    }
+
+    const validation = validateSubtitleSegments(segments, videoDuration || null);
+    if (validation.allEmpty) {
+      setError('Alle Untertitel sind leer — bitte füge Text hinzu, bevor du exportierst.');
+      return;
+    }
+    if (validation.issues.length > 0) {
+      const summary = validation.issues
+        .slice(0, 5)
+        .map((issue) => issue.message)
+        .join('\n');
+      const proceed = window.confirm(
+        `Es gibt Probleme mit den Untertiteln:\n\n${summary}\n\nTrotzdem exportieren?`
+      );
+      if (!proceed) return;
     }
 
     try {
@@ -513,9 +535,22 @@ const SubtitleEditor: React.FC<SubtitleEditorProps> = ({
       {error && (
         <div className="mb-md flex items-center justify-between gap-md rounded-lg border border-red-600 bg-red-50 p-md text-red-600 dark:bg-grey-800">
           <span>{error}</span>
-          <Button variant="outline" size="sm" onClick={() => setError(null)}>
-            Schließen
-          </Button>
+          <div className="flex shrink-0 gap-xs">
+            {exportStatus === 'error' && (
+              <Button
+                size="sm"
+                onClick={() => {
+                  setError(null);
+                  void retryExport();
+                }}
+              >
+                Erneut versuchen
+              </Button>
+            )}
+            <Button variant="outline" size="sm" onClick={() => setError(null)}>
+              Schließen
+            </Button>
+          </div>
         </div>
       )}
 

--- a/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
+++ b/apps/web/src/features/subtitler/components/SubtitlerPage.tsx
@@ -303,7 +303,7 @@ const SubtitlerPage = (): React.ReactElement => {
         currentUploadRef.current = upload;
         upload.start();
       } catch (err) {
-        setError('Upload konnte nicht gestartet werden.');
+        setError(err instanceof Error ? err.message : 'Upload konnte nicht gestartet werden.');
         setIsUploading(false);
         currentUploadRef.current = null;
       }

--- a/apps/web/src/features/subtitler/utils/videoUtils.ts
+++ b/apps/web/src/features/subtitler/utils/videoUtils.ts
@@ -7,22 +7,48 @@ export interface VideoMetadata {
   [key: string]: unknown;
 }
 
+const METADATA_TIMEOUT_MS = 10000;
+
 /**
  * Extracts metadata (duration, dimensions) from a video File using a temporary video element.
+ * Rejects on undecodable files and after a timeout — without these, a corrupt
+ * upload would leave the promise pending forever.
  */
 export function getVideoMetadata(file: File): Promise<VideoMetadata> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const video = document.createElement('video');
     video.preload = 'metadata';
+    const objectUrl = URL.createObjectURL(file);
+
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      video.onloadedmetadata = null;
+      video.onerror = null;
+      video.removeAttribute('src');
+      URL.revokeObjectURL(objectUrl);
+    };
+
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Video-Metadaten konnten nicht gelesen werden (Timeout)'));
+    }, METADATA_TIMEOUT_MS);
+
     video.onloadedmetadata = () => {
-      resolve({
+      const metadata = {
         duration: video.duration,
         width: video.videoWidth,
         height: video.videoHeight,
-      });
-      URL.revokeObjectURL(video.src);
+      };
+      cleanup();
+      resolve(metadata);
     };
-    video.src = URL.createObjectURL(file);
+
+    video.onerror = () => {
+      cleanup();
+      reject(new Error('Videoformat wird nicht unterstützt oder die Datei ist beschädigt'));
+    };
+
+    video.src = objectUrl;
   });
 }
 

--- a/apps/web/src/stores/subtitlerExportStore.ts
+++ b/apps/web/src/stores/subtitlerExportStore.ts
@@ -77,7 +77,7 @@ interface SubtitlerExportStoreState {
   timeRemaining: number | null;
 
   // Internal polling state
-  pollingInterval: ReturnType<typeof setInterval> | null;
+  pollingInterval: ReturnType<typeof setTimeout> | null;
   pollingStartTime: number | null;
   retryCount: number;
   lastSuccessfulPoll: number | null;
@@ -288,15 +288,8 @@ export const useSubtitlerExportStore = create<SubtitlerExportStoreState>((set, g
           console.log(
             `[SubtitlerExportStore] Retrying polling (${newRetryCount}/${POLLING_CONFIG.MAX_RETRY_COUNT})`
           );
+          // The scheduling loop below picks up retryCount and applies backoff
           set({ retryCount: newRetryCount });
-
-          // Use exponential backoff for retries
-          const retryDelay = POLLING_CONFIG.RETRY_DELAY_BASE * Math.pow(2, newRetryCount - 1);
-          setTimeout(() => {
-            if (get().status === EXPORT_STATUS.EXPORTING) {
-              void poll();
-            }
-          }, retryDelay);
         } else {
           console.error('[SubtitlerExportStore] Max retries reached, stopping polling');
           set({
@@ -310,19 +303,33 @@ export const useSubtitlerExportStore = create<SubtitlerExportStoreState>((set, g
 
     // Calculate polling interval based on elapsed time
     const getPollingInterval = () => {
-      const elapsed = Date.now() - (state.pollingStartTime || Date.now());
+      const elapsed = Date.now() - (get().pollingStartTime || Date.now());
       return elapsed > POLLING_CONFIG.EXTENDED_TIME_THRESHOLD
         ? POLLING_CONFIG.EXTENDED_INTERVAL
         : POLLING_CONFIG.INITIAL_INTERVAL;
     };
 
-    // Start initial poll immediately
-    void poll();
+    // Self-rescheduling timeout loop: setInterval would evaluate the
+    // adaptive interval only once, and a queued tick could still fire
+    // after the export reaches a terminal state.
+    const runPoll = async () => {
+      await poll();
 
-    // Set up recurring polling with adaptive interval
-    const intervalId = setInterval(poll, getPollingInterval());
+      const currentState = get();
+      if (currentState.status !== EXPORT_STATUS.EXPORTING) {
+        return;
+      }
 
-    set({ pollingInterval: intervalId });
+      const delay =
+        currentState.retryCount > 0
+          ? POLLING_CONFIG.RETRY_DELAY_BASE * Math.pow(2, currentState.retryCount - 1)
+          : getPollingInterval();
+      set({ pollingInterval: setTimeout(() => void runPoll(), delay) });
+    };
+
+    // Schedule (not call) the first poll so pollingInterval is set
+    // synchronously and the duplicate-start guard above holds.
+    set({ pollingInterval: setTimeout(() => void runPoll(), 0) });
   },
 
   // Stop polling
@@ -330,7 +337,7 @@ export const useSubtitlerExportStore = create<SubtitlerExportStoreState>((set, g
     const state = get();
     if (state.pollingInterval) {
       console.log('[SubtitlerExportStore] Stopping progress polling');
-      clearInterval(state.pollingInterval);
+      clearTimeout(state.pollingInterval);
       set({ pollingInterval: null });
     }
   },
@@ -441,10 +448,9 @@ export const useSubtitlerExportStore = create<SubtitlerExportStoreState>((set, g
       link.click();
       document.body.removeChild(link);
 
-      // Clean up URL after delay
-      setTimeout(() => {
-        window.URL.revokeObjectURL(url);
-      }, 60000);
+      // Browsers keep a started download alive after revoke; revoking now
+      // avoids leaking the blob URL if the tab closes before a timer fires.
+      window.URL.revokeObjectURL(url);
 
       console.log(`[SubtitlerExportStore] Download triggered successfully: ${filename}`);
     } catch (error) {

--- a/packages/contracts/src/schemas/subtitler.ts
+++ b/packages/contracts/src/schemas/subtitler.ts
@@ -254,12 +254,15 @@ export const exportStartResponseSchema = z.object({
  */
 export const exportProgressSchema = z.object({
   status: z.enum(['exporting', 'complete', 'error']),
+  /** Percentage 0–100 */
   progress: z.number().nullish(),
+  /** ffmpeg timemark string ("HH:MM:SS.ss" processed so far), not an ETA */
   timeRemaining: z.union([z.string(), z.number()]).nullish(),
   message: z.string().nullish(),
   outputPath: z.string().nullish(),
   originalFilename: z.string().nullish(),
   projectId: z.string().nullish(),
+  /** Video duration in seconds */
   duration: z.number().nullish(),
   error: z.string().nullish(),
 });

--- a/packages/shared/src/subtitle-editor/index.ts
+++ b/packages/shared/src/subtitle-editor/index.ts
@@ -37,6 +37,9 @@ export {
   getNextSegment,
   getPreviousSegment,
   validateSegment,
+  validateSubtitleSegments,
   cloneSegments,
   segmentsEqual,
 } from './subtitle-utils.js';
+
+export type { SubtitleValidationIssue, SubtitleValidationResult } from './subtitle-utils.js';

--- a/packages/shared/src/subtitle-editor/subtitle-utils.ts
+++ b/packages/shared/src/subtitle-editor/subtitle-utils.ts
@@ -121,10 +121,11 @@ export function findActiveSegment(
   segments: SubtitleSegment[],
   currentTime: number
 ): SubtitleSegment | null {
+  // End boundary is exclusive: with adjacent segments (a.end === b.start)
+  // an inclusive check would match both at the exact boundary time.
   return (
-    segments.find(
-      (segment) => currentTime >= segment.startTime && currentTime <= segment.endTime
-    ) || null
+    segments.find((segment) => currentTime >= segment.startTime && currentTime < segment.endTime) ||
+    null
   );
 }
 
@@ -137,7 +138,7 @@ export function findActiveSegment(
  */
 export function findActiveSegmentIndex(segments: SubtitleSegment[], currentTime: number): number {
   return segments.findIndex(
-    (segment) => currentTime >= segment.startTime && currentTime <= segment.endTime
+    (segment) => currentTime >= segment.startTime && currentTime < segment.endTime
   );
 }
 
@@ -212,6 +213,81 @@ export function validateSegment(segment: SubtitleSegment): {
   return {
     valid: errors.length === 0,
     errors,
+  };
+}
+
+export interface SubtitleValidationIssue {
+  /** Index of the offending segment in the input array */
+  index: number;
+  type: 'empty-text' | 'invalid-times' | 'overlap' | 'exceeds-duration';
+  message: string;
+}
+
+export interface SubtitleValidationResult {
+  issues: SubtitleValidationIssue[];
+  /** True when every segment has empty/whitespace-only text */
+  allEmpty: boolean;
+}
+
+/**
+ * Validate a full segment list before export/save: empty texts,
+ * non-positive durations, overlaps between neighbours (in start order)
+ * and segments running past the video duration.
+ *
+ * @param segments - Segments to validate (id not required)
+ * @param videoDuration - Video duration in seconds, if known
+ */
+export function validateSubtitleSegments(
+  segments: ReadonlyArray<Pick<SubtitleSegment, 'startTime' | 'endTime' | 'text'>>,
+  videoDuration?: number | null
+): SubtitleValidationResult {
+  const issues: SubtitleValidationIssue[] = [];
+
+  const formatRange = (segment: Pick<SubtitleSegment, 'startTime' | 'endTime'>): string =>
+    `${formatTime(segment.startTime)}–${formatTime(segment.endTime)}`;
+
+  segments.forEach((segment, index) => {
+    if (segment.text.trim() === '') {
+      issues.push({
+        index,
+        type: 'empty-text',
+        message: `Untertitel ${index + 1} (${formatRange(segment)}) hat keinen Text.`,
+      });
+    }
+    if (segment.endTime <= segment.startTime || segment.startTime < 0) {
+      issues.push({
+        index,
+        type: 'invalid-times',
+        message: `Untertitel ${index + 1} hat ungültige Zeiten (${formatRange(segment)}).`,
+      });
+    }
+    if (videoDuration != null && videoDuration > 0 && segment.endTime > videoDuration) {
+      issues.push({
+        index,
+        type: 'exceeds-duration',
+        message: `Untertitel ${index + 1} endet nach dem Videoende (${formatRange(segment)}).`,
+      });
+    }
+  });
+
+  const byStart = segments
+    .map((segment, index) => ({ segment, index }))
+    .sort((a, b) => a.segment.startTime - b.segment.startTime);
+  for (let i = 1; i < byStart.length; i++) {
+    const prev = byStart[i - 1];
+    const curr = byStart[i];
+    if (curr.segment.startTime < prev.segment.endTime) {
+      issues.push({
+        index: curr.index,
+        type: 'overlap',
+        message: `Untertitel ${prev.index + 1} und ${curr.index + 1} überschneiden sich zeitlich.`,
+      });
+    }
+  }
+
+  return {
+    issues,
+    allEmpty: segments.length > 0 && segments.every((segment) => segment.text.trim() === ''),
   };
 }
 


### PR DESCRIPTION
## Summary

Full-stack bug-fix pass over the Reel/Subtitler feature (web `features/subtitler`, API `routes/services/subtitler`, `packages/shared` subtitle-editor, mobile reel editor), based on a frontend-to-backend code review.

### Web
- **Export polling never adapted and could tick after completion** — `setInterval(poll, getPollingInterval())` evaluated the adaptive 2s→5s interval exactly once. Replaced with a self-rescheduling timeout loop that recomputes the interval per tick, applies retry backoff, and can't fire after a terminal state (`subtitlerExportStore.ts`).
- **`getVideoMetadata` hung forever on corrupt/unsupported files** — no `onerror`, no timeout. Now rejects (10s timeout) with a German error surfaced in the upload step, and revokes the object URL on all paths (`videoUtils.ts`).
- Blob download URL is revoked right after `click()` instead of after 60s (leaked when the tab closed first).
- Timeline seeks are clamped to the video duration so UI time can't drift from playback.
- Export errors now show an **"Erneut versuchen"** button (the store already implemented `retryExport`), and segments are validated before export (all-empty blocks, overlap/invalid-time/over-duration warnings with confirm).

### API
- **ffmpeg `subtitles=` filter paths were unescaped on the CPU path** — a `:` or `'` in the ASS/font path broke the filter graph; the VAAPI path already escaped. Extracted `buildSubtitlesFilter()` in `hwaccelUtils` and reused it (`downloadUtils.ts`).
- **Progress-write race** — ffmpeg emits >10 progress events/sec; unserialized Redis writes could land after the terminal status and resurrect the key as `exporting` (frontend then polls forever). Writes are throttled to 500ms and stop once the job finishes (`backgroundExportService.ts`, `downloadUtils.ts`).
- ASS/font/Redis cleanup is awaited in the ffmpeg error handler before rejecting (temp `subtitles_*.ass` files were orphaned on error).
- Background transcription/export chains got terminal catches — if the error handler itself threw (e.g. Redis down), jobs silently stayed `processing` for 24h (`processingController.ts`).
- `projectSavingService` refuses to unlink outside `PROJECTS_DIR` even for a tampered DB row, and logs instead of swallowing unlink errors.
- Documented why subtitle timestamps stay at tenths precision: all deployed parsers (shared, web, downloadUtils) match exactly one fractional digit, so emitting centiseconds would break older mobile clients.

### Shared + mobile
- **`findActiveSegment`/`findActiveSegmentIndex` matched two segments at adjacent boundaries** (`t == a.end == b.start`) due to the inclusive end check → flicker at boundaries. End boundary is now exclusive, mirrored in the mobile store selectors.
- New `validateSubtitleSegments()` in `@gruenerator/shared/subtitle-editor` (empty text, invalid times, overlaps, exceeds-duration), used by web and mobile export paths; covered by new vitest suite.
- Mobile: auto-save reads all state from the store at fire time (stale closure-captured `projectId` risk), the editor store resets on fullscreen-editor unmount, and `exportProgressSchema` documents its units.

## Verification
- `pnpm typecheck` — 20/20 packages pass
- `pnpm lint` — 11/11 pass (warnings pre-existing)
- `pnpm --filter @gruenerator/api test` subtitler suite: 19 passed (incl. 12 new tests); the 10 failing chat/ChatGraph tests also fail on untouched master (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)