### PR TITLE
fix(api): restore 5-year Brandenburg archive coverage in scraper config

### DIFF
--- a/apps/api/config/landesverbaendeConfig.ts
+++ b/apps/api/config/landesverbaendeConfig.ts
@@ -777,19 +777,24 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
           listSelector: 'a[href*="/single-news/"]',
           paginationPattern: '/seite-{page}',
           paginationOffset: -1,
-          maxPages: 15,
+          // Frozen archive (ends Mai 2025), ~5 articles/page; page ~60 reaches
+          // Mitte 2021, so 70 covers the full 5-year window (maxAgeYears).
+          maxPages: 70,
         },
       ],
       contentSelectors: {
-        title: ['h1', '.news-single h2', 'meta[property="og:title"]'],
+        // h1 is the site logo link; the headline is the h2 inside the
+        // single-news container's <header>.
+        title: ['.news.single header h2', 'meta[property="og:title"]', 'h1'],
+        // No bare 'time' selector: the sidebar event calendar renders upcoming
+        // dates as <time> tags, which previously stamped every article with a
+        // future event date.
         date: [
-          'time[datetime]',
-          'time',
-          '.date',
-          '.news-date',
           'meta[property="article:published_time"]',
+          'time[datetime]',
+          '.ce-bodytext p.inlineleft',
         ],
-        content: ['.news-text', '.bodytext', 'article', 'main .content'],
+        content: ['.ce-bodytext', '.news-text', '.bodytext'],
         categories: ['.news-category', '.tags a', 'a[href*="/themen/"]'],
         author: ['.author', '.byline'],
       },
