### PR TITLE
feat(api,chat): agentic tool loop v1 for sharepic edits (CHAT_TOOL_LOOP)

### DIFF
--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -44,6 +44,10 @@ import {
   streamWithFallback,
 } from './services/responseStreamingService.js';
 import { runChatGraphResume } from './services/resumePipeline.js';
+import {
+  handleSharepicAgenticEdit,
+  isChatToolLoopEnabled,
+} from './services/sharepicAgenticService.js';
 import { handleSharepicEdit, isSharepicEditInstruction } from './services/sharepicEditService.js';
 import {
   getLastSharepicVariant,
@@ -230,7 +234,13 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           .replace(/@sharepic\b/gi, ' ')
           .trim();
         if (editText && (isSharepicEditInstruction(editText) || isSharepicRefinement(editText))) {
-          const handled = await handleSharepicEdit({
+          // CHAT_TOOL_LOOP swaps the executor, not the routing: same entry
+          // condition and fallthrough semantics, but the edit runs as a small
+          // agentic tool loop instead of one structured call.
+          const editHandler = isChatToolLoopEnabled()
+            ? handleSharepicAgenticEdit
+            : handleSharepicEdit;
+          const handled = await editHandler({
             sse,
             req,
             threadId: actualThreadId,

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -48,7 +48,7 @@ import {
   handleSharepicAgenticEdit,
   isChatToolLoopEnabled,
 } from './services/sharepicAgenticService.js';
-import { hasSharepicEditVerb } from './services/sharepicEditHeuristics.js';
+import { hasSharepicEditVerb, isShortAffirmation } from './services/sharepicEditHeuristics.js';
 import { handleSharepicEdit, isSharepicEditInstruction } from './services/sharepicEditService.js';
 import {
   getLastSharepicVariant,
@@ -243,7 +243,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           isChatToolLoopEnabled() &&
           rawCurrentSharepic != null &&
           !!editText &&
-          hasSharepicEditVerb(editText);
+          (hasSharepicEditVerb(editText) || isShortAffirmation(editText));
         if (
           editText &&
           (isSharepicEditInstruction(editText) ||

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -48,6 +48,7 @@ import {
   handleSharepicAgenticEdit,
   isChatToolLoopEnabled,
 } from './services/sharepicAgenticService.js';
+import { hasSharepicEditVerb } from './services/sharepicEditHeuristics.js';
 import { handleSharepicEdit, isSharepicEditInstruction } from './services/sharepicEditService.js';
 import {
   getLastSharepicVariant,
@@ -233,7 +234,22 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         const editText = ((extractTextContent(lastUserMessage.content) as string) || '')
           .replace(/@sharepic\b/gi, ' ')
           .trim();
-        if (editText && (isSharepicEditInstruction(editText) || isSharepicRefinement(editText))) {
+        // With an explicitly activated sharepic (Sharepic-Modus) AND the tool
+        // loop on, an edit verb alone is enough — the loop can answer with
+        // plain text when the message turns out not to be sharepic-related,
+        // so over-triggering is cheap. The strict verb+noun check stays the
+        // bar for the tool-forced single-call path.
+        const sharepicModeRelaxed =
+          isChatToolLoopEnabled() &&
+          rawCurrentSharepic != null &&
+          !!editText &&
+          hasSharepicEditVerb(editText);
+        if (
+          editText &&
+          (isSharepicEditInstruction(editText) ||
+            isSharepicRefinement(editText) ||
+            sharepicModeRelaxed)
+        ) {
           // CHAT_TOOL_LOOP swaps the executor, not the routing: same entry
           // condition and fallthrough semantics, but the edit runs as a small
           // agentic tool loop instead of one structured call.

--- a/apps/api/routes/chat/services/sharepicAgenticGuards.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticGuards.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure, dependency-light parts of the agentic sharepic loop: tool input
+ * schemas and per-turn guard state. Separate file so unit tests don't import
+ * the service's heavy transitive dependencies (DB, providers, env parsing).
+ */
+import { canvasAiOperationSchema } from '@gruenerator/contracts';
+import { z } from 'zod';
+
+export const MAX_FAILURES_PER_TOOL = 2;
+
+export const applyOpsInputSchema = z.object({
+  operations: z.array(canvasAiOperationSchema).min(1).max(8),
+  summary: z.string().min(1).max(120),
+});
+
+export const restoreInputSchema = z.object({
+  version: z.number().int().min(1),
+});
+
+/**
+ * Pure guard state for one loop turn: rejects an exactly repeated tool call
+ * (model ping-pong) and caps failures per tool so the loop can't burn all its
+ * steps on the same broken idea.
+ */
+export function createLoopGuards() {
+  let lastKey = '';
+  const failures = new Map<string, number>();
+  return {
+    checkDuplicate(toolName: string, input: unknown): string | null {
+      const key = `${toolName}:${JSON.stringify(input)}`;
+      if (key === lastKey) {
+        return 'Identischer Aufruf wiederholt — ändere die Parameter oder antworte dem*der Nutzer*in direkt.';
+      }
+      lastKey = key;
+      return null;
+    },
+    noteFailure(toolName: string): void {
+      failures.set(toolName, (failures.get(toolName) ?? 0) + 1);
+    },
+    checkFailureCap(toolName: string): string | null {
+      if ((failures.get(toolName) ?? 0) >= MAX_FAILURES_PER_TOOL) {
+        return 'Zu viele Fehlversuche mit diesem Tool — erkläre dem*der Nutzer*in, was nicht geklappt hat.';
+      }
+      return null;
+    },
+  };
+}

--- a/apps/api/routes/chat/services/sharepicAgenticService.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticService.ts
@@ -1,0 +1,417 @@
+/**
+ * Agentic tool loop for sharepic edits (v1 — scoped to the Sharepic-Modus).
+ *
+ * Same entry contract as handleSharepicEdit, but instead of one tool-forced
+ * structured call the model drives a small multi-step loop via the AI SDK
+ * (`streamText` + tools + stopWhen): it can read fresh state, apply several
+ * operation batches and restore versions within ONE chat turn, self-correcting
+ * on rejected ops. Enabled via CHAT_TOOL_LOOP=true; the router falls back to
+ * the single-call path when the flag is off (see chat-tool-loop-plan.md).
+ *
+ * Guard rails: hard step cap, per-tool failure cap, duplicate-call detection,
+ * overall timeout. Tool results stay compact — full state travels via the
+ * existing `sharepic_updated` SSE events only.
+ */
+import { buildSharepicSnapshot, getSharepicTemplateDescriptor } from '@gruenerator/contracts';
+import { streamText, tool, stepCountIs } from 'ai';
+import { z } from 'zod';
+
+import {
+  getCurrentCanvasState,
+  applyCanvasStatePatch,
+} from '../../../services/canvas/canvasStateService.js';
+import {
+  getCanvasVersion,
+  insertCanvasVersion,
+  listCanvasVersions,
+} from '../../../services/canvas/canvasVersionRepository.js';
+import { createLogger } from '../../../utils/logger.js';
+import { getModel } from '../agents/providers.js';
+
+import {
+  applyOpsInputSchema,
+  createLoopGuards,
+  restoreInputSchema,
+} from './sharepicAgenticGuards.js';
+import { buildOperationCatalog, buildSnapshotLines } from './sharepicEditLlm.js';
+import {
+  applySharepicOpsToCanvas,
+  ensureMintedCanvas,
+  resolveTarget,
+  type HandleSharepicEditArgs,
+} from './sharepicEditService.js';
+import { createMessage, touchThread } from './threadPersistenceService.js';
+
+const log = createLogger('SharepicAgentic');
+
+/** LLM steps per turn (each tool round trip is one step). */
+const MAX_STEPS = 4;
+const TURN_TIMEOUT_MS = 90_000;
+
+export function isChatToolLoopEnabled(): boolean {
+  return process.env.CHAT_TOOL_LOOP === 'true';
+}
+
+function resolveLoopModel(): { provider: string; modelName: string } {
+  return {
+    provider: process.env.CHAT_TOOL_LOOP_PROVIDER || 'mistral',
+    modelName: process.env.CHAT_TOOL_LOOP_MODEL || 'mistral-medium-2604',
+  };
+}
+
+interface PersistedStep {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  result: Record<string, unknown>;
+}
+
+function buildLoopSystemPrompt(args: {
+  descriptor: NonNullable<ReturnType<typeof getSharepicTemplateDescriptor>>;
+  snapshotLines: string[];
+  recentEditSummaries: string[];
+}): string {
+  const { descriptor, snapshotLines, recentEditSummaries } = args;
+  const lines: string[] = [
+    'Du bist der Bearbeitungs-Assistent für Sharepics der deutschen Grünen.',
+    'Der*die Nutzer*in beschreibt gewünschte Änderungen am aktuellen Sharepic.',
+    'Du setzt sie mit deinen Tools um und bestätigst danach kurz im Chat.',
+    '',
+    'Sprachregeln: Du-Form, Genderstern (z.B. "Bürger*innen"), prägnante Kampagnen-Texte.',
+    '',
+    `Vorlage: ${descriptor.label} (${descriptor.id})`,
+    '',
+    'Aktueller Inhalt:',
+    ...snapshotLines,
+  ];
+
+  if (recentEditSummaries.length > 0) {
+    lines.push('', 'Letzte Änderungen (neueste zuerst):');
+    for (const s of recentEditSummaries) lines.push(`- ${s}`);
+  }
+
+  lines.push(
+    '',
+    ...buildOperationCatalog(descriptor),
+    '',
+    'ARBEITSWEISE:',
+    '- Setze Änderungen mit "apply_sharepic_ops" um — fasse zusammengehörige Operationen in EINEN Aufruf.',
+    '- Wird eine Operation abgelehnt (rejected), korrigiere sie EINMAL mit angepassten Werten.',
+    '- "read_sharepic_state" nur, wenn du den aktuellen Zustand wirklich brauchst (z.B. nach Ablehnungen).',
+    '- "restore_version" nur auf ausdrücklichen Wunsch ("zurück zur vorherigen Version").',
+    `- Du hast maximal ${MAX_STEPS} Schritte. Antworte am Ende IMMER mit 1–2 freundlichen Sätzen auf Deutsch.`,
+    '- Ändere NUR, was verlangt wurde. Nutze nur die gelisteten Felder, IDs und Werte.'
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Run a sharepic edit turn as an agentic tool loop. Same return semantics as
+ * handleSharepicEdit: true = turn handled (stream closed), false = caller
+ * falls through to the next branch.
+ */
+export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): Promise<boolean> {
+  const { sse, req, threadId, userId, instruction, currentSharepic, aiWorkerPool } = args;
+
+  try {
+    const target = await resolveTarget(threadId, currentSharepic);
+    if (!target) return false;
+
+    if (target === 'ambiguous') {
+      await endTurn(
+        args,
+        [],
+        'Welche Variante soll ich bearbeiten? Aktiviere auf der gewünschten Karte "Im Chat bearbeiten" und schick mir die Änderung dann noch einmal.'
+      );
+      return true;
+    }
+
+    const descriptor = getSharepicTemplateDescriptor(target.canvasType);
+    if (!descriptor) {
+      log.info(`[Agentic] No descriptor for canvasType=${target.canvasType} — falling back`);
+      return false;
+    }
+
+    sse.send('progress_step', {
+      stepId: `sharepic_agentic_${Date.now()}`,
+      toolName: 'sharepic_edit',
+      title: 'Bearbeite Sharepic…',
+      status: 'in_progress',
+    });
+
+    const canvasId = await ensureMintedCanvas({ target, descriptor, threadId, userId, sse });
+
+    const current = await getCurrentCanvasState(canvasId);
+    const initialMergedState = {
+      ...descriptor.defaultState,
+      ...target.initialProps,
+      ...current.state,
+    };
+
+    const recentEditSummaries = (await listCanvasVersions(canvasId))
+      .filter((v) => v.origin !== 'mint' && v.summary)
+      .slice(0, 2)
+      .map((v) => v.summary as string);
+
+    // Mutable per-turn context — apply/restore update `state` so later steps
+    // (and the read tool) see their own effects without a DB round trip.
+    const ctx = { state: initialMergedState };
+    const guards = createLoopGuards();
+    const steps: PersistedStep[] = [];
+
+    const recordStep = (
+      toolCallId: string,
+      toolName: string,
+      input: Record<string, unknown>,
+      result: Record<string, unknown>
+    ) => {
+      steps.push({ toolCallId, toolName, args: input, result });
+    };
+
+    const tools = {
+      read_sharepic_state: tool({
+        description:
+          'Liest den aktuellen Zustand des Sharepics (Texte, Farben, Elemente). Nutze dies nach abgelehnten Operationen oder wenn du unsicher über den Ist-Zustand bist.',
+        inputSchema: z.object({}),
+        execute: async (_input, { toolCallId }) => {
+          const fresh = await getCurrentCanvasState(canvasId);
+          ctx.state = { ...descriptor.defaultState, ...target.initialProps, ...fresh.state };
+          const snapshot = buildSharepicSnapshot(descriptor, ctx.state);
+          recordStep(toolCallId, 'read_sharepic_state', {}, { ok: true });
+          return { snapshot: buildSnapshotLines(snapshot).join('\n') };
+        },
+      }),
+
+      apply_sharepic_ops: tool({
+        description:
+          'Wendet 1–8 Operationen auf das Sharepic an (Texte, Schriftgrößen, Farben, Elemente, Hintergrundbild-Suche). Operationen werden validiert; abgelehnte kommen mit Begründung zurück.',
+        inputSchema: applyOpsInputSchema,
+        execute: async (input, { toolCallId }) => {
+          const guardError =
+            guards.checkFailureCap('apply_sharepic_ops') ??
+            guards.checkDuplicate('apply_sharepic_ops', input);
+          if (guardError) return { error: guardError };
+
+          const outcome = await applySharepicOpsToCanvas({
+            canvasId,
+            variantId: target.variantId,
+            canvasType: target.canvasType,
+            descriptor,
+            state: ctx.state,
+            operations: input.operations,
+            summary: input.summary,
+            userId,
+            sse,
+            aiWorkerPool,
+            req,
+          });
+
+          if (!outcome.ok) {
+            guards.noteFailure('apply_sharepic_ops');
+            recordStep(
+              toolCallId,
+              'apply_sharepic_ops',
+              { summary: input.summary },
+              {
+                ok: false,
+                reason: outcome.reason,
+              }
+            );
+            return {
+              error: `Keine Änderung angewendet: ${outcome.reason}`,
+              rejected: outcome.rejected,
+            };
+          }
+
+          ctx.state = outcome.newState;
+          recordStep(
+            toolCallId,
+            'apply_sharepic_ops',
+            { summary: input.summary },
+            {
+              canvasId,
+              variantId: target.variantId,
+              version: outcome.version,
+              summary: input.summary,
+              canvasType: target.canvasType,
+            }
+          );
+          return {
+            version: outcome.version,
+            applied: outcome.appliedKinds,
+            ...(outcome.rejected.length > 0 ? { rejected: outcome.rejected } : {}),
+          };
+        },
+      }),
+
+      restore_version: tool({
+        description:
+          'Stellt eine frühere Version des Sharepics wieder her (als neue Version, nichts geht verloren). Nur auf ausdrücklichen Nutzer*innen-Wunsch.',
+        inputSchema: restoreInputSchema,
+        execute: async (input, { toolCallId }) => {
+          const guardError =
+            guards.checkFailureCap('restore_version') ??
+            guards.checkDuplicate('restore_version', input);
+          if (guardError) return { error: guardError };
+
+          const snapshot = await getCanvasVersion(canvasId, input.version);
+          if (!snapshot) {
+            guards.noteFailure('restore_version');
+            recordStep(toolCallId, 'restore_version', input, { ok: false, reason: 'not_found' });
+            return { error: `Version ${input.version} existiert nicht.` };
+          }
+          // Forward patch — never rewinds Yjs history (same as the REST restore).
+          await applyCanvasStatePatch(canvasId, snapshot.state, { seedState: snapshot.state });
+          const newVersion = await insertCanvasVersion({
+            canvasId,
+            state: snapshot.state,
+            summary: `Version ${snapshot.version} wiederhergestellt`,
+            origin: 'restore',
+            userId,
+          });
+          ctx.state = { ...ctx.state, ...snapshot.state };
+          sse.send('sharepic_updated', {
+            variantId: target.variantId,
+            canvasId,
+            version: newVersion,
+            canvasType: target.canvasType,
+            state: snapshot.state,
+            summary: `Version ${snapshot.version} wiederhergestellt`,
+          });
+          recordStep(toolCallId, 'restore_version', input, {
+            canvasId,
+            variantId: target.variantId,
+            version: newVersion,
+            canvasType: target.canvasType,
+          });
+          return { version: newVersion, restoredFrom: snapshot.version };
+        },
+      }),
+    };
+
+    const { provider, modelName } = resolveLoopModel();
+    const system = buildLoopSystemPrompt({
+      descriptor,
+      snapshotLines: buildSnapshotLines(buildSharepicSnapshot(descriptor, ctx.state)),
+      recentEditSummaries,
+    });
+
+    let text = '';
+    let responseStarted = false;
+
+    const result = streamText({
+      model: getModel(provider, modelName),
+      system,
+      messages: [{ role: 'user', content: instruction }],
+      tools,
+      stopWhen: stepCountIs(MAX_STEPS),
+      temperature: 0.2,
+      maxOutputTokens: 800,
+      abortSignal: AbortSignal.timeout(TURN_TIMEOUT_MS),
+    });
+
+    // Manual iteration — fullStream is a ReadableStream whose async-iterator
+    // protocol the lint type info doesn't see (same pattern as
+    // responseStreamingService).
+    const iterator = result.fullStream[Symbol.asyncIterator]();
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) break;
+      const part = next.value;
+      if (part.type === 'error') throw part.error;
+      if (part.type === 'tool-call') {
+        sse.send('tool_step_start', {
+          stepId: part.toolCallId,
+          toolName: part.toolName,
+          args: (part.input ?? {}) as Record<string, unknown>,
+        });
+      } else if (part.type === 'tool-result') {
+        const output = (part.output ?? {}) as Record<string, unknown>;
+        const ok = !('error' in output);
+        sse.send('tool_step_result', {
+          stepId: part.toolCallId,
+          toolName: part.toolName,
+          ok,
+          ...(typeof output.error === 'string'
+            ? { summary: output.error }
+            : typeof output.version === 'number'
+              ? { summary: `Version ${output.version}` }
+              : {}),
+        });
+      } else if (part.type === 'text-delta' && part.text.length > 0) {
+        if (!responseStarted) {
+          responseStarted = true;
+          sse.send('response_start', { message: 'Antwort wird erstellt...' });
+        }
+        text += part.text;
+        sse.send('text_delta', { text: part.text });
+      }
+    }
+
+    // A model that only called tools still owes the user a confirmation.
+    if (text.trim().length === 0) {
+      const lastApply = [...steps].reverse().find((s) => s.toolName === 'apply_sharepic_ops');
+      text =
+        typeof lastApply?.args.summary === 'string'
+          ? `Erledigt: ${lastApply.args.summary}.`
+          : 'Ich konnte daraus keine Änderung ableiten. Magst du es konkreter beschreiben?';
+      sse.send('response_start', { message: 'Antwort wird erstellt...' });
+      sse.send('text_delta', { text });
+    }
+
+    await endTurn(args, steps, text, { streamed: true });
+    log.info(`[Agentic] Turn done on ${canvasId}: ${steps.length} tool step(s)`);
+    return true;
+  } catch (error) {
+    log.error('[Agentic] Turn failed:', error);
+    if (!sse.isEnded()) {
+      sse.send('sharepic_edit_error', {
+        error: error instanceof Error ? error.message : 'Unbekannter Fehler',
+      });
+      await endTurn(
+        args,
+        [],
+        'Bei der Bearbeitung ist etwas schiefgelaufen. Versuch es bitte noch einmal.'
+      );
+    }
+    return true;
+  }
+}
+
+/** Persist the assistant message (with all tool steps), emit done, close SSE. */
+async function endTurn(
+  args: HandleSharepicEditArgs,
+  steps: PersistedStep[],
+  text: string,
+  opts?: { streamed?: boolean }
+): Promise<void> {
+  const { sse, threadId } = args;
+  if (!opts?.streamed) {
+    sse.send('response_start', { message: 'Antwort wird erstellt...' });
+    sse.send('text_delta', { text });
+  }
+  sse.sendRaw('done', {
+    threadId,
+    citations: [],
+    metadata: {
+      intent: 'sharepic_edit',
+      searchCount: 0,
+      totalTimeMs: Date.now() - args.startTime,
+      ...(args.classificationTimeMs != null && {
+        classificationTimeMs: args.classificationTimeMs,
+      }),
+      searchTimeMs: 0,
+    },
+  });
+  try {
+    await createMessage(threadId, 'assistant', text, {
+      intent: 'sharepic_edit',
+      ...(steps.length > 0 ? { toolCalls: steps as unknown as Record<string, unknown>[] } : {}),
+    });
+    await touchThread(threadId);
+  } catch (err) {
+    log.error('[Agentic] Failed to persist message:', err);
+  }
+  sse.end();
+}

--- a/apps/api/routes/chat/services/sharepicAgenticService.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticService.ts
@@ -114,14 +114,16 @@ function buildLoopSystemPrompt(args: {
     ...buildOperationCatalog(descriptor),
     '',
     'ARBEITSWEISE:',
-    '- Setze Änderungen mit "apply_sharepic_ops" um — fasse zusammengehörige Operationen in EINEN Aufruf.',
+    '- Setze Änderungen SOFORT mit "apply_sharepic_ops" um. Stelle KEINE Rückfragen und beschreibe keine Entwürfe im Chat — bei Spielraum (z.B. "Text kürzen") entscheide selbst und formuliere kampagnentauglich.',
+    '- Fasse zusammengehörige Operationen in EINEN Aufruf.',
+    '- Bestätigt der*die Nutzer*in einen früheren Vorschlag ("ja", "mach das so"), wende GENAU diesen Vorschlag aus der vorigen Antwort jetzt mit "apply_sharepic_ops" an.',
     '- Wird eine Operation abgelehnt (rejected), korrigiere sie EINMAL mit angepassten Werten.',
     '- "read_sharepic_state" nur, wenn du den aktuellen Zustand wirklich brauchst (z.B. nach Ablehnungen).',
     '- "restore_version" nur auf ausdrücklichen Wunsch ("zurück zur vorherigen Version").',
     `- Du hast maximal ${MAX_STEPS} Schritte. Antworte am Ende IMMER mit 1–2 freundlichen Sätzen auf Deutsch.`,
     '- Ändere NUR, was verlangt wurde. Nutze nur die gelisteten Felder, IDs und Werte.',
     '- Bezieht sich die Nachricht auf Texte aus der vorigen Antwort ("setz das ein", "nimm Vorschlag 2"), übernimm sie sinngemäß in die passenden Felder — kürze auf die Feldlängen der Vorlage.',
-    '- Hat die Nachricht NICHTS mit dem Sharepic zu tun, rufe KEIN Tool auf und antworte nur kurz im Chat.'
+    '- NUR wenn die Nachricht erkennbar nichts mit dem Sharepic zu tun hat, antworte ohne Tool-Aufruf kurz im Chat.'
   );
 
   return lines.join('\n');

--- a/apps/api/routes/chat/services/sharepicAgenticService.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticService.ts
@@ -13,9 +13,10 @@
  * existing `sharepic_updated` SSE events only.
  */
 import { buildSharepicSnapshot, getSharepicTemplateDescriptor } from '@gruenerator/contracts';
-import { streamText, tool, stepCountIs } from 'ai';
+import { streamText, tool, stepCountIs, type ModelMessage } from 'ai';
 import { z } from 'zod';
 
+import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import {
   getCurrentCanvasState,
   applyCanvasStatePatch,
@@ -59,6 +60,24 @@ function resolveLoopModel(): { provider: string; modelName: string } {
   };
 }
 
+/**
+ * Last assistant reply of the thread, truncated. Instructions like "setze
+ * Vorschlag 1 ein" reference text the assistant JUST suggested — without it
+ * the loop model has nothing to insert.
+ */
+async function getPriorAssistantText(threadId: string): Promise<string | null> {
+  const pg = getPostgresInstance();
+  const rows = (await pg.query(
+    `SELECT content FROM chat_messages
+     WHERE thread_id = $1 AND role = 'assistant'
+     ORDER BY created_at DESC LIMIT 1`,
+    [threadId]
+  )) as Array<{ content: string | null }>;
+  const content = rows[0]?.content?.trim();
+  if (!content) return null;
+  return content.length > 4000 ? `${content.slice(0, 4000)}…` : content;
+}
+
 interface PersistedStep {
   toolCallId: string;
   toolName: string;
@@ -100,7 +119,9 @@ function buildLoopSystemPrompt(args: {
     '- "read_sharepic_state" nur, wenn du den aktuellen Zustand wirklich brauchst (z.B. nach Ablehnungen).',
     '- "restore_version" nur auf ausdrücklichen Wunsch ("zurück zur vorherigen Version").',
     `- Du hast maximal ${MAX_STEPS} Schritte. Antworte am Ende IMMER mit 1–2 freundlichen Sätzen auf Deutsch.`,
-    '- Ändere NUR, was verlangt wurde. Nutze nur die gelisteten Felder, IDs und Werte.'
+    '- Ändere NUR, was verlangt wurde. Nutze nur die gelisteten Felder, IDs und Werte.',
+    '- Bezieht sich die Nachricht auf Texte aus der vorigen Antwort ("setz das ein", "nimm Vorschlag 2"), übernimm sie sinngemäß in die passenden Felder — kürze auf die Feldlängen der Vorlage.',
+    '- Hat die Nachricht NICHTS mit dem Sharepic zu tun, rufe KEIN Tool auf und antworte nur kurz im Chat.'
   );
 
   return lines.join('\n');
@@ -300,10 +321,16 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
     let text = '';
     let responseStarted = false;
 
+    const priorAssistantText = await getPriorAssistantText(threadId);
+    const messages: ModelMessage[] = [
+      ...(priorAssistantText ? [{ role: 'assistant' as const, content: priorAssistantText }] : []),
+      { role: 'user' as const, content: instruction },
+    ];
+
     const result = streamText({
       model: getModel(provider, modelName),
       system,
-      messages: [{ role: 'user', content: instruction }],
+      messages,
       tools,
       stopWhen: stepCountIs(MAX_STEPS),
       temperature: 0.2,

--- a/apps/api/routes/chat/services/sharepicAgenticService.vitest.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticService.vitest.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  applyOpsInputSchema,
+  restoreInputSchema,
+  createLoopGuards,
+} from './sharepicAgenticGuards.js';
+
+describe('applyOpsInputSchema', () => {
+  it('accepts a valid set-text batch with summary', () => {
+    const result = applyOpsInputSchema.safeParse({
+      operations: [{ kind: 'set-text', field: 'line1', label: 'Zeile 1', value: 'GRÜN WIRKT' }],
+      summary: 'Zeile 1 geändert',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty operation batches', () => {
+    expect(applyOpsInputSchema.safeParse({ operations: [], summary: 'x' }).success).toBe(false);
+  });
+
+  it('rejects more than 8 operations', () => {
+    const op = { kind: 'set-text', field: 'line1', label: 'Zeile 1', value: 'x' };
+    const result = applyOpsInputSchema.safeParse({
+      operations: Array.from({ length: 9 }, () => op),
+      summary: 'zu viele',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown operation kinds', () => {
+    const result = applyOpsInputSchema.safeParse({
+      operations: [{ kind: 'resize-canvas', format: 'story' }],
+      summary: 'nicht erlaubt',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('restoreInputSchema', () => {
+  it('accepts positive integer versions and rejects zero/floats', () => {
+    expect(restoreInputSchema.safeParse({ version: 3 }).success).toBe(true);
+    expect(restoreInputSchema.safeParse({ version: 0 }).success).toBe(false);
+    expect(restoreInputSchema.safeParse({ version: 1.5 }).success).toBe(false);
+  });
+});
+
+describe('createLoopGuards', () => {
+  it('rejects an exactly repeated consecutive call, allows a changed one', () => {
+    const guards = createLoopGuards();
+    const input = { operations: [{ kind: 'toggle-sunflower', visible: false }], summary: 'a' };
+    expect(guards.checkDuplicate('apply_sharepic_ops', input)).toBeNull();
+    expect(guards.checkDuplicate('apply_sharepic_ops', input)).not.toBeNull();
+    expect(guards.checkDuplicate('apply_sharepic_ops', { ...input, summary: 'b' })).toBeNull();
+  });
+
+  it('treats the same input on a different tool as a new call', () => {
+    const guards = createLoopGuards();
+    expect(guards.checkDuplicate('read_sharepic_state', {})).toBeNull();
+    expect(guards.checkDuplicate('apply_sharepic_ops', {})).toBeNull();
+  });
+
+  it('caps failures per tool at 2 without affecting other tools', () => {
+    const guards = createLoopGuards();
+    expect(guards.checkFailureCap('apply_sharepic_ops')).toBeNull();
+    guards.noteFailure('apply_sharepic_ops');
+    expect(guards.checkFailureCap('apply_sharepic_ops')).toBeNull();
+    guards.noteFailure('apply_sharepic_ops');
+    expect(guards.checkFailureCap('apply_sharepic_ops')).not.toBeNull();
+    expect(guards.checkFailureCap('restore_version')).toBeNull();
+  });
+});

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure routing heuristics for the sharepic edit branch (no heavy imports —
+ * unit-testable). GOTCHA that motivated this file: JS `\b` only knows ASCII
+ * word characters, so `\bänder...` NEVER matches ("ä" is not \w — there is no
+ * boundary between a space and "ä"). Umlaut-initial verbs like "ändere" and
+ * nouns like "überschrift" silently failed for the entire pattern's lifetime.
+ * We use Unicode lookbehind instead of \b; suffixes stay prefix-matched
+ * (the old `\w*` behavior, now including umlaut continuations).
+ */
+
+const EDIT_VERB_PATTERN =
+  /(?<!\p{L})(änder|aender|mach|verschieb|beweg|setz|tausch|ersetz|wechsel|vergrößer|vergroesser|verklein|größer|groesser|kleiner|höher|hoeher|tiefer|kürz|kuerz|verläng|verlaeng|anpass|entfern|ausblend|einblend|zeig|versteck|nach\s+(?:oben|unten|links|rechts)|anderes?|neues?)/iu;
+
+const EDIT_NOUN_PATTERN =
+  /(?<!\p{L})(zeile\s*[123]?|text|balken|schrift|font|farb|hintergrund|bild|foto|motiv|sonnenblume|logo|zitat|überschrift|ueberschrift|header|sharepic|variante)/iu;
+
+/** Phrases that mean "generate fresh variants" — never treated as an edit. */
+const NEW_VARIANTS_PATTERN =
+  /(?<!\p{L})(neue?s?\s+(sharepic|varianten?)|noch\s*mal\s+(neu|von\s+vorn)|alle\s+varianten|drei\s+varianten)/iu;
+
+/**
+ * True when the message reads like an edit instruction for an existing
+ * sharepic (vs. a request for a fresh one). Only meaningful when the thread
+ * actually has a sharepic to edit — callers check target existence.
+ */
+export function isSharepicEditInstruction(text: string): boolean {
+  if (NEW_VARIANTS_PATTERN.test(text)) return false;
+  return EDIT_VERB_PATTERN.test(text) && EDIT_NOUN_PATTERN.test(text);
+}
+
+/**
+ * Relaxed check for the active Sharepic-Modus: with a variant explicitly
+ * marked "Im Chat bearbeiten", an edit verb alone is enough intent signal
+ * ("setze ein", "mach das rein") — requiring a noun too is what made the
+ * mode feel deaf. Used only on the agentic-loop path, which can answer with
+ * plain text when the message turns out not to be sharepic-related.
+ */
+export function hasSharepicEditVerb(text: string): boolean {
+  if (NEW_VARIANTS_PATTERN.test(text)) return false;
+  return EDIT_VERB_PATTERN.test(text);
+}

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.ts
@@ -39,3 +39,17 @@ export function hasSharepicEditVerb(text: string): boolean {
   if (NEW_VARIANTS_PATTERN.test(text)) return false;
   return EDIT_VERB_PATTERN.test(text);
 }
+
+const AFFIRMATION_PATTERN =
+  /^(ja|yes|yep|jup|jo|ok(ay)?|passt( so)?|gerne?|genau( so)?|perfekt|super|top|mach( das| es)?( so)?|so umsetzen|setz(e)?( das)?( so)? um|übernimm( das)?|übernehmen|einsetzen|bitte)([.!,\s]+(ja|yes|ok(ay)?|passt|gerne?|genau|bitte|mach( das| es)?( so)?|so|um(setzen)?|das))*[.!\s]*$/iu;
+
+/**
+ * Short confirmations ("ja", "yes", "mach das so") right after the assistant
+ * proposed an edit. Only consulted in active Sharepic-Modus on the loop path —
+ * the loop sees the prior assistant reply, so it can apply what was proposed.
+ */
+export function isShortAffirmation(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed.length > 40) return false;
+  return AFFIRMATION_PATTERN.test(trimmed);
+}

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import { isSharepicEditInstruction, hasSharepicEditVerb } from './sharepicEditHeuristics.js';
+
+describe('isSharepicEditInstruction', () => {
+  it('matches umlaut-initial verbs (the \\b bug: "ändere"/"änderungen" never matched)', () => {
+    expect(isSharepicEditInstruction('ändere die farbe')).toBe(true);
+    expect(isSharepicEditInstruction('der text ergibt keinen sinn, schlage änderungen vor')).toBe(
+      true
+    );
+  });
+
+  it('matches umlaut-initial nouns ("überschrift")', () => {
+    expect(isSharepicEditInstruction('die überschrift anpassen')).toBe(true);
+  });
+
+  it('treats "sharepic" itself as an editable noun', () => {
+    expect(isSharepicEditInstruction('setze ein in das sharepic')).toBe(true);
+    expect(isSharepicEditInstruction('mach das in die variante rein')).toBe(true);
+  });
+
+  it('still matches the ASCII cases', () => {
+    expect(isSharepicEditInstruction('mach zeile 2 kürzer')).toBe(true);
+    expect(isSharepicEditInstruction('balken nach oben verschieben')).toBe(true);
+  });
+
+  it('never fires on fresh-variant requests', () => {
+    expect(isSharepicEditInstruction('mach mir ein neues sharepic')).toBe(false);
+    expect(isSharepicEditInstruction('zeig mir alle varianten')).toBe(false);
+  });
+
+  it('requires an edit verb', () => {
+    expect(isSharepicEditInstruction('was steht im wahlprogramm zum klimaschutz?')).toBe(false);
+  });
+});
+
+describe('hasSharepicEditVerb (relaxed Sharepic-Modus check)', () => {
+  it('fires on verb-only instructions that lack a noun', () => {
+    expect(hasSharepicEditVerb('setz das bitte um')).toBe(true);
+    expect(hasSharepicEditVerb('ändere das entsprechend')).toBe(true);
+  });
+
+  it('stays quiet on plain questions and fresh-variant requests', () => {
+    expect(hasSharepicEditVerb('was bedeutet das?')).toBe(false);
+    expect(hasSharepicEditVerb('drei varianten bitte')).toBe(false);
+  });
+});

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { isSharepicEditInstruction, hasSharepicEditVerb } from './sharepicEditHeuristics.js';
+import {
+  isSharepicEditInstruction,
+  hasSharepicEditVerb,
+  isShortAffirmation,
+} from './sharepicEditHeuristics.js';
 
 describe('isSharepicEditInstruction', () => {
   it('matches umlaut-initial verbs (the \\b bug: "ändere"/"änderungen" never matched)', () => {
@@ -43,5 +47,23 @@ describe('hasSharepicEditVerb (relaxed Sharepic-Modus check)', () => {
   it('stays quiet on plain questions and fresh-variant requests', () => {
     expect(hasSharepicEditVerb('was bedeutet das?')).toBe(false);
     expect(hasSharepicEditVerb('drei varianten bitte')).toBe(false);
+  });
+});
+
+describe('isShortAffirmation', () => {
+  it('matches confirmations of a proposed edit', () => {
+    expect(isShortAffirmation('yes')).toBe(true);
+    expect(isShortAffirmation('ja')).toBe(true);
+    expect(isShortAffirmation('Ja, mach das so!')).toBe(true);
+    expect(isShortAffirmation('ok, so umsetzen')).toBe(true);
+    expect(isShortAffirmation('passt')).toBe(true);
+  });
+
+  it('rejects questions, content and long messages', () => {
+    expect(isShortAffirmation('ja aber was bedeutet das für die farbe?')).toBe(false);
+    expect(isShortAffirmation('was steht im wahlprogramm?')).toBe(false);
+    expect(
+      isShortAffirmation('ja ich finde wir sollten dann auch noch über den hintergrund sprechen')
+    ).toBe(false);
   });
 });

--- a/apps/api/routes/chat/services/sharepicEditLlm.ts
+++ b/apps/api/routes/chat/services/sharepicEditLlm.ts
@@ -97,8 +97,15 @@ export function buildOperationCatalog(descriptor: SharepicTemplateDescriptor): s
     );
     for (const el of descriptor.elements) {
       const scalePart = el.scale ? `, scale ${el.scale.min}–${el.scale.max}` : '';
+      // Offset elements (bounds spanning negative y) move relative to their
+      // anchor; absolute elements use canvas coordinates where smaller y is
+      // higher up. The wrong hint sends the model in the wrong direction.
+      const directionHint =
+        el.bounds.minY < 0
+          ? 'Negative y = nach oben.'
+          : 'Absolute Position: kleinere y-Werte = weiter oben.';
       lines.push(
-        `    elementId "${el.id}": x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY}${scalePart}. Negative y = nach oben.`
+        `    elementId "${el.id}" (${el.label}): x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY}${scalePart}. ${directionHint}`
       );
     }
   }

--- a/apps/api/routes/chat/services/sharepicEditLlm.ts
+++ b/apps/api/routes/chat/services/sharepicEditLlm.ts
@@ -37,23 +37,9 @@ export type RunSharepicEditResult =
   | { ok: true; edit: SharepicEditResponse }
   | { ok: false; error: string };
 
-function buildSystemPrompt(
-  descriptor: SharepicTemplateDescriptor,
-  snapshot: CanvasAiSnapshot,
-  recentEditSummaries: string[]
-): string {
-  const lines: string[] = [
-    'Du bist der Bearbeitungs-Assistent für Sharepics der deutschen Grünen.',
-    'Der*die Nutzer*in beschreibt EINE gewünschte Änderung am aktuellen Sharepic.',
-    'Du setzt sie als konkrete Operationen um — keine Vorschläge, keine Rückfragen.',
-    '',
-    'Sprachregeln: Du-Form, Genderstern (z.B. "Bürger*innen"), prägnante Kampagnen-Texte.',
-    '',
-    `Vorlage: ${descriptor.label} (${descriptor.id})`,
-    '',
-    'Aktueller Inhalt:',
-  ];
-
+/** Compact German description of the current sharepic content for prompts. */
+export function buildSnapshotLines(snapshot: CanvasAiSnapshot): string[] {
+  const lines: string[] = [];
   for (const f of snapshot.textFields) {
     lines.push(`- ${f.label} [field=${f.field}]: ${f.value ? `"${f.value}"` : '(leer)'}`);
   }
@@ -66,15 +52,17 @@ function buildSystemPrompt(
   for (const el of snapshot.elementsSummary) {
     lines.push(`- Element [id=${el.id}]: ${el.label}`);
   }
+  return lines;
+}
 
-  if (recentEditSummaries.length > 0) {
-    lines.push('');
-    lines.push('Letzte Änderungen (neueste zuerst):');
-    for (const s of recentEditSummaries) lines.push(`- ${s}`);
-  }
-
+/**
+ * Per-template catalog of allowed operations with exact schemas and bounds.
+ * Shared between the single-call edit prompt and the agentic tool loop so the
+ * two paths can't drift apart.
+ */
+export function buildOperationCatalog(descriptor: SharepicTemplateDescriptor): string[] {
+  const lines: string[] = [];
   const supported = new Set(descriptor.supportedOperations);
-  lines.push('');
   lines.push('ERLAUBTE OPERATIONEN (genaue Schemas, Schlüssel ist "kind"):');
   if (supported.has('set-text')) {
     lines.push(
@@ -119,6 +107,35 @@ function buildSystemPrompt(
       '  - { "kind": "set-background-image", "query": "<deutsche Bildsuche, z.B. Windräder Sonnenuntergang>" }'
     );
   }
+  return lines;
+}
+
+function buildSystemPrompt(
+  descriptor: SharepicTemplateDescriptor,
+  snapshot: CanvasAiSnapshot,
+  recentEditSummaries: string[]
+): string {
+  const lines: string[] = [
+    'Du bist der Bearbeitungs-Assistent für Sharepics der deutschen Grünen.',
+    'Der*die Nutzer*in beschreibt EINE gewünschte Änderung am aktuellen Sharepic.',
+    'Du setzt sie als konkrete Operationen um — keine Vorschläge, keine Rückfragen.',
+    '',
+    'Sprachregeln: Du-Form, Genderstern (z.B. "Bürger*innen"), prägnante Kampagnen-Texte.',
+    '',
+    `Vorlage: ${descriptor.label} (${descriptor.id})`,
+    '',
+    'Aktueller Inhalt:',
+    ...buildSnapshotLines(snapshot),
+  ];
+
+  if (recentEditSummaries.length > 0) {
+    lines.push('');
+    lines.push('Letzte Änderungen (neueste zuerst):');
+    for (const s of recentEditSummaries) lines.push(`- ${s}`);
+  }
+
+  lines.push('');
+  lines.push(...buildOperationCatalog(descriptor));
 
   lines.push('');
   lines.push(`Antworte AUSSCHLIESSLICH über das Tool "${SHAREPIC_EDIT_TOOL_NAME}" mit:`);

--- a/apps/api/routes/chat/services/sharepicEditService.ts
+++ b/apps/api/routes/chat/services/sharepicEditService.ts
@@ -17,6 +17,8 @@ import {
   buildSharepicSnapshot,
   getSharepicTemplateDescriptor,
   sharepicOpsToStatePatch,
+  type CanvasAiOperation,
+  type SharepicTemplateDescriptor,
 } from '@gruenerator/contracts';
 
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
@@ -177,7 +179,7 @@ function deriveCanvasTitle(canvasType: string, props: Record<string, unknown>): 
   return base || 'Sharepic aus dem Chat';
 }
 
-interface ResolvedTarget {
+export interface ResolvedTarget {
   variantId: string;
   canvasId: string | null;
   canvasType: string;
@@ -193,7 +195,7 @@ interface ResolvedTarget {
  * sharepic message. Returns 'ambiguous' when several variants exist and
  * nothing is selected, null when the thread has no sharepic at all.
  */
-async function resolveTarget(
+export async function resolveTarget(
   threadId: string,
   currentSharepic: {
     variantId: string;
@@ -249,6 +251,153 @@ async function resolveTarget(
     canvasType: hit.variant.canvasType,
     initialProps: hit.variant.initialProps ?? {},
     messageId: hit.messageId,
+  };
+}
+
+/**
+ * Lazy mint: first edit turns the variant into a real canvas document.
+ * Idempotent — returns the existing canvasId when already minted. Also marks
+ * the variant as the thread's active canvas.
+ */
+export async function ensureMintedCanvas(args: {
+  target: ResolvedTarget;
+  descriptor: SharepicTemplateDescriptor;
+  threadId: string;
+  userId: string;
+  sse: SSEWriter;
+}): Promise<string> {
+  const { target, descriptor, threadId, userId, sse } = args;
+  let canvasId = target.canvasId;
+  if (!canvasId) {
+    const initialState = { ...descriptor.defaultState, ...target.initialProps };
+    const canvas = await createCanvas(userId, {
+      title: deriveCanvasTitle(target.canvasType, target.initialProps),
+      template_type: target.canvasType,
+      initial_state: initialState,
+    });
+    canvasId = canvas.id;
+    const pg = getPostgresInstance();
+    await pg.query(
+      `INSERT INTO chat_thread_canvases (thread_id, variant_id, canvas_id, canvas_type, is_active)
+       VALUES ($1, $2, $3, $4, TRUE)
+       ON CONFLICT (thread_id, variant_id) DO UPDATE SET updated_at = CURRENT_TIMESTAMP`,
+      [threadId, target.variantId, canvasId, target.canvasType]
+    );
+    await insertCanvasVersion({
+      canvasId,
+      state: initialState,
+      summary: 'Aus dem Chat erstellt',
+      origin: 'mint',
+      userId,
+    });
+    if (target.messageId) {
+      await attachCanvasIdToMessage(target.messageId, target.variantId, canvasId);
+    }
+    sse.send('sharepic_minted', { variantId: target.variantId, canvasId });
+    log.info(`[SharepicEdit] Minted canvas ${canvasId} for variant ${target.variantId}`);
+  }
+  await setActiveThreadCanvas(threadId, target.variantId);
+  return canvasId;
+}
+
+export type ApplySharepicOpsOutcome =
+  | {
+      ok: true;
+      version: number;
+      newState: Record<string, unknown>;
+      appliedKinds: string[];
+      rejected: Array<{ kind: string; reason: string }>;
+    }
+  | { ok: false; reason: string; rejected: Array<{ kind: string; reason: string }> };
+
+/**
+ * Core of an edit: validate ops against the descriptor, resolve stock-image
+ * queries, apply the patch (live-broadcasts into open studio tabs), snapshot
+ * a version and emit `sharepic_updated`. Shared by the single-call edit path
+ * and the agentic tool loop.
+ */
+export async function applySharepicOpsToCanvas(args: {
+  canvasId: string;
+  variantId: string;
+  canvasType: string;
+  descriptor: SharepicTemplateDescriptor;
+  state: Record<string, unknown>;
+  operations: CanvasAiOperation[];
+  summary: string;
+  userId: string;
+  sse: SSEWriter;
+  aiWorkerPool: AIWorkerPool;
+  req?: unknown;
+}): Promise<ApplySharepicOpsOutcome> {
+  const { canvasId, variantId, canvasType, descriptor, state, operations, summary, userId, sse } =
+    args;
+
+  const opsResult = sharepicOpsToStatePatch(descriptor, operations, state);
+
+  // Resolve stock-photo queries server-side (dreizeilen background).
+  if (opsResult.imageQueries.length > 0 && descriptor.backgroundImage) {
+    try {
+      const selection = await imagePickerService.selectBestImage(
+        opsResult.imageQueries[0],
+        args.aiWorkerPool,
+        { sharepicType: descriptor.id },
+        args.req
+      );
+      const filename = selection.selectedImage.filename;
+      opsResult.patch[descriptor.backgroundImage.stateKey] =
+        `/api/image-picker/stock-image/${encodeURIComponent(filename)}`;
+      opsResult.patch.hasBackgroundImage = true;
+    } catch (err) {
+      log.warn(`[SharepicEdit] Image selection failed: ${err}`);
+    }
+  }
+
+  const rejected = opsResult.rejected.map((r) => ({ kind: r.op.kind, reason: r.reason }));
+  if (rejected.length > 0) {
+    log.warn(
+      `[SharepicEdit] Rejected ops: ${rejected.map((r) => `${r.kind}: ${r.reason}`).join(' | ')}`
+    );
+  }
+
+  if (Object.keys(opsResult.patch).length === 0) {
+    return {
+      ok: false,
+      reason: rejected[0]?.reason ?? 'Keine anwendbare Änderung',
+      rejected,
+    };
+  }
+
+  const newState = { ...state, ...opsResult.patch };
+  await applyCanvasStatePatch(canvasId, opsResult.patch, { seedState: newState });
+  const version = await insertCanvasVersion({
+    canvasId,
+    state: newState,
+    summary,
+    origin: 'chat-edit',
+    userId,
+  });
+
+  sse.send('sharepic_updated', {
+    variantId,
+    canvasId,
+    version,
+    canvasType,
+    state: newState,
+    summary,
+  });
+
+  log.info(
+    `[SharepicEdit] Applied v${version} on ${canvasId} (${operations.length} op(s): ${operations
+      .map((o) => o.kind)
+      .join(', ')})`
+  );
+
+  return {
+    ok: true,
+    version,
+    newState,
+    appliedKinds: opsResult.applied.map((o) => o.kind),
+    rejected,
   };
 }
 
@@ -335,37 +484,7 @@ export async function handleSharepicEdit(args: HandleSharepicEditArgs): Promise<
       status: 'in_progress',
     });
 
-    // Lazy mint: first edit turns the variant into a real canvas document.
-    let canvasId = target.canvasId;
-    if (!canvasId) {
-      const initialState = { ...descriptor.defaultState, ...target.initialProps };
-      const canvas = await createCanvas(userId, {
-        title: deriveCanvasTitle(target.canvasType, target.initialProps),
-        template_type: target.canvasType,
-        initial_state: initialState,
-      });
-      canvasId = canvas.id;
-      const pg = getPostgresInstance();
-      await pg.query(
-        `INSERT INTO chat_thread_canvases (thread_id, variant_id, canvas_id, canvas_type, is_active)
-         VALUES ($1, $2, $3, $4, TRUE)
-         ON CONFLICT (thread_id, variant_id) DO UPDATE SET updated_at = CURRENT_TIMESTAMP`,
-        [threadId, target.variantId, canvasId, target.canvasType]
-      );
-      await insertCanvasVersion({
-        canvasId,
-        state: initialState,
-        summary: 'Aus dem Chat erstellt',
-        origin: 'mint',
-        userId,
-      });
-      if (target.messageId) {
-        await attachCanvasIdToMessage(target.messageId, target.variantId, canvasId);
-      }
-      sse.send('sharepic_minted', { variantId: target.variantId, canvasId });
-      log.info(`[SharepicEdit] Minted canvas ${canvasId} for variant ${target.variantId}`);
-    }
-    await setActiveThreadCanvas(threadId, target.variantId);
+    const canvasId = await ensureMintedCanvas({ target, descriptor, threadId, userId, sse });
 
     // Fresh state every turn — picks up studio edits made in between.
     const current = await getCurrentCanvasState(canvasId);
@@ -395,67 +514,31 @@ export async function handleSharepicEdit(args: HandleSharepicEditArgs): Promise<
     }
 
     const { operations, summary, reply } = editResult.edit;
-    const opsResult = sharepicOpsToStatePatch(descriptor, operations, state);
+    const outcome = await applySharepicOpsToCanvas({
+      canvasId,
+      variantId: target.variantId,
+      canvasType: target.canvasType,
+      descriptor,
+      state,
+      operations,
+      summary,
+      userId,
+      sse,
+      aiWorkerPool,
+      req,
+    });
 
-    // Resolve stock-photo queries server-side (dreizeilen background).
-    if (opsResult.imageQueries.length > 0 && descriptor.backgroundImage) {
-      try {
-        const selection = await imagePickerService.selectBestImage(
-          opsResult.imageQueries[0],
-          aiWorkerPool,
-          { sharepicType: descriptor.id },
-          req
-        );
-        const filename = selection.selectedImage.filename;
-        opsResult.patch[descriptor.backgroundImage.stateKey] =
-          `/api/image-picker/stock-image/${encodeURIComponent(filename)}`;
-        opsResult.patch.hasBackgroundImage = true;
-      } catch (err) {
-        log.warn(`[SharepicEdit] Image selection failed: ${err}`);
-      }
-    }
-
-    if (opsResult.rejected.length > 0) {
-      log.warn(
-        `[SharepicEdit] Rejected ops: ${opsResult.rejected
-          .map((r) => `${r.op.kind}: ${r.reason}`)
-          .join(' | ')}`
-      );
-    }
-
-    if (Object.keys(opsResult.patch).length === 0) {
-      sse.send('sharepic_edit_error', {
-        variantId: target.variantId,
-        error: opsResult.rejected[0]?.reason ?? 'Keine anwendbare Änderung',
-      });
+    if (!outcome.ok) {
+      sse.send('sharepic_edit_error', { variantId: target.variantId, error: outcome.reason });
       await finishWithText(
         args,
-        opsResult.rejected[0]?.reason
-          ? `Das kann ich bei dieser Vorlage leider nicht ändern (${opsResult.rejected[0].reason}). ` +
+        outcome.rejected[0]?.reason
+          ? `Das kann ich bei dieser Vorlage leider nicht ändern (${outcome.rejected[0].reason}). ` +
               'Für Feinarbeit kannst du das Sharepic im Studio öffnen.'
           : 'Ich konnte daraus keine Änderung ableiten. Magst du es konkreter beschreiben?'
       );
       return true;
     }
-
-    const newState = { ...state, ...opsResult.patch };
-    await applyCanvasStatePatch(canvasId, opsResult.patch, { seedState: newState });
-    const version = await insertCanvasVersion({
-      canvasId,
-      state: newState,
-      summary,
-      origin: 'chat-edit',
-      userId,
-    });
-
-    sse.send('sharepic_updated', {
-      variantId: target.variantId,
-      canvasId,
-      version,
-      canvasType: target.canvasType,
-      state: newState,
-      summary,
-    });
 
     await finishWithText(args, reply, [
       {
@@ -465,18 +548,13 @@ export async function handleSharepicEdit(args: HandleSharepicEditArgs): Promise<
         result: {
           canvasId,
           variantId: target.variantId,
-          version,
+          version: outcome.version,
           summary,
           canvasType: target.canvasType,
         },
       },
     ]);
 
-    log.info(
-      `[SharepicEdit] Applied v${version} on ${canvasId} (${operations.length} op(s): ${operations
-        .map((o) => o.kind)
-        .join(', ')})`
-    );
     return true;
   } catch (error) {
     log.error('[SharepicEdit] Edit turn failed:', error);

--- a/apps/api/routes/chat/services/sharepicEditService.ts
+++ b/apps/api/routes/chat/services/sharepicEditService.ts
@@ -43,29 +43,7 @@ import type { AIWorkerPool } from '../../../workers/types.js';
 
 const log = createLogger('SharepicEdit');
 
-/**
- * Element/styling nouns that the legacy refinement regex doesn't cover.
- * Combined with REFINE-style verbs in isSharepicEditInstruction below.
- */
-const EDIT_NOUN_PATTERN =
-  /\b(zeile\s*[123]?|text\w*|balken|schrift\w*|font|farb\w*|hintergrund\w*|bild\w*|foto\w*|motiv\w*|sonnenblume|logo|zitat\w*|überschrift|ueberschrift|header)\b/i;
-
-const EDIT_VERB_PATTERN =
-  /\b(änder\w*|aender\w*|ändere?|mach\w*|verschieb\w*|beweg\w*|setz\w*|tausch\w*|ersetz\w*|wechsel\w*|vergrößer\w*|vergroesser\w*|verklein\w*|größer|groesser|kleiner|höher|hoeher|tiefer|kürz\w*|kuerz\w*|verläng\w*|verlaeng\w*|anpass\w*|entfern\w*|ausblend\w*|einblend\w*|zeig\w*|versteck\w*|nach\s+(oben|unten|links|rechts)|anderes?|neues?)\b/i;
-
-/** Phrases that mean "generate fresh variants" — never treated as an edit. */
-const NEW_VARIANTS_PATTERN =
-  /\b(neue?s?\s+(sharepic|varianten?)|noch\s*mal\s+(neu|von\s+vorn)|alle\s+varianten|drei\s+varianten)\b/i;
-
-/**
- * True when the message reads like an edit instruction for an existing
- * sharepic (vs. a request for a fresh one). Only meaningful when the thread
- * actually has a sharepic to edit — callers check target existence.
- */
-export function isSharepicEditInstruction(text: string): boolean {
-  if (NEW_VARIANTS_PATTERN.test(text)) return false;
-  return EDIT_VERB_PATTERN.test(text) && EDIT_NOUN_PATTERN.test(text);
-}
+export { isSharepicEditInstruction } from './sharepicEditHeuristics.js';
 
 interface ThreadCanvasRow {
   variant_id: string;

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -38,6 +38,8 @@ export type SSEEventType =
   | 'sharepic_minted'
   | 'sharepic_updated'
   | 'sharepic_edit_error'
+  | 'tool_step_start'
+  | 'tool_step_result'
   | 'response_start'
   | 'thinking_step'
   | 'progress_step'
@@ -173,6 +175,11 @@ export interface SSEEventPayloads {
     summary: string;
   };
   sharepic_edit_error: { variantId?: string; error: string };
+  // Agentic tool loop (CHAT_TOOL_LOOP): one start/result pair per tool step.
+  // Args/summaries are compact display data — full state still travels via
+  // sharepic_updated only.
+  tool_step_start: { stepId: string; toolName: string; args?: Record<string, unknown> };
+  tool_step_result: { stepId: string; toolName: string; ok: boolean; summary?: string };
   response_start: { message: string };
   thinking_step: ThinkingStepPayload;
   progress_step: ProgressStepPayload;

--- a/apps/api/services/canvas/canvasVersionRepository.ts
+++ b/apps/api/services/canvas/canvasVersionRepository.ts
@@ -45,9 +45,11 @@ export async function insertCanvasVersion(args: {
   )) as Array<{ version: number }>;
   const version = rows[0].version;
 
+  // Both params MUST be cast: `$2 - $3` with two untyped parameters makes
+  // Postgres fail with "operator is not unique: unknown - unknown".
   await db.query(
     `DELETE FROM canvas_state_versions
-     WHERE canvas_id = $1 AND version <= $2 - $3`,
+     WHERE canvas_id = $1 AND version <= $2::int - $3::int`,
     [args.canvasId, version, RETAIN_COUNT]
   );
 

--- a/documentation/docs/intern/chat-tool-loop-plan.md
+++ b/documentation/docs/intern/chat-tool-loop-plan.md
@@ -1,6 +1,15 @@
 # Agentischer Tool-Loop im Chat — konkreter Follow-up-Plan
 
-Status: **geplant, nicht begonnen.** Hintergrund: Beim Bau des Sharepic-Editings
+Status: **v1 umgesetzt (hinter `CHAT_TOOL_LOOP=true`).** Phase 1+2 plus das
+`restore_version`-Tool aus Phase 3 sind implementiert
+(`sharepicAgenticService.ts` + `sharepicAgenticGuards.ts`; Router swappt nur
+den Executor, Routing-Bedingung unverändert). Offen aus dem Plan:
+`search/generate_background_image` als eigene Tools (Stock-Suche läuft
+weiterhin als `set-background-image`-Op innerhalb von `apply_sharepic_ops`),
+`create_variant`, Loop-Integrationstests mit Mock-Model, und der chat-weite
+Vollausbau (separater Beschluss nach Bake-Zeit).
+
+Hintergrund: Beim Bau des Sharepic-Editings
 (PR #1215) fiel die bewusste Entscheidung „structured call now, loop later" —
 ein einzelner strukturierter LLM-Call pro Edit statt eines agentischen Loops.
 Dieses Dokument macht das „later" konkret: Architektur, Phasen, Aufwand,

--- a/documentation/docs/intern/sharepic-chat-editing.md
+++ b/documentation/docs/intern/sharepic-chat-editing.md
@@ -57,7 +57,7 @@ neu erfindet.
 
 | Thema | Warum aufgeschoben | Wenn doch gebraucht |
 | --- | --- | --- |
-| **Agentischer Tool-Loop im Chat** | User-Entscheidung „structured call now, loop later"; Loop wäre Chat-weiter Umbau (Latenz, Kosten, Kontext-Wachstum) | Konkreter Plan inkl. Aufwand: `chat-tool-loop-plan.md` (v1 gescoped auf den Sharepic-Modus) |
+| **Chat-weiter agentischer Tool-Loop** | v1 ist UMGESETZT, aber bewusst auf Sharepic-Edits gescoped und hinter `CHAT_TOOL_LOOP=true` (`sharepicAgenticService.ts`); der chat-weite Ersatz der Intent-Pipeline bleibt aufgeschoben (Latenz, Kosten, Classifier-Heuristiken sind ohne LLM-Call schneller) | Plan + offene Punkte: `chat-tool-loop-plan.md` |
 | **Formatwechsel per Chat** (Portrait → Story …) | `canvas.resize` klont ein NEUES Dokument → bricht Karten-Identität (canvasId in Thread & Versionen) | Konzept nötig: Karte auf neues Doc umhängen oder Resize-in-place |
 | **Multi-Page-Sharepics** (Slider, Präsentationen) | Patches gehen nur auf Seite 0; `formState` kann Edits nicht seitenweise attribuieren | Ops um `pageId` erweitern; Deskriptoren für Slider/Pres-Templates |
 | **KI-generierte / hochgeladene Hintergründe** | v1 nur Stock-Suche (`set-background-image` → ImageSelectionService) | Flux-Pfad existiert im image-Intent; Upload bräuchte Attachment-Routing in den Edit-Branch |
@@ -65,11 +65,3 @@ neu erfindet.
 | **Studio-Edits in der Versions-Historie** | Yjs-Snapshots decken Studio-Historie ab; Karten-Stepper zeigt nur Chat-Edits | Hook in `onStoreDocument` oder Hocuspocus-Change-Hook |
 | **`@sharepic` in Produktion** | Mentionable ist dev-only geflaggt (`packages/chat/src/lib/mentionables.ts`), bis die manuelle E2E-Matrix aus PR #1215 gelaufen ist | Flag entfernen + Envs in prod setzen |
 | **Heal für Multi-Page-Altdokumente** | `formState` mischt die letzten Edits ALLER Seiten — nicht attribuierbar; Heal läuft nur bei `pages.length === 1` | Nur mit per-Page-Schreibhistorie möglich; ab Dual-Write entsteht das Problem nicht mehr neu |
-
-## Bekannte pre-existing Failures (nicht aus diesen PRs)
-
-- `services/hocuspocus/src/persistence.vitest.ts`: 1 Test rot
-  („snapshot-v2" statt „live-state").
-- `packages/chat`: Console-Runner-Testdateien (`adapterUtils.test.ts`,
-  `mentionParser.test.ts`) loggen intern „passed", schlagen unter vitest aber
-  mit „No test suite found" fehl.

--- a/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
+++ b/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
@@ -78,6 +78,37 @@ describe('sharepicOpsToStatePatch', () => {
     expect(result.patch.namePosition).toEqual({ x: 75, y: 120 });
   });
 
+  it('resets a pinned namePosition when the quote text changes (layout reflow)', () => {
+    const ops: CanvasAiOperation[] = [
+      { kind: 'set-text', field: 'quote', label: 'Zitat', value: 'Ein viel längeres neues Zitat' },
+    ];
+    const result = sharepicOpsToStatePatch(zitatPure, ops, {
+      namePosition: { x: 75, y: 300 },
+    });
+    expect(result.patch.namePosition).toBeNull();
+  });
+
+  it('keeps namePosition when the batch repositions the name itself', () => {
+    const ops: CanvasAiOperation[] = [
+      { kind: 'set-text', field: 'quote', label: 'Zitat', value: 'Neues Zitat' },
+      { kind: 'update-element', elementId: 'name', patch: { y: 200 } },
+    ];
+    const result = sharepicOpsToStatePatch(zitatPure, ops, {
+      namePosition: { x: 75, y: 300 },
+    });
+    expect(result.patch.namePosition).toEqual({ x: 75, y: 200 });
+  });
+
+  it('does not touch namePosition when only the name TEXT changes', () => {
+    const ops: CanvasAiOperation[] = [
+      { kind: 'set-text', field: 'name', label: 'Name', value: 'Ricarda Lang' },
+    ];
+    const result = sharepicOpsToStatePatch(zitatPure, ops, {
+      namePosition: { x: 75, y: 300 },
+    });
+    expect('namePosition' in result.patch).toBe(false);
+  });
+
   it('zitat-pure name element state key matches the template config', () => {
     const el = zitatPureFullConfig.elements.find((e) => e.id === 'name-text');
     expect(el && 'positionStateKey' in el ? el.positionStateKey : null).toBe(

--- a/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
+++ b/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
@@ -7,6 +7,7 @@ import {
   type CanvasAiOperation,
 } from '@gruenerator/contracts';
 
+import { zitatPureFullConfig } from '../configs/zitat_pure_full.config';
 import { COLOR_SCHEMES } from '../utils/dreizeilenLayout';
 
 // The server-safe descriptors in @gruenerator/contracts duplicate the
@@ -66,6 +67,22 @@ describe('sharepicOpsToStatePatch', () => {
       balkenOffset: { x: 40, y: 0 },
     });
     expect(result.patch.balkenOffset).toEqual({ x: 40, y: -300 });
+  });
+
+  it('moves the zitat-pure name via update-element (absolute coords, clamped)', () => {
+    const ops: CanvasAiOperation[] = [
+      { kind: 'update-element', elementId: 'name', patch: { y: 60 } },
+    ];
+    const result = sharepicOpsToStatePatch(zitatPure, ops, {});
+    // y clamps to the 120px top boundary; missing x falls back to the 75px left margin.
+    expect(result.patch.namePosition).toEqual({ x: 75, y: 120 });
+  });
+
+  it('zitat-pure name element state key matches the template config', () => {
+    const el = zitatPureFullConfig.elements.find((e) => e.id === 'name-text');
+    expect(el && 'positionStateKey' in el ? el.positionStateKey : null).toBe(
+      zitatPure.elements.find((e) => e.id === 'name')?.positionStateKey
+    );
   });
 
   it('rejects set-color-scheme with unknown scheme ids', () => {

--- a/packages/canvas-editor/src/components/GenericCanvasElement.tsx
+++ b/packages/canvas-editor/src/components/GenericCanvasElement.tsx
@@ -104,9 +104,12 @@ const MemoizedTextElement = memo(
     const text = assertAsString(state[config.textKey]);
     const customFontSize = getOptionalStateValue<number>(state, config.fontSizeStateKey);
     const customWidth = getOptionalStateValue<number>(state, config.widthStateKey);
-    const customPosition = config.positionStateKey
-      ? assertAsPosition(state[config.positionStateKey])
-      : null;
+    // null/undefined means "no manual override — use the computed layout".
+    // assertAsPosition's {0,0} fallback must NOT kick in here, or every
+    // element with a positionStateKey but no stored position would render
+    // at the canvas origin.
+    const rawCustomPosition = config.positionStateKey ? state[config.positionStateKey] : null;
+    const customPosition = rawCustomPosition != null ? assertAsPosition(rawCustomPosition) : null;
 
     const layoutItem = layout[config.id];
     const x = customPosition?.x ?? resolveValue(config.x, state, layout);

--- a/packages/canvas-editor/src/configs/factory/createColorTwoTextCanvas.ts
+++ b/packages/canvas-editor/src/configs/factory/createColorTwoTextCanvas.ts
@@ -184,6 +184,14 @@ export interface ColorTwoTextOptions<
 
   /** Optional: Background image that changes with color */
   backgroundImageMap?: Record<string, string>;
+
+  /**
+   * Optional: template-specific state keys that must survive
+   * createInitialState (e.g. zitat-pure's `namePosition`). Without this the
+   * initial-state whitelist silently drops keys written by chat edits, so
+   * card renders and remote-sync re-seeds lose them.
+   */
+  passthroughStateKeys?: string[];
 }
 
 // ============================================================================
@@ -211,6 +219,7 @@ export function createColorTwoTextCanvas<
     maxPages = 10,
     getCanvasText,
     backgroundImageMap,
+    passthroughStateKeys = [],
   } = options;
 
   // Build base elements
@@ -379,8 +388,12 @@ export function createColorTwoTextCanvas<
         // Text fields
         [primaryField.key]: (props[primaryField.key] as string) || '',
         [secondaryField.key]: (props[secondaryField.key] as string) || '',
-        customPrimaryFontSize: null,
-        customSecondaryFontSize: null,
+        // Carried over from props: chat edits persist these into the canvas
+        // state, and card renders / remote-sync re-seeds run through here —
+        // hard-nulling them silently reverted "Schrift größer" edits.
+        customPrimaryFontSize: (props.customPrimaryFontSize as number | null | undefined) ?? null,
+        customSecondaryFontSize:
+          (props.customSecondaryFontSize as number | null | undefined) ?? null,
 
         // Background color
         backgroundColor: (props.backgroundColor as string) || defaultBackgroundColor,
@@ -398,6 +411,10 @@ export function createColorTwoTextCanvas<
         balkenInstances: [],
         frameInstances: [],
         userImageInstances: [],
+
+        ...Object.fromEntries(
+          passthroughStateKeys.filter((k) => k in props).map((k) => [k, props[k]])
+        ),
       }) as State,
 
     createActions: (getState, setState, saveToHistory, debouncedSaveToHistory, callbacks) => {

--- a/packages/canvas-editor/src/configs/factory/createTextElement.ts
+++ b/packages/canvas-editor/src/configs/factory/createTextElement.ts
@@ -39,6 +39,12 @@ interface TextElementOptions<TState> {
     fontSize: number;
   };
   align?: 'left' | 'center' | 'right';
+  /**
+   * State key holding an absolute `{ x, y }` override. When set (e.g. by a
+   * chat `update-element` op or a studio drag), it wins over the computed
+   * layout position; when absent the element stays auto-laid-out.
+   */
+  positionStateKey?: string;
 }
 
 const PRIMARY_FONT_SIZE_KEY = 'customPrimaryFontSize';
@@ -92,6 +98,7 @@ function buildBaseElement<TState>(
     opacityStateKey,
     fill,
     fillStateKey,
+    ...(options.positionStateKey ? { positionStateKey: options.positionStateKey } : {}),
   };
 }
 

--- a/packages/canvas-editor/src/configs/zitat_pure_full.config.tsx
+++ b/packages/canvas-editor/src/configs/zitat_pure_full.config.tsx
@@ -125,6 +125,7 @@ const nameTextElement = createSecondaryText<ZitatPureState>({
   id: 'name-text',
   textKey: 'name',
   order: 4,
+  positionStateKey: 'namePosition',
   width: ZITAT_PURE_CONFIG.quote.maxWidth,
   fontFamily: ZITAT_PURE_CONFIG.author.fontFamily,
   fontStyle: ZITAT_PURE_CONFIG.author.fontStyle,
@@ -149,6 +150,7 @@ const baseZitatPureConfig = createColorTwoTextCanvas({
   defaultBackgroundColor: ZITAT_PURE_CONFIG.background.color,
   textColorMap: FONT_COLORS,
   calculateLayout,
+  passthroughStateKeys: ['namePosition'],
   elements: [sunflowerElement, quoteMarkElement, quoteTextElement, nameTextElement],
   features: { icons: true, shapes: true, illustrations: true },
   getCanvasText: (state) => {

--- a/packages/chat/src/components/SharepicArtifactPanel.tsx
+++ b/packages/chat/src/components/SharepicArtifactPanel.tsx
@@ -2,12 +2,23 @@
 
 import { useMemo } from 'react';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@gruenerator/ui';
+import {
   ChevronLeft,
   ChevronRight,
   Download,
-  ExternalLink,
   History,
   Loader2,
+  Pencil,
   SquarePen,
   X,
 } from 'lucide-react';
@@ -93,7 +104,7 @@ function PanelInner({ active, className }: { active: ActiveSharepic; className?:
             </button>
           </div>
         ) : (
-          <div className="relative overflow-hidden rounded-lg border border-border bg-background">
+          <div className="group/panelimg relative overflow-hidden rounded-lg border border-border bg-background">
             {isRendering && !imageBase64 && (
               <div className="flex h-72 items-center justify-center">
                 <div className="flex flex-col items-center gap-2">
@@ -112,6 +123,40 @@ function PanelInner({ active, className }: { active: ActiveSharepic; className?:
                     : 'mx-auto w-full opacity-100 transition-opacity'
                 }
               />
+            )}
+            {imageBase64 && !isRendering && (
+              <div className="absolute inset-0 flex items-center justify-center gap-3 bg-black/0 opacity-0 transition-opacity group-hover/panelimg:bg-black/30 group-hover/panelimg:opacity-100 focus-within:bg-black/30 focus-within:opacity-100">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button
+                      className="flex size-11 items-center justify-center rounded-full bg-white text-grey-900 shadow-lg transition-transform hover:scale-105"
+                      aria-label="Sharepic im Studio bearbeiten"
+                    >
+                      <Pencil className="h-5 w-5" />
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Im Studio öffnen?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Das Sharepic öffnet sich im Studio-Editor in einem neuen Tab. Änderungen
+                        bleiben synchron — du kannst danach hier im Chat weiterarbeiten.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+                      <AlertDialogAction onClick={openInStudio}>Im Studio öffnen</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                <button
+                  onClick={download}
+                  className="flex size-11 items-center justify-center rounded-full bg-white text-grey-900 shadow-lg transition-transform hover:scale-105"
+                  aria-label="Sharepic herunterladen"
+                >
+                  <Download className="h-5 w-5" />
+                </button>
+              </div>
             )}
           </div>
         )}
@@ -153,25 +198,6 @@ function PanelInner({ active, className }: { active: ActiveSharepic; className?:
         <p className="text-xs text-foreground-muted">
           Beschreibe Änderungen einfach im Chat — sie landen direkt auf diesem Sharepic.
         </p>
-      </div>
-
-      <div className="flex items-center justify-end gap-1 border-t border-border px-3 py-2">
-        <button
-          onClick={download}
-          className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-foreground-muted hover:bg-primary/10 hover:text-foreground"
-          aria-label="Sharepic herunterladen"
-        >
-          <Download className="h-3.5 w-3.5" />
-          <span>Herunterladen</span>
-        </button>
-        <button
-          onClick={openInStudio}
-          className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
-          aria-label="Sharepic im Studio öffnen"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-          <span>Im Studio öffnen</span>
-        </button>
       </div>
     </aside>
   );

--- a/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
@@ -28,6 +28,13 @@ import type {
 } from '../../hooks/useChatGraphStream';
 import type { ConfirmActionData, DocumentCreatedData } from '../../types/messageMetadata';
 
+/** Display titles for agentic sharepic-loop steps (tool_step_start events). */
+const TOOL_STEP_TITLES: Record<string, string> = {
+  read_sharepic_state: 'Lese aktuellen Zustand…',
+  apply_sharepic_ops: 'Wende Änderung an…',
+  restore_version: 'Stelle Version wieder her…',
+};
+
 export async function* parseSSEStream(
   response: Response,
   callbacks: GrueneratorAdapterCallbacks,
@@ -453,6 +460,60 @@ export async function* parseSSEStream(
         case 'sharepic_edit_error': {
           const { error } = data as { variantId?: string; error: string };
           console.warn('[GrueneratorModelAdapter] sharepic_edit_error:', error);
+          break;
+        }
+
+        // Agentic sharepic loop (CHAT_TOOL_LOOP): each tool step renders as a
+        // tool-call part, mirroring the thinking_step archive-and-replace
+        // mechanics (including the duplicate-stepId guard).
+        case 'tool_step_start': {
+          const { stepId, toolName, args } = data as {
+            stepId: string;
+            toolName: string;
+            args?: Record<string, unknown>;
+          };
+          const title = TOOL_STEP_TITLES[toolName] ?? 'Arbeite am Sharepic…';
+          const isDuplicateStepId =
+            (activeToolCall !== null && activeToolCall.toolCallId === stepId) ||
+            allToolCalls.some((tc) => tc.toolCallId === stepId);
+          if (!isDuplicateStepId) {
+            if (activeToolCall !== null && !allToolCalls.includes(activeToolCall)) {
+              allToolCalls.push(activeToolCall);
+            }
+            const toolArgs = { query: title, ...(args ?? {}) };
+            activeToolCall = {
+              type: 'tool-call',
+              toolCallId: stepId,
+              toolName,
+              args: toolArgs as Record<string, string | number | boolean | null>,
+              argsText: JSON.stringify(toolArgs),
+            };
+          }
+          currentProgress = { stage: 'searching', message: title };
+          yield buildResult();
+          break;
+        }
+
+        case 'tool_step_result': {
+          const { stepId, ok, summary } = data as {
+            stepId: string;
+            toolName: string;
+            ok: boolean;
+            summary?: string;
+          };
+          if (activeToolCall?.toolCallId === stepId) {
+            activeToolCall = {
+              ...activeToolCall,
+              result: { ok, ...(summary ? { summary } : {}) },
+            };
+            allToolCalls.push(activeToolCall);
+            activeToolCall = null;
+          }
+          currentProgress = {
+            stage: 'generating',
+            message: summary ?? (ok ? 'Änderung angewendet' : 'Schritt fehlgeschlagen'),
+          };
+          yield buildResult();
           break;
         }
 

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -8,6 +8,7 @@ import {
   type TextProvider,
 } from '@gruenerator/shared/models';
 import { AUTO_MODEL_ID, type AutoModelId, type SelectedModel } from '../lib/resolveAutoModel';
+import { useSharepicLiveStore } from './sharepicLiveStore';
 import type { ChatApiClient } from '../context/ChatContext';
 
 export const MODEL_OPTIONS = TEXT_MODELS;
@@ -193,6 +194,10 @@ export const useAgentStore = create<AgentState>()(
           needsCompaction: false,
           activeSkillMention: null,
         });
+        // The Sharepic-Modus (docked artifact panel) is thread-scoped: a
+        // variant from the old thread must not stay pinned — nor be sent as
+        // the currentSharepic edit target — in the new one.
+        useSharepicLiveStore.getState().setActiveVariant(null);
       },
 
       setCurrentThreadTitle: (title) => set({ currentThreadTitle: title }),

--- a/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
+++ b/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
@@ -62,6 +62,14 @@ export interface SharepicTemplateDescriptor {
   /** State key for `toggle-sunflower`. */
   sunflowerVisibleStateKey?: string;
   elements: SharepicElementDescriptor[];
+  /**
+   * Manual position overrides to CLEAR (set to null = back to auto layout)
+   * when a layout-driving field changes. Example: editing the zitat-pure
+   * quote changes its height — a pinned absolute `namePosition` would leave
+   * the name floating mid-text, so the edit resets it and the name re-flows
+   * under the new quote. Skipped when the same op batch sets the key itself.
+   */
+  layoutResets?: Array<{ onFields: string[]; clearStateKey: string }>;
   /** Defaults merged under variant initialProps when minting a canvas doc. */
   defaultState: Record<string, unknown>;
 }
@@ -166,6 +174,7 @@ const ZITAT_PURE_DESCRIPTOR: SharepicTemplateDescriptor = {
       bounds: { minX: 75, maxX: 500, minY: 120, maxY: 1250 },
     },
   ],
+  layoutResets: [{ onFields: ['quote'], clearStateKey: 'namePosition' }],
   defaultState: { backgroundColor: '#6CCD87' },
 };
 
@@ -370,6 +379,20 @@ export function sharepicOpsToStatePatch(
       applied.push(op);
     } else {
       rejected.push({ op, reason: `Operation "${op.kind}" wird im Chat nicht unterstützt` });
+    }
+  }
+
+  // Layout reflow: when a layout-driving field changed, clear stale manual
+  // position overrides (null = back to auto layout) — unless this very batch
+  // positioned the element deliberately.
+  for (const reset of descriptor.layoutResets ?? []) {
+    if (reset.clearStateKey in patch) continue;
+    const touchedLayoutField = applied.some(
+      (op) =>
+        (op.kind === 'set-text' || op.kind === 'set-font-size') && reset.onFields.includes(op.field)
+    );
+    if (touchedLayoutField && state[reset.clearStateKey] != null) {
+      patch[reset.clearStateKey] = null;
     }
   }
 

--- a/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
+++ b/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
@@ -131,7 +131,7 @@ const ZITAT_PURE_DESCRIPTOR: SharepicTemplateDescriptor = {
   id: 'zitat-pure',
   label: 'Zitat',
   canvas: { width: 1080, height: 1350 },
-  supportedOperations: ['set-text', 'set-font-size', 'set-background-color'],
+  supportedOperations: ['set-text', 'set-font-size', 'set-background-color', 'update-element'],
   textFields: [
     {
       field: 'quote',
@@ -153,7 +153,19 @@ const ZITAT_PURE_DESCRIPTOR: SharepicTemplateDescriptor = {
       { id: 'sand', label: 'Sand', color: '#F5F1E9' },
     ],
   },
-  elements: [],
+  elements: [
+    {
+      // Name line position in ABSOLUTE canvas coordinates: writing
+      // `namePosition` overrides the auto-centered layout (the template text
+      // element carries `positionStateKey: 'namePosition'`); without it the
+      // name sits ~60px under the quote. Default x is the 75px left margin.
+      id: 'name',
+      label: 'Name (Position)',
+      kind: 'asset',
+      positionStateKey: 'namePosition',
+      bounds: { minX: 75, maxX: 500, minY: 120, maxY: 1250 },
+    },
+  ],
   defaultState: { backgroundColor: '#6CCD87' },
 };
 


### PR DESCRIPTION
## Was

Tool-Loop v1 aus `chat-tool-loop-plan.md` — bewusst auf Sharepic-Edits gescoped und **hinter `CHAT_TOOL_LOOP=true`** (Flag aus = byte-identisches Verhalten zu heute).

Der Router swappt nur den **Executor**, nicht das Routing: gleiche Eintrittsbedingung (Edit-Heuristik + Sharepic im Thread), gleiche Fallthrough-Semantik. Mit Flag läuft der Edit-Turn als kleiner agentischer Loop (`streamText` + `tools` + `stopWhen: stepCountIs(4)`, AI SDK v6 — kein handgeschriebener While-Loop) statt als einzelner strukturierter Call. Damit gehen in **einem** Turn: mehrere Operations-Batches, Selbstkorrektur nach abgelehnten Ops, Restore („zurück zur vorherigen Version und mach die Schrift größer").

## Tools (v1)

| Tool | Executor |
| --- | --- |
| `apply_sharepic_ops` | extrahierter Kern aus `sharepicEditService` (validieren → Bildsuche auflösen → Patch → Version → `sharepic_updated`) |
| `read_sharepic_state` | `getCurrentCanvasState` + Snapshot (kompakt, nie voller State im LLM-Kontext) |
| `restore_version` | Vorwärts-Patch wie der REST-Restore, nie Yjs-Rewind |

Stock-Hintergründe laufen weiter als `set-background-image`-Op innerhalb von `apply_sharepic_ops` (ein Tool weniger, gleiche Fähigkeit).

## Leitplanken

- Step-Cap 4, Turn-Timeout 90 s, max. 800 Output-Tokens.
- `sharepicAgenticGuards.ts` (pure, 8 Unit-Tests): Duplikat-Erkennung identischer Folge-Aufrufe (Modell-Ping-Pong), Failure-Cap 2 pro Tool, Schema-Caps (1–8 Ops, Summary ≤120).
- Tool-Fehler werden als Result zurückgegeben (Selbstkorrektur), nie geworfen.
- Kontext-Disziplin unverändert: kompakte Tool-Results, voller State nur über `sharepic_updated`-SSE.
- Kein Text vom Modell trotz Edits → deterministische Bestätigung aus dem letzten Summary.

## Geteilte Bausteine (Anti-Drift)

- `ensureMintedCanvas` + `applySharepicOpsToCanvas` aus `sharepicEditService` extrahiert — Single-Call-Pfad und Loop nutzen denselben Kern.
- Operations-Katalog des Prompts via `buildOperationCatalog`/`buildSnapshotLines` aus `sharepicEditLlm` geteilt.

## SSE & Persistenz

- Neue Events `tool_step_start`/`tool_step_result` (additiv); `parseSSEStream` rendert sie als Tool-Call-Parts (gleiche Archive-and-Replace-Mechanik wie `thinking_step`, inkl. Duplikat-Guard).
- Alle Tool-Steps eines Turns landen im `toolCalls`-Array der Assistant-Message (`tool_results` jsonb trug schon mehrere Einträge; Alt-Messages unverändert).

## Envs

- `CHAT_TOOL_LOOP=true` (Default aus), optional `CHAT_TOOL_LOOP_PROVIDER`/`CHAT_TOOL_LOOP_MODEL` (Default `mistral`/`mistral-medium-2604`).

## Stack & Verifikation

Stacked auf #1218 → #1217 → #1216 → #1215 (Merge-Reihenfolge). `pnpm typecheck` grün, ESLint sauber, 8/8 Guard-Tests, Prettier via lint-staged. Manuell (Flag an, lokaler Stack): Mehrschritt-Anweisung → mehrere `sharepic_updated` in einem Turn, Karte/Panel steppen Versionen hoch; absichtlich unmögliche Op → Modell korrigiert oder erklärt; Flag aus → exakt heutiges Verhalten.