### PR TITLE
fix(canvas-editor): Studio-zu-Studio-Live-Sync für Template-Texte

### DIFF
--- a/documentation/docs/intern/sharepic-chat-editing.md
+++ b/documentation/docs/intern/sharepic-chat-editing.md
@@ -1,0 +1,62 @@
+# Sharepic-Editing im Chat — Architektur & bewusst Aufgeschobenes
+
+Eingeführt mit PR #1215 (`sharepic_edit`-Intent) und dem Follow-up-PR
+`fix/canvas-template-text-collab-sync`. Diese Datei hält fest, wo die Teile
+liegen und was BEWUSST nicht umgesetzt wurde — damit spätere Arbeit nicht
+versehentlich „fehlende Features" als Bugs behandelt oder Scope-Entscheidungen
+neu erfindet.
+
+## Architektur-Pointer
+
+- **Intent-Branch:** `apps/api/routes/chat/chatGraphContractRouter.ts` →
+  `handleSharepicEdit` in `routes/chat/services/sharepicEditService.ts`
+  (Ziel-Auflösung, Lazy-Mint, LLM-Call, Patch, Version, SSE). Legacy-Refinement
+  (Text-Regeneration) bleibt als Fallback dahinter.
+- **Ein strukturierter LLM-Call, kein Tool-Loop** (`sharepicEditLlm.ts`,
+  Muster aus `runCanvasSuggest`). Bewusste Entscheidung: der Chat bleibt
+  intent-basiert; ein agentischer Tool-Loop wäre ein eigenes
+  Architektur-Projekt für den gesamten Chat.
+- **Editierbare Oberfläche pro Template:**
+  `packages/contracts/src/schemas/canvasTemplateDescriptors.ts` (server-sicher,
+  pure data; Parity-Vitest in
+  `packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts`).
+- **Yjs-Autorität:** Hocuspocus-interner Endpoint
+  `GET/POST /internal/canvas/:id/state` (`services/hocuspocus/src/internalApi.ts`,
+  `openDirectConnection`). API-Fassade: `apps/api/services/canvas/canvasStateService.ts`
+  (`initial_state` ist nur Lese-Mirror/Fallback). Envs:
+  `HOCUSPOCUS_INTERNAL_TOKEN` (Feature aus, wenn unset), `HOCUSPOCUS_INTERNAL_URL`.
+- **Y-Topologie-Gotcha:** Template-Felder leben doppelt — root `formState`
+  (Schreibziel der Host-Callbacks) und `pages[i].state` (Mount-Quelle der
+  GenericCanvas-Seiten). Seit dem Follow-up-PR dual-writen Studio-Callbacks
+  in beide (`wrapCallbacksWithPageSync`), gemountete Seiten übernehmen externe
+  Änderungen via `useYjsPageStateSync`, und ein One-Shot-Heal in
+  `CanvasEditorRouter` kopiert bei Single-Page-Altdokumenten formState →
+  `pages[0].state`. Chat-Patches schreiben serverseitig ebenfalls in beide.
+- **Versionen:** `canvas_state_versions` (volle flache States, max. 20,
+  Origins `mint`/`chat-edit`/`restore`); Restore = Vorwärts-Patch, nie
+  Yjs-Rewind. Varianten-Mapping: `chat_thread_canvases`.
+- **Kontext-Disziplin:** pro Edit landen nur `{ canvasId, variantId, version,
+  summary }` in `tool_results`; voller State reist ausschließlich über SSE
+  (`sharepic_minted` / `sharepic_updated` / `sharepic_edit_error`).
+
+## Bewusst aufgeschoben (kein Bug — Scope-Entscheidung)
+
+| Thema | Warum aufgeschoben | Wenn doch gebraucht |
+| --- | --- | --- |
+| **Agentischer Tool-Loop im Chat** | User-Entscheidung „structured call now, loop later"; Loop wäre Chat-weiter Umbau (Latenz, Kosten, Kontext-Wachstum) | `sharepicEditService` ist als Tool-Executor wiederverwendbar gebaut |
+| **Formatwechsel per Chat** (Portrait → Story …) | `canvas.resize` klont ein NEUES Dokument → bricht Karten-Identität (canvasId in Thread & Versionen) | Konzept nötig: Karte auf neues Doc umhängen oder Resize-in-place |
+| **Multi-Page-Sharepics** (Slider, Präsentationen) | Patches gehen nur auf Seite 0; `formState` kann Edits nicht seitenweise attribuieren | Ops um `pageId` erweitern; Deskriptoren für Slider/Pres-Templates |
+| **KI-generierte / hochgeladene Hintergründe** | v1 nur Stock-Suche (`set-background-image` → ImageSelectionService) | Flux-Pfad existiert im image-Intent; Upload bräuchte Attachment-Routing in den Edit-Branch |
+| **Chat-Edits auf fremden / nicht im Chat geminteten Canvases** | Berechtigungs- und UX-Fragen ungelöst (wessen Karte? welcher Thread?) | `chat_thread_canvases` um externe Docs erweitern + ACL-Prüfung |
+| **Studio-Edits in der Versions-Historie** | Yjs-Snapshots decken Studio-Historie ab; Karten-Stepper zeigt nur Chat-Edits | Hook in `onStoreDocument` oder Hocuspocus-Change-Hook |
+| **Thumbnail-Update nach Chat-Edits** | Nice-to-have; Studio-Galerie zeigt bis dahin das Mint-Thumbnail | Frontend: nach Re-Render PNG via Media-Library + `PATCH /api/canvas/:id` |
+| **`@sharepic` in Produktion** | Mentionable ist dev-only geflaggt (`packages/chat/src/lib/mentionables.ts`), bis die manuelle E2E-Matrix aus PR #1215 gelaufen ist | Flag entfernen + Envs in prod setzen |
+| **Heal für Multi-Page-Altdokumente** | `formState` mischt die letzten Edits ALLER Seiten — nicht attribuierbar; Heal läuft nur bei `pages.length === 1` | Nur mit per-Page-Schreibhistorie möglich; ab Dual-Write entsteht das Problem nicht mehr neu |
+
+## Bekannte pre-existing Failures (nicht aus diesen PRs)
+
+- `services/hocuspocus/src/persistence.vitest.ts`: 1 Test rot
+  („snapshot-v2" statt „live-state").
+- `packages/chat`: Console-Runner-Testdateien (`adapterUtils.test.ts`,
+  `mentionParser.test.ts`) loggen intern „passed", schlagen unter vitest aber
+  mit „No test suite found" fehl.

