### PR TITLE
fix: first click on sidebar thread no longer opens a new thread (test-branch)

### DIFF
--- a/packages/chat/src/components/thread/ThreadListItem.tsx
+++ b/packages/chat/src/components/thread/ThreadListItem.tsx
@@ -86,7 +86,11 @@ export function GrueneratorThreadListItem() {
           }
         }
       }
-      useAgentStore.getState().setChatViewMode('thread');
+      const store = useAgentStore.getState();
+      // Explicit thread pick: drop queued auto-send state so a stale persisted
+      // value can't make AutoMessageSender hijack the switch into a new thread.
+      store.setPendingInitialAssistantMessage(null);
+      store.setChatViewMode('thread');
       baseSwitchTo(e);
     },
     [baseSwitchTo, remoteId, ctx]
@@ -178,7 +182,9 @@ export function GrueneratorArchivedThreadListItem() {
   const handleDelete = useSafeThreadAction('delete');
   const handleSwitch = useCallback(
     (e: MouseEvent) => {
-      useAgentStore.getState().setChatViewMode('thread');
+      const store = useAgentStore.getState();
+      store.setPendingInitialAssistantMessage(null);
+      store.setChatViewMode('thread');
       baseSwitchTo(e);
     },
     [baseSwitchTo]

--- a/packages/chat/src/runtime/AgentSwitchListener.tsx
+++ b/packages/chat/src/runtime/AgentSwitchListener.tsx
@@ -17,6 +17,14 @@ export function AgentSwitchListener() {
     if (prevRef.current === selectedAgentId) return;
     prevRef.current = selectedAgentId;
 
+    // A deselect-to-null while in thread view is the side effect of opening an
+    // existing thread (ChatPage clears the agent on /chat without an agent
+    // param) — not a user-initiated agent switch. Resetting here would stomp
+    // the just-switched thread with a blank new one.
+    if (selectedAgentId === null && useAgentStore.getState().chatViewMode === 'thread') {
+      return;
+    }
+
     const store = useAgentStore.getState();
     store.setThreadMode('chat');
     store.setCustomSystemPrompt(null);


### PR DESCRIPTION
Same change as #1208, targeting `test-branch` for testing.

Fixes the first click on an existing sidebar thread opening a blank new thread (AgentSwitchListener stomping the switch after ChatPage resets the persisted `selectedAgentId`), plus hardening against stale `pendingInitialAssistantMessage` hijacking the switch via AutoMessageSender. See #1208 for the full root-cause trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)