### PR TITLE
feat(chat,web): update canvas thumbnail after chat sharepic edits

### DIFF
--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { renderSharepicToImage } from '../features/image-studio/renderSharepicToImage';
+import { uploadBlobToMediaLibrary } from '../features/image-studio/services/mediaUploadService';
 import { useModelPreferences } from '../features/models/hooks/useModelPreferences';
 import { useNotebookChatStore } from '../features/notebook/stores/notebookChatStore';
 import useNotebookStore from '../features/notebook/stores/notebookStore';
@@ -166,6 +167,18 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
         });
         if (result.status !== 200) return null;
         return result.body.state;
+      },
+      updateSharepicThumbnail: async (canvasId: string, imageDataUrl: string) => {
+        const blob = await (await fetch(imageDataUrl)).blob();
+        const thumbnailUrl = await uploadBlobToMediaLibrary(blob, {
+          filename: `sharepic-thumbnail-${canvasId}.png`,
+          uploadSource: 'chat-sharepic-thumbnail',
+        });
+        if (!thumbnailUrl) return;
+        await getContractsClient().canvas.update({
+          params: { id: canvasId },
+          body: { thumbnail_url: thumbnailUrl },
+        });
       },
       restoreSharepicVersion: async (canvasId: string, version: number) => {
         const result = await getContractsClient().canvas.restoreVersion({

--- a/documentation/docs/intern/sharepic-chat-editing.md
+++ b/documentation/docs/intern/sharepic-chat-editing.md
@@ -38,6 +38,12 @@ neu erfindet.
 - **Kontext-Disziplin:** pro Edit landen nur `{ canvasId, variantId, version,
   summary }` in `tool_results`; voller State reist ausschließlich über SSE
   (`sharepic_minted` / `sharepic_updated` / `sharepic_edit_error`).
+- **Thumbnails:** nach jedem echten Edit (SSE-Update/Restore, NICHT
+  Mount-Rehydration) markiert der Client den Eintrag `thumbnailDirty`;
+  `SharepicVariantCard` lädt den nächsten erfolgreichen Head-Render als
+  Thumbnail hoch (`updateSharepicThumbnail`-Callback in
+  `GlobalChatProvider`: Media-Library-Upload + `PATCH /api/canvas/:id`).
+  Best-effort — Fehler erscheinen nie in der Chat-UI.
 
 ## Bewusst aufgeschoben (kein Bug — Scope-Entscheidung)
 
@@ -49,7 +55,6 @@ neu erfindet.
 | **KI-generierte / hochgeladene Hintergründe** | v1 nur Stock-Suche (`set-background-image` → ImageSelectionService) | Flux-Pfad existiert im image-Intent; Upload bräuchte Attachment-Routing in den Edit-Branch |
 | **Chat-Edits auf fremden / nicht im Chat geminteten Canvases** | Berechtigungs- und UX-Fragen ungelöst (wessen Karte? welcher Thread?) | `chat_thread_canvases` um externe Docs erweitern + ACL-Prüfung |
 | **Studio-Edits in der Versions-Historie** | Yjs-Snapshots decken Studio-Historie ab; Karten-Stepper zeigt nur Chat-Edits | Hook in `onStoreDocument` oder Hocuspocus-Change-Hook |
-| **Thumbnail-Update nach Chat-Edits** | Nice-to-have; Studio-Galerie zeigt bis dahin das Mint-Thumbnail | Frontend: nach Re-Render PNG via Media-Library + `PATCH /api/canvas/:id` |
 | **`@sharepic` in Produktion** | Mentionable ist dev-only geflaggt (`packages/chat/src/lib/mentionables.ts`), bis die manuelle E2E-Matrix aus PR #1215 gelaufen ist | Flag entfernen + Envs in prod setzen |
 | **Heal für Multi-Page-Altdokumente** | `formState` mischt die letzten Edits ALLER Seiten — nicht attribuierbar; Heal läuft nur bei `pages.length === 1` | Nur mit per-Page-Schreibhistorie möglich; ab Dual-Write entsteht das Problem nicht mehr neu |
 

--- a/packages/chat/src/components/message-parts/SharepicVariantCard.tsx
+++ b/packages/chat/src/components/message-parts/SharepicVariantCard.tsx
@@ -35,6 +35,24 @@ interface VersionEntry {
   summary: string | null;
 }
 
+/**
+ * After a real edit (entry is thumbnail-dirty) the freshly rendered head PNG
+ * doubles as the canvas thumbnail. Version previews never qualify, and the
+ * flag is cleared up front — a failed upload is not worth a retry loop.
+ */
+function maybeUploadThumbnail(variantId: string, dataUrl: string, isVersionPreview: boolean) {
+  if (isVersionPreview) return;
+  const store = useSharepicLiveStore.getState();
+  const entry = store.entries[variantId];
+  if (!entry?.thumbnailDirty || !entry.canvasId) return;
+  const upload = useChatConfigStore.getState().updateSharepicThumbnail;
+  if (!upload) return;
+  store.clearThumbnailDirty(variantId);
+  upload(entry.canvasId, dataUrl).catch((err) => {
+    console.warn('[SharepicVariantCard] Thumbnail-Update fehlgeschlagen:', err);
+  });
+}
+
 export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
   const [imageBase64, setImageBase64] = useState<string | null>(null);
   const [isRendering, setIsRendering] = useState(true);
@@ -71,6 +89,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
         if (dataUrl) {
           setImageBase64(dataUrl);
           setRenderError(false);
+          maybeUploadThumbnail(variant.id, dataUrl, viewState != null);
         } else {
           setRenderError(true);
         }
@@ -84,7 +103,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
     return () => {
       cancelled = true;
     };
-  }, [variant.canvasType, renderInput]);
+  }, [variant.canvasType, variant.id, renderInput, viewState]);
 
   // Thread-reload rehydration: a minted variant renders its CURRENT state
   // (which may have changed in the studio), not the stale initialProps.
