### PR TITLE
Canvas editor: real-world UX, performance, collab and mobile improvements

### DIFF
--- a/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
+++ b/apps/web/src/features/image-studio/CollabCanvasStudioPage.tsx
@@ -162,7 +162,9 @@ function CollabCanvasStudioContent() {
             onExport={handleExport}
             onCancel={handleCancel}
             collaborative={
-              collab.ydoc ? { ydoc: collab.ydoc, isSynced: collab.isSynced } : undefined
+              collab.ydoc
+                ? { ydoc: collab.ydoc, isSynced: collab.isSynced, provider: collab.provider }
+                : undefined
             }
             chromeCenter={chromeCenter}
             chromeRight={chromeRight}

--- a/packages/canvas-editor/package.json
+++ b/packages/canvas-editor/package.json
@@ -29,7 +29,8 @@
   },
   "scripts": {
     "build:css": "tailwindcss -i ./src/styles/tailwind-input.css -o ./dist/canvas-editor-bundle.css --minify",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gruenerator/collab": "workspace:*",
@@ -57,7 +58,8 @@
     "@tailwindcss/cli": "^4.3.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",

--- a/packages/canvas-editor/src/CanvasEditorRouter.tsx
+++ b/packages/canvas-editor/src/CanvasEditorRouter.tsx
@@ -130,6 +130,8 @@ export interface ControllableCanvasWrapperProps {
   collaborative?: {
     ydoc: Y.Doc;
     isSynced: boolean;
+    /** Hocuspocus provider — enables awareness features (remote selections). */
+    provider?: import('@hocuspocus/provider').HocuspocusProvider | null;
   };
   /** Host-supplied content rendered at the very left of the toolbar (in-flow). */
   chromeLeft?: React.ReactNode;

--- a/packages/canvas-editor/src/ai/curatedIllustrations.vitest.ts
+++ b/packages/canvas-editor/src/ai/curatedIllustrations.vitest.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildIllustrationCapability } from './illustrationCapability';
+
+// The curated {id, label} pairs are baked statically so the AI capability
+// module never pulls the ~280 KB undraw catalog into an eager chunk. This
+// test keeps them honest: every curated id must still resolve against the
+// real catalog, so a registry rename can't silently degrade the AI surface.
+describe('curated AI illustration ids', () => {
+  it('every curated id exists in the illustration catalog', async () => {
+    const { UNDRAW_ALL } = await import('../utils/illustrations/undrawAll');
+    const { OPENDOODLES } = await import('../utils/illustrations/opendoodles');
+    const knownIds = new Set([...UNDRAW_ALL, ...OPENDOODLES].map((def) => def.id));
+
+    for (const option of buildIllustrationCapability()) {
+      expect(knownIds.has(option.id), `unknown illustration id: ${option.id}`).toBe(true);
+    }
+  });
+});

--- a/packages/canvas-editor/src/ai/illustrationCapability.ts
+++ b/packages/canvas-editor/src/ai/illustrationCapability.ts
@@ -3,56 +3,43 @@
  *
  * The full undraw registry has 1600+ illustrations — too many to fit in an
  * LLM prompt. We expose a hand-picked subset of politically-relevant
- * illustrations, plus the lightweight Opendoodles set (33 items).
+ * illustrations, plus the lightweight Opendoodles set.
  *
  * Adding a new id here lets the AI reference it via `add-illustration`.
  * The applier (utils/illustrations/registry.createIllustration) will
  * resolve it at apply time.
  */
-import { UNDRAW_ALL } from '../utils/illustrations/undrawAll';
-
 import type { CanvasAiNamedOption } from './types';
 
 /**
  * Hand-picked Undraw illustrations relevant to political / civic content
- * for Die Grünen. Keep this list short (~20) so prompt cost stays low.
- *
- * Each id is verified against UNDRAW_ALL at build time via the helper
- * below — unknown ids are filtered out so a registry rename doesn't
- * silently degrade the AI surface.
+ * for Die Grünen, mirrored from utils/illustrations/undrawAll.ts so this
+ * module never loads the ~280 KB catalog (it must stay in a lazy chunk).
+ * A vitest (curatedIllustrations.vitest.ts) asserts every id still resolves
+ * against the catalog, so a registry rename can't silently degrade the AI
+ * surface. Keep this list short (~20) so prompt cost stays low.
  */
-const CURATED_UNDRAW_IDS = [
-  'ud-election-day',
-  'ud-environment',
-  'ud-among-nature',
-  'ud-everywhere-together',
-  'ud-design-community',
-  'ud-eating-together',
-  'ud-bright-ideas',
-  'ud-conceptual-idea',
-  'ud-electric-car',
-  'ud-electricity',
-  'ud-growth-analytics',
-  'ud-growth-curve',
-] as const;
+const CURATED_UNDRAW: CanvasAiNamedOption[] = [
+  { id: 'ud-election-day', label: 'Wahltag' },
+  { id: 'ud-environment', label: 'Umwelt' },
+  { id: 'ud-among-nature', label: 'Among Nature' },
+  { id: 'ud-everywhere-together', label: 'Everywhere Together' },
+  { id: 'ud-design-community', label: 'Design Community' },
+  { id: 'ud-eating-together', label: 'Eating Together' },
+  { id: 'ud-bright-ideas', label: 'Bright Ideas' },
+  { id: 'ud-conceptual-idea', label: 'Conceptual Idea' },
+  { id: 'ud-electric-car', label: 'Elektroauto' },
+  { id: 'ud-electricity', label: 'Electricity' },
+  { id: 'ud-growth-analytics', label: 'Growth Analytics' },
+  { id: 'ud-growth-curve', label: 'Growth Curve' },
+];
 
 /**
  * Build the AI illustration capability list. Returns a curated set of
  * `{id, label}` pairs the LLM can use for `add-illustration` operations.
  */
 export function buildIllustrationCapability(): CanvasAiNamedOption[] {
-  const undrawById = new Map(UNDRAW_ALL.map((u) => [u.id, u]));
-  const undrawCurated: CanvasAiNamedOption[] = CURATED_UNDRAW_IDS.flatMap((id) => {
-    const def = undrawById.get(id);
-    return def ? [{ id: def.id, label: def.name }] : [];
-  });
-
-  // Opendoodles is small enough to expose entirely. Lazy-imported via a
-  // dynamic require would defeat tree-shaking; instead we bake in the
-  // lightweight metadata here.
-  const opendoodles: CanvasAiNamedOption[] = OPENDOODLES_FOR_AI;
-
-  return [...undrawCurated, ...opendoodles];
+  return [...CURATED_UNDRAW, ...OPENDOODLES_FOR_AI];
 }
 
 // Hand-mirrored from utils/illustrations/opendoodles.ts so this module

--- a/packages/canvas-editor/src/canvas-editor.css
+++ b/packages/canvas-editor/src/canvas-editor.css
@@ -64,6 +64,12 @@
   overflow: visible;
 }
 
+/* Keep one-finger scrolling, but route two-finger pinch to the editor zoom
+   (useZoomGestures) instead of the browser's page zoom. */
+.canvas-editor-layout__canvas {
+  touch-action: pan-x pan-y;
+}
+
 /* ── Zoom (CSS scale) on the entire pages container ── */
 .heterogeneous-multipage__pages-container {
   transform: scale(var(--canvas-zoom, 1));

--- a/packages/canvas-editor/src/collab/useSelectionAwareness.ts
+++ b/packages/canvas-editor/src/collab/useSelectionAwareness.ts
@@ -24,6 +24,12 @@ interface AwarenessRecord {
 interface UseSelectionAwarenessOptions {
   /** Multi-page only — the local user's currently active page id. */
   activePageId?: string | null;
+  /**
+   * Whether this instance publishes the local selection. In multi-page mode
+   * every page mounts the hook on the same provider — only the active page
+   * may publish, or instances would overwrite each other.
+   */
+  publish?: boolean;
 }
 
 export function useSelectionAwareness(
@@ -31,17 +37,22 @@ export function useSelectionAwareness(
   options?: UseSelectionAwarenessOptions
 ): RemoteSelection[] {
   const localSelection = useCanvasStoreSelector((s) => s.selectedLayerIds);
+  // The config-driven editor tracks its selection in selectedElement (single id);
+  // selectedLayerIds is only populated by the layer API. Publish whichever is active.
+  const localElement = useCanvasStoreSelector((s) => s.selectedElement);
   const activePageId = options?.activePageId ?? null;
+  const publish = options?.publish ?? true;
 
   useEffect(() => {
-    if (!provider?.awareness) return;
-    provider.awareness.setLocalStateField('selectedLayerIds', localSelection);
-  }, [provider, localSelection]);
+    if (!provider?.awareness || !publish) return;
+    const published = localElement ? [localElement] : localSelection;
+    provider.awareness.setLocalStateField('selectedLayerIds', published);
+  }, [provider, localSelection, localElement, publish]);
 
   useEffect(() => {
-    if (!provider?.awareness) return;
+    if (!provider?.awareness || !publish) return;
     provider.awareness.setLocalStateField('activePageId', activePageId);
-  }, [provider, activePageId]);
+  }, [provider, activePageId, publish]);
 
   const remote = useAwarenessState<RemoteSelection[]>(
     provider,

--- a/packages/canvas-editor/src/components/CanvasEditor/index.tsx
+++ b/packages/canvas-editor/src/components/CanvasEditor/index.tsx
@@ -189,10 +189,18 @@ function CanvasEditorInner({
   }, [zoom, pagesContainerRef]);
 
   const pageCollaborativeAt = useCallback(
-    (index: number) => {
+    (index: number, pageId?: string, isActivePage?: boolean) => {
       if (!collaborative) return undefined;
       const pageYMap = getPageYMap(index);
-      return pageYMap ? { pageYMap, isSynced: collaborative.isSynced } : undefined;
+      return pageYMap
+        ? {
+            pageYMap,
+            isSynced: collaborative.isSynced,
+            provider: collaborative.provider ?? null,
+            pageId: pageId ?? null,
+            publishSelection: isActivePage ?? false,
+          }
+        : undefined;
     },
     [collaborative, getPageYMap]
   );
@@ -947,7 +955,7 @@ function CanvasEditorInner({
                 onStateChange={handlePageStateChange}
                 onToolbarStateChange={isActive ? handleToolbarStateChange : undefined}
                 mobileBridge={isActive ? mobileBridge : undefined}
-                pageCollaborative={pageCollaborativeAt(index)}
+                pageCollaborative={pageCollaborativeAt(index, page.id, isActive)}
               />
             );
           })}

--- a/packages/canvas-editor/src/components/CanvasEditor/index.tsx
+++ b/packages/canvas-editor/src/components/CanvasEditor/index.tsx
@@ -33,6 +33,7 @@ import {
   usePresentationExport,
   usePageThumbnails,
 } from '../../hooks';
