### PR TITLE
fix(web): Infra-Hiccups loggen Nutzer nicht mehr aus; Fehler-Toasts werden hilfreich

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -71,8 +71,11 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false, // Verhindert unnötige Neuladungen
       refetchOnReconnect: 'always', // Nur bei Reconnect neu laden
       retry: (failureCount, error: unknown) => {
-        // Smart retry logic
-        const status = (error as { status?: number })?.status;
+        // Smart retry logic. Status lives at `.status` on AxiosErrors and
+        // ApiErrors, but at `.response.status` on older transformed shapes —
+        // read both so 401/403/404 are reliably excluded from retries.
+        const err = error as { status?: number; response?: { status?: number } } | undefined;
+        const status = err?.status ?? err?.response?.status;
         if (status === 404 || status === 401 || status === 403) return false;
         return failureCount < 2; // Max 2 retries
       },

--- a/apps/web/src/axios.d.ts
+++ b/apps/web/src/axios.d.ts
@@ -4,5 +4,7 @@ declare module 'axios' {
   interface AxiosRequestConfig {
     /** When true, the 401 response interceptor skips redirecting to login */
     skipAuthRedirect?: boolean;
+    /** Internal: marks a request already re-fired once after a transient 401 */
+    _retried401?: boolean;
   }
 }

--- a/apps/web/src/components/utils/apiClient.ts
+++ b/apps/web/src/components/utils/apiClient.ts
@@ -7,6 +7,7 @@ import {
   INSTANT_AUTH_CACHE,
   LOGOUT_TIMESTAMP,
   REDIRECT_TIMESTAMPS,
+  SESSION_EXPIRED_FLAG,
 } from '../../features/auth/storageKeys';
 import { captureAuthIssue } from '../../lib/observability/captureAuthIssue';
 import { buildLoginUrl, isPublicPage } from '../../utils/authRedirect';
