### PR TITLE
fix: first click on sidebar thread no longer opens a new thread

### DIFF
--- a/packages/chat/src/components/thread/ThreadListItem.tsx
+++ b/packages/chat/src/components/thread/ThreadListItem.tsx
@@ -86,7 +86,11 @@ export function GrueneratorThreadListItem() {
           }
         }
       }
-      useAgentStore.getState().setChatViewMode('thread');
+      const store = useAgentStore.getState();
+      // Explicit thread pick: drop queued auto-send state so a stale persisted
+      // value can't make AutoMessageSender hijack the switch into a new thread.
+      store.setPendingInitialAssistantMessage(null);
+      store.setChatViewMode('thread');
       baseSwitchTo(e);
     },
     [baseSwitchTo, remoteId, ctx]
@@ -178,7 +182,9 @@ export function GrueneratorArchivedThreadListItem() {
   const handleDelete = useSafeThreadAction('delete');
   const handleSwitch = useCallback(
     (e: MouseEvent) => {
-      useAgentStore.getState().setChatViewMode('thread');
+      const store = useAgentStore.getState();
+      store.setPendingInitialAssistantMessage(null);
+      store.setChatViewMode('thread');
       baseSwitchTo(e);
     },
     [baseSwitchTo]

--- a/packages/chat/src/runtime/AgentSwitchListener.tsx
+++ b/packages/chat/src/runtime/AgentSwitchListener.tsx
@@ -17,6 +17,14 @@ export function AgentSwitchListener() {
     if (prevRef.current === selectedAgentId) return;
     prevRef.current = selectedAgentId;
 
+    // A deselect-to-null while in thread view is the side effect of opening an
+    // existing thread (ChatPage clears the agent on /chat without an agent
+    // param) — not a user-initiated agent switch. Resetting here would stomp
+    // the just-switched thread with a blank new one.
+    if (selectedAgentId === null && useAgentStore.getState().chatViewMode === 'thread') {
+      return;
+    }
+
     const store = useAgentStore.getState();
     store.setThreadMode('chat');
     store.setCustomSystemPrompt(null);


### PR DESCRIPTION
## Problem

Clicking an existing thread in the global sidebar opened a blank **new** thread; clicking the same thread a second time opened the right one.

## Root cause

The thread switch itself succeeds — and is then stomped:

1. The sidebar portal click also navigates to `/chat` (`GlobalChatProvider.openChat`).
2. `ChatPage` sees no agent in the URL and resets the **persisted** `selectedAgentId` to `null`.
3. The global `AgentSwitchListener` treats that deselect as an agent switch and runs `setCurrentThread(null)` + `switchToNewThread()` — after the click's `switchTo`, so the blank thread wins.
4. Second click works because `selectedAgentId` is already `null` → listener doesn't fire. The bug re-arms every time an agent is used (persisted id becomes non-null again).

assistant-ui internals are not at fault — `initialize()` resolves the existing `remoteId` correctly for list-loaded threads.

## Fix

- **AgentSwitchListener**: skip the reset when the agent is deselected (`null`) while `chatViewMode === 'thread'` — that's the side effect of opening an existing thread, not a user-initiated agent switch. Agent→agent switches and the Chat nav button (which sets `'overview'` before navigating) keep today's behavior.
- **ThreadListItem**: clear `pendingInitialAssistantMessage` on explicit thread clicks so a stale persisted value can't make `AutoMessageSender` hijack the switch the same way (identical symptom, secondary path).

## Verification

- Typecheck passes (`pnpm --filter @gruenerator/chat typecheck`).
- Manual repro: with a persisted agent id, click an existing thread from a non-chat page → opens that thread on the first click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)