--- a/packages/canvas-editor/src/CanvasEditorRouter.tsx
+++ b/packages/canvas-editor/src/CanvasEditorRouter.tsx
@@ -8,7 +8,7 @@ import { loadCanvasConfig, isValidCanvasType } from './configs/configLoader';
 import type { FullCanvasConfig, CanvasConfigId } from './configs/types';
 import type { MobileBridgeProps } from './hooks/useMobileBridge';
 import type { InitialPageDef } from './hooks/usePageManager';
-import type * as Y from 'yjs';
+import * as Y from 'yjs';
 
 type CanvasState = Record<string, unknown>;
 
@@ -188,6 +188,32 @@ export function ControllableCanvasWrapper({
   });
 
   const effectiveState = isCollab ? yFormState : internalState;
+
+  // One-shot heal for docs from before template callbacks dual-wrote into
+  // pages[i].state: their text edits live only in root formState, while the
+  // mounted page renders from the stale page seed. Copy differing formState
+  // values into the page state map (single-page docs only — for multi-page
+  // docs formState mixes the last edits of ALL pages and can't be attributed).
+  // The non-local origin lets useYjsPageStateSync apply the values to the
+  // already-mounted canvas as well.
+  const healedRef = useRef(false);
+  useEffect(() => {
+    if (!collaborative?.ydoc || !collaborative.isSynced || healedRef.current) return;
+    healedRef.current = true;
+    const ydoc = collaborative.ydoc;
+    const pagesArr = ydoc.getArray<Y.Map<unknown>>('pages');
+    const formState = ydoc.getMap<unknown>('formState');
+    if (pagesArr.length !== 1 || formState.size === 0) return;
+    const stateY = pagesArr.get(0).get('state');
+    if (!(stateY instanceof Y.Map)) return;
+    ydoc.transact(() => {
+      formState.forEach((value, key) => {
+        if ((stateY as Y.Map<unknown>).get(key) !== value) {
+          (stateY as Y.Map<unknown>).set(key, value);
+        }
+      });
+    }, 'canvas-form-state-heal');
+  }, [collaborative?.ydoc, collaborative?.isSynced]);
 
   // Load config dynamically when type changes (for config-driven canvases)
   // Now includes 'zitat' and 'dreizeilen' for unified multi-page support