@@ -41,44 +42,51 @@ const baseURL: string = (import.meta.env.VITE_API_BASE_URL as string | undefined
 // back → user loses state.
 //
 // New rule: **never trust a single 401 as proof of dead session**.
-// Instead, on the first 401, do a silent session probe against
-// `/auth/status`. If the probe returns `isAuthenticated: true`, the
-// 401 was transient — swallow it and let the caller's query retry
-// mechanism do its thing. If the probe returns unauthenticated (or
-// itself 401s), THEN redirect.
+// Instead, on the first 401, do a silent session probe. The probe
+// yields a three-way verdict:
+//
+//   'alive'         — probe confirmed the session: the 401 was transient
+//                     (cookie rotation mid-flight). Retry the original
+//                     request once instead of failing the user's action.
+//   'dead'          — probe definitively saw no session (200 without a
+//                     user, or the probe itself 401/403'd). Redirect.
+//   'indeterminate' — probe failed for OTHER reasons (timeout, network,
+//                     5xx — e.g. the backend's auth_unavailable 503 while
+//                     Redis is down). This says NOTHING about the session;
+//                     treating it as dead used to log users out during
+//                     pure infra hiccups. Neither retry nor redirect —
+//                     propagate the error to the caller's handling.
 //
 // The probe result is cached for 5 seconds so a cascade of 401s
 // across multiple routes (e.g. 10 TanStack queries re-firing after
-// window focus) share one probe instead of DOSing `/auth/status`.
+// window focus) share one probe instead of DOSing the endpoint.
 //
 // Routes tagged `skipAuthRedirect: true` still bypass the whole
 // path — they explicitly opt out of any redirect behavior.
 
 const PROBE_CACHE_TTL_MS = 5_000;
 
+type ProbeVerdict = 'alive' | 'dead' | 'indeterminate';
+
 interface ProbeState {
   timestamp: number;
-  isAuthenticated: boolean;
+  verdict: ProbeVerdict;
 }
 
-let probeInFlight: Promise<boolean> | null = null;
+let probeInFlight: Promise<ProbeVerdict> | null = null;
 let lastProbe: ProbeState | null = null;
 
 /**
- * Silently probe `/auth/status` to decide whether the session is
- * actually dead or whether the 401 we just saw was transient. Returns
- * `true` if the session is healthy (caller should swallow the 401),
- * `false` if the session is dead (caller should redirect).
- *
- * Coalesces concurrent probes: the first caller kicks off the fetch,
- * every other caller within the same tick awaits the same promise.
- * Caches the result for 5s to collapse 401 cascades across routes.
+ * Silently probe Better Auth's session endpoint to classify the 401 we
+ * just saw. Coalesces concurrent probes: the first caller kicks off the
+ * fetch, every other caller within the same tick awaits the same promise.
+ * Caches the verdict for 5s to collapse 401 cascades across routes.
  */
-async function isSessionStillAlive(): Promise<boolean> {
+async function probeSessionVerdict(): Promise<ProbeVerdict> {
   // Return cached result if recent.
   const now = Date.now();
   if (lastProbe && now - lastProbe.timestamp < PROBE_CACHE_TTL_MS) {
-    return lastProbe.isAuthenticated;
+    return lastProbe.verdict;
   }
 
   // Coalesce in-flight probes.
@@ -86,44 +94,33 @@ async function isSessionStillAlive(): Promise<boolean> {
     return probeInFlight;
   }
 
-  probeInFlight = (async (): Promise<boolean> => {
+  probeInFlight = (async (): Promise<ProbeVerdict> => {
+    let verdict: ProbeVerdict;
     try {
       // Hit Better Auth's native session endpoint directly. Going through
       // `apiClient` would re-enter the interceptor and infinite-loop;
-      // `authClient.getSession()` is a peer of `apiClient` so it doesn't
+      // this raw axios call is a peer of `apiClient` so it doesn't
       // share the interceptor chain.
       const response = await axios.get(`${baseURL}/auth/v2/get-session`, {
         withCredentials: useCredentials,
         timeout: 10_000,
       });
       const data = response.data as { user?: unknown } | null | undefined;
-      const alive = data != null && data.user != null;
-      lastProbe = { timestamp: Date.now(), isAuthenticated: alive };
-      return alive;
-    } catch {
-      // Probe itself failed (usually 401 — session really is dead).
-      lastProbe = { timestamp: Date.now(), isAuthenticated: false };
-      return false;
+      verdict = data != null && data.user != null ? 'alive' : 'dead';
+    } catch (probeError) {
+      // Only a definitive 401/403 from the probe proves the session is
+      // dead. Anything else (timeout, network error, 5xx) is an infra
+      // signal, not a session signal.
+      const status = (probeError as AxiosError).response?.status;
+      verdict = status === 401 || status === 403 ? 'dead' : 'indeterminate';
     } finally {
       probeInFlight = null;
     }
+    lastProbe = { timestamp: Date.now(), verdict };
+    return verdict;
   })();
 
   return probeInFlight;
-}
-
-/**
- * Decide whether a 401 from an arbitrary request should trigger a
- * full-page redirect to login. Returns `true` if the caller should
- * redirect, `false` if the 401 was transient and should be swallowed.
- */
-async function shouldRedirectOn401(): Promise<boolean> {
-  if (_isLoggingOut) return false;
-  if (isPublicPage()) return false;
-  if (window.location.pathname === '/login') return false;
-
-  const alive = await isSessionStillAlive();
-  return !alive;
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -246,6 +243,16 @@ function performLoginRedirect(): void {
     .concat(now);
   writeRedirectTimestamps(recent);
 
+  // Tell the login page WHY the user landed there. sessionStorage so it
+  // survives the full-page navigation but stays scoped to this tab; the
+  // login page reads-and-removes it to show a "Sitzung abgelaufen" banner
+  // instead of silently dropping the user on a bare login screen.
+  try {
+    sessionStorage.setItem(SESSION_EXPIRED_FLAG, '1');
+  } catch {
+    // Non-fatal.
+  }
+
   // Always wipe the instant-auth cache + set the cooldown marker before
   // navigating. This is the load-bearing fix: without it, the next /login
   // mount reads stale "isAuthenticated:true" from cache and bounces back.
@@ -292,7 +299,9 @@ const useCredentials: boolean = !isDesktopApp();
 //   - Return `false` → shared client propagates the 401 to the caller. We
 //     return false when the probe says the session is dead; `performLoginRedirect`
 //     has already fired, so the navigation is in flight and the rejected
-//     promise just unblocks any await'ing code.
+//     promise just unblocks any await'ing code. An 'indeterminate' verdict
+//     (probe failed on infra, not auth) also returns false — but WITHOUT
+//     the redirect, so an outage doesn't log the user out.
 const sharedApiClient = createApiClient({
   baseURL,
   authMode: isDesktopApp() ? 'bearer' : 'cookie',
@@ -301,14 +310,15 @@ const sharedApiClient = createApiClient({
     if (_isLoggingOut || isPublicPage() || window.location.pathname === '/login') {
       return false;
     }
-    const alive = await isSessionStillAlive();
-    if (alive) {
+    const verdict = await probeSessionVerdict();
+    if (verdict === 'alive') {
       // Session is actually healthy — tell the shared client to retry
       // the original request. The cookie just got rotated mid-flight.
       return true;
     }
-    // Real dead session. Fire the redirect and let the 401 propagate.
-    performLoginRedirect();
+    if (verdict === 'dead') {
+      performLoginRedirect();
+    }
     return false;
   },
   timeout: 900000,
@@ -359,28 +369,40 @@ apiClient.interceptors.request.use(
 
 // Response interceptor for error handling.
 //
-// Goes through `shouldRedirectOn401` which probes `/auth/status`
-// silently before deciding. A single transient 401 — e.g. from a
-// background poller firing during a Better Auth cookie revalidation —
-// is swallowed because the probe finds the session is actually alive.
-// Only when the probe itself 401s (or returns `isAuthenticated: false`)
-// does the redirect fire. See the long-form explanation above the
-// `shouldRedirectOn401` helper.
+// On a 401, `probeSessionVerdict` silently classifies the failure (see the
+// long-form explanation above the helper):
+//   'alive'         → the 401 was transient (cookie rotation mid-flight).
+//                     Re-fire the original request ONCE. Without this, the
+//                     swallowed 401 reached the caller, `toastApiError`
+//                     skipped it (401s never toast), and the user's click
+//                     simply did nothing — especially for mutations, which
+//                     TanStack Query never retries. Safe to replay: a 401
+//                     means `requireAuth` rejected before the handler ran,
+//                     so no server-side side effect happened; the re-dispatch
+//                     re-runs the request interceptor (fresh desktop token).
+//   'dead'          → redirect to login (except on public pages / /login).
+//   'indeterminate' → neither: propagate the error to the caller.
 //
 // Routes tagged `skipAuthRedirect: true` bypass the whole path.
 apiClient.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
-    if (error.config?.skipAuthRedirect) {
+    const config = error.config;
+    if (config?.skipAuthRedirect) {
       return Promise.reject(error);
     }
 
-    if (error.response && error.response.status === 401) {
-      if (await shouldRedirectOn401()) {
+    if (error.response && error.response.status === 401 && !_isLoggingOut) {
+      const verdict = await probeSessionVerdict();
+      if (verdict === 'alive' && config && !config._retried401) {
+        config._retried401 = true;
+        return apiClient.request(config);
+      }
+      if (verdict === 'dead' && !isPublicPage() && window.location.pathname !== '/login') {
         performLoginRedirect();
       }
-      // Always reject so the caller's `.catch` / TanStack Query error
-      // handler can surface a sensible error state. Swallowing to
+      // Always reject otherwise so the caller's `.catch` / TanStack Query
+      // error handler can surface a sensible error state. Swallowing to
       // `undefined` would hide real failures (non-auth 500s, network
       // errors) from component-level retry logic.
     }
@@ -509,6 +531,10 @@ const handleApiError = (error: AxiosError): never => {
         errorData.message || `Serverfehler (Status ${status})`
       );
       friendlyError.name = errorData.errorType || 'ServerError';
+      // Without `.status` this error is opaque to every status-based consumer:
+      // `getErrorMessage` falls through to the generic "Unerwarteter Fehler"
+      // toast and `toastApiError`'s 401/404 skip never matches.
+      friendlyError.status = status;
       friendlyError.originalError = error;
       friendlyError.errorId = errorData.errorId;
       friendlyError.timestamp = errorData.timestamp;

--- a/apps/web/src/components/utils/errorMessages.ts
+++ b/apps/web/src/components/utils/errorMessages.ts
@@ -91,6 +91,13 @@ const errorMessages: Record<ErrorCode, ErrorMessageInfo> = {
       'Der KI-Dienst ist derzeit überlastet. Bitte versuchen Sie es in einigen Minuten erneut.',
   },
 
+  // Backend error codes
+  auth_unavailable: {
+    title: 'Anmeldedienst nicht erreichbar',
+    message:
+      'Der Anmeldedienst ist vorübergehend nicht erreichbar. Deine Sitzung ist nicht abgelaufen — bitte versuche es gleich erneut.',
+  },
+
   // Axios Error Codes
   ERR_NETWORK: {
     title: 'Netzwerkfehler',
@@ -159,6 +166,11 @@ export const getErrorMessage = (error: ErrorInput): ErrorMessageInfo => {
     errorType = error.response?.status || error.code || 'ERR_NETWORK';
   } else if (isAnthropicError(error)) {
     errorType = error.error?.type || 'default';
+  } else if (typeof (error as { status?: unknown })?.status === 'number') {
+    // ApiErrors thrown by handleApiError (apiClient.ts) are plain Errors
+    // carrying `.status` — without this branch they all fell through to the
+    // generic "Unerwarteter Fehler" fallback regardless of the actual code.
+    errorType = (error as { status: number }).status;
   } else if (hasCode(error)) {
     errorType = error.code || 'default';
   } else if (typeof error === 'string') {

--- a/apps/web/src/components/utils/toastError.ts
+++ b/apps/web/src/components/utils/toastError.ts
@@ -11,11 +11,45 @@ const TOAST_IDS = {
   rateLimited: 'api-error-429',
   network: 'api-error-network',
   serverError: 'api-error-5xx',
+  authUnavailable: 'api-error-auth-unavailable',
   generic: 'api-error-generic',
 } as const;
 
+/**
+ * Errors reach this layer in two shapes: raw AxiosErrors (status under
+ * `response.status`) and ApiErrors thrown by `handleApiError` in apiClient.ts
+ * (plain Errors carrying `.status`, `.errorId` and the original AxiosError
+ * under `.originalError`). Both must resolve, or the 401/404 skip and the
+ * status-based messages silently fall back to the generic toast.
+ */
+interface ApiErrorLike {
+  status?: number;
+  errorId?: string;
+  message?: string;
+  response?: AxiosError['response'];
+  originalError?: AxiosError;
+}
+
+interface ApiErrorBody {
+  error?: string;
+  message?: string;
+  errorId?: string;
+}
+
+function resolveStatus(error: unknown): number | undefined {
+  const e = error as ApiErrorLike | undefined;
+  return e?.response?.status ?? e?.status ?? e?.originalError?.response?.status;
+}
+
+function resolveBody(error: unknown): ApiErrorBody | null {
+  const e = error as ApiErrorLike | undefined;
+  const data = e?.response?.data ?? e?.originalError?.response?.data;
+  return typeof data === 'object' && data !== null ? (data as ApiErrorBody) : null;
+}
+
 function readRetryAfterSeconds(error: unknown): number | null {
-  const headers = (error as AxiosError | undefined)?.response?.headers;
+  const e = error as ApiErrorLike | undefined;
+  const headers = e?.response?.headers ?? e?.originalError?.response?.headers;
   if (!headers) return null;
   const raw: unknown = headers['retry-after'] ?? headers['Retry-After'];
   if (!raw) return null;
@@ -42,17 +76,48 @@ function pickToastId(status: number | undefined): string {
  * category collapse into a single toast via sonner's id-based dedup.
  */
 export function toastApiError(error: unknown): void {
-  const status = (error as AxiosError | undefined)?.response?.status;
+  const status = resolveStatus(error);
 
   // 401 is handled by the auth-redirect layer (apiClient interceptor + AuthRoute).
   // Toasting "Authentifizierungsfehler" on every logged-out page load is noise.
   // 404 typically reflects a stale or wrong URL — callers show inline empty states.
   if (status === 401 || status === 404) return;
 
+  const body = resolveBody(error);
+
+  // The backend's "auth backend is down" signal (authMiddleware 503). The
+  // session is NOT expired — say so explicitly, the generic 5xx wording
+  // would read like data loss.
+  if (status === 503 && body?.error === 'auth_unavailable') {
+    const { title, message } = getErrorMessage({ code: 'auth_unavailable' });
+    toast.error(title, {
+      id: TOAST_IDS.authUnavailable,
+      description: message,
+    });
+    return;
+  }
+
   const { title, message } = getErrorMessage(error);
   const retryAfter = status === 429 ? readRetryAfterSeconds(error) : null;
-  const description =
-    retryAfter !== null ? `Bitte versuche es in ${retryAfter} Sekunden erneut.` : message;
+
+  // Prefer the backend-provided human message over the static dictionary —
+  // it knows WHY the request failed ("Datei zu groß", "Notebook nicht
+  // gefunden", …). The errorId lets support find the exact log line.
+  const apiError = error as ApiErrorLike | undefined;
+  const backendMessage =
+    (typeof body?.message === 'string' && body.message) ||
+    (apiError?.errorId && typeof apiError.message === 'string' ? apiError.message : null);
+  const errorId = body?.errorId ?? apiError?.errorId;
+
+  let description: string;
+  if (retryAfter !== null) {
+    description = `Bitte versuche es in ${retryAfter} Sekunden erneut.`;
+  } else {
+    description = backendMessage || message;
+    if (errorId) {
+      description += `\nFehler-ID: ${errorId}`;
+    }
+  }
 
   toast.error(title, {
     id: pickToastId(status),

--- a/apps/web/src/features/auth/pages/LoginPage.tsx
+++ b/apps/web/src/features/auth/pages/LoginPage.tsx
@@ -7,6 +7,7 @@ import { getIntendedRedirect, isMobileAppContext } from '../../../utils/authRedi
 import { cn } from '../../../utils/cn';
 import { openDesktopLogin, type AuthSource } from '../../../utils/desktopAuth';
 import { isDesktopApp } from '../../../utils/platform';
+import { SESSION_EXPIRED_FLAG } from '../storageKeys';
 
 // Auth Backend URL from environment variable or fallback to relative path
 const AUTH_BASE_URL = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? '/api';
@@ -61,6 +62,25 @@ const LoginPage = ({
   const isMobileApp = isMobileAppContext(location);
 
   const successMessage = (location.state as { message?: string } | null)?.message;
+
+  // Read-and-remove: set by performLoginRedirect (apiClient) when a dead
+  // session forced the user here. Lazy initializer so it survives re-renders
+  // but is consumed exactly once per redirect.
+  const [sessionExpired] = useState(() => {
+    try {
+      const flag = sessionStorage.getItem(SESSION_EXPIRED_FLAG);
+      if (flag !== null) sessionStorage.removeItem(SESSION_EXPIRED_FLAG);
+      return flag !== null;
+    } catch {
+      return false;
+    }
+  });
+
+  const sessionExpiredBanner = sessionExpired && !successMessage && (
+    <div className="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-500 p-md mb-md rounded-sm text-foreground">
+      Deine Sitzung ist abgelaufen — bitte melde dich erneut an.
+    </div>
+  );
 
   const displayPageName =
     pageName || (mode === 'required' ? getPageName(location.pathname) : undefined);
@@ -193,6 +213,8 @@ const LoginPage = ({
             >
               {getHeaderContent()}
 
+              {sessionExpiredBanner}
+
               {successMessage && (
                 <div className="bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500 p-md mb-md rounded-sm">
                   {successMessage}
@@ -254,6 +276,8 @@ const LoginPage = ({
           )}
         >
           {getHeaderContent()}
+
+          {sessionExpiredBanner}
 
           {successMessage && (
             <div className="bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500 p-md mb-md rounded-sm">

--- a/apps/web/src/features/auth/storageKeys.ts
+++ b/apps/web/src/features/auth/storageKeys.ts
@@ -23,6 +23,13 @@ export const SESSION_ACTIVE = 'gruenerator_session_active';
 // reload that `performLoginRedirect` triggers but resets when the tab closes.
 export const REDIRECT_TIMESTAMPS = 'gruenerator_redirect_timestamps';
 
+// Set by `performLoginRedirect` right before navigating to /login; the login
+// page reads-and-removes it to show a "Sitzung abgelaufen" banner so the user
+// knows WHY they landed there. sessionStorage (per-tab, survives the redirect's
+// full-page navigation) and intentionally NOT in ALL_AUTH_LOCAL_KEYS — it must
+// outlive the auth-cache wipe that precedes the redirect.
+export const SESSION_EXPIRED_FLAG = 'gruenerator_session_expired';
+
 /**
  * All localStorage keys that hold any form of "user is authenticated" hint.
  * Use this when nuking auth state in defensive paths (circuit breaker, dead


### PR DESCRIPTION
## Problem

Drei Symptome aus der Praxis: sporadische generische "Ein unerwarteter Fehler"-Toasts, plötzliche Redirects zum Login (Session war eigentlich gültig), und Klicks, bei denen "einfach nichts passiert".

## Root Causes & Fixes

1. **Session-Probe wertete jeden Fehler als tote Session** (`apiClient.ts`): Timeout/Netzwerkfehler/5xx bei der Probe → `performLoginRedirect()`. Jetzt ein Drei-Wege-Verdikt: nur ein definitives 401/403 (oder 200 ohne User) gilt als tot; Infra-Fehler sind `indeterminate` → kein Redirect, Fehler propagiert zum Aufrufer.
2. **Verschluckte transiente 401er wurden nie retried**: Sagte die Probe "Session lebt", wurde der 401 trotzdem rejected — `toastApiError` skippt 401er, also sah der Nutzer nichts (v.a. bei Mutations). Der Interceptor re-fired den Original-Request jetzt einmal (begrenzt durch `_retried401`), analog zur bestehenden Shared-Client-Semantik. Sicher: 401 heißt, `requireAuth` hat vor dem Handler abgelehnt — kein Server-Side-Effect.
3. **`handleApiError` verlor den Statuscode**: Transformierte Fehler mit Backend-JSON-Message hatten kein `.status`/`.response` → `getErrorMessage` fiel immer auf den generischen Fallback, und der 401/404-Toast-Skip griff nie. Status wird jetzt gesetzt und über alle Fehler-Shapes aufgelöst (`response.status` / `.status` / `originalError`).

## Hilfreichere Toasts

- Backend-Message wird bevorzugt angezeigt (statt statischem Wörterbuch), `Fehler-ID: …` für Support-Lookups angehängt.
- Eigener Toast für das neue `auth_unavailable`-503 des Backends: "Deine Sitzung ist nicht abgelaufen — bitte versuche es gleich erneut."
- /login zeigt ein "Sitzung abgelaufen"-Banner (sessionStorage-Flag, read-and-remove), statt Nutzer kommentarlos auf dem Login abzusetzen.
- Dedup-IDs bleiben erhalten; React-Query-Retry-Check liest den Status jetzt robust.

## Companion-PR

Backend-Teil: #1210 (503 statt 401 bei Auth-Backend-Ausfall). Beide unabhängig deploybar.

## Test

`pnpm --filter @gruenerator/web typecheck` grün, ESLint/Prettier sauber. Manuelle Repro-Szenarien (Redis stoppen → Toast statt Logout; Session-Cookie löschen → Banner auf /login) in der Plan-Datei dokumentiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)