@@ -168,6 +187,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
         canvasType: variant.canvasType,
         version: result.version,
         state: result.state,
+        thumbnailDirty: true,
       });
     }
   }, [canvasId, viewVersion, variant.id, variant.canvasType]);

--- a/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
@@ -445,6 +445,7 @@ export async function* parseSSEStream(
             version: payload.version,
             state: payload.state,
             summary: payload.summary,
+            thumbnailDirty: true,
           });
           break;
         }

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -54,6 +54,12 @@ export interface ChatConfig {
     version: number
   ) => Promise<{ version: number; state: Record<string, unknown> } | null>;
   /**
+   * Persists a freshly rendered PNG (data URL) as the canvas document's
+   * thumbnail after a chat edit, so galleries don't keep showing the mint
+   * state. Best-effort — failures must not surface in the chat UI.
+   */
+  updateSharepicThumbnail?: (canvasId: string, imageDataUrl: string) => Promise<void>;
+  /**
    * URL the @wolke picker links to when the user hasn't connected any
    * Nextcloud share link yet. Platform-specific (web: `/wolke`, native: a deep
    * link). Omit to hide the CTA — only the warning copy renders.
@@ -162,6 +168,7 @@ interface ChatConfigStore extends ResolvedChatConfig {
   fetchSharepicVersions?: ChatConfig['fetchSharepicVersions'];
   fetchSharepicVersionState?: ChatConfig['fetchSharepicVersionState'];
   restoreSharepicVersion?: ChatConfig['restoreSharepicVersion'];
+  updateSharepicThumbnail?: ChatConfig['updateSharepicThumbnail'];
   /** URL the @wolke empty-state CTA opens (new tab). Hidden when unset. */
   wolkeConnectUrl?: string;
   /** threadId → context-getter, populated by host surfaces (e.g. docs editor). */
@@ -251,6 +258,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
       fetchSharepicVersions: config?.fetchSharepicVersions,
       fetchSharepicVersionState: config?.fetchSharepicVersionState,
       restoreSharepicVersion: config?.restoreSharepicVersion,