+import { useZoomGestures } from '../../hooks/useZoomGestures';
 import { CanvasEditorLayout } from '../../layouts';
 import { MobileSubsectionBridgeContext } from '../../sidebar/MobileSubsectionBridgeContext';
 import { UserUploadsProvider } from '../../sidebar/UserUploadsProvider';
@@ -187,6 +188,9 @@ function CanvasEditorInner({
   useEffect(() => {
     pagesContainerRef.current?.style.setProperty('--canvas-zoom', String(zoom));
   }, [zoom, pagesContainerRef]);
+
+  // Pinch and ctrl/cmd+wheel drive the same zoom as the CanvasMetaBar buttons
+  useZoomGestures(pagesContainerRef, setZoom);
 
   const pageCollaborativeAt = useCallback(
     (index: number, pageId?: string, isActivePage?: boolean) => {

--- a/packages/canvas-editor/src/components/CanvasEditor/types.ts
+++ b/packages/canvas-editor/src/components/CanvasEditor/types.ts
@@ -27,6 +27,8 @@ export interface CanvasEditorProps {
   collaborative?: {
     ydoc: import('yjs').Doc;
     isSynced: boolean;
+    /** Hocuspocus provider — enables awareness features (remote selections). */
+    provider?: import('@hocuspocus/provider').HocuspocusProvider | null;
   };
   /** Host-supplied content rendered at the very left of the toolbar (in-flow). */
   chromeLeft?: React.ReactNode;
@@ -83,6 +85,12 @@ export interface PageWrapperProps {
   pageCollaborative?: {
     pageYMap: import('yjs').Map<unknown>;
     isSynced: boolean;
+    /** Hocuspocus provider — enables awareness features (remote selections). */
+    provider?: import('@hocuspocus/provider').HocuspocusProvider | null;
+    /** Id of this page, published to awareness so peers can filter selections per page. */
+    pageId?: string | null;
+    /** Only the active page publishes its selection to awareness. */
+    publishSelection?: boolean;
   };
   /** Forwarded ref to the wrapper div — used for IntersectionObserver tracking */
   pageRef?: React.Ref<HTMLDivElement>;

--- a/packages/canvas-editor/src/components/CanvasRenderLayer.tsx
+++ b/packages/canvas-editor/src/components/CanvasRenderLayer.tsx
@@ -14,6 +14,7 @@ import { useIsElementSelected } from '../stores/CanvasStoreProvider';
 import { getIconMapSync } from '../utils/canvasIcons';
 
 import { GenericCanvasElement } from './GenericCanvasElement';
+import { RemoteSelectionOverlay, type RemoteSelector } from './RemoteSelectionOverlay';
 
 import type { CanvasElementConfig, FullCanvasConfig, LayoutResult } from '../configs/types';
 import type { BalkenInstance, CircleBadgeInstance } from '../primitives';
@@ -148,6 +149,8 @@ interface CanvasRenderLayerProps<
   stageWidth: number;
   stageHeight: number;
   isFontAvailable?: boolean;
+  /** elementId → remote collaborator currently selecting it (collab mode only). */
+  remoteSelections?: ReadonlyMap<string, RemoteSelector>;
 }
 
 // Selectable wrapper factory: each wrapper subscribes to the store for its
@@ -193,313 +196,317 @@ function CanvasRenderLayerInner<
   stageWidth,
   stageHeight,
   isFontAvailable,
+  remoteSelections,
 }: CanvasRenderLayerProps<TState, TActions>) {
+  const renderCanvasItem = (item: CanvasItem) => {
+    // Render Config Element
+    if (item.type === 'element') {
+      const elementConfig = item.data;
+      return (
+        <GenericCanvasElement
+          key={elementConfig.id}
+          config={elementConfig}
+          state={state}
+          layout={layout}
+          onSelect={handlers.handleElementSelect}
+          onTextChange={handlers.handleTextChange}
+          onFontSizeChange={handlers.handleFontSizeChange}
+          onPositionChange={handlers.handleElementPositionChange}
+          onImageDragEnd={handlers.handleImageDragEnd}
+          onImageTransformEnd={handlers.handleImageTransformEnd}
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={setSnapLines}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+          snapTargets={getSnapTargets(elementConfig.id)}
+        />
+      );
+    }
+
+    // Render Balken
+    if (item.type === 'balken') {
+      const balken = item.data;
+      return (
+        <SelectableBalkenGroup
+          key={balken.id}
+          elementId={balken.id}
+          mode={balken.mode}
+          colorSchemeId={balken.colorSchemeId}
+          offset={balken.offset}
+          scale={balken.scale}
+          widthScale={balken.widthScale}
+          texts={balken.texts}
+          rotation={balken.rotation}
+          barOffsets={balken.barOffsets}
+          onSelect={() => handlers.handleBalkenSelect(balken.id)}
+          onTextChange={(idx, txt) => handlers.handleBalkenTextChange(balken.id, idx, txt)}
+          onDragEnd={(x, y) => handlers.handleBalkenDragEnd(balken.id, x, y)}
+          onTransformEnd={(x, y, s, r) => handlers.handleBalkenTransformEnd(balken.id, x, y, s, r)}
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
+          getSnapTargets={getSnapTargets}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+          opacity={balken.opacity ?? 1}
+        />
+      );
+    }
+
+    // Render Icon
+    if (item.type === 'icon') {
+      const iconId = item.id;
+      const iconDef = getIconMapSync()?.[iconId];
+
+      // Type-safe access to optional iconStates property
+      const stateWithOptional = state as TState & Partial<OptionalCanvasStateProperties>;
+      const iconState = stateWithOptional.iconStates?.[iconId];
+
+      const x = iconState?.x ?? stageWidth / 2;
+      const y = iconState?.y ?? stageHeight / 2;
+      const scale = iconState?.scale ?? 1;
+      const rotation = iconState?.rotation ?? 0;
+      const color = iconState?.color ?? '#000000';
+
+      if (!iconDef) return null;
+
+      return (
+        <SelectableIconPrimitive
+          key={iconId}
+          elementId={iconId}
+          id={iconId}
+          icon={iconDef.id}
+          x={x}
+          y={y}
+          scale={scale}
+          rotation={rotation}
+          color={color}
+          opacity={iconState?.opacity ?? 1}
+          onSelect={() => handlers.handleElementSelect(iconId)}
+          onDragEnd={(nx, ny) => handlers.handleIconDragEnd(iconId, nx, ny)}
+          onTransformEnd={(nx, ny, ns, nr) =>
+            handlers.handleIconTransformEnd(iconId, nx, ny, ns, nr)
+          }
+        />
+      );
+    }
+
+    // Render Shape
+    if (item.type === 'shape') {
+      const shape = item.data;
+      return (
+        <SelectableShapePrimitive
+          key={shape.id}
+          elementId={shape.id}
+          shape={shape}
+          onSelect={handlers.handleElementSelect}
+          onChange={(attrs) => handlers.handleShapeChange(shape.id, attrs)}
+          draggable={true}
+        />
+      );
+    }
+
+    // Render Frame
+    if (item.type === 'frame') {
+      const frame = item.data;
+      return (
+        <SelectableFramePrimitive
+          key={frame.id}
+          elementId={frame.id}
+          frame={frame}
+          onSelect={handlers.handleElementSelect}
+          onChange={(attrs) => handlers.handleFrameChange(frame.id, attrs)}
+          onImageUpload={handlers.handleFrameImageUpload}
+          draggable={true}
+        />
+      );
+    }
+
+    // Render Illustration
+    if (item.type === 'illustration') {
+      const ill = item.data;
+      return (
+        <SelectableIllustrationPrimitive
+          key={ill.id}
+          elementId={ill.id}
+          illustration={ill}
+          onSelect={() => handlers.handleElementSelect(ill.id)}
+          onDragEnd={(x: number, y: number) => handlers.handleIllustrationDragEnd(ill.id, x, y)}
+          onTransformEnd={(x: number, y: number, scale: number, rotation: number) =>
+            handlers.handleIllustrationTransformEnd(ill.id, x, y, scale, rotation)
+          }
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
+          getSnapTargets={getSnapTargets}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+        />
+      );
+    }
+
+    // Render Asset (decorative elements like sunflowers, arrows)
+    if (item.type === 'asset') {
+      const asset = item.data;
+      return (
+        <SelectableAssetPrimitive
+          key={asset.id}
+          elementId={asset.id}
+          asset={asset}
+          onSelect={() => handlers.handleElementSelect(asset.id)}
+          onDragEnd={(x: number, y: number) => handlers.handleAssetDragEnd(asset.id, x, y)}
+          onTransformEnd={(x: number, y: number, scale: number, rotation: number) =>
+            handlers.handleAssetTransformEnd(asset.id, x, y, scale, rotation)
+          }
+        />
+      );
+    }
+
+    // Render Circle Badge (e.g., date circles)
+    if (item.type === 'circle-badge') {
+      const badge = item.data;
+      return (
+        <SelectableCircleBadge
+          key={badge.id}
+          elementId={badge.id}
+          id={badge.id}
+          x={badge.x}
+          y={badge.y}
+          radius={badge.radius}
+          backgroundColor={badge.backgroundColor}
+          textColor={badge.textColor}
+          rotation={badge.rotation}
+          scale={badge.scale}
+          opacity={badge.opacity ?? 1}
+          textLines={badge.textLines}
+          onSelect={() => handlers.handleCircleBadgeSelect(badge.id)}
+          onDragEnd={(x, y) => handlers.handleCircleBadgeDragEnd(badge.id, x, y)}
+          onTransformEnd={(x, y, s, r) =>
+            handlers.handleCircleBadgeTransformEnd(badge.id, x, y, s, r)
+          }
+          onTextLineChange={(lineIndex, text) =>
+            handlers.handleCircleBadgeTextLineChange(badge.id, lineIndex, text)
+          }
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
+          getSnapTargets={getSnapTargets}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+        />
+      );
+    }
+
+    // Render Pill Badge (e.g., "Wusstest du?" labels)
+    if (item.type === 'pill-badge') {
+      const pill = item.data;
+      return (
+        <SelectablePillBadge
+          key={pill.id}
+          elementId={pill.id}
+          id={pill.id}
+          text={pill.text}
+          x={pill.x}
+          y={pill.y}
+          backgroundColor={pill.backgroundColor}
+          textColor={pill.textColor}
+          fontSize={pill.fontSize}
+          fontFamily={pill.fontFamily}
+          fontStyle={pill.fontStyle}
+          rotation={pill.rotation}
+          scale={pill.scale}
+          opacity={pill.opacity ?? 1}
+          paddingX={pill.paddingX}
+          paddingY={pill.paddingY}
+          cornerRadius={pill.cornerRadius}
+          onSelect={() => handlers.handlePillBadgeSelect(pill.id)}
+          onTextChange={(text) => handlers.handlePillBadgeTextChange(pill.id, text)}
+          onDragEnd={(x, y) => handlers.handlePillBadgeDragEnd(pill.id, x, y)}
+          onTransformEnd={(x, y, s, r) => handlers.handlePillBadgeTransformEnd(pill.id, x, y, s, r)}
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
+          getSnapTargets={getSnapTargets}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+          isFontAvailable={isFontAvailable}
+        />
+      );
+    }
+
+    // Render User Image
+    if (item.type === 'user-image') {
+      const userImage = item.data;
+      return (
+        <SelectableUserImagePrimitive
+          key={userImage.id}
+          elementId={userImage.id}
+          userImage={userImage}
+          onSelect={() => handlers.handleElementSelect(userImage.id)}
+          onDragEnd={(x: number, y: number) => handlers.handleUserImageDragEnd(userImage.id, x, y)}
+          onTransformEnd={(x: number, y: number, w: number, h: number, r: number) =>
+            handlers.handleUserImageTransformEnd(userImage.id, x, y, w, h, r)
+          }
+        />
+      );
+    }
+
+    // Render Additional Text
+    if (item.type === 'additional-text') {
+      const textItem = item.data;
+      if (!textItem) return null;
+      return (
+        <SelectableCanvasText
+          key={textItem.id}
+          elementId={textItem.id}
+          id={textItem.id}
+          text={textItem.text}
+          x={textItem.x}
+          y={textItem.y}
+          width={textItem.width}
+          fontSize={textItem.fontSize}
+          fontFamily={textItem.fontFamily}
+          fontStyle={textItem.fontStyle || 'normal'}
+          fill={textItem.fill}
+          align="left"
+          opacity={textItem.opacity ?? 1}
+          rotation={textItem.rotation || 0}
+          scaleX={textItem.scale || 1}
+          scaleY={textItem.scale || 1}
+          draggable={true}
+          onSelect={() => handlers.handleElementSelect(textItem.id)}
+          onTextChange={(val) => handlers.handleAdditionalTextChange(textItem.id, { text: val })}
+          onDragEnd={(x, y) => {
+            handlers.handleAdditionalTextChange(textItem.id, { x, y });
+          }}
+          onTransformEnd={(x, y, width, scaleX) => {
+            handlers.handleAdditionalTextChange(textItem.id, {
+              x,
+              y,
+              width,
+              scale: scaleX,
+            });
+          }}
+          editable={true}
+          onSnapChange={handleSnapChange}
+          onSnapLinesChange={setSnapLines}
+          snapTargets={getSnapTargets(textItem.id)}
+          stageWidth={stageWidth}
+          stageHeight={stageHeight}
+        />
+      );
+    }
+
+    return null;
+  };
+
   return (
     <>
       {sortedRenderList.map((item) => {
-        // Render Config Element
-        if (item.type === 'element') {
-          const elementConfig = item.data;
-          return (
-            <GenericCanvasElement
-              key={elementConfig.id}
-              config={elementConfig}
-              state={state}
-              layout={layout}
-              onSelect={handlers.handleElementSelect}
-              onTextChange={handlers.handleTextChange}
-              onFontSizeChange={handlers.handleFontSizeChange}
-              onPositionChange={handlers.handleElementPositionChange}
-              onImageDragEnd={handlers.handleImageDragEnd}
-              onImageTransformEnd={handlers.handleImageTransformEnd}
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={setSnapLines}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-              snapTargets={getSnapTargets(elementConfig.id)}
-            />
-          );
-        }
-
-        // Render Balken
-        if (item.type === 'balken') {
-          const balken = item.data;
-          return (
-            <SelectableBalkenGroup
-              key={balken.id}
-              elementId={balken.id}
-              mode={balken.mode}
-              colorSchemeId={balken.colorSchemeId}
-              offset={balken.offset}
-              scale={balken.scale}
-              widthScale={balken.widthScale}
-              texts={balken.texts}
-              rotation={balken.rotation}
-              barOffsets={balken.barOffsets}
-              onSelect={() => handlers.handleBalkenSelect(balken.id)}
-              onTextChange={(idx, txt) => handlers.handleBalkenTextChange(balken.id, idx, txt)}
-              onDragEnd={(x, y) => handlers.handleBalkenDragEnd(balken.id, x, y)}
-              onTransformEnd={(x, y, s, r) =>
-                handlers.handleBalkenTransformEnd(balken.id, x, y, s, r)
-              }
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
-              getSnapTargets={getSnapTargets}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-              opacity={balken.opacity ?? 1}
-            />
-          );
-        }
-
-        // Render Icon
-        if (item.type === 'icon') {
-          const iconId = item.id;
-          const iconDef = getIconMapSync()?.[iconId];
-
-          // Type-safe access to optional iconStates property
-          const stateWithOptional = state as TState & Partial<OptionalCanvasStateProperties>;
-          const iconState = stateWithOptional.iconStates?.[iconId];
-
-          const x = iconState?.x ?? stageWidth / 2;
-          const y = iconState?.y ?? stageHeight / 2;
-          const scale = iconState?.scale ?? 1;
-          const rotation = iconState?.rotation ?? 0;
-          const color = iconState?.color ?? '#000000';
-
-          if (!iconDef) return null;
-
-          return (
-            <SelectableIconPrimitive
-              key={iconId}
-              elementId={iconId}
-              id={iconId}
-              icon={iconDef.id}
-              x={x}
-              y={y}
-              scale={scale}
-              rotation={rotation}
-              color={color}
-              opacity={iconState?.opacity ?? 1}
-              onSelect={() => handlers.handleElementSelect(iconId)}
-              onDragEnd={(nx, ny) => handlers.handleIconDragEnd(iconId, nx, ny)}
-              onTransformEnd={(nx, ny, ns, nr) =>
-                handlers.handleIconTransformEnd(iconId, nx, ny, ns, nr)
-              }
-            />
-          );
-        }
-
-        // Render Shape
-        if (item.type === 'shape') {
-          const shape = item.data;
-          return (
-            <SelectableShapePrimitive
-              key={shape.id}
-              elementId={shape.id}
-              shape={shape}
-              onSelect={handlers.handleElementSelect}
-              onChange={(attrs) => handlers.handleShapeChange(shape.id, attrs)}
-              draggable={true}
-            />
-          );
-        }
-
-        // Render Frame
-        if (item.type === 'frame') {
-          const frame = item.data;
-          return (
-            <SelectableFramePrimitive
-              key={frame.id}
-              elementId={frame.id}
-              frame={frame}
-              onSelect={handlers.handleElementSelect}
-              onChange={(attrs) => handlers.handleFrameChange(frame.id, attrs)}
-              onImageUpload={handlers.handleFrameImageUpload}
-              draggable={true}
-            />
-          );
-        }
-
-        // Render Illustration
-        if (item.type === 'illustration') {
-          const ill = item.data;
-          return (
-            <SelectableIllustrationPrimitive
-              key={ill.id}
-              elementId={ill.id}
-              illustration={ill}
-              onSelect={() => handlers.handleElementSelect(ill.id)}
-              onDragEnd={(x: number, y: number) => handlers.handleIllustrationDragEnd(ill.id, x, y)}
-              onTransformEnd={(x: number, y: number, scale: number, rotation: number) =>
-                handlers.handleIllustrationTransformEnd(ill.id, x, y, scale, rotation)
-              }
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
-              getSnapTargets={getSnapTargets}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-            />
-          );
-        }
-
-        // Render Asset (decorative elements like sunflowers, arrows)
-        if (item.type === 'asset') {
-          const asset = item.data;
-          return (
-            <SelectableAssetPrimitive
-              key={asset.id}
-              elementId={asset.id}
-              asset={asset}
-              onSelect={() => handlers.handleElementSelect(asset.id)}
-              onDragEnd={(x: number, y: number) => handlers.handleAssetDragEnd(asset.id, x, y)}
-              onTransformEnd={(x: number, y: number, scale: number, rotation: number) =>
-                handlers.handleAssetTransformEnd(asset.id, x, y, scale, rotation)
-              }
-            />
-          );
-        }
-
-        // Render Circle Badge (e.g., date circles)
-        if (item.type === 'circle-badge') {
-          const badge = item.data;
-          return (
-            <SelectableCircleBadge
-              key={badge.id}
-              elementId={badge.id}
-              id={badge.id}
-              x={badge.x}
-              y={badge.y}
-              radius={badge.radius}
-              backgroundColor={badge.backgroundColor}
-              textColor={badge.textColor}
-              rotation={badge.rotation}
-              scale={badge.scale}
-              opacity={badge.opacity ?? 1}
-              textLines={badge.textLines}
-              onSelect={() => handlers.handleCircleBadgeSelect(badge.id)}
-              onDragEnd={(x, y) => handlers.handleCircleBadgeDragEnd(badge.id, x, y)}
-              onTransformEnd={(x, y, s, r) =>
-                handlers.handleCircleBadgeTransformEnd(badge.id, x, y, s, r)
-              }
-              onTextLineChange={(lineIndex, text) =>
-                handlers.handleCircleBadgeTextLineChange(badge.id, lineIndex, text)
-              }
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
-              getSnapTargets={getSnapTargets}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-            />
-          );
-        }
-
-        // Render Pill Badge (e.g., "Wusstest du?" labels)
-        if (item.type === 'pill-badge') {
-          const pill = item.data;
-          return (
-            <SelectablePillBadge
-              key={pill.id}
-              elementId={pill.id}
-              id={pill.id}
-              text={pill.text}
-              x={pill.x}
-              y={pill.y}
-              backgroundColor={pill.backgroundColor}
-              textColor={pill.textColor}
-              fontSize={pill.fontSize}
-              fontFamily={pill.fontFamily}
-              fontStyle={pill.fontStyle}
-              rotation={pill.rotation}
-              scale={pill.scale}
-              opacity={pill.opacity ?? 1}
-              paddingX={pill.paddingX}
-              paddingY={pill.paddingY}
-              cornerRadius={pill.cornerRadius}
-              onSelect={() => handlers.handlePillBadgeSelect(pill.id)}
-              onTextChange={(text) => handlers.handlePillBadgeTextChange(pill.id, text)}
-              onDragEnd={(x, y) => handlers.handlePillBadgeDragEnd(pill.id, x, y)}
-              onTransformEnd={(x, y, s, r) =>
-                handlers.handlePillBadgeTransformEnd(pill.id, x, y, s, r)
-              }
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={(lines) => setSnapLines(lines as SnapLine[])}
-              getSnapTargets={getSnapTargets}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-              isFontAvailable={isFontAvailable}
-            />
-          );
-        }
-
-        // Render User Image
-        if (item.type === 'user-image') {
-          const userImage = item.data;
-          return (
-            <SelectableUserImagePrimitive
-              key={userImage.id}
-              elementId={userImage.id}
-              userImage={userImage}
-              onSelect={() => handlers.handleElementSelect(userImage.id)}
-              onDragEnd={(x: number, y: number) =>
-                handlers.handleUserImageDragEnd(userImage.id, x, y)
-              }
-              onTransformEnd={(x: number, y: number, w: number, h: number, r: number) =>
-                handlers.handleUserImageTransformEnd(userImage.id, x, y, w, h, r)
-              }
-            />
-          );
-        }
-
-        // Render Additional Text
-        if (item.type === 'additional-text') {
-          const textItem = item.data;
-          if (!textItem) return null;
-          return (
-            <SelectableCanvasText
-              key={textItem.id}
-              elementId={textItem.id}
-              id={textItem.id}
-              text={textItem.text}
-              x={textItem.x}
-              y={textItem.y}
-              width={textItem.width}
-              fontSize={textItem.fontSize}
-              fontFamily={textItem.fontFamily}
-              fontStyle={textItem.fontStyle || 'normal'}
-              fill={textItem.fill}
-              align="left"
-              opacity={textItem.opacity ?? 1}
-              rotation={textItem.rotation || 0}
-              scaleX={textItem.scale || 1}
-              scaleY={textItem.scale || 1}
-              draggable={true}
-              onSelect={() => handlers.handleElementSelect(textItem.id)}
-              onTextChange={(val) =>
-                handlers.handleAdditionalTextChange(textItem.id, { text: val })
-              }
-              onDragEnd={(x, y) => {
-                handlers.handleAdditionalTextChange(textItem.id, { x, y });
-              }}
-              onTransformEnd={(x, y, width, scaleX) => {
-                handlers.handleAdditionalTextChange(textItem.id, {
-                  x,
-                  y,
-                  width,
-                  scale: scaleX,
-                });
-              }}
-              editable={true}
-              onSnapChange={handleSnapChange}
-              onSnapLinesChange={setSnapLines}
-              snapTargets={getSnapTargets(textItem.id)}
-              stageWidth={stageWidth}
-              stageHeight={stageHeight}
-            />
-          );
-        }
-
-        return null;
+        const remote = remoteSelections?.get(item.id) ?? null;
+        const rendered = renderCanvasItem(item);
+        if (!rendered || !remote) return rendered;
+        return (
+          <RemoteSelectionOverlay key={item.id} selector={remote}>
+            {rendered}
+          </RemoteSelectionOverlay>
+        );
       })}
     </>
   );

--- a/packages/canvas-editor/src/components/GenericCanvas.tsx
+++ b/packages/canvas-editor/src/components/GenericCanvas.tsx
@@ -18,6 +18,7 @@ import React, {
 } from 'react';
 import { Layer } from 'react-konva';
 
+import { useSelectionAwareness } from '../collab/useSelectionAwareness';
 import { useYjsCanvasBinding } from '../collab/useYjsCanvasBinding';
 import {
   CanvasStoreProvider,
@@ -43,6 +44,8 @@ import { getOptimalContainerWidth } from '../utils/viewport';
 
 import { CanvasRenderLayer } from './CanvasRenderLayer';
 import { ToolbarStateBridge } from './ToolbarStateBridge';
+
+import type { RemoteSelector } from './RemoteSelectionOverlay';
 
 import type { ToolbarBridgeState } from './ToolbarStateBridge';
 
@@ -111,6 +114,12 @@ export interface GenericCanvasProps<TState, TActions extends OptionalCanvasActio
   collaborative?: {
     pageYMap: import('yjs').Map<unknown>;
     isSynced: boolean;
+    /** Hocuspocus provider — enables awareness features (remote selections). */
+    provider?: import('@hocuspocus/provider').HocuspocusProvider | null;
+    /** Id of this page, published to awareness so peers can filter selections per page. */
+    pageId?: string | null;
+    /** Only the active page publishes its selection to awareness. */
+    publishSelection?: boolean;
   };
 }
 
@@ -380,6 +389,26 @@ function GenericCanvasWithRef<
     setAutoSaveDirty,
   ]);
 
+  // Live remote selections (collab mode). Publishes the local selection to
+  // awareness (active page only) and maps remote peers' selections on this
+  // page to element ids for the render layer's outlines.
+  const collabPageId = props.collaborative?.pageId ?? null;
+  const remoteSelectionsRaw = useSelectionAwareness(props.collaborative?.provider ?? null, {
+    activePageId: collabPageId,
+    publish: props.collaborative?.publishSelection ?? true,
+  });
+  const remoteSelections = useMemo(() => {
+    if (remoteSelectionsRaw.length === 0) return undefined;
+    const map = new Map<string, RemoteSelector>();
+    for (const peer of remoteSelectionsRaw) {
+      if (peer.activePageId !== collabPageId) continue;
+      for (const id of peer.selectedLayerIds) {
+        if (!map.has(id)) map.set(id, { userName: peer.userName, color: peer.color });
+      }
+    }
+    return map.size > 0 ? map : undefined;
+  }, [remoteSelectionsRaw, collabPageId]);
+
   const elementHandlers = useCanvasElementHandlers({
     config,
     state,
@@ -527,6 +556,7 @@ function GenericCanvasWithRef<
           stageWidth={config.canvas.width}
           stageHeight={config.canvas.height}
           isFontAvailable={isFontAvailable}
+          remoteSelections={remoteSelections}
         />
 
         {/* Attribution overlay - only visible during export */}

--- a/packages/canvas-editor/src/components/GenericCanvas.tsx
+++ b/packages/canvas-editor/src/components/GenericCanvas.tsx
@@ -31,6 +31,7 @@ import {
   useFontLoader,
 } from '../hooks';
 import { useCanvasAutoSave } from '../hooks/useCanvasAutoSave';
+import { useAutoSaveStore } from '../stores/useAutoSaveStore';
 import { useCanvasElementHandlers } from '../hooks/useCanvasElementHandlers';
 import { useCanvasKeyboardHandlers } from '../hooks/useCanvasKeyboardHandlers';
 import { getCanvasFormatOrDefault } from '../formats';
@@ -325,66 +326,59 @@ function GenericCanvasWithRef<
   // Auto-save hook for gallery integration. Skipped in collaborative mode —
   // Hocuspocus persists Yjs updates server-side; the gallery share-token path
   // would race with Y.Doc state.
+  const autoSaveEnabled = !mobileBridge && !props.collaborative;
   useCanvasAutoSave(exportedImage, {
     canvasType: config.id,
     canvasState: state,
-    enabled: !mobileBridge && !props.collaborative,
+    enabled: autoSaveEnabled,
   });
 
   // History-synced auto-save: capture canvas whenever undo/redo history changes
   const historyIndex = useCanvasStoreSelector((s) => s.historyIndex);
+  const selectedElementForCapture = useCanvasStoreSelector((s) => s.selectedElement);
+  const setAutoSaveDirty = useAutoSaveStore((s) => s.setDirty);
   const lastAutoSaveHistoryIndexRef = useRef(-1);
 
   useEffect(() => {
-    console.log('[AutoSave][historyEffect] tick', {
-      historyIndex,
-      isExporting,
-      lastSavedAt: lastAutoSaveHistoryIndexRef.current,
-      selectedElement: store.getState().selectedElement,
-    });
-    if (historyIndex < 0 || isExporting) {
-      console.log('[AutoSave][historyEffect] skip: initial or exporting');
-      return;
+    if (historyIndex < 0 || isExporting) return;
+    // historyIndex 0 is the initial mount snapshot — an untouched canvas is not dirty
+    if (
+      autoSaveEnabled &&
+      historyIndex > 0 &&
+      lastAutoSaveHistoryIndexRef.current !== historyIndex
+    ) {
+      setAutoSaveDirty(true);
     }
-    if (store.getState().selectedElement) {
-      console.log('[AutoSave][historyEffect] skip: element selected');
-      return;
-    }
-    if (lastAutoSaveHistoryIndexRef.current === historyIndex) {
-      console.log('[AutoSave][historyEffect] skip: already captured for this historyIndex');
-      return;
-    }
+    // Capture waits until nothing is selected (selection handles would end up in
+    // the screenshot); selectedElementForCapture in the deps re-runs this effect
+    // on deselect so the pending historyIndex still gets captured.
+    if (store.getState().selectedElement) return;
+    if (lastAutoSaveHistoryIndexRef.current === historyIndex) return;
 
     // Debounce screenshot capture — toDataURL at pixelRatio:2 is expensive (~100-200ms).
     // 1500ms ensures we only capture after the user stops editing.
     const timer = setTimeout(() => {
       // Re-check at capture time in case selection changed during debounce
-      if (store.getState().selectedElement) {
-        console.log('[AutoSave][historyEffect] capture aborted: element selected at capture time');
-        return;
-      }
-      console.log('[AutoSave][historyEffect] capturing stage at historyIndex', historyIndex);
+      if (store.getState().selectedElement) return;
       const dataUrl = stageRef.current?.toDataURL({ format: 'png', pixelRatio: 2 });
       if (dataUrl) {
-        console.log('[AutoSave][historyEffect] capture OK, setExportedImage', {
-          historyIndex,
-          dataUrlLen: dataUrl.length,
-        });
         setExportedImage(dataUrl);
         exportedImageRef.current = dataUrl;
         lastAutoSaveHistoryIndexRef.current = historyIndex;
       } else {
-        console.warn(
-          '[AutoSave][historyEffect] capture FAILED: stageRef.current.toDataURL() returned null',
-          {
-            stageRefSet: !!stageRef.current,
-          }
-        );
+        console.warn('[AutoSave] capture failed: stage toDataURL returned null');
       }
     }, 1500);
 
     return () => clearTimeout(timer);
-  }, [historyIndex, isExporting, store]);
+  }, [
+    historyIndex,
+    isExporting,
+    store,
+    selectedElementForCapture,
+    autoSaveEnabled,
+    setAutoSaveDirty,
+  ]);
 
   const elementHandlers = useCanvasElementHandlers({
     config,

--- a/packages/canvas-editor/src/components/RemoteSelectionOverlay.tsx
+++ b/packages/canvas-editor/src/components/RemoteSelectionOverlay.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Group, Label, Rect, Tag, Text } from 'react-konva';
+
+import type Konva from 'konva';
+
+export interface RemoteSelector {
+  userName: string;
+  color: string;
+}
+
+interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Draws a colored dashed outline + name chip around an element that a remote
+ * collaborator currently has selected. The child renders inside an
+ * identity-transform Group that is measured after each commit, so the outline
+ * tracks remote drags/transforms (they arrive as Yjs -> state -> re-render).
+ */
+export function RemoteSelectionOverlay({
+  selector,
+  children,
+}: {
+  selector: RemoteSelector;
+  children: React.ReactNode;
+}) {
+  const groupRef = useRef<Konva.Group>(null);
+  const [box, setBox] = useState<Box | null>(null);
+
+  useEffect(() => {
+    const node = groupRef.current;
+    const parent = node?.getParent();
+    if (!node || !parent) return;
+    const rect = node.getClientRect({ relativeTo: parent as Konva.Container });
+    setBox((prev) =>
+      prev &&
+      prev.x === rect.x &&
+      prev.y === rect.y &&
+      prev.width === rect.width &&
+      prev.height === rect.height
+        ? prev
+        : rect
+    );
+  });
+
+  return (
+    <Group>
+      <Group ref={groupRef}>{children}</Group>
+      {box && box.width > 0 && box.height > 0 && (
+        <>
+          <Rect
+            x={box.x}
+            y={box.y}
+            width={box.width}
+            height={box.height}
+            stroke={selector.color}
+            strokeWidth={2}
+            strokeScaleEnabled={false}
+            dash={[6, 4]}
+            listening={false}
+          />
+          <Label x={box.x} y={box.y - 34} listening={false}>
+            <Tag fill={selector.color} cornerRadius={4} />
+            <Text text={selector.userName} fontSize={22} fill="#ffffff" padding={6} />
+          </Label>
+        </>
+      )}
+    </Group>
+  );
+}

--- a/packages/canvas-editor/src/components/TopBar/modules/FloatingHistoryControls.tsx
+++ b/packages/canvas-editor/src/components/TopBar/modules/FloatingHistoryControls.tsx
@@ -11,6 +11,8 @@ interface FloatingHistoryControlsProps {
   canRedo: boolean;
 }
 
+const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform);
+
 export function FloatingHistoryControls({
   onUndo,
   onRedo,
@@ -26,7 +28,7 @@ export function FloatingHistoryControls({
           onUndo();
         }}
         disabled={!canUndo}
-        title="Rückgängig"
+        title={isMac ? 'Rückgängig (⌘Z)' : 'Rückgängig (Strg+Z)'}
         type="button"
       >
         <PiArrowCounterClockwise size={20} />
@@ -38,7 +40,7 @@ export function FloatingHistoryControls({
           onRedo();
         }}
         disabled={!canRedo}
-        title="Wiederholen"
+        title={isMac ? 'Wiederholen (⌘⇧Z)' : 'Wiederholen (Strg+Y)'}
         type="button"
       >
         <PiArrowClockwise size={20} />

--- a/packages/canvas-editor/src/configs/dreizeilen_full.config.tsx
+++ b/packages/canvas-editor/src/configs/dreizeilen_full.config.tsx
@@ -549,6 +549,7 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT
     );
@@ -567,6 +568,7 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT,
       '#005538'
@@ -606,6 +608,7 @@ export const dreizeilenFullConfig: FullCanvasConfig<DreizeilenFullState, Dreizei
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       DREIZEILEN_CONFIG.canvas.width,
       DREIZEILEN_CONFIG.canvas.height
     );

--- a/packages/canvas-editor/src/configs/factory/commonActions.ts
+++ b/packages/canvas-editor/src/configs/factory/commonActions.ts
@@ -45,6 +45,7 @@ export function createAssetActions<TState extends { assetInstances: AssetInstanc
   getState: () => TState,
   setState: StateSetter<TState>,
   saveToHistory: HistorySaver<TState>,
+  debouncedSaveToHistory: HistorySaver<TState>,
   canvasWidth: number,
   canvasHeight: number
 ) {
@@ -62,6 +63,7 @@ export function createAssetActions<TState extends { assetInstances: AssetInstanc
         ...prev,
         assetInstances: prev.assetInstances.map((a) => (a.id === id ? { ...a, ...partial } : a)),
       }));
+      debouncedSaveToHistory(getState());
     },
     removeAsset: (id: string) => {
       setState((prev) => ({
@@ -154,6 +156,7 @@ export function createShapeActions<TState extends { shapeInstances: ShapeInstanc
   getState: () => TState,
   setState: StateSetter<TState>,
   saveToHistory: HistorySaver<TState>,
+  debouncedSaveToHistory: HistorySaver<TState>,
   canvasWidth: number,
   canvasHeight: number,
   defaultColor: string = BRAND_COLORS[0].value
@@ -172,6 +175,7 @@ export function createShapeActions<TState extends { shapeInstances: ShapeInstanc
         ...prev,
         shapeInstances: prev.shapeInstances.map((s) => (s.id === id ? { ...s, ...partial } : s)),
       }));
+      debouncedSaveToHistory(getState());
     },
     removeShape: (id: string) => {
       setState((prev) => ({
@@ -297,6 +301,7 @@ export function createAdditionalTextActions<TState extends { additionalTexts: Ad
   getState: () => TState,
   setState: StateSetter<TState>,
   saveToHistory: HistorySaver<TState>,
+  debouncedSaveToHistory: HistorySaver<TState>,
   canvasWidth: number,
   canvasHeight: number,
   fontColor: string = '#ffffff'
@@ -375,6 +380,7 @@ export function createAdditionalTextActions<TState extends { additionalTexts: Ad
         ...prev,
         additionalTexts: prev.additionalTexts.map((t) => (t.id === id ? { ...t, ...partial } : t)),
       }));
+      debouncedSaveToHistory(getState());
     },
     removeAdditionalText: (id: string) => {
       setState((prev) => ({
@@ -533,6 +539,7 @@ export function createFrameActions<TState extends { frameInstances: FrameInstanc
   getState: () => TState,
   setState: StateSetter<TState>,
   saveToHistory: HistorySaver<TState>,
+  debouncedSaveToHistory: HistorySaver<TState>,
   canvasWidth: number,
   canvasHeight: number
 ) {
@@ -550,6 +557,7 @@ export function createFrameActions<TState extends { frameInstances: FrameInstanc
         ...prev,
         frameInstances: prev.frameInstances.map((f) => (f.id === id ? { ...f, ...partial } : f)),
       }));
+      debouncedSaveToHistory(getState());
     },
     removeFrame: (id: string) => {
       const frame = getState().frameInstances.find((f) => f.id === id);
@@ -588,6 +596,7 @@ export function createUserImageActions<TState extends { userImageInstances: User
   getState: () => TState,
   setState: StateSetter<TState>,
   saveToHistory: HistorySaver<TState>,
+  debouncedSaveToHistory: HistorySaver<TState>,
   canvasWidth: number,
   canvasHeight: number
 ) {
@@ -619,6 +628,7 @@ export function createUserImageActions<TState extends { userImageInstances: User
           u.id === id ? { ...u, ...partial } : u
         ),
       }));
+      debouncedSaveToHistory(getState());
     },
     removeUserImage: (id: string) => {
       const instance = getState().userImageInstances.find((u) => u.id === id);
@@ -648,7 +658,14 @@ export function createBaseActions<TState extends BaseCanvasState>(
   fontColor?: string
 ) {
   return {
-    ...createAssetActions(getState, setState, saveToHistory, canvasWidth, canvasHeight),
+    ...createAssetActions(
+      getState,
+      setState,
+      saveToHistory,
+      debouncedSaveToHistory,
+      canvasWidth,
+      canvasHeight
+    ),
     ...createIconActions(
       getState,
       setState,
@@ -657,7 +674,14 @@ export function createBaseActions<TState extends BaseCanvasState>(
       canvasWidth,
       canvasHeight
     ),
-    ...createShapeActions(getState, setState, saveToHistory, canvasWidth, canvasHeight),
+    ...createShapeActions(
+      getState,
+      setState,
+      saveToHistory,
+      debouncedSaveToHistory,
+      canvasWidth,
+      canvasHeight
+    ),
     ...createIllustrationActions(
       getState,
       setState,
@@ -670,6 +694,7 @@ export function createBaseActions<TState extends BaseCanvasState>(
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       canvasWidth,
       canvasHeight,
       fontColor
@@ -677,7 +702,21 @@ export function createBaseActions<TState extends BaseCanvasState>(
     ...createPillBadgeActions(getState, setState, saveToHistory, debouncedSaveToHistory),
     ...createCircleBadgeActions(getState, setState, saveToHistory, debouncedSaveToHistory),
     ...createBalkenActions(getState, setState, saveToHistory, debouncedSaveToHistory),
-    ...createFrameActions(getState, setState, saveToHistory, canvasWidth, canvasHeight),
-    ...createUserImageActions(getState, setState, saveToHistory, canvasWidth, canvasHeight),
+    ...createFrameActions(
+      getState,
+      setState,
+      saveToHistory,
+      debouncedSaveToHistory,
+      canvasWidth,
+      canvasHeight
+    ),
+    ...createUserImageActions(
+      getState,
+      setState,
+      saveToHistory,
+      debouncedSaveToHistory,
+      canvasWidth,
+      canvasHeight
+    ),
   };
 }

--- a/packages/canvas-editor/src/configs/veranstaltung_full.config.tsx
+++ b/packages/canvas-editor/src/configs/veranstaltung_full.config.tsx
@@ -570,6 +570,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT
     );
@@ -588,6 +589,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT,
       '#005538'
@@ -627,6 +629,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT
     );
@@ -635,6 +638,7 @@ export const veranstaltungFullConfig: FullCanvasConfig<
       getState,
       setState,
       saveToHistory,
+      debouncedSaveToHistory,
       CANVAS_WIDTH,
       CANVAS_HEIGHT
     );

--- a/packages/canvas-editor/src/hooks/useCanvasAutoSave.ts
+++ b/packages/canvas-editor/src/hooks/useCanvasAutoSave.ts
@@ -188,7 +188,10 @@ export const useCanvasAutoSave = (
       if (!imageSrc) return;
       if (refs.enabled === false) return;
       if (storeState.autoSaveStatus === 'saving') return;
-      if (storeState.lastAutoSavedImageSrc === imageSrc) return;
+      if (storeState.lastAutoSavedImageSrc === imageSrc) {
+        storeState.setDirty(false);
+        return;
+      }
 
       refs.setAutoSaveStatus('saving');
 
@@ -252,6 +255,7 @@ export const useCanvasAutoSave = (
           refs.setAutoSavedShareToken(share.shareToken);
           refs.setLastAutoSavedImageSrc(imageSrc);
           refs.setAutoSaveStatus('saved');
+          autoSaveStoreApi.getState().setDirty(false);
         } else {
           console.warn('[AutoSave][performAutoSave] api returned no shareToken');
           refs.setAutoSaveStatus('error');
@@ -275,10 +279,12 @@ export const useCanvasAutoSave = (
     return () => clearTimeout(timer);
   }, [generatedImage, performAutoSave]);
 
-  // Warn before leaving while a save is still in flight
+  // Warn before leaving while a save is in flight or edits are not yet persisted
   useEffect(() => {
     const onBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (autoSaveStoreApi.getState().autoSaveStatus === 'saving') e.preventDefault();
+      const s = autoSaveStoreApi.getState();
+      const enabled = latestRefs.current.enabled !== false;
+      if (s.autoSaveStatus === 'saving' || (enabled && s.isDirty)) e.preventDefault();
     };
     window.addEventListener('beforeunload', onBeforeUnload);
     return () => window.removeEventListener('beforeunload', onBeforeUnload);

--- a/packages/canvas-editor/src/hooks/useCanvasAutoSave.ts
+++ b/packages/canvas-editor/src/hooks/useCanvasAutoSave.ts
@@ -290,6 +290,18 @@ export const useCanvasAutoSave = (
     return () => window.removeEventListener('beforeunload', onBeforeUnload);
   }, [autoSaveStoreApi]);
 
+  // Expose a retry through the store so UI outside this hook (share section,
+  // sidebar tab bar) can re-run a failed save.
+  const generatedImageRef = useRef(generatedImage);
+  generatedImageRef.current = generatedImage;
+  useEffect(() => {
+    autoSaveStoreApi.getState().setRetryAutoSave(() => {
+      const image = generatedImageRef.current;
+      if (image) void performAutoSave(image);
+    });
+    return () => autoSaveStoreApi.getState().setRetryAutoSave(null);
+  }, [autoSaveStoreApi, performAutoSave]);
+
   // Return status by reading directly from store (no subscription = no re-renders)
   return {
     status: autoSaveStoreApi.getState().autoSaveStatus,

--- a/packages/canvas-editor/src/hooks/useCanvasElementHandlers.ts
+++ b/packages/canvas-editor/src/hooks/useCanvasElementHandlers.ts
@@ -250,10 +250,8 @@ export function useCanvasElementHandlers<
 
       const additionalTexts = getStateArray<{ id: string }>(state, 'additionalTexts');
       if (additionalTexts.find((t) => t.id === id)) {
-        if (actions.updateAdditionalText) {
-          actions.updateAdditionalText(id, { fontSize: size });
-          debouncedSaveToHistory(state);
-        }
+        // updateAdditionalText saves history itself with the post-change state
+        actions.updateAdditionalText?.(id, { fontSize: size });
       }
     },
     [config.elements, state, actions, setState, debouncedSaveToHistory]
@@ -539,22 +537,17 @@ export function useCanvasElementHandlers<
 
   const handleUserImageDragEnd = useCallback(
     (id: string, x: number, y: number) => {
-      if (actions.updateUserImage) {
-        actions.updateUserImage(id, { x, y });
-        saveToHistory({ ...state, userImageInstances: getStateArray(state, 'userImageInstances') });
-      }
+      // updateUserImage saves history itself with the post-change state
+      actions.updateUserImage?.(id, { x, y });
     },
-    [actions, saveToHistory, state]
+    [actions]
   );
 
   const handleUserImageTransformEnd = useCallback(
     (id: string, x: number, y: number, width: number, height: number, rotation: number) => {
-      if (actions.updateUserImage) {
-        actions.updateUserImage(id, { x, y, width, height, rotation });
-        saveToHistory({ ...state, userImageInstances: getStateArray(state, 'userImageInstances') });
-      }
+      actions.updateUserImage?.(id, { x, y, width, height, rotation });
     },
-    [actions, saveToHistory, state]
+    [actions]
   );
 
   return useMemo(

--- a/packages/canvas-editor/src/hooks/useCanvasKeyboardHandlers.ts
+++ b/packages/canvas-editor/src/hooks/useCanvasKeyboardHandlers.ts
@@ -57,6 +57,20 @@ export function useCanvasKeyboardHandlers<TState extends Partial<BaseCanvasState
       const currentState = stateRef.current;
       const currentActions = actionsRef.current;
 
+      // ESCAPE — deselect (skipped while typing in an inline editor or input)
+      if (e.key === 'Escape') {
+        const target = e.target as HTMLElement | null;
+        if (
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          target?.isContentEditable
+        ) {
+          return;
+        }
+        if (selectedElement) setSelectedElement(null);
+        return;
+      }
+
       // DUPLICATE (Ctrl+D) — copy + paste in one step
       if (isCtrlOrCmd && e.key === 'd' && selectedElement) {
         e.preventDefault();

--- a/packages/canvas-editor/src/hooks/useZoomGestures.ts
+++ b/packages/canvas-editor/src/hooks/useZoomGestures.ts
@@ -1,0 +1,99 @@
+import { useEffect } from 'react';
+
+interface ZoomGestureOptions {
+  minZoom?: number;
+  maxZoom?: number;
+}
+
+/**
+ * Wires pinch (two-finger touch) and ctrl/cmd + wheel gestures to the
+ * editor's existing zoom state (the CSS `--canvas-zoom` scale that
+ * CanvasMetaBar's buttons already control).
+ *
+ * Listeners attach to the surrounding canvas region rather than the pages
+ * container itself, so gestures still work over the empty margin when the
+ * canvas is zoomed out. Double-click/double-tap on that empty margin resets
+ * to 100% (the canvas itself keeps double-click for inline text editing).
+ */
+export function useZoomGestures(
+  containerRef: React.RefObject<HTMLElement | null>,
+  onZoomChange: React.Dispatch<React.SetStateAction<number>>,
+  { minZoom = 0.25, maxZoom = 1.5 }: ZoomGestureOptions = {}
+): void {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const target =
+      (container.closest('.canvas-editor-layout__canvas') as HTMLElement | null) ??
+      container.parentElement ??
+      container;
+
+    const clamp = (z: number) => Math.min(maxZoom, Math.max(minZoom, z));
+
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey && !e.metaKey) return;
+      e.preventDefault();
+      const factor = Math.exp(-e.deltaY * 0.002);
+      onZoomChange((prev) => clamp(prev * factor));
+    };
+
+    const pointers = new Map<number, { x: number; y: number }>();
+    let lastDistance = 0;
+
+    const currentDistance = () => {
+      const [a, b] = [...pointers.values()];
+      return Math.hypot(a.x - b.x, a.y - b.y);
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType !== 'touch') return;
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (pointers.size === 2) lastDistance = currentDistance();
+    };
+
+    const onPointerMove = (e: PointerEvent) => {
+      if (!pointers.has(e.pointerId)) return;
+      pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (pointers.size !== 2) return;
+      const dist = currentDistance();
+      if (lastDistance > 0 && dist > 0) {
+        const factor = dist / lastDistance;
+        onZoomChange((prev) => clamp(prev * factor));
+      }
+      lastDistance = dist;
+    };
+
+    const onPointerEnd = (e: PointerEvent) => {
+      pointers.delete(e.pointerId);
+      lastDistance = 0;
+    };
+
+    const onDoubleClick = (e: MouseEvent) => {
+      // Only the empty margin resets — the canvas keeps dblclick-to-edit-text
+      if (e.target === target || e.target === container) onZoomChange(1);
+    };
+
+    // iOS Safari fires proprietary gesture events that zoom the page itself
+    const preventGesture = (e: Event) => e.preventDefault();
+
+    target.addEventListener('wheel', onWheel, { passive: false });
+    target.addEventListener('pointerdown', onPointerDown);
+    target.addEventListener('pointermove', onPointerMove);
+    target.addEventListener('pointerup', onPointerEnd);
+    target.addEventListener('pointercancel', onPointerEnd);
+    target.addEventListener('dblclick', onDoubleClick);
+    target.addEventListener('gesturestart', preventGesture);
+    target.addEventListener('gesturechange', preventGesture);
+
+    return () => {
+      target.removeEventListener('wheel', onWheel);
+      target.removeEventListener('pointerdown', onPointerDown);
+      target.removeEventListener('pointermove', onPointerMove);
+      target.removeEventListener('pointerup', onPointerEnd);
+      target.removeEventListener('pointercancel', onPointerEnd);
+      target.removeEventListener('dblclick', onDoubleClick);
+      target.removeEventListener('gesturestart', preventGesture);
+      target.removeEventListener('gesturechange', preventGesture);
+    };
+  }, [containerRef, onZoomChange, minZoom, maxZoom]);
+}

--- a/packages/canvas-editor/src/sidebar/SidebarTabBar.tsx
+++ b/packages/canvas-editor/src/sidebar/SidebarTabBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, memo, useCallback } from 'react';
-import { FaCheck } from 'react-icons/fa';
+import { FaCheck, FaExclamationTriangle } from 'react-icons/fa';
 import { useMediaQuery } from '@gruenerator/shared/hooks';
 
 import { useAutoSaveStore } from '../stores/useAutoSaveStore';
@@ -84,6 +84,7 @@ export const SidebarTabBar = memo(function SidebarTabBar({
   horizontal = false,
 }: SidebarTabBarProps) {
   const autoSaveStatus = useAutoSaveStore((s) => s.autoSaveStatus);
+  const retryAutoSave = useAutoSaveStore((s) => s.retryAutoSave);
   const isMobile = useMediaQuery('(max-width: 899px)');
   const [showSaved, setShowSaved] = useState(false);
 
@@ -140,6 +141,7 @@ export const SidebarTabBar = memo(function SidebarTabBar({
           className={cn(
             'flex items-center justify-center size-10 opacity-0 transition-opacity duration-300',
             autoSaveStatus === 'saving' && 'opacity-100',
+            autoSaveStatus === 'error' && 'opacity-100',
             showSaved && 'opacity-100'
           )}
           title={
@@ -148,7 +150,7 @@ export const SidebarTabBar = memo(function SidebarTabBar({
               : autoSaveStatus === 'saved'
                 ? 'Gespeichert'
                 : autoSaveStatus === 'error'
-                  ? 'Fehler beim Speichern'
+                  ? 'Fehler beim Speichern — klicken zum Wiederholen'
                   : ''
           }
         >
@@ -156,6 +158,16 @@ export const SidebarTabBar = memo(function SidebarTabBar({
             <div className="size-4 border-2 border-[var(--border-subtle)] border-t-[var(--interactive-accent-color)] rounded-full animate-auto-save-spin" />
           )}
           {showSaved && <FaCheck size={14} className="text-green-500 animate-auto-save-check" />}
+          {autoSaveStatus === 'error' && (
+            <button
+              className="bg-transparent border-none p-0 cursor-pointer flex items-center justify-center"
+              onClick={() => retryAutoSave?.()}
+              aria-label="Speichern erneut versuchen"
+              type="button"
+            >
+              <FaExclamationTriangle size={14} className="text-red-500" />
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/packages/canvas-editor/src/sidebar/sections/GenericShareSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/GenericShareSection.tsx
@@ -172,14 +172,14 @@ function DownloadShareSubsection({
 
   const handleDownloadPptx = onDownloadPptx
     ? async () => {
-        lastExportOpRef.current = handleDownloadPptx;
+        lastExportOpRef.current = onDownloadPptx;
         await onDownloadPptx();
       }
     : undefined;
 
   const handleDownloadPdf = onDownloadPdf
     ? async () => {
-        lastExportOpRef.current = handleDownloadPdf;
+        lastExportOpRef.current = onDownloadPdf;
         await onDownloadPdf();
       }
     : undefined;

--- a/packages/canvas-editor/src/sidebar/sections/GenericShareSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/GenericShareSection.tsx
@@ -142,8 +142,12 @@ function DownloadShareSubsection({
     }
   }, [shareToken, autoSaveStoreApi]);
 
+  // Remembers the last export attempt so a failed export can be retried
+  const lastExportOpRef = useRef<(() => Promise<void> | void) | null>(null);
+
   const handleSingleDownload = async () => {
     dlDropdown.setOpen(false);
+    lastExportOpRef.current = handleSingleDownload;
     setDownloadState('capturing');
     try {
       onCaptureCanvas();
@@ -160,10 +164,25 @@ function DownloadShareSubsection({
 
   const handleDownloadAllZip = async () => {
     dlDropdown.setOpen(false);
+    lastExportOpRef.current = handleDownloadAllZip;
     if (onDownloadAllZip) {
       await onDownloadAllZip();
     }
   };
+
+  const handleDownloadPptx = onDownloadPptx
+    ? async () => {
+        lastExportOpRef.current = handleDownloadPptx;
+        await onDownloadPptx();
+      }
+    : undefined;
+
+  const handleDownloadPdf = onDownloadPdf
+    ? async () => {
+        lastExportOpRef.current = handleDownloadPdf;
+        await onDownloadPdf();
+      }
+    : undefined;
 
   const handleDownloadClick = async () => {
     if (isMultiPage) {
@@ -300,10 +319,10 @@ function DownloadShareSubsection({
                     </>
                   )}
                 </button>
-                {onDownloadPptx && (
+                {handleDownloadPptx && (
                   <button
                     className={dropdownOption}
-                    onClick={onDownloadPptx}
+                    onClick={handleDownloadPptx}
                     disabled={isMultiExporting}
                     role="menuitem"
                     type="button"
@@ -312,10 +331,10 @@ function DownloadShareSubsection({
                     <span>PowerPoint (PPTX)</span>
                   </button>
                 )}
-                {onDownloadPdf && (
+                {handleDownloadPdf && (
                   <button
                     className={dropdownOption}
-                    onClick={onDownloadPdf}
+                    onClick={handleDownloadPdf}
                     disabled={isMultiExporting}
                     role="menuitem"
                     type="button"
@@ -402,6 +421,15 @@ function DownloadShareSubsection({
       {exportError && !isMultiExporting && (
         <div className="flex items-center gap-2 text-sm text-red-600">
           <span>{exportError}</span>
+          {lastExportOpRef.current && (
+            <button
+              className="bg-transparent border-none p-0 cursor-pointer text-sm font-medium text-primary-600 hover:underline"
+              onClick={() => void lastExportOpRef.current?.()}
+              type="button"
+            >
+              Erneut versuchen
+            </button>
+          )}
         </div>
       )}
 
@@ -425,9 +453,16 @@ function DownloadShareSubsection({
         </>
       )}
 
-      {downloadState === 'success' && autoSaveStatus === 'error' && (
+      {autoSaveStatus === 'error' && (
         <div className="flex items-center gap-2 text-sm text-red-600">
           <span>Fehler beim Speichern</span>
+          <button
+            className="bg-transparent border-none p-0 cursor-pointer text-sm font-medium text-primary-600 hover:underline"
+            onClick={() => autoSaveStoreApi.getState().retryAutoSave?.()}
+            type="button"
+          >
+            Erneut versuchen
+          </button>
         </div>
       )}
     </div>

--- a/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
@@ -5,7 +5,8 @@ import { PiFrameCornersFill, PiSmileyWink, PiTagFill } from 'react-icons/pi';
 
 import { LOGO_ASSETS, type AssetInstance } from '../../../utils/canvasAssets';
 import { getIconsSync, loadAllIcons } from '../../../utils/canvasIcons';
-import { ALL_ILLUSTRATIONS, UNDRAW_FEATURED } from '../../../utils/illustrations/registry';
+import { ALL_ILLUSTRATIONS } from '../../../utils/illustrations/fullCatalog';
+import { UNDRAW_FEATURED } from '../../../utils/illustrations/registry';
 import { prefetchBackground } from '../../../utils/illustrations/svgCache';
 import { ALL_SHAPES, type ShapeInstance, type ShapeType } from '../../../utils/shapes';
 import {

--- a/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
@@ -3,8 +3,8 @@ import { FaPuzzlePiece, FaSearch, FaShapes } from 'react-icons/fa';
 import { HiSparkles } from 'react-icons/hi2';
 import { PiFrameCornersFill, PiSmileyWink, PiTagFill } from 'react-icons/pi';
 
+import { useIconCatalog } from '../../../hooks/useIconCatalog';
 import { LOGO_ASSETS, type AssetInstance } from '../../../utils/canvasAssets';
-import { getIconsSync, loadAllIcons } from '../../../utils/canvasIcons';
 import { ALL_ILLUSTRATIONS } from '../../../utils/illustrations/fullCatalog';
 import { UNDRAW_FEATURED } from '../../../utils/illustrations/registry';
 import { prefetchBackground } from '../../../utils/illustrations/svgCache';
@@ -33,9 +33,6 @@ import type { FrameClipType, FrameInstance } from '../../../utils/frameUtils';
 import type { IllustrationInstance } from '../../../utils/illustrations/types';
 
 import { cn } from '../../../utils/cn';
-
-// Preload icons as soon as this module is imported (idempotent, cached)
-loadAllIcons();
 
 export interface ExtendedAssetsSectionProps {
   recommendedAssetIds?: string[];
@@ -105,6 +102,9 @@ export function AssetsSection(props: ExtendedAssetsSectionProps) {
 
   const hasAssetsFeature = onAddAsset !== undefined;
   const hasIconsFeature = selectedIcons !== undefined && onIconToggle !== undefined;
+  // Loads the Iconify catalog when the section mounts (React Query, cached)
+  // and re-renders the icon subsection + search once it arrives.
+  const { data: iconCatalog = [] } = useIconCatalog();
   const hasBadgesFeature =
     onAddPillBadge !== undefined || onAddCircleBadge !== undefined || onAddBalken !== undefined;
   const hasShapesFeature = onAddShape !== undefined;
@@ -433,7 +433,7 @@ function MobileView({
   }
 
   if (hasIconsFeature) {
-    const hasMoreIcons = (getIconsSync()?.length ?? 0) > 4;
+    const hasMoreIcons = iconCatalog.length > 4;
     subsections.push({
       id: 'icons',
       icon: HiSparkles,

--- a/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/AssetsSection.tsx
@@ -104,7 +104,7 @@ export function AssetsSection(props: ExtendedAssetsSectionProps) {
   const hasIconsFeature = selectedIcons !== undefined && onIconToggle !== undefined;
   // Loads the Iconify catalog when the section mounts (React Query, cached)
   // and re-renders the icon subsection + search once it arrives.
-  const { data: iconCatalog = [] } = useIconCatalog();
+  useIconCatalog();
   const hasBadgesFeature =
     onAddPillBadge !== undefined || onAddCircleBadge !== undefined || onAddBalken !== undefined;
   const hasShapesFeature = onAddShape !== undefined;
@@ -202,6 +202,7 @@ function MobileView({
   const [iconsExpanded, setIconsExpanded] = useState(false);
   const [illustrationenExpanded, setIllustrationenExpanded] = useState(false);
 
+  const { data: iconCatalog = [] } = useIconCatalog();
   const bridge = useMobileSubsectionBridge();
   const effectiveFormenExpanded = bridge.active || formenExpanded;
   const effectiveIconsExpanded = bridge.active || iconsExpanded;

--- a/packages/canvas-editor/src/sidebar/sections/assets/BrowseView.tsx
+++ b/packages/canvas-editor/src/sidebar/sections/assets/BrowseView.tsx
@@ -5,8 +5,8 @@ import useDebounce from '../../../hooks/useDebounce';
 import { useCanvasEditorServices } from '../../../CanvasEditorProvider';
 import { ALL_ASSETS, LOGO_ASSETS, type UniversalAsset } from '../../../utils/canvasAssets';
 import { filterIllustrations, matchesQuery } from '../../../utils/filterUtils';
+import { ALL_ILLUSTRATIONS } from '../../../utils/illustrations/fullCatalog';
 import {
-  ALL_ILLUSTRATIONS,
   getIllustrationThumbPath,
   getIllustrationPath,
 } from '../../../utils/illustrations/registry';

--- a/packages/canvas-editor/src/sidebar/sections/assets/useAssetSearch.ts
+++ b/packages/canvas-editor/src/sidebar/sections/assets/useAssetSearch.ts
@@ -5,7 +5,7 @@ import { ALL_ASSETS, type UniversalAsset } from '../../../utils/canvasAssets';
 import { getIconsSync, type IconDef } from '../../../utils/canvasIcons';
 import { filterIcons, filterIllustrations, matchesQuery } from '../../../utils/filterUtils';
 import { FRAME_PRESETS } from '../../../utils/frameUtils';
-import { ALL_ILLUSTRATIONS } from '../../../utils/illustrations/registry';
+import { ALL_ILLUSTRATIONS } from '../../../utils/illustrations/fullCatalog';
 import { ALL_SHAPES, type ShapeDef } from '../../../utils/shapes';
 
 import type { FrameClipType } from '../../../utils/frameUtils';

--- a/packages/canvas-editor/src/stores/createAutoSaveStore.ts
+++ b/packages/canvas-editor/src/stores/createAutoSaveStore.ts
@@ -16,6 +16,8 @@ export interface AutoSaveState {
   lastAutoSavedImageSrc: string | null;
   /** True while there are edits that have not been persisted yet. */
   isDirty: boolean;
+  /** Re-runs the last auto-save attempt. Registered by useCanvasAutoSave. */
+  retryAutoSave: (() => void) | null;
 }
 
 export interface AutoSaveActions {
@@ -23,6 +25,7 @@ export interface AutoSaveActions {
   setAutoSavedShareToken: (token: string | null) => void;
   setLastAutoSavedImageSrc: (src: string | null) => void;
   setDirty: (dirty: boolean) => void;
+  setRetryAutoSave: (retry: (() => void) | null) => void;
   clearAutoSaveState: () => void;
 }
 
@@ -44,17 +47,20 @@ export function createAutoSaveStore(options: CreateAutoSaveStoreOptions = {}) {
     autoSavedShareToken: initialShareToken,
     lastAutoSavedImageSrc: null,
     isDirty: false,
+    retryAutoSave: null,
 
     setAutoSaveStatus: (status) => set({ autoSaveStatus: status }),
     setAutoSavedShareToken: (token) => set({ autoSavedShareToken: token }),
     setLastAutoSavedImageSrc: (src) => set({ lastAutoSavedImageSrc: src }),
     setDirty: (dirty) => set({ isDirty: dirty }),
+    setRetryAutoSave: (retry) => set({ retryAutoSave: retry }),
     clearAutoSaveState: () =>
       set({
         autoSaveStatus: 'idle',
         autoSavedShareToken: null,
         lastAutoSavedImageSrc: null,
         isDirty: false,
+        retryAutoSave: null,
       }),
   }));
 }

--- a/packages/canvas-editor/src/stores/createAutoSaveStore.ts
+++ b/packages/canvas-editor/src/stores/createAutoSaveStore.ts
@@ -14,12 +14,15 @@ export interface AutoSaveState {
   autoSaveStatus: AutoSaveStatus;
   autoSavedShareToken: string | null;
   lastAutoSavedImageSrc: string | null;
+  /** True while there are edits that have not been persisted yet. */
+  isDirty: boolean;
 }
 
 export interface AutoSaveActions {
   setAutoSaveStatus: (status: AutoSaveStatus) => void;
   setAutoSavedShareToken: (token: string | null) => void;
   setLastAutoSavedImageSrc: (src: string | null) => void;
+  setDirty: (dirty: boolean) => void;
   clearAutoSaveState: () => void;
 }
 
@@ -40,15 +43,18 @@ export function createAutoSaveStore(options: CreateAutoSaveStoreOptions = {}) {
     autoSaveStatus: 'idle',
     autoSavedShareToken: initialShareToken,
     lastAutoSavedImageSrc: null,
+    isDirty: false,
 
     setAutoSaveStatus: (status) => set({ autoSaveStatus: status }),
     setAutoSavedShareToken: (token) => set({ autoSavedShareToken: token }),
     setLastAutoSavedImageSrc: (src) => set({ lastAutoSavedImageSrc: src }),
+    setDirty: (dirty) => set({ isDirty: dirty }),
     clearAutoSaveState: () =>
       set({
         autoSaveStatus: 'idle',
         autoSavedShareToken: null,
         lastAutoSavedImageSrc: null,
+        isDirty: false,
       }),
   }));
 }

--- a/packages/canvas-editor/src/utils/illustrations/fullCatalog.ts
+++ b/packages/canvas-editor/src/utils/illustrations/fullCatalog.ts
@@ -1,0 +1,25 @@
+/**
+ * Synchronous access to the complete illustration catalog, including the
+ * ~1600-entry undraw set (~280 KB of metadata).
+ *
+ * Import this ONLY from modules that already live in a lazy chunk (the
+ * assets sidebar section). Eager editor-core code must go through the async
+ * loaders in registry.ts instead, so the catalog stays out of the initial
+ * editor bundle.
+ */
+
+import { KAWAII_ILLUSTRATIONS } from './kawaii';
+import { OPENDOODLES } from './opendoodles';
+import { UNDRAW_ALL } from './undrawAll';
+
+import type { IllustrationDef, SvgDef } from './types';
+
+export const ALL_ILLUSTRATIONS: IllustrationDef[] = [
+  ...KAWAII_ILLUSTRATIONS,
+  ...OPENDOODLES,
+  ...UNDRAW_ALL,
+];
+
+export const ALL_SVG_ILLUSTRATIONS: SvgDef[] = [...OPENDOODLES, ...UNDRAW_ALL];
+
+export { UNDRAW_ALL };

--- a/packages/canvas-editor/src/utils/illustrations/registry.ts
+++ b/packages/canvas-editor/src/utils/illustrations/registry.ts
@@ -1,8 +1,11 @@
 /**
  * Illustration Registry
  *
- * Loads all illustration definitions synchronously at module load time,
- * similar to how icons are loaded in canvasIcons.ts.
+ * Small illustration sets (kawaii, opendoodles, featured undraw) load
+ * statically; the full ~1600-entry undraw catalog (~280 KB of metadata) is
+ * pulled in via dynamic import only when an async lookup first needs it, so
+ * it stays out of the editor-core chunk. Sync access to the full catalog
+ * lives in fullCatalog.ts (used only inside the lazy assets chunk).
  */
 
 import type {
@@ -16,7 +19,6 @@ import type {
 import { KAWAII_ILLUSTRATIONS } from './kawaii';
 import { OPENDOODLES } from './opendoodles';
 import { UNDRAW_FEATURED } from './undraw';
-import { UNDRAW_ALL } from './undrawAll';
 
 // Re-export types and constants for convenience
 export type {
@@ -33,20 +35,13 @@ export type {
 export { ILLUSTRATION_COLORS, KAWAII_MOODS } from './types';
 
 // =============================================================================
-// STATIC EXPORTS (loaded at module initialization, like icons)
+// ASYNC LOADERS
 // =============================================================================
 
-export const ALL_ILLUSTRATIONS: IllustrationDef[] = [
-  ...KAWAII_ILLUSTRATIONS,
-  ...OPENDOODLES,
-  ...UNDRAW_ALL,
-];
-
-export const ALL_SVG_ILLUSTRATIONS: SvgDef[] = [...OPENDOODLES, ...UNDRAW_ALL];
-
-// =============================================================================
-// LEGACY ASYNC LOADERS (kept for backward compatibility)
-// =============================================================================
+let undrawAllPromise: Promise<SvgDef[]> | null = null;
+function loadUndrawAll(): Promise<SvgDef[]> {
+  return (undrawAllPromise ??= import('./undrawAll').then((m) => m.UNDRAW_ALL));
+}
 
 export async function loadKawaiiIllustrations(): Promise<KawaiiDef[]> {
   return KAWAII_ILLUSTRATIONS;
@@ -61,11 +56,13 @@ export async function loadUndrawIllustrations(): Promise<SvgDef[]> {
 }
 
 export async function getAllIllustrations(): Promise<IllustrationDef[]> {
-  return ALL_ILLUSTRATIONS;
+  const undrawAll = await loadUndrawAll();
+  return [...KAWAII_ILLUSTRATIONS, ...OPENDOODLES, ...undrawAll];
 }
 
 export async function getAllSvgIllustrations(): Promise<SvgDef[]> {
-  return ALL_SVG_ILLUSTRATIONS;
+  const undrawAll = await loadUndrawAll();
+  return [...OPENDOODLES, ...undrawAll];
 }
 
 // =============================================================================
@@ -166,5 +163,7 @@ export async function getAllSvgCategories(): Promise<string[]> {
 export const getSvgIllustrationsByCategory = getIllustrationsByCategory;
 export const searchSvgIllustrations = searchIllustrations;
 
-// Re-export source arrays for direct access if needed
-export { KAWAII_ILLUSTRATIONS, OPENDOODLES, UNDRAW_FEATURED, UNDRAW_ALL };
+// Re-export the small static source arrays for direct access if needed.
+// The full undraw catalog is intentionally NOT re-exported here — sync
+// consumers use fullCatalog.ts so the data stays in a lazy chunk.
+export { KAWAII_ILLUSTRATIONS, OPENDOODLES, UNDRAW_FEATURED };

--- a/packages/canvas-editor/vitest.config.ts
+++ b/packages/canvas-editor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.vitest.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1148,6 +1148,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@26.1.0(canvas@3.2.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/chat:
     dependencies:
@@ -35408,7 +35411,7 @@ snapshots:
       cosmiconfig: 7.1.0
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@25.9.1)(babel-plugin-macros@3.1.0))(typescript@6.0.3)
       eslint-plugin-jsdoc: 46.10.1(eslint@8.57.1)
@@ -38794,7 +38797,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       debug: 4.4.3
       eslint: 8.57.1
@@ -38817,7 +38820,7 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

Follow-up to #1202 (**stacked on that branch** — GitHub will retarget this PR to `master` automatically once #1202 merges). Nine verified improvements across editing UX/data safety, performance, collaboration and mobile. Every item was adversarially verified against the code before implementation; several originally-claimed issues turned out to be false positives and were dropped.

### Editing UX & data safety
- **Undo now works for shape/asset/frame/extra-text/user-image edits** — their `update*` actions in `commonActions.ts` saved no history while `add`/`remove` did, so color, opacity and drag/transform edits could not be undone. Also fixes two handler-side saves that captured the stale pre-change state.
- **Autosave data-loss windows closed** — auto-capture skipped its turn while an element was selected and never re-ran on deselect ("drag element, close tab" lost the change); plus a new `isDirty` flag so the `beforeunload` warning covers unsaved edits, not just the in-flight request.
- **Error recovery** — "Erneut versuchen" buttons for failed autosaves and exports; the sidebar tab bar no longer renders autosave errors at `opacity-0` (they were invisible).
- **Escape deselects** (skipped while typing in inline editors); undo/redo tooltips show platform-specific shortcuts.

### Performance
- **~280 KB undraw catalog out of the editor-core chunk** — `undrawAll.ts` was statically imported via `registry.ts → IllustrationPrimitive → CanvasRenderLayer` into every editor session. Now behind a memoized dynamic import (registry APIs were already async — zero consumer changes); sync access for the already-lazy assets chunk lives in `fullCatalog.ts`; the AI capability bakes its curated `{id, label}` pairs statically, guarded by a new vitest.
- **Iconify catalog fan-out** moved from module-eval side effect to the existing `useIconCatalog` React Query hook — icon subsection and search now update reactively when the catalog arrives.

### Collaboration
- **Remote selections are finally rendered** — `useSelectionAwareness` existed with zero call sites. The Hocuspocus provider is threaded through to each page; the active page publishes the local selection (using `selectedElement`, which the config-driven editor actually uses — `selectedLayerIds` was always empty), and remotely-selected elements get a dashed outline in the peer's color plus a name chip.

### Mobile / desktop ergonomics
- **Pinch + ctrl/cmd-wheel zoom** — the editor already had zoom (CSS `--canvas-zoom` via CanvasMetaBar buttons) but no gesture input. New `useZoomGestures` hook drives the same state; double-click/tap on the empty margin resets; `touch-action: pan-x pan-y` keeps one-finger scrolling.

## Test plan
- [x] `pnpm typecheck` — 20/20
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter @gruenerator/canvas-editor test` — curated-illustration-id vitest passes
- [ ] Manual: shape color/drag → Ctrl+Z reverts; edit + close tab → leave warning; kill API → visible error + retry works; Escape deselects; undrawAll chunk loads only with the assets panel; two windows on a collab canvas show each other's selections; pinch zoom on mobile emulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)