--- a/packages/canvas-editor/src/collab/useYjsFormState.ts
+++ b/packages/canvas-editor/src/collab/useYjsFormState.ts
@@ -75,7 +75,10 @@ export function useYjsFormState({ ydoc, isSynced, fallback }: Options): Result {
       const yMap = ydoc.getMap<unknown>(YDOC_KEYS.formState);
       ydoc.transact(() => {
         for (const [k, v] of Object.entries(changes)) {
-          yMap.set(k, v);
+          // Skip identical values — GenericCanvas re-emits synced image keys
+          // whenever component state changes (including remote page-state
+          // merges), so unconditional writes would echo between clients.
+          if (yMap.get(k) !== v) yMap.set(k, v);
         }
       }, LOCAL_ORIGIN);
     },

--- a/packages/canvas-editor/src/collab/useYjsPageStateSync.ts
+++ b/packages/canvas-editor/src/collab/useYjsPageStateSync.ts
@@ -1,19 +1,21 @@
 import { useEffect, useRef } from 'react';
 import * as Y from 'yjs';
 
+import { PAGES_LOCAL_ORIGIN } from './useYjsPages';
 import { YDOC_KEYS } from './ydocKeys';
 
 /**
- * Push remote changes of a page's `state` Y.Map into the mounted canvas.
+ * Push external changes of a page's `state` Y.Map into the mounted canvas.
  *
  * GenericCanvas holds template-field state as local React state seeded once
- * from `page.state` — without this observer a server-side edit (chat sharepic
- * editing applies patches via the Hocuspocus internal API into formState AND
- * pages[i].state) would not appear in an open studio tab until reload.
+ * from `page.state` — without this observer neither a chat sharepic edit
+ * (applied server-side via the Hocuspocus internal API) nor another studio
+ * client's edit (dual-written into the page state map by CanvasEditor) would
+ * appear in an open studio tab until reload.
  *
- * The studio itself never writes `page.state` for a mounted page (text edits
- * flow through callbacks → root formState), so every observed change here is
- * external and safe to merge.
+ * This client's own dual-writes carry PAGES_LOCAL_ORIGIN and are skipped —
+ * the local component state already has those values, and rebuilding it on
+ * every keystroke would disrupt inline text editing.
  */
 export function useYjsPageStateSync(options: {
   pageYMap: Y.Map<unknown> | null;
@@ -33,6 +35,7 @@ export function useYjsPageStateSync(options: {
       const partial: Record<string, unknown> = {};
       for (const event of events) {
         if (event.target !== stateY) continue;
+        if (event.transaction.origin === PAGES_LOCAL_ORIGIN) continue;
         for (const key of (event as Y.YMapEvent<unknown>).keysChanged) {
           partial[key] = (stateY as Y.Map<unknown>).get(key);
         }

--- a/packages/canvas-editor/src/collab/useYjsPages.ts
+++ b/packages/canvas-editor/src/collab/useYjsPages.ts
@@ -6,6 +6,15 @@ import { YDOC_KEYS } from './ydocKeys';
 const LOCAL_ORIGIN = Symbol('canvas-editor-pages-local');
 const LEGACY_PROMOTE_ORIGIN = Symbol('canvas-editor-pages-legacy-promote');
 
+/**
+ * Origin of this client's own page-state writes. Exported so
+ * useYjsPageStateSync can skip self-originated transactions — without the
+ * filter every local keystroke (dual-written into the page state map by
+ * CanvasEditor) would round-trip back into component state and rebuild it
+ * mid-typing.
+ */
+export const PAGES_LOCAL_ORIGIN: unknown = LOCAL_ORIGIN;
+
 export interface YjsPageView {
   id: string;
   configId: string;
@@ -259,7 +268,14 @@ export function useYjsPages(ydoc: Y.Doc | null, isSynced: boolean): YjsPagesApi 
         const stateY = page.get(YDOC_KEYS.state);
         if (!(stateY instanceof Y.Map)) return;
         for (const [k, v] of Object.entries(partial)) {
-          (stateY as Y.Map<unknown>).set(k, v);
+          // Equality guard: Y.Map.set on an identical value still emits an
+          // update. Since remote page-state changes now merge back into
+          // component state (useYjsPageStateSync) and GenericCanvas re-emits
+          // synced image keys on state change, unconditional writes would
+          // ping-pong identical values between clients forever.
+          if ((stateY as Y.Map<unknown>).get(k) !== v) {
+            (stateY as Y.Map<unknown>).set(k, v);
+          }
         }
       }, LOCAL_ORIGIN);
     };

--- a/packages/canvas-editor/src/collab/wrapCallbacksWithPageSync.ts
+++ b/packages/canvas-editor/src/collab/wrapCallbacksWithPageSync.ts
@@ -1,0 +1,35 @@
+/**
+ * Dual-write wrapper for template-field callbacks in collaborative mode.
+ *
+ * Template-field edits flow `on<Key>Change` → host (CanvasEditorRouter) →
+ * root `formState` Y.Map. But a mounted collab page renders from
+ * `pages[i].state`, which historically was only written at seed time — so
+ * studio→studio text edits never reached other clients live, and a reload
+ * mounted the stale seed. Wrapping each callback to ALSO write the page's
+ * state map keeps `pages[i].state` current: remote clients pick the change
+ * up via useYjsPageStateSync, and reloads mount the edited values.
+ *
+ * Callback names follow the `on<Key>Change` convention (see
+ * CanvasEditorRouter.createCallbacks); anything else passes through untouched.
+ */
+const CALLBACK_NAME = /^on([A-Z].*)Change$/;
+
+export function wrapCallbacksWithPageSync(
+  callbacks: Record<string, (val: unknown) => void>,
+  writePageState: (partial: Record<string, unknown>) => void
+): Record<string, (val: unknown) => void> {
+  const wrapped: Record<string, (val: unknown) => void> = {};
+  for (const [name, fn] of Object.entries(callbacks)) {
+    const match = CALLBACK_NAME.exec(name);
+    if (!match) {
+      wrapped[name] = fn;
+      continue;
+    }
+    const stateKey = match[1].charAt(0).toLowerCase() + match[1].slice(1);
+    wrapped[name] = (val: unknown) => {
+      fn(val);
+      writePageState({ [stateKey]: val });
+    };
+  }
+  return wrapped;
+}

--- a/packages/canvas-editor/src/collab/wrapCallbacksWithPageSync.vitest.ts
+++ b/packages/canvas-editor/src/collab/wrapCallbacksWithPageSync.vitest.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { wrapCallbacksWithPageSync } from './wrapCallbacksWithPageSync';
+
+describe('wrapCallbacksWithPageSync', () => {
+  it('dual-writes on<Key>Change callbacks into page state with the lowercased key', () => {
+    const onLine1Change = vi.fn();
+    const writePageState = vi.fn();
+    const wrapped = wrapCallbacksWithPageSync({ onLine1Change }, writePageState);
+
+    wrapped.onLine1Change('GRÜN WIRKT');
+
+    expect(onLine1Change).toHaveBeenCalledWith('GRÜN WIRKT');
+    expect(writePageState).toHaveBeenCalledWith({ line1: 'GRÜN WIRKT' });
+  });
+
+  it('maps multi-word keys (onCurrentImageSrcChange → currentImageSrc)', () => {
+    const fn = vi.fn();
+    const writePageState = vi.fn();
+    const wrapped = wrapCallbacksWithPageSync({ onCurrentImageSrcChange: fn }, writePageState);
+
+    wrapped.onCurrentImageSrcChange('/img.jpg');
+
+    expect(writePageState).toHaveBeenCalledWith({ currentImageSrc: '/img.jpg' });
+  });
+
+  it('passes non-conventional callback names through untouched', () => {
+    const onReset = vi.fn();
+    const writePageState = vi.fn();
+    const wrapped = wrapCallbacksWithPageSync({ onReset }, writePageState);
+
+    wrapped.onReset(undefined);
+
+    expect(onReset).toHaveBeenCalled();
+    expect(writePageState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/canvas-editor/src/components/CanvasEditor/index.tsx
+++ b/packages/canvas-editor/src/components/CanvasEditor/index.tsx
@@ -48,6 +48,7 @@ import { PageThumbnailStrip } from '../PageThumbnailStrip';
 import { Toolbar } from '../Toolbar';
 import { AddPageButton } from '../TemplatePickerFlyout';
 
+import { wrapCallbacksWithPageSync } from '../../collab/wrapCallbacksWithPageSync';
 import { PageWrapper } from './PageWrapper';
 import { useMobileWebViewport } from './hooks/useMobileWebViewport';
 import { usePageRefs } from './hooks/usePageRefs';
@@ -146,6 +147,7 @@ function CanvasEditorInner({
     pageCount,
     getConfigForPage,
     getPageYMap,
+    updatePageState,
     undoPageOp,
     redoPageOp,
     canUndoPageOp,
@@ -160,6 +162,21 @@ function CanvasEditorInner({
 
   // Store loaded configs for rendering
   const loadedConfigs = useLoadedConfigs({ pages, getConfigForPage });
+
+  // Collab mode: template-field callbacks dual-write into the page's `state`
+  // Y.Map so other clients (useYjsPageStateSync) and reloads see the edits —
+  // the host's own callback chain only persists them to root formState.
+  const collabPageCallbacks = useMemo(() => {
+    if (!collaborative) return null;
+    const map = new Map<string, Record<string, (val: unknown) => void>>();
+    for (const page of pages) {
+      map.set(
+        page.id,
+        wrapCallbacksWithPageSync(callbacks, (partial) => updatePageState(page.id, partial))
+      );
+    }
+    return map;
+  }, [collaborative, callbacks, pages, updatePageState]);
 
   // Sidebar state - ONE shared sidebar for all pages
   // In mobile bridge mode, activeTab is controlled by native via mobileBridge.activeTab
@@ -954,7 +971,7 @@ function CanvasEditorInner({
                 onDuplicatePage={duplicatePage}
                 onExport={handleExport}
                 onCancel={onCancel}
-                callbacks={callbacks}
+                callbacks={collabPageCallbacks?.get(page.id) ?? callbacks}
                 multiPageExport={index === 0 ? multiPageExportProps : undefined}
                 onStateChange={handlePageStateChange}
                 onToolbarStateChange={isActive ? handleToolbarStateChange : undefined}


### PR DESCRIPTION
**Stacked auf #1215** — bitte erst danach mergen (GitHub retargetet die Base automatisch auf master).

## Problem (verifiziert)

Template-Feld-Edits im Studio schrieben nur ins Root-`formState` Y.Map (`on<Key>Change` → `handlePartChange` → `updateFormState`), während gemountete Collab-Seiten aus `pages[i].state` rendern (`PageWrapper` → `GenericCanvas initialProps={page.state}`, lokaler React-State, einmalig geseedet). Folgen:

1. **Studio↔Studio:** Ein zweiter offener Client sah Text-Edits nie live (der Observer aus #1215 beobachtet nur `pages[i].state`, das Studio-Edits nie anfassten).
2. **Reload:** Das Dokument mountete mit dem **stalen Seed** — Text-Edits wirkten nach Reload verloren, obwohl sie im formState persistiert waren.

## Fix

- **Dual-Write:** `CanvasEditor` wrappt die `on<Key>Change`-Callbacks im Collab-Modus (`wrapCallbacksWithPageSync`, pure + unit-getestet), sodass jeder Edit zusätzlich ins `state`-Y.Map der Seite geht. Andere Clients übernehmen ihn via `useYjsPageStateSync`; Reloads mounten die aktuellen Werte.
- **Selbst-Echo verhindert:** `useYjsPageStateSync` überspringt Transaktionen mit dem eigenen `PAGES_LOCAL_ORIGIN` — sonst würde jeder Tastendruck den Component-State mid-typing neu aufbauen.
- **Ping-Pong verhindert:** Equality-Guards in `updatePageState` und `updateFormState`. Nötig, weil GenericCanvas bei State-Änderungen die synced Image-Keys re-emittet — ohne Guard würden zwei Clients identische Werte endlos hin- und herschreiben (Y.Map.set dedupliziert nicht).
- **Altdokumente:** One-Shot-Heal in `CanvasEditorRouter` kopiert bei Single-Page-Docs abweichende formState-Werte einmalig nach `pages[0].state` (Origin ≠ local, damit auch der eigene gemountete Canvas die Werte übernimmt). Multi-Page wird bewusst übersprungen: formState mischt die letzten Edits aller Seiten und ist nicht attribuierbar — ab Dual-Write entsteht das Problem nicht mehr neu.

## Doku

`documentation/docs/intern/sharepic-chat-editing.md` (force-added wie die bestehenden intern-Docs): Architektur-Pointer + die **bewusst aufgeschobenen** Scope-Entscheidungen aus #1215 als Tabelle (Tool-Loop, Formatwechsel, Multi-Page, KI-/Upload-Hintergründe, fremde Canvases, Studio-Versionen, Thumbnails, Prod-Flag, Multi-Page-Heal) inkl. „wenn doch gebraucht"-Hinweisen.

## Checks

- `pnpm typecheck` ✅, Prettier ✅, canvas-editor vitest 15/15 ✅ (3 neue für `wrapCallbacksWithPageSync`)
- Manuell zu verifizieren (Stack): zwei Studio-Tabs auf demselben Canvas → Text tippen in A erscheint in B; Reload nach Text-Edit zeigt den Edit; Altdokument (vor diesem PR editiert) zeigt nach Öffnen den formState-Stand; kein Re-Render-Flackern beim Tippen.