+      updateSharepicThumbnail: config?.updateSharepicThumbnail,
       wolkeConnectUrl: config?.wolkeConnectUrl,
     });
   },

--- a/packages/chat/src/stores/sharepicLiveStore.ts
+++ b/packages/chat/src/stores/sharepicLiveStore.ts
@@ -15,6 +15,12 @@ export interface SharepicLiveEntry {
   /** Full flat state of the latest version; null until first fetch/update. */
   state: Record<string, unknown> | null;
   summary?: string;
+  /**
+   * Set when the state changed through a real edit (SSE update / restore) —
+   * NOT on mount rehydration. The card uploads its next successful head
+   * render as the canvas thumbnail and clears the flag.
+   */
+  thumbnailDirty?: boolean;
 }
 
 export interface ActiveSharepic {
@@ -32,6 +38,7 @@ interface SharepicLiveStore {
     entry: Partial<SharepicLiveEntry> & { canvasId: string }
   ) => void;
   setActiveVariant: (active: ActiveSharepic | null) => void;
+  clearThumbnailDirty: (variantId: string) => void;
 }
 
 export const useSharepicLiveStore = create<SharepicLiveStore>((set, get) => ({
@@ -51,4 +58,10 @@ export const useSharepicLiveStore = create<SharepicLiveStore>((set, get) => ({
   },
 
   setActiveVariant: (active) => set({ activeVariant: active }),
+
+  clearThumbnailDirty: (variantId) => {
+    const prev = get().entries[variantId];
+    if (!prev?.thumbnailDirty) return;
+    set({ entries: { ...get().entries, [variantId]: { ...prev, thumbnailDirty: false } } });
+  },
 }));


### PR DESCRIPTION
## Was

Nach jedem echten Chat-Edit eines Sharepics (SSE `sharepic_updated` oder Versions-Restore) lädt die Variant-Karte ihr ohnehin frisch gerendertes Head-PNG in die Media-Library hoch und patcht `thumbnail_url` am Canvas-Dokument. Galerien (z. B. Gruppen-Shares, `DocumentOverview`) zeigen damit nicht mehr dauerhaft den Mint-Stand.

Bisher setzte **niemand** `thumbnail_url` für chat-geminte Canvases — `createCanvas` kennt kein Thumbnail und das Collab-Studio lädt keins hoch (`handleExport` ist dort no-op).

## Wie

- `sharepicLiveStore`: neues `thumbnailDirty`-Flag pro Eintrag + `clearThumbnailDirty`. Gesetzt vom SSE-Parser (`sharepic_updated`) und beim Restore — **nicht** bei Mount-Rehydration, sonst würde jeder Thread-Reload einen Upload auslösen.
- `SharepicVariantCard`: nach erfolgreichem Head-Render (keine Versions-Vorschau) wird das PNG per neuem Config-Callback hochgeladen; Flag wird vorab gecleart (best effort, kein Retry-Loop, Fehler nie in der Chat-UI).
- `chatConfigStore`: optionaler Callback `updateSharepicThumbnail(canvasId, imageDataUrl)`.
- `GlobalChatProvider` (web): Implementierung via `uploadBlobToMediaLibrary` (uploadSource `chat-sharepic-thumbnail`) + `canvas.update` PATCH.
- Intern-Doku: Thumbnail-Zeile aus der „Bewusst aufgeschoben"-Tabelle entfernt, Flow als Architektur-Pointer dokumentiert.

## Stack

Stacked auf #1216 (das auf #1215). Nach deren Merges retargetet GitHub automatisch. Merge-Reihenfolge: #1215 → #1216 → dieser.

## Verifikation

- `pnpm typecheck` grün (20/20), Prettier sauber, lint-staged beim Commit grün.
- Manuell (Teil der bestehenden E2E-Matrix): Sharepic im Chat editieren → Canvas-Galerie/Gruppen-Share zeigt den neuen Stand; Thread-Reload ohne Edit löst keinen Upload aus (Netzwerk-Tab: kein `/media/upload`).