@@ -803,24 +808,38 @@ export const LANDESVERBAENDE_CONFIG: LandesverbaendeConfig = {
       baseUrl: 'https://archiv.gruene-brandenburg.de',
       cms: 'typo3',
       maxAgeYears: 5,
+      // /beschluesse is only an index of per-year listing pages; the PDFs live
+      // on those year pages. Only years inside the 5-year window are listed —
+      // older year pages would be OCR'd and then dropped by the age filter.
+      // PDF URLs embed the year (/beschluesse/2022/2022-03/...), so
+      // DateExtractor dates them without processUndatedPdfs.
       contentPaths: [
         {
           type: 'beschluss',
-          path: '/beschluesse',
-          listSelector: 'a[href*="/beschluesse/"], a[href$=".pdf"]',
+          path: '/partei/parteitage/beschluesse/2021',
+          listSelector: 'a[href$=".pdf"]',
+          isPdfArchive: true,
+          maxPages: 1,
+        },
+        {
+          type: 'beschluss',
+          path: '/partei/parteitage/beschluesse/2022',
+          listSelector: 'a[href$=".pdf"]',
+          isPdfArchive: true,
+          maxPages: 1,
+        },
+        {
+          type: 'beschluss',
+          path: '/partei/parteitage/beschluesse/2022-1',
+          listSelector: 'a[href$=".pdf"]',
+          isPdfArchive: true,
           maxPages: 1,
         },
       ],
       contentSelectors: {
-        title: ['h1', '.news-single h2', 'meta[property="og:title"]'],
-        date: [
-          'time[datetime]',
-          'time',
-          '.date',
-          '.news-date',
-          'meta[property="article:published_time"]',
-        ],
-        content: ['.news-text', '.bodytext', 'article', 'main .content'],
+        title: ['.news.single header h2', 'meta[property="og:title"]', 'h1'],
+        date: ['meta[property="article:published_time"]', 'time[datetime]'],
+        content: ['.ce-bodytext', '.news-text', '.bodytext'],
         categories: ['.news-category', '.tags a'],
         author: ['.author', '.byline'],
       },

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/DateExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/DateExtractor.ts
@@ -41,14 +41,20 @@ export class DateExtractor {
     tenYearsAgo.setFullYear(tenYearsAgo.getFullYear() - 10);
     const currentYear = new Date().getFullYear();
 
-    // Date patterns to try (in priority order)
-    const patterns = [
+    // Full-date patterns (in priority order)
+    const strongPatterns = [
       /(\d{4})-(\d{1,2})-(\d{1,2})/, // ISO format: 2023-05-15
       /(\d{1,2})-(\d{1,2})-(\d{4})/, // US format: 05-15-2023
       /(\d{1,2})\.(\d{1,2})\.(\d{4})/, // German format: 15.05.2023
       /(\d{1,2})_(\d{1,2})_(\d{4})/, // Underscore: 15_05_2023
       /(\d{4})_(\d{1,2})_(\d{1,2})/, // Underscore ISO: 2023_05_15
       GERMAN_MONTH_PATTERN, // German text month: 24. Mai 2025
+    ];
+    // Year-only fallbacks. Tried only after NO text yielded a full date:
+    // WordPress upload paths (/uploads/2025/07/) put the upload year in the
+    // URL, which must not outrank a real publish date in the link context
+    // (e.g. "29.04.2023 | Landesdelegiertenkonferenz" next to the PDF link).
+    const weakPatterns = [
       /_(20[0-2]\d)_/, // Year between underscores: LDK_2023_Potsdam (\b never matches next to _, a word char)
       /\b(20[0-2]\d)\b/, // Year only: 2023
       /\b(199\d)\b/, // Year only: 1990s
@@ -57,49 +63,55 @@ export class DateExtractor {
     // Try to extract date from URL, title, or context (in priority order)
     const texts = [url, title, context].filter(Boolean);
 
-    for (const text of texts) {
-      for (const pattern of patterns) {
-        const match = text.match(pattern);
-        if (match) {
-          let year: number | undefined, month: number | undefined, day: number | undefined;
+    for (const patterns of [strongPatterns, weakPatterns])
+      for (const text of texts) {
+        for (const pattern of patterns) {
+          const match = text.match(pattern);
+          if (match) {
+            let year: number | undefined, month: number | undefined, day: number | undefined;
 
-          if (match.length === 4) {
-            // Check for German text month (e.g. "24. Mai 2025")
-            const germanMonth = GERMAN_MONTHS[match[2].toLowerCase()];
-            if (germanMonth) {
-              year = parseInt(match[3]);
-              month = germanMonth;
-              day = parseInt(match[1]) || 1;
-            } else if (match[1].length === 4) {
-              // Format: YYYY-MM-DD or YYYY_MM_DD
+            if (match.length === 4) {
+              // Check for German text month (e.g. "24. Mai 2025")
+              const germanMonth = GERMAN_MONTHS[match[2].toLowerCase()];
+              if (germanMonth) {
+                year = parseInt(match[3]);
+                month = germanMonth;
+                day = parseInt(match[1]) || 1;
+              } else if (match[1].length === 4) {
+                // Format: YYYY-MM-DD or YYYY_MM_DD
+                year = parseInt(match[1]);
+                month = parseInt(match[2]) || 1;
+                day = parseInt(match[3]) || 1;
+              } else if (match[3].length === 4) {
+                // Format: DD-MM-YYYY or DD.MM.YYYY or DD_MM_YYYY
+                year = parseInt(match[3]);
+                month = parseInt(match[2]) || 1;
+                day = parseInt(match[1]) || 1;
+              }
+            } else if (match.length === 2) {
+              // Year only - use mid-year date
               year = parseInt(match[1]);
-              month = parseInt(match[2]) || 1;
-              day = parseInt(match[3]) || 1;
-            } else if (match[3].length === 4) {
-              // Format: DD-MM-YYYY or DD.MM.YYYY or DD_MM_YYYY
-              year = parseInt(match[3]);
-              month = parseInt(match[2]) || 1;
-              day = parseInt(match[1]) || 1;
+              month = 6;
+              day = 15;
             }
-          } else if (match.length === 2) {
-            // Year only - use mid-year date
-            year = parseInt(match[1]);
-            month = 6;
-            day = 15;
-          }
 
-          // Validate year range (1990 to current year)
-          if (year && year >= 1990 && year <= currentYear) {
-            const date = new Date(year, (month || 1) - 1, day || 1);
-            return {
-              date,
-              dateString: date.toISOString().split('T')[0],
-              isTooOld: date < tenYearsAgo,
-            };
+            // Validate year range (1990 to current year)
+            if (year && year >= 1990 && year <= currentYear) {
+              const date = new Date(year, (month || 1) - 1, day || 1);
+              // Build the string from the parsed fields, not via toISOString():
+              // the Date is local midnight, so the UTC round-trip shifts it to
+              // the previous day on any timezone east of UTC.
+              const mm = String(month || 1).padStart(2, '0');
+              const dd = String(day || 1).padStart(2, '0');
+              return {
+                date,
+                dateString: `${year}-${mm}-${dd}`,
+                isTooOld: date < tenYearsAgo,
+              };
+            }
           }
         }
       }
-    }
 
     // No date found
     return { date: null, dateString: null, isTooOld: null };

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/DateExtractor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/extractors/DateExtractor.ts
@@ -49,6 +49,7 @@ export class DateExtractor {
       /(\d{1,2})_(\d{1,2})_(\d{4})/, // Underscore: 15_05_2023
       /(\d{4})_(\d{1,2})_(\d{1,2})/, // Underscore ISO: 2023_05_15
       GERMAN_MONTH_PATTERN, // German text month: 24. Mai 2025
+      /_(20[0-2]\d)_/, // Year between underscores: LDK_2023_Potsdam (\b never matches next to _, a word char)
       /\b(20[0-2]\d)\b/, // Year only: 2023
       /\b(199\d)\b/, // Year only: 1990s
     ];


### PR DESCRIPTION
## Problem

Das Brandenburg-Notebook enthielt nur ~1 Jahr Inhalt (282 Docs, alle 2025–2026) statt der vorgesehenen 5 Jahre (`maxAgeYears: 5`).

## Root Causes & Fixes (3 Commits)

**1. `4bee7b6` — Scraper-Config Brandenburg:**
- gruene-brandenburg.de wurde Mai 2025 auf WordPress relauncht (ältester Post 2025-05-28); die Historie liegt auf dem eingefrorenen Typo3-Archiv `archiv.gruene-brandenburg.de`
- Archiv-Pagination war auf `maxPages: 15` (≈ März 2025) begrenzt; das 5-Jahres-Fenster braucht ~60 Seiten → jetzt **70**
- Der bare-`time`-Date-Selector traf den **Sidebar-Terminkalender** (kommende Events) statt des Publikationsdatums — alle 75 Archiv-Docs hatten `published_at` ≈ Scrape-Datum. Korrekt ist `meta[property=article:published_time]`
- `h1` traf das Site-Logo statt der Headline; kein Content-Selector traf Typo3s `.ce-bodytext` → Volltext-Fallback mit Nav-Müll
- `/beschluesse` ist nur ein Index von Jahresseiten; die PDFs (2021/2022/2023, 57 Stück) wurden nie erreicht → Jahresseiten im 5-Jahres-Fenster werden jetzt als PDF-Archive gecrawlt

**2. `1b69af4` — DateExtractor: Underscore-Jahre:**
`\b(20[0-2]\d)\b` matcht nie in `LDK_2023_Potsdam`-Segmenten (Underscore ist Word-Char) — ohne Fix würden die 16 LDK-2023-PDFs bei einem Re-Index als undatiert übersprungen.

**3. `9ad2f7e` — DateExtractor: strong-before-weak + Timezone:**
Vollständige Datums-Muster werden jetzt über URL+Titel+Kontext gesucht, *bevor* Jahres-Fallbacks greifen. Vorher schlug das Upload-Jahr in WP-Pfaden (`/uploads/2025/07/`) das echte LDK-Datum im Linkkontext (`29.04.2023 | Landesdelegiertenkonferenz`) — alle 42 Beschluss-PDFs der WP-Seite waren auf 2025 datiert. Außerdem: `dateString` aus geparsten Feldern statt `toISOString()` (UTC-Roundtrip verschob Daten auf Nicht-UTC-Maschinen um einen Tag; CI läuft UTC, Prod war nicht betroffen).

## Direkt in Prod-Qdrant erledigt (kein Aktionsbedarf beim Merge)

- 78 defekte Archiv-Docs gelöscht, Archiv neu gescrapt: **290 Presse-Artikel** (0 Fehler) + **57 Beschluss-PDFs** (OCR) → Brandenburg jetzt **551 Docs, 2021→2026** (Verteilung im Kommentar unten)
- 42 falsch datierte WP-Beschluss-PDFs auf echte LDK-Daten gepatcht
- Beifang aus der Dubletten-Analyse über alle LVs: **LSA-Fraktion** hatte 46 % Dubletten durch Domain-Wechsel (`gruene-fraktion-lsa.de` → `gruene-fraktion-sachsen-anhalt.de`) → 1.259 verifizierte Duplikat-Punkte gelöscht (62 Altdomain-Unikate erhalten); **Berlin-Fraktion**: 887 Legacy-`?tmstv=`-Duplikate gelöscht

## Verifikation

- `pnpm --filter @gruenerator/api typecheck` clean, CI grün
- DateExtractor-Verhalten mit Standalone-Tests gegen die realen URL/Kontext-Fälle verifiziert
- Qdrant-Jahresverteilung BB nach Backfill: 2021: 52 · 2022: 37 · 2023: 30 · 2024: 119 · 2025: 220 · 2026: 75