### PR TITLE
fix(api): 503 statt 401, wenn das Auth-Backend nicht erreichbar ist

### DIFF
--- a/apps/api/config/betterAuth.ts
+++ b/apps/api/config/betterAuth.ts
@@ -234,20 +234,39 @@ export const auth = betterAuth({
     },
   },
 
+  // Redis failures must not bubble into Better Auth's session resolution:
+  // `get` returning null falls back to the Postgres session row
+  // (storeSessionInDatabase: true), and a lost `set` only skips the cache.
+  // `delete` is the exception — swallowing it would leave a revoked session
+  // readable from Redis until its TTL expires, so it logs and rethrows.
   secondaryStorage: {
     get: async (key) => {
-      const value = await redisClient.get(`ba:${key}`);
-      return value ?? null;
+      try {
+        const value = await redisClient.get(`ba:${key}`);
+        return value ?? null;
+      } catch (err) {
+        log.warn('secondaryStorage.get failed for ba:%s — falling back to DB: %s', key, err);
+        return null;
+      }
     },
     set: async (key, value, ttl) => {
-      if (ttl) {
-        await redisClient.set(`ba:${key}`, value, { EX: ttl });
-      } else {
-        await redisClient.set(`ba:${key}`, value);
+      try {
+        if (ttl) {
+          await redisClient.set(`ba:${key}`, value, { EX: ttl });
+        } else {
+          await redisClient.set(`ba:${key}`, value);
+        }
+      } catch (err) {
+        log.warn('secondaryStorage.set failed for ba:%s — cache write skipped: %s', key, err);
       }
     },
     delete: async (key) => {
-      await redisClient.del(`ba:${key}`);
+      try {
+        await redisClient.del(`ba:${key}`);
+      } catch (err) {
+        log.error('secondaryStorage.delete failed for ba:%s — session revocation at risk', key);
+        throw err;
+      }
     },
   },
 

--- a/apps/api/middleware/authMiddleware.ts
+++ b/apps/api/middleware/authMiddleware.ts
@@ -93,7 +93,18 @@ export function toBetterAuthUser(user: BetterAuthUser): UserProfile {
   return parsed;
 }
 
-async function tryResolveUser(req: Request): Promise<Express.User | null> {
+/**
+ * Returned by `tryResolveUser` when the auth backend (Postgres/Redis) failed
+ * while resolving the session — as opposed to `null`, which means "no valid
+ * session". The distinction matters: an infra hiccup must surface as 503, not
+ * 401, or the frontend treats a logged-in user as logged out and forces a
+ * re-login (observed in production as sporadic forced logouts).
+ */
+const AUTH_UNAVAILABLE = Symbol('auth-unavailable');
+
+async function tryResolveUser(
+  req: Request
+): Promise<Express.User | null | typeof AUTH_UNAVAILABLE> {
   if (
     env.NODE_ENV === 'development' &&
     env.ALLOW_DEV_AUTH_BYPASS &&
@@ -127,12 +138,12 @@ async function tryResolveUser(req: Request): Promise<Express.User | null> {
       req.headers.authorization ? 'present' : 'absent'
     );
   } catch (err) {
-    // Silent-catch boundary: returning `null` below produces a generic 401
-    // for the user without any error reaching Express's error middleware,
-    // so Sentry's `setupExpressErrorHandler` would never see this. Capture
+    // Silent-catch boundary: this never reaches Express's error middleware,
+    // so Sentry's `setupExpressErrorHandler` would never see it. Capture
     // explicitly to surface session-resolution failures (DB errors, Redis
     // outages, malformed cookies) that would otherwise be invisible.
     captureAuthIssue({ stage: 'session-resolve', cause: err, req });
+    return AUTH_UNAVAILABLE;
   }
 
   return null;
@@ -183,6 +194,17 @@ async function requireAuth(req: Request, res: Response, next: NextFunction): Pro
   }
 
   const user = await tryResolveUser(req);
+  if (user === AUTH_UNAVAILABLE) {
+    // Auth backend failure, not a dead session — 503 instead of 401 so the
+    // client neither wipes its auth state nor redirects to login. No
+    // /auth/login redirect in the HTML branch either: that bounce is exactly
+    // what forces an unnecessary re-login.
+    res.status(503).json({
+      error: 'auth_unavailable',
+      message: 'Anmeldedienst vorübergehend nicht erreichbar',
+    });
+    return;
+  }
   if (user) {
     req.user = user;
     return next();
@@ -219,7 +241,10 @@ async function optionalAuth(req: Request, _res: Response, next: NextFunction): P
   }
 
   const user = await tryResolveUser(req);
-  if (user) {
+  // AUTH_UNAVAILABLE degrades to the guest view here instead of failing the
+  // whole request: optional-auth routes serve public content, and a logged-in
+  // user transiently seeing the guest variant beats a hard 503 on it.
+  if (user && user !== AUTH_UNAVAILABLE) {
     req.user = user;
   }
   return next();

--- a/apps/api/middleware/authMiddleware.vitest.ts
+++ b/apps/api/middleware/authMiddleware.vitest.ts
@@ -242,7 +242,10 @@ describe('requireAuth', () => {
     expect(state.statusCode).toBe(401);
   });
 
-  it('401s when Better Auth throws during session resolution', async () => {
+  it('503s with auth_unavailable when Better Auth throws during session resolution', async () => {
+    // An infra failure (Redis/Postgres down) is NOT a dead session. A 401
+    // here makes the frontend wipe its auth state and force a re-login —
+    // the exact production bug this distinction fixes.
     getSessionMock.mockRejectedValue(new Error('Redis connection lost'));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -252,8 +255,24 @@ describe('requireAuth', () => {
 
     await requireAuth(req, res, next);
 
-    // Must not crash; must 401 the request; must log the error.
-    expect(state.statusCode).toBe(401);
+    expect(state.statusCode).toBe(503);
+    expect(state.body).toMatchObject({ error: 'auth_unavailable' });
+    expect(next).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('503s (no login redirect) for HTML requests when Better Auth throws', async () => {
+    getSessionMock.mockRejectedValue(new Error('Postgres timeout'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = mockReq({ originalUrl: '/dashboard', headers: { accept: 'text/html' } });
+    const { res, state } = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await requireAuth(req, res, next);
+
+    expect(state.statusCode).toBe(503);
+    expect(state.redirected).toBeNull();
     expect(next).not.toHaveBeenCalled();
     errorSpy.mockRestore();
   });
@@ -312,6 +331,22 @@ describe('optionalAuth', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(state.statusCode).toBe(200); // untouched
     expect(req.user).toBeUndefined();
+  });
+
+  it('degrades to guest (next(), no user) when Better Auth throws', async () => {
+    getSessionMock.mockRejectedValue(new Error('Redis connection lost'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = mockReq({ headers: { cookie: 'better-auth.session=xyz' } });
+    const { res, state } = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await optionalAuth(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(state.statusCode).toBe(200); // untouched — no 503 on public content
+    expect(req.user).toBeUndefined();
+    errorSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Problem

Wirft `auth.api.getSession()` (Redis-/Postgres-Hiccup, fehlgeschlagene Cookie-Cache-Revalidierung), wurde der Fehler still geschluckt und als **401** beantwortet — für das Frontend ununterscheidbar von einer abgelaufenen Session. Folge: Auth-Caches werden gewiped, Redirect zu /login, Nutzer*innen müssen sich neu anmelden, obwohl ihre Session gültig war. Das ist eine der Ursachen für die sporadischen "Ein unerwarteter Fehler"-Toasts und Zwangs-Logouts.

## Änderungen

- **authMiddleware**: Infra-Fehler bei der Session-Auflösung werden jetzt per `AUTH_UNAVAILABLE`-Sentinel von "keine Session" unterschieden. `requireAuth` antwortet **503 `{ error: 'auth_unavailable' }`** ohne Login-Redirect (auch im HTML-Zweig). `optionalAuth` degradiert zur Gast-Ansicht statt hart zu failen.
- **betterAuth secondaryStorage**: Redis-Fehler propagieren nicht mehr in Better-Auth-Interna — `get` → `null` (Fallback auf die Postgres-Session-Row dank `storeSessionInDatabase: true`), `set` best-effort. `delete` loggt und rethrowt weiterhin, damit eine fehlgeschlagene Session-Revocation nie still bleibt.
- **Tests**: Der Test, der das 401-bei-Throw-Verhalten festgepinnt hatte, ist auf 503 umgeschrieben; neue Tests für den 503-Pfad (JSON + HTML) und die optionalAuth-Degradierung. `requireAuth` gibt bei `getSession → null` weiterhin 401 (Regression-Guard).

## Companion-PR

Frontend-Teil (Probe-Verdikt, 401-Retry, Toasts): `fix/auth-probe-retry-toasts` — beide sind unabhängig deploybar, dieser hier stoppt das schlimmste Symptom (Infra-Blip → Zwangs-Logout).

## Test

`pnpm --filter @gruenerator/api test` — 19/19 grün (authMiddleware.vitest.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)