### PR TITLE
feat(chat,web): docked sharepic artifact panel (Sharepic-Modus) + tool-loop plan

### DIFF
--- a/apps/web/src/features/chat/ChatPage.tsx
+++ b/apps/web/src/features/chat/ChatPage.tsx
@@ -2,6 +2,7 @@ import {
   ChatOverview,
   type NotebookLink,
   GrueneratorThread,
+  SharepicArtifactPanel,
   setMentionLocale,
   useAgentStore,
   useUserAgentsRegistry,
@@ -178,6 +179,12 @@ function ChatPage() {
           />
         )}
       </main>
+      {!hub && effectiveViewMode === 'thread' && (
+        // Sharepic-Modus: pins the active sharepic as a docked artifact while
+        // the user iterates via chat. Below xl the inline card stays the only
+        // surface (the panel would crowd out the thread).
+        <SharepicArtifactPanel className="hidden w-[24rem] shrink-0 flex-col overflow-hidden border-l border-border bg-background-alt xl:flex" />
+      )}
     </div>
   );
 }

--- a/documentation/docs/intern/chat-tool-loop-plan.md
+++ b/documentation/docs/intern/chat-tool-loop-plan.md
@@ -1,0 +1,149 @@
+# Agentischer Tool-Loop im Chat — konkreter Follow-up-Plan
+
+Status: **geplant, nicht begonnen.** Hintergrund: Beim Bau des Sharepic-Editings
+(PR #1215) fiel die bewusste Entscheidung „structured call now, loop later" —
+ein einzelner strukturierter LLM-Call pro Edit statt eines agentischen Loops.
+Dieses Dokument macht das „later" konkret: Architektur, Phasen, Aufwand,
+Risiken. Zahlen und Dateiverweise sind am echten Code verifiziert (Stand
+2026-06-11).
+
+## Verifizierte Ausgangslage
+
+Was die Codebasis schon mitbringt (senkt den Aufwand erheblich):
+
+- **Streaming läuft über das Vercel AI SDK v6.** `streamText()` in
+  `apps/api/routes/chat/services/responseStreamingService.ts:325` — derzeit
+  ohne `tools`-Parameter. Das SDK beherrscht Multi-Step-Tool-Loops nativ
+  (`tools` + `stopWhen`/`stepCountIs`); der Loop muss NICHT handgeschrieben
+  werden und läuft im API-Prozess. Der `aiWorkerPool` ist nur für
+  Non-Streaming-Calls zuständig (Classifier, Canvas-Suggest) und bleibt
+  unangetastet.
+- **DB-Schema trägt Multi-Tool-Messages bereits.** `chat_messages.tool_calls`
+  ist `jsonb[]`; nur die Persistenz-Logik (`postResponseService.ts`) schreibt
+  heute maximal einen Tool-Call pro Assistant-Message.
+- **Die Tool-Executors existieren als Services** mit sauberen Signaturen:
+  `handleSharepicEdit`, `generateSharepicVariants`, `handleBoardCreation`,
+  `generateAndCreateDocument`, `handleShareDoc`, `imageNode`/`imageEditNode`,
+  `executeResearch`, Suche via `searchNode`. Zod-Schemas für viele Parameter
+  liegen schon in `@gruenerator/contracts`.
+- **HITL ist wiederverwendbar:** `pipelineStateStore` (Interrupt/Resume) +
+  `pendingActionStore` + `POST /api/chat-service/confirm`.
+- **Kontrast — was der Loop ablöst:** `chatGraphContractRouter.ts` (806 LOC)
+  hat ~23 Intent-Branches/Sonderpfade; der Classifier kennt 18 Intents mit
+  4-Tier-Heuristik. Jedes neue Feature wächst heute mit O(Branches), mit Loop
+  mit O(Tools).
+
+## Zielbild v1: gescoped auf den Sharepic-Modus
+
+NICHT chat-weit starten. Der Sharepic-Modus (gedocktes Artifact-Panel,
+`SharepicArtifactPanel`) liefert den idealen begrenzten Scope:
+
+- Aktiviert nur, wenn `currentSharepic` gesetzt ist UND Feature-Flag an.
+- Kleines Tool-Set (s. u.), klare UI-Fläche, klar abgegrenzter Fehlerradius.
+- Alle anderen Intents laufen unverändert über die bestehende Pipeline —
+  der Loop ist ein zusätzlicher Branch, kein Umbau.
+
+### Tool-Set v1 (Sharepic-Modus)
+
+| Tool | Executor (existiert) | Parameter-Schema |
+| --- | --- | --- |
+| `apply_sharepic_ops` | Kern von `handleSharepicEdit` (Ops → Patch → Version) | `canvasAiOperationSchema[]` (existiert) |
+| `search_background_image` | `imagePickerService.selectBestImage` | `{ query }` (existiert als Op) |
+| `generate_background_image` | Flux-Pfad aus dem image-Intent | `{ prompt }` |
+| `read_sharepic_state` | `getCurrentCanvasState` + `buildSharepicSnapshot` | `{ }` (Ziel implizit) |
+| `restore_version` | Restore-Pfad aus `canvasContractRouter` | `{ version }` |
+| `create_variant` | `generateSharepicVariants` | `{ topic, templates? }` |
+
+Damit gehen Mehrschritt-Anweisungen in EINEM Turn: „such ein passendes
+Hintergrundbild, mach die Schrift größer und zeig mir das Ergebnis" =
+`search_background_image` → `apply_sharepic_ops` → Antworttext.
+
+## Architektur
+
+### Neuer Service: `agenticResponseService.ts`
+
+`apps/api/routes/chat/services/agenticResponseService.ts` (~400–500 LOC):
+
+```
+streamText({
+  model,                      // bestehende Provider-Auswahl
+  system: <Modus-Prompt + Snapshot + Capabilities>,
+  messages,
+  tools: buildToolRegistry(ctx),
+  stopWhen: stepCountIs(MAX_STEPS),   // v1: 4
+  onStepFinish: (step) => emitSseToolEvents(step),
+})
+```
+
+- Pro Tool-Schritt: SSE `tool_step_start { toolName, args }` und
+  `tool_step_result { toolName, summary }` (NUR kompakte Summaries über SSE
+  an die UI; Sharepic-State reist weiter über die bestehenden
+  `sharepic_updated`-Events aus den Executors).
+- Harte Limits: max. 4 Steps, max. 1 `generate_background_image` pro Turn
+  (Kosten), Timeout pro Tool 30 s, Gesamtbudget pro Turn.
+- Fehlerpfad: Tool-Fehler wird als Tool-Result ans Modell zurückgegeben
+  (Selbstkorrektur), nach 2 Fehlschlägen desselben Tools Abbruch mit
+  verständlicher Antwort.
+
+### Tool-Registry: `chatToolRegistry.ts`
+
+`apps/api/routes/chat/services/chatToolRegistry.ts` (~300–400 LOC): wrappt
+die existierenden Services als AI-SDK-Tools (`tool({ description,
+inputSchema: zodSchema, execute })`). Gating analog `forcedTools`/
+`enabledTools`: Registry wird pro Request aus Kontext (currentSharepic,
+User-Locale, Flags) zusammengestellt. KEINE neue Berechtigungslogik — die
+Executors prüfen Ownership bereits selbst (z. B. `getCanvas` vor Patch).
+
+### Kontext-Disziplin (übernimmt die #1215-Regeln)
+
+- Tool-Results im LLM-Kontext: nur kompakte Summaries (≤120 Zeichen) +
+  Snapshot-Refresh via `read_sharepic_state` bei Bedarf — nie voller State.
+- Persistiert wird wie heute: `tool_calls[]` mit kompakten Ergebnissen
+  (`{ canvasId, variantId, version, summary }`), jetzt mehrere pro Message.
+- Der Modus-Systemprompt wird pro Turn frisch gebaut (Snapshot des aktiven
+  Sharepics), nie in die Message-History geschrieben.
+
+### Persistenz & Frontend
+
+- `postResponseService.ts`: Tool-Call-Liste aus den Loop-Steps befüllen
+  (~150–200 LOC Anpassung; Schema-Änderung NICHT nötig).
+- `sseHelpers.ts`: 2 neue Event-Typen (`tool_step_start`,
+  `tool_step_result`), ~60 LOC.
+- `parseSSEStream.ts` (753 LOC, ~35 Cases): 2 neue Cases, die Steps als
+  ToolCallParts an die laufende Assistant-Message hängen (assistant-ui
+  unterstützt mehrere ToolCallParts pro Message bereits); ToolCallUI um
+  Step-Darstellung erweitern. ~250–400 LOC inkl. UI.
+
+## Phasen
+
+| Phase | Inhalt | Umfang | PR |
+| --- | --- | --- | --- |
+| 1 | Tool-Registry + `apply_sharepic_ops` + `read_sharepic_state`; `agenticResponseService` mit stopWhen, SSE-Events; Router-Branch hinter `CHAT_TOOL_LOOP`-Flag (nur Sharepic-Modus) | ~800–1000 LOC | 1 |
+| 2 | Persistenz Multi-Tool-Calls + Frontend-Steps (parseSSEStream, ToolCallUI) | ~400–600 LOC | 2 |
+| 3 | Restliche Tools (`search/generate_background_image`, `restore_version`, `create_variant`) + Budget-/Fehler-Härtung | ~300–400 LOC | 3 |
+| 4 | Tests: Registry-Unit-Tests, Loop-Integration mit Mock-Model (AI SDK `MockLanguageModel`), SSE-Contract | ~500–800 LOC | 3–4 |
+
+**Gesamt MVP: ~1.800–2.500 LOC hinter Flag, 3–4 gestackte PRs.** Erst nach
+Bake-Zeit im Sharepic-Modus entscheiden, ob weitere Intents (Boards, Docs)
+auf Tools umziehen — der chat-weite Vollausbau (~2–3k LOC Refactor des
+806-LOC-Routers) ist ein separater Beschluss und derzeit NICHT empfohlen:
+die 4-Tier-Classifier-Heuristiken beantworten häufige Fälle ohne LLM-Call,
+ein Loop kostet pro Schritt einen vollen Modell-Roundtrip.
+
+## Risiken
+
+| Risiko | Gegenmaßnahme |
+| --- | --- |
+| Latenz: jeder Tool-Step = voller Roundtrip mit wachsendem Kontext | Step-Cap 4; Modus-Scope klein halten; `tool_step_*`-Events zeigen Fortschritt sofort |
+| Token-Kosten 2–4× pro agentischem Turn | Flag + nur Sharepic-Modus; kompakte Tool-Results; Snapshot statt History |
+| Provider-Kompatibilität (Mistral primär — Tool-Calling-Qualität schwankt) | v1 auf das Modell pinnen, das `canvas_ai_suggest` heute nutzt (tool-forced bewährt); Fallback: ein Step = bisheriger structured call |
+| Doppel-Pfad-Drift (Loop vs. `sharepicEditService`) | Kern (Ops→Patch→Version→SSE) in gemeinsame Funktion extrahieren; `sharepicEditService` wird dünner Aufrufer |
+| Endlos-/Pendel-Loops (Modell ruft wiederholt dasselbe Tool) | stopWhen + Dedup identischer aufeinanderfolgender Tool-Calls (Args-Hash) |
+
+## Bewusst NICHT Ziel von v1
+
+- Kein chat-weiter Ersatz der Intent-Pipeline (eigener Beschluss nach Bake-Zeit).
+- Keine neuen Fähigkeiten, die es als Service nicht gibt (z. B. Formatwechsel —
+  siehe `sharepic-chat-editing.md`, „Bewusst aufgeschoben").
+- Kein paralleler Tool-Aufruf (AI SDK kann es; v1 sequenziell, einfacher zu
+  debuggen und SSE-seitig darzustellen).

--- a/documentation/docs/intern/sharepic-chat-editing.md
+++ b/documentation/docs/intern/sharepic-chat-editing.md
@@ -38,6 +38,14 @@ neu erfindet.
 - **Kontext-Disziplin:** pro Edit landen nur `{ canvasId, variantId, version,
   summary }` in `tool_results`; voller State reist ausschließlich über SSE
   (`sharepic_minted` / `sharepic_updated` / `sharepic_edit_error`).
+- **Sharepic-Modus (Artifact-Panel):** das aktiv geschaltete Sharepic dockt
+  als `SharepicArtifactPanel` rechts an die Chat-Surface (`ChatPage`, nur ≥xl;
+  darunter bleibt die Inline-Karte die einzige Fläche). Karte und Panel teilen
+  sich die komplette Render-/Versions-/Restore-Logik über
+  `useSharepicArtifact` und denselben `sharepicLiveStore`-Eintrag — SSE-Updates
+  erreichen beide identisch. `ActiveSharepic` trägt dafür `initialProps`/
+  `label` (client-only; der Request-Body mappt weiterhin nur
+  `{ variantId, canvasId, canvasType }`).
 - **Thumbnails:** nach jedem echten Edit (SSE-Update/Restore, NICHT
   Mount-Rehydration) markiert der Client den Eintrag `thumbnailDirty`;
   `SharepicVariantCard` lädt den nächsten erfolgreichen Head-Render als
@@ -49,7 +57,7 @@ neu erfindet.
 
 | Thema | Warum aufgeschoben | Wenn doch gebraucht |
 | --- | --- | --- |
-| **Agentischer Tool-Loop im Chat** | User-Entscheidung „structured call now, loop later"; Loop wäre Chat-weiter Umbau (Latenz, Kosten, Kontext-Wachstum) | `sharepicEditService` ist als Tool-Executor wiederverwendbar gebaut |
+| **Agentischer Tool-Loop im Chat** | User-Entscheidung „structured call now, loop later"; Loop wäre Chat-weiter Umbau (Latenz, Kosten, Kontext-Wachstum) | Konkreter Plan inkl. Aufwand: `chat-tool-loop-plan.md` (v1 gescoped auf den Sharepic-Modus) |
 | **Formatwechsel per Chat** (Portrait → Story …) | `canvas.resize` klont ein NEUES Dokument → bricht Karten-Identität (canvasId in Thread & Versionen) | Konzept nötig: Karte auf neues Doc umhängen oder Resize-in-place |
 | **Multi-Page-Sharepics** (Slider, Präsentationen) | Patches gehen nur auf Seite 0; `formState` kann Edits nicht seitenweise attribuieren | Ops um `pageId` erweitern; Deskriptoren für Slider/Pres-Templates |
 | **KI-generierte / hochgeladene Hintergründe** | v1 nur Stock-Suche (`set-background-image` → ImageSelectionService) | Flux-Pfad existiert im image-Intent; Upload bräuchte Attachment-Routing in den Edit-Branch |

--- a/packages/chat/src/components/SharepicArtifactPanel.tsx
+++ b/packages/chat/src/components/SharepicArtifactPanel.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useMemo } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  ExternalLink,
+  History,
+  Loader2,
+  SquarePen,
+  X,
+} from 'lucide-react';
+
+import { useSharepicArtifact } from '../hooks/useSharepicArtifact';
+import { useSharepicLiveStore, type ActiveSharepic } from '../stores/sharepicLiveStore';
+
+import type { SharepicVariant } from '../hooks/useChatGraphStream';
+
+/**
+ * Docked right-rail artifact view of the sharepic the user marked "active for
+ * chat editing". While the inline card scrolls away during an iterative edit
+ * session, this panel keeps the artifact pinned — the chat becomes the command
+ * line. Renders nothing while no variant is active; hosts decide where (and at
+ * which breakpoint) to dock it.
+ */
+export function SharepicArtifactPanel({ className }: { className?: string }) {
+  const active = useSharepicLiveStore((s) => s.activeVariant);
+  if (!active) return null;
+  // Key by variant so stepper/preview state never leaks across sharepics.
+  return <PanelInner key={active.variantId} active={active} className={className} />;
+}
+
+function PanelInner({ active, className }: { active: ActiveSharepic; className?: string }) {
+  const variant = useMemo<SharepicVariant>(
+    () => ({
+      id: active.variantId,
+      canvasType: active.canvasType,
+      initialProps: active.initialProps,
+      ...(active.label ? { label: active.label } : {}),
+      ...(active.canvasId ? { canvasId: active.canvasId } : {}),
+    }),
+    [active]
+  );
+
+  const {
+    imageBase64,
+    isRendering,
+    renderError,
+    headVersion,
+    viewVersion,
+    showStepper,
+    label,
+    stepToVersion,
+    restoreViewVersion,
+    download,
+    openInStudio,
+  } = useSharepicArtifact(variant);
+
+  const close = () => useSharepicLiveStore.getState().setActiveVariant(null);
+
+  return (
+    <aside
+      className={
+        className ??
+        'flex w-[24rem] shrink-0 flex-col overflow-hidden border-l border-border bg-background-alt'
+      }
+      aria-label={`Aktives Sharepic: ${label}`}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
+            <SquarePen className="h-3 w-3" />
+            Sharepic-Modus
+          </span>
+          <span className="truncate text-sm font-medium text-foreground">{label}</span>
+        </div>
+        <button
+          onClick={close}
+          className="rounded p-1 text-foreground-muted hover:bg-primary/10 hover:text-foreground"
+          aria-label="Sharepic-Modus beenden"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3">
+        {renderError ? (
+          <div className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
+            Sharepic-Vorschau konnte nicht gerendert werden.
+            <button onClick={openInStudio} className="ml-2 text-primary hover:underline">
+              Im Editor öffnen
+            </button>
+          </div>
+        ) : (
+          <div className="relative overflow-hidden rounded-lg border border-border bg-background">
+            {isRendering && !imageBase64 && (
+              <div className="flex h-72 items-center justify-center">
+                <div className="flex flex-col items-center gap-2">
+                  <Loader2 className="h-8 w-8 animate-spin text-foreground-muted" />
+                  <span className="text-xs text-foreground-muted">Rendere {label}...</span>
+                </div>
+              </div>
+            )}
+            {imageBase64 && (
+              <img
+                src={imageBase64}
+                alt={`${label}-Sharepic`}
+                className={
+                  isRendering
+                    ? 'mx-auto w-full opacity-50 transition-opacity'
+                    : 'mx-auto w-full opacity-100 transition-opacity'
+                }
+              />
+            )}
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          {showStepper ? (
+            <span className="inline-flex items-center gap-0.5 text-xs text-foreground-muted">
+              <button
+                onClick={() => void stepToVersion(-1)}
+                className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                aria-label="Vorherige Version anzeigen"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </button>
+              v{viewVersion ?? headVersion}/{headVersion}
+              <button
+                onClick={() => void stepToVersion(1)}
+                className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                aria-label="Nächste Version anzeigen"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </button>
+            </span>
+          ) : (
+            <span />
+          )}
+          {viewVersion != null && (
+            <button
+              onClick={() => void restoreViewVersion()}
+              className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
+              aria-label={`Version ${viewVersion} wiederherstellen`}
+            >
+              <History className="h-3.5 w-3.5" />
+              <span>Wiederherstellen</span>
+            </button>
+          )}
+        </div>
+
+        <p className="text-xs text-foreground-muted">
+          Beschreibe Änderungen einfach im Chat — sie landen direkt auf diesem Sharepic.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-end gap-1 border-t border-border px-3 py-2">
+        <button
+          onClick={download}
+          className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-foreground-muted hover:bg-primary/10 hover:text-foreground"
+          aria-label="Sharepic herunterladen"
+        >
+          <Download className="h-3.5 w-3.5" />
+          <span>Herunterladen</span>
+        </button>
+        <button
+          onClick={openInStudio}
+          className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
+          aria-label="Sharepic im Studio öffnen"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          <span>Im Studio öffnen</span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/packages/chat/src/components/message-parts/SharepicVariantCard.tsx
+++ b/packages/chat/src/components/message-parts/SharepicVariantCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import {
   Loader2,
   Pencil,
@@ -10,8 +10,7 @@ import {
   History,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
-import { useChatConfigStore } from '../../stores/chatConfigStore';
-import { useSharepicLiveStore } from '../../stores/sharepicLiveStore';
+import { useSharepicArtifact } from '../../hooks/useSharepicArtifact';
 
 import type { SharepicVariant } from '../../hooks/useChatGraphStream';
 
@@ -19,222 +18,36 @@ interface SharepicVariantCardProps {
   variant: SharepicVariant;
 }
 
-const FALLBACK_LABELS: Record<string, string> = {
-  dreizeilen: 'Dreizeiler',
-  'zitat-pure': 'Zitat',
-  zitat: 'Zitat',
-  info: 'Info',
-  simple: 'Sharepic',
-  veranstaltung: 'Veranstaltung',
-  slider: 'Slider',
-  freeform: 'Freeform',
-};
-
-interface VersionEntry {
-  version: number;
-  summary: string | null;
-}
-
-/**
- * After a real edit (entry is thumbnail-dirty) the freshly rendered head PNG
- * doubles as the canvas thumbnail. Version previews never qualify, and the
- * flag is cleared up front — a failed upload is not worth a retry loop.
- */
-function maybeUploadThumbnail(variantId: string, dataUrl: string, isVersionPreview: boolean) {
-  if (isVersionPreview) return;
-  const store = useSharepicLiveStore.getState();
-  const entry = store.entries[variantId];
-  if (!entry?.thumbnailDirty || !entry.canvasId) return;
-  const upload = useChatConfigStore.getState().updateSharepicThumbnail;
-  if (!upload) return;
-  store.clearThumbnailDirty(variantId);
-  upload(entry.canvasId, dataUrl).catch((err) => {
-    console.warn('[SharepicVariantCard] Thumbnail-Update fehlgeschlagen:', err);
-  });
-}
-
 export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
-  const [imageBase64, setImageBase64] = useState<string | null>(null);
-  const [isRendering, setIsRendering] = useState(true);
-  const [renderError, setRenderError] = useState(false);
-  const [versions, setVersions] = useState<VersionEntry[] | null>(null);
-  /** Version being previewed via the stepper; null = current head. */
-  const [viewVersion, setViewVersion] = useState<number | null>(null);
-  const [viewState, setViewState] = useState<Record<string, unknown> | null>(null);
-  const versionStateCache = useRef(new Map<number, Record<string, unknown>>());
-  const hydratedRef = useRef(false);
-
-  const live = useSharepicLiveStore((s) => s.entries[variant.id]);
-  const isActiveForChat = useSharepicLiveStore((s) => s.activeVariant?.variantId === variant.id);
-
-  const canvasId = live?.canvasId ?? variant.canvasId ?? null;
-  const headVersion = live?.version ?? null;
-  const renderInput = viewState ?? live?.state ?? variant.initialProps;
-
-  // Render (and re-render after each chat edit / version step). renderInput
-  // is the full flat state — StandaloneCanvas's createInitialState accepts it
-  // in place of the original initialProps.
-  useEffect(() => {
-    let cancelled = false;
-    const renderFn = useChatConfigStore.getState().renderSharepic;
-    if (!renderFn) {
-      setRenderError(true);
-      setIsRendering(false);
-      return undefined;
-    }
-    setIsRendering(true);
-    renderFn(variant.canvasType, renderInput)
-      .then((dataUrl) => {
-        if (cancelled) return;
-        if (dataUrl) {
-          setImageBase64(dataUrl);
-          setRenderError(false);
-          maybeUploadThumbnail(variant.id, dataUrl, viewState != null);
-        } else {
-          setRenderError(true);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setRenderError(true);
-      })
-      .finally(() => {
-        if (!cancelled) setIsRendering(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [variant.canvasType, variant.id, renderInput, viewState]);
-
-  // Thread-reload rehydration: a minted variant renders its CURRENT state
-  // (which may have changed in the studio), not the stale initialProps.
-  useEffect(() => {
-    if (!canvasId || hydratedRef.current || live?.state) return;
-    const fetchState = useChatConfigStore.getState().fetchSharepicState;
-    if (!fetchState) return;
-    hydratedRef.current = true;
-    void fetchState(canvasId).then((result) => {
-      if (!result) return;
-      useSharepicLiveStore.getState().upsertEntry(variant.id, {
-        canvasId,
-        canvasType: variant.canvasType,
-        version: result.version,
-        state: result.state,
-      });
-    });
-  }, [canvasId, live?.state, variant.id, variant.canvasType]);
-
-  // New head version (chat edit applied) → drop any stale version preview.
-  useEffect(() => {
-    setViewVersion(null);
-    setViewState(null);
-    setVersions(null);
-  }, [headVersion]);
-
-  const loadVersions = useCallback(async (): Promise<VersionEntry[]> => {
-    if (versions) return versions;
-    const fetchVersions = useChatConfigStore.getState().fetchSharepicVersions;
-    if (!canvasId || !fetchVersions) return [];
-    const list = await fetchVersions(canvasId).catch(() => []);
-    const entries = list.map((v) => ({ version: v.version, summary: v.summary }));
-    setVersions(entries);
-    return entries;
-  }, [canvasId, versions]);
-
-  const stepToVersion = useCallback(
-    async (direction: -1 | 1) => {
-      if (!canvasId) return;
-      const list = await loadVersions();
-      if (list.length < 2) return;
-      const ordered = [...list].sort((a, b) => a.version - b.version);
-      const currentIdx =
-        viewVersion == null
-          ? ordered.length - 1
-          : ordered.findIndex((v) => v.version === viewVersion);
-      const nextIdx = Math.min(Math.max(currentIdx + direction, 0), ordered.length - 1);
-      const target = ordered[nextIdx];
-      if (!target) return;
-      if (nextIdx === ordered.length - 1) {
-        setViewVersion(null);
-        setViewState(null);
-        return;
-      }
-      const cached = versionStateCache.current.get(target.version);
-      if (cached) {
-        setViewVersion(target.version);
-        setViewState(cached);
-        return;
-      }
-      const fetchVersionState = useChatConfigStore.getState().fetchSharepicVersionState;
-      if (!fetchVersionState) return;
-      const state = await fetchVersionState(canvasId, target.version).catch(() => null);
-      if (state) {
-        versionStateCache.current.set(target.version, state);
-        setViewVersion(target.version);
-        setViewState(state);
-      }
-    },
-    [canvasId, loadVersions, viewVersion]
-  );
-
-  const handleRestore = useCallback(async () => {
-    if (!canvasId || viewVersion == null) return;
-    const restore = useChatConfigStore.getState().restoreSharepicVersion;
-    if (!restore) return;
-    const result = await restore(canvasId, viewVersion).catch(() => null);
-    if (result) {
-      useSharepicLiveStore.getState().upsertEntry(variant.id, {
-        canvasId,
-        canvasType: variant.canvasType,
-        version: result.version,
-        state: result.state,
-        thumbnailDirty: true,
-      });
-    }
-  }, [canvasId, viewVersion, variant.id, variant.canvasType]);
-
-  const handleToggleActive = useCallback(() => {
-    const store = useSharepicLiveStore.getState();
-    if (store.activeVariant?.variantId === variant.id) {
-      store.setActiveVariant(null);
-    } else {
-      store.setActiveVariant({
-        variantId: variant.id,
-        canvasId,
-        canvasType: variant.canvasType,
-      });
-    }
-  }, [variant.id, variant.canvasType, canvasId]);
+  const {
+    imageBase64,
+    isRendering,
+    renderError,
+    headVersion,
+    viewVersion,
+    isActiveForChat,
+    showStepper,
+    label,
+    stepToVersion,
+    restoreViewVersion,
+    toggleActive,
+    download,
+    openInStudio,
+  } = useSharepicArtifact(variant);
 
   const handleDownload = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      if (!imageBase64) return;
-      const link = document.createElement('a');
-      link.href = imageBase64;
-      link.download = `sharepic-${variant.canvasType}.png`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      download();
     },
-    [imageBase64, variant.canvasType]
+    [download]
   );
-
-  const handleEdit = useCallback(() => {
-    useChatConfigStore.getState().onEditSharepic?.({
-      ...variant,
-      initialProps: live?.state ?? variant.initialProps,
-      ...(canvasId ? { canvasId } : {}),
-    });
-  }, [variant, live?.state, canvasId]);
-
-  const label = variant.label ?? FALLBACK_LABELS[variant.canvasType] ?? 'Sharepic';
-  const showStepper = canvasId != null && headVersion != null && headVersion > 1;
 
   if (renderError) {
     return (
       <div className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
         Sharepic-Vorschau konnte nicht gerendert werden.
-        <button onClick={handleEdit} className="ml-2 text-primary hover:underline">
+        <button onClick={openInStudio} className="ml-2 text-primary hover:underline">
           Im Editor öffnen
         </button>
       </div>
@@ -252,7 +65,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
     >
       <button
         type="button"
-        onClick={handleEdit}
+        onClick={openInStudio}
         className="block w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         aria-label={`${label}-Variante im Editor öffnen`}
       >
@@ -319,7 +132,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
             )}
             {viewVersion != null && (
               <button
-                onClick={() => void handleRestore()}
+                onClick={() => void restoreViewVersion()}
                 className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
                 aria-label={`Version ${viewVersion} wiederherstellen`}
               >
@@ -330,7 +143,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
           </div>
           <div className="flex items-center gap-1">
             <button
-              onClick={handleToggleActive}
+              onClick={toggleActive}
               className={cn(
                 'flex items-center gap-1 rounded-lg px-2 py-1 text-xs',
                 isActiveForChat
@@ -352,7 +165,7 @@ export function SharepicVariantCard({ variant }: SharepicVariantCardProps) {
               <span>Herunterladen</span>
             </button>
             <button
-              onClick={handleEdit}
+              onClick={openInStudio}
               className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
               aria-label="Sharepic im Studio bearbeiten"
             >

--- a/packages/chat/src/hooks/useSharepicArtifact.ts
+++ b/packages/chat/src/hooks/useSharepicArtifact.ts
@@ -1,0 +1,243 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+import { useChatConfigStore } from '../stores/chatConfigStore';
+import { useSharepicLiveStore } from '../stores/sharepicLiveStore';
+
+import type { SharepicVariant } from './useChatGraphStream';
+
+export interface SharepicVersionEntry {
+  version: number;
+  summary: string | null;
+}
+
+const FALLBACK_LABELS: Record<string, string> = {
+  dreizeilen: 'Dreizeiler',
+  'zitat-pure': 'Zitat',
+  zitat: 'Zitat',
+  info: 'Info',
+  simple: 'Sharepic',
+  veranstaltung: 'Veranstaltung',
+  slider: 'Slider',
+  freeform: 'Freeform',
+};
+
+export function sharepicLabel(variant: Pick<SharepicVariant, 'label' | 'canvasType'>): string {
+  return variant.label ?? FALLBACK_LABELS[variant.canvasType] ?? 'Sharepic';
+}
+
+/**
+ * After a real edit (entry is thumbnail-dirty) the freshly rendered head PNG
+ * doubles as the canvas thumbnail. Version previews never qualify, and the
+ * flag is cleared up front — a failed upload is not worth a retry loop.
+ * Clearing is synchronous, so when card and panel render the same variant
+ * concurrently only the first completed render uploads.
+ */
+function maybeUploadThumbnail(variantId: string, dataUrl: string, isVersionPreview: boolean) {
+  if (isVersionPreview) return;
+  const store = useSharepicLiveStore.getState();
+  const entry = store.entries[variantId];
+  if (!entry?.thumbnailDirty || !entry.canvasId) return;
+  const upload = useChatConfigStore.getState().updateSharepicThumbnail;
+  if (!upload) return;
+  store.clearThumbnailDirty(variantId);
+  upload(entry.canvasId, dataUrl).catch((err) => {
+    console.warn('[useSharepicArtifact] Thumbnail-Update fehlgeschlagen:', err);
+  });
+}
+
+/**
+ * Shared live-rendering + version logic for a chat sharepic variant. Used by
+ * the inline message card AND the docked artifact panel — both render from
+ * the same sharepicLiveStore entry, so SSE updates reach them identically.
+ */
+export function useSharepicArtifact(variant: SharepicVariant) {
+  const [imageBase64, setImageBase64] = useState<string | null>(null);
+  const [isRendering, setIsRendering] = useState(true);
+  const [renderError, setRenderError] = useState(false);
+  const [versions, setVersions] = useState<SharepicVersionEntry[] | null>(null);
+  /** Version being previewed via the stepper; null = current head. */
+  const [viewVersion, setViewVersion] = useState<number | null>(null);
+  const [viewState, setViewState] = useState<Record<string, unknown> | null>(null);
+  const versionStateCache = useRef(new Map<number, Record<string, unknown>>());
+  const hydratedRef = useRef(false);
+
+  const live = useSharepicLiveStore((s) => s.entries[variant.id]);
+  const isActiveForChat = useSharepicLiveStore((s) => s.activeVariant?.variantId === variant.id);
+
+  const canvasId = live?.canvasId ?? variant.canvasId ?? null;
+  const headVersion = live?.version ?? null;
+  const renderInput = viewState ?? live?.state ?? variant.initialProps;
+
+  // Render (and re-render after each chat edit / version step). renderInput
+  // is the full flat state — StandaloneCanvas's createInitialState accepts it
+  // in place of the original initialProps.
+  useEffect(() => {
+    let cancelled = false;
+    const renderFn = useChatConfigStore.getState().renderSharepic;
+    if (!renderFn) {
+      setRenderError(true);
+      setIsRendering(false);
+      return undefined;
+    }
+    setIsRendering(true);
+    renderFn(variant.canvasType, renderInput)
+      .then((dataUrl) => {
+        if (cancelled) return;
+        if (dataUrl) {
+          setImageBase64(dataUrl);
+          setRenderError(false);
+          maybeUploadThumbnail(variant.id, dataUrl, viewState != null);
+        } else {
+          setRenderError(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRenderError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setIsRendering(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [variant.canvasType, variant.id, renderInput, viewState]);
+
+  // Thread-reload rehydration: a minted variant renders its CURRENT state
+  // (which may have changed in the studio), not the stale initialProps.
+  useEffect(() => {
+    if (!canvasId || hydratedRef.current || live?.state) return;
+    const fetchState = useChatConfigStore.getState().fetchSharepicState;
+    if (!fetchState) return;
+    hydratedRef.current = true;
+    void fetchState(canvasId).then((result) => {
+      if (!result) return;
+      useSharepicLiveStore.getState().upsertEntry(variant.id, {
+        canvasId,
+        canvasType: variant.canvasType,
+        version: result.version,
+        state: result.state,
+      });
+    });
+  }, [canvasId, live?.state, variant.id, variant.canvasType]);
+
+  // New head version (chat edit applied) → drop any stale version preview.
+  useEffect(() => {
+    setViewVersion(null);
+    setViewState(null);
+    setVersions(null);
+  }, [headVersion]);
+
+  const loadVersions = useCallback(async (): Promise<SharepicVersionEntry[]> => {
+    if (versions) return versions;
+    const fetchVersions = useChatConfigStore.getState().fetchSharepicVersions;
+    if (!canvasId || !fetchVersions) return [];
+    const list = await fetchVersions(canvasId).catch(() => []);
+    const entries = list.map((v) => ({ version: v.version, summary: v.summary }));
+    setVersions(entries);
+    return entries;
+  }, [canvasId, versions]);
+
+  const stepToVersion = useCallback(
+    async (direction: -1 | 1) => {
+      if (!canvasId) return;
+      const list = await loadVersions();
+      if (list.length < 2) return;
+      const ordered = [...list].sort((a, b) => a.version - b.version);
+      const currentIdx =
+        viewVersion == null
+          ? ordered.length - 1
+          : ordered.findIndex((v) => v.version === viewVersion);
+      const nextIdx = Math.min(Math.max(currentIdx + direction, 0), ordered.length - 1);
+      const target = ordered[nextIdx];
+      if (!target) return;
+      if (nextIdx === ordered.length - 1) {
+        setViewVersion(null);
+        setViewState(null);
+        return;
+      }
+      const cached = versionStateCache.current.get(target.version);
+      if (cached) {
+        setViewVersion(target.version);
+        setViewState(cached);
+        return;
+      }
+      const fetchVersionState = useChatConfigStore.getState().fetchSharepicVersionState;
+      if (!fetchVersionState) return;
+      const state = await fetchVersionState(canvasId, target.version).catch(() => null);
+      if (state) {
+        versionStateCache.current.set(target.version, state);
+        setViewVersion(target.version);
+        setViewState(state);
+      }
+    },
+    [canvasId, loadVersions, viewVersion]
+  );
+
+  const restoreViewVersion = useCallback(async () => {
+    if (!canvasId || viewVersion == null) return;
+    const restore = useChatConfigStore.getState().restoreSharepicVersion;
+    if (!restore) return;
+    const result = await restore(canvasId, viewVersion).catch(() => null);
+    if (result) {
+      useSharepicLiveStore.getState().upsertEntry(variant.id, {
+        canvasId,
+        canvasType: variant.canvasType,
+        version: result.version,
+        state: result.state,
+        thumbnailDirty: true,
+      });
+    }
+  }, [canvasId, viewVersion, variant.id, variant.canvasType]);
+
+  const toggleActive = useCallback(() => {
+    const store = useSharepicLiveStore.getState();
+    if (store.activeVariant?.variantId === variant.id) {
+      store.setActiveVariant(null);
+    } else {
+      store.setActiveVariant({
+        variantId: variant.id,
+        canvasId,
+        canvasType: variant.canvasType,
+        initialProps: variant.initialProps,
+        ...(variant.label ? { label: variant.label } : {}),
+      });
+    }
+  }, [variant.id, variant.canvasType, variant.initialProps, variant.label, canvasId]);
+
+  const download = useCallback(() => {
+    if (!imageBase64) return;
+    const link = document.createElement('a');
+    link.href = imageBase64;
+    link.download = `sharepic-${variant.canvasType}.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }, [imageBase64, variant.canvasType]);
+
+  const openInStudio = useCallback(() => {
+    useChatConfigStore.getState().onEditSharepic?.({
+      ...variant,
+      initialProps: live?.state ?? variant.initialProps,
+      ...(canvasId ? { canvasId } : {}),
+    });
+  }, [variant, live?.state, canvasId]);
+
+  const showStepper = canvasId != null && headVersion != null && headVersion > 1;
+
+  return {
+    imageBase64,
+    isRendering,
+    renderError,
+    canvasId,
+    headVersion,
+    viewVersion,
+    isActiveForChat,
+    showStepper,
+    label: sharepicLabel(variant),
+    stepToVersion,
+    restoreViewVersion,
+    toggleActive,
+    download,
+    openInStudio,
+  };
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -117,6 +117,7 @@ export { type CategoryFilterField } from './components/notebook/CategoryFilterDr
 
 // Thread Components
 export { GrueneratorThread } from './components/thread/GrueneratorThread';
+export { SharepicArtifactPanel } from './components/SharepicArtifactPanel';
 export { composerToolbarButtonClass } from './lib/utils';
 export { useChatDensity, type ChatDensity } from './components/thread/chatDensityContext';
 export { GrueneratorComposer } from './components/thread/GrueneratorComposer';

--- a/packages/chat/src/runtime/GrueneratorModelAdapter/index.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter/index.ts
@@ -449,7 +449,12 @@ export function createGrueneratorModelAdapter(
         injectedCurrentDocument,
         injectedAttachmentContext,
         seededInitialAssistantMessage,
-        currentSharepic: useSharepicLiveStore.getState().activeVariant,
+        currentSharepic: (() => {
+          const active = useSharepicLiveStore.getState().activeVariant;
+          if (!active) return null;
+          const { variantId, canvasId, canvasType } = active;
+          return { variantId, canvasId, canvasType };
+        })(),
       });
 
       let response: Response;

--- a/packages/chat/src/stores/sharepicLiveStore.ts
+++ b/packages/chat/src/stores/sharepicLiveStore.ts
@@ -27,6 +27,13 @@ export interface ActiveSharepic {
   variantId: string;
   canvasId: string | null;
   canvasType: string;
+  /**
+   * Render seed for surfaces that don't hold the original variant (the docked
+   * artifact panel). Client-only — the request body maps the identifying
+   * fields explicitly and never sends props.
+   */
+  initialProps: Record<string, unknown>;
+  label?: string;
 }
 
 interface SharepicLiveStore {


### PR DESCRIPTION
## Was

**Sharepic-Modus:** Die per „Im Chat bearbeiten" aktiv geschaltete Variante dockt jetzt als Artifact-Panel rechts an die Chat-Seite (≥xl). Beim iterativen Editieren scrollte die Karte bisher nach oben weg — mit Panel bleibt das Artefakt fix im Blick und der Chat wird zur Kommandozeile (Artifacts-Muster). Unterhalb xl bleibt die Inline-Karte die einzige Fläche.

Außerdem: `documentation/docs/intern/chat-tool-loop-plan.md` — der konkrete, am Code verifizierte Follow-up-Plan für den agentischen Tool-Loop (v1 bewusst auf den Sharepic-Modus gescoped, ~1.8–2.5k LOC hinter Flag, 3–4 PRs; Kernbefund: `streamText()` ist bereits AI SDK v6, der Loop braucht keinen handgeschriebenen While-Loop und keinen Worker-Pool-Umbau).

## Wie

- **`useSharepicArtifact`** (neu): komplette Render-/Rehydrations-/Versions-Stepper-/Restore-/Thumbnail-Logik aus `SharepicVariantCard` extrahiert. Karte ist jetzt rein präsentational; Panel nutzt denselben Hook und denselben `sharepicLiveStore`-Eintrag — SSE-Updates erreichen beide identisch. Doppel-Upload des Thumbnails ist durch das synchrone Clearen des `thumbnailDirty`-Flags ausgeschlossen (First-Completer gewinnt).
- **`SharepicArtifactPanel`** (neu): Header (Modus-Badge, Label, Schließen = Modus beenden), Live-PNG, Versions-Stepper + Restore, Download, „Im Studio öffnen", Hinweistext. `key={variantId}` verhindert State-Leak zwischen Sharepics.
- **`ActiveSharepic`** trägt jetzt `initialProps`/`label` (Render-Seed für das Panel, client-only). Der Adapter mappt den Request-Body ab sofort explizit auf `{ variantId, canvasId, canvasType }` — Props wandern nie ins Backend.
- **Mount:** `ChatPage` (Flex-Geschwister von `<main>`, nur Thread-Modus, `hidden xl:flex`). Kein Backend-Change in diesem PR.

## Stack

Stacked auf #1217 → #1216 → #1215; GitHub retargetet nach Merges automatisch.

## Verifikation

- `pnpm typecheck` grün (20/20), Prettier sauber, lint-staged beim Commit grün.
- Manuell: Variante aktiv schalten → Panel dockt rechts an; Chat-Edit → Panel und Karte aktualisieren gleichzeitig; Stepper/Restore im Panel; Schließen-Button beendet den Modus (Karte verliert Badge); Fenster < xl → kein Panel, Karte unverändert.