### PR TITLE
feat(docs): web accept/reject review bar for chat-triggered AI edits

### DIFF
--- a/apps/web/src/features/docs/DocAiReviewBar.tsx
+++ b/apps/web/src/features/docs/DocAiReviewBar.tsx
@@ -1,0 +1,87 @@
+import { useDocAIReviewState, acceptDocumentAI, rejectDocumentAI } from '@gruenerator/docs';
+import { useState } from 'react';
+import { PiSparkle, PiSpinner } from 'react-icons/pi';
+
+import type { BlockNoteEditor } from '@blocknote/core';
+
+/**
+ * Floating review bar for chat-triggered AI suggestions — the web counterpart
+ * to mobile's native DocAiReviewBar. Chat edits apply diff marks without ever
+ * opening BlockNote's AI popover (the popover would lock the editor and anchor
+ * to a block the edit may delete), so this bar hosts Accept/Reject instead.
+ * Hidden while the popover is open (toolbar/slash-menu AI reviews itself).
+ */
+export function DocAiReviewBar({
+  documentId,
+  editor,
+}: {
+  documentId: string;
+  editor: BlockNoteEditor | null;
+}) {
+  const { isPendingReview, isStreaming } = useDocAIReviewState(editor, documentId);
+  const [busy, setBusy] = useState(false);
+
+  if (!isPendingReview) return null;
+
+  const handleAccept = () => {
+    setBusy(true);
+    try {
+      const result = acceptDocumentAI(documentId);
+      if (result === 'not-broadcast') {
+        void import('sonner').then(({ toast }) =>
+          toast.error(
+            'Änderung übernommen, aber nicht an Mitarbeitende übertragen. Bitte Verbindung prüfen und das Dokument neu laden.'
+          )
+        );
+      } else if (result === 'no-extension') {
+        void import('sonner').then(({ toast }) =>
+          toast.error('Übernehmen fehlgeschlagen — der Editor ist nicht bereit.')
+        );
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleReject = () => {
+    rejectDocumentAI(documentId);
+  };
+
+  const disabled = isStreaming || busy;
+
+  return (
+    <div className="flex items-center gap-3 rounded-full bg-white/85 dark:bg-grey-900/85 backdrop-blur-xl border border-black/8 dark:border-white/10 shadow-lg px-4 py-2">
+      <span className="flex items-center gap-1.5 text-sm font-semibold text-grey-800 dark:text-grey-200">
+        {isStreaming ? (
+          <>
+            <PiSpinner size={16} className="animate-spin text-secondary-600" />
+            KI schreibt …
+          </>
+        ) : (
+          <>
+            <PiSparkle size={16} className="text-secondary-600" />
+            KI-Vorschlag
+          </>
+        )}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleReject}
+          disabled={disabled}
+          className="px-3 py-1.5 text-sm font-medium rounded-lg border border-grey-300 dark:border-grey-600 text-grey-700 dark:text-grey-300 transition-colors hover:bg-grey-100 dark:hover:bg-grey-800 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="KI-Vorschlag verwerfen"
+        >
+          Verwerfen
+        </button>
+        <button
+          onClick={handleAccept}
+          disabled={disabled}
+          className="px-3 py-1.5 text-sm font-semibold rounded-lg bg-primary-600 text-white transition-colors hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="KI-Vorschlag übernehmen"
+        >
+          Übernehmen
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -57,6 +57,7 @@ import { useDocumentTitle } from '../../components/hooks/useDocumentTitle';
 import { useAuth } from '../../hooks/useAuth';
 import { useCollaborationConfig } from '../../hooks/useCollaborationConfig';
 
+import { DocAiReviewBar } from './DocAiReviewBar';
 import { webAppDocsAdapter } from './docsAdapter';
 import { GuestBadge, GUEST_ANIMALS } from './GuestBadge';
 import { useDocsLiveWolkeSync } from './useDocsLiveWolkeSync';
@@ -758,6 +759,9 @@ function EditorContent() {
             commentsPortalTarget={commentsPortalTarget}
             onEditorReady={handleEditorReady}
           />
+          <div className="sticky bottom-4 z-[150] flex justify-center pointer-events-none [&>*]:pointer-events-auto">
+            <DocAiReviewBar documentId={id!} editor={editor} />
+          </div>
         </main>
 
         {hasOpenedChat && id && (

--- a/packages/docs/src/hooks/useDocAIReviewState.ts
+++ b/packages/docs/src/hooks/useDocAIReviewState.ts
@@ -1,0 +1,71 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { ForkYDocExtension } from '@blocknote/core/extensions';
+
+import { getDocAIMenuStore } from '../lib/aiExtension';
+import { isDocAIInvocationInFlight, subscribeDocAIInFlight } from '../lib/invokeDocumentAI';
+
+/**
+ * Review state for AI suggestions that were applied without opening the AI
+ * popover — i.e. chat-triggered edits via {@link invokeDocumentAI}.
+ *
+ * - `isPendingReview`: the doc is forked AND the AI menu is closed. When the
+ *   user invokes AI through the toolbar/slash menu, BlockNote's own popover
+ *   hosts Accept/Reject, so external review UI must stay hidden.
+ * - `isStreaming`: an invocation is still writing into the fork. Accept/reject
+ *   must be blocked during this window — with the menu closed the extension's
+ *   abort is a no-op, and merging mid-stream would let the rest of the stream
+ *   land in the live doc.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EditorLike = { getExtension?: (factory: any) => unknown } | null | undefined;
+type ForkStore = {
+  store?: {
+    state?: { isForked?: boolean };
+    subscribe?: (listener: () => void) => () => void;
+  };
+};
+
+function getForkStore(editor: EditorLike): ForkStore['store'] | null {
+  if (!editor) return null;
+  const fork = editor.getExtension?.(ForkYDocExtension) as ForkStore | undefined;
+  return fork?.store ?? null;
+}
+
+export interface DocAIReviewState {
+  isPendingReview: boolean;
+  isStreaming: boolean;
+}
+
+export function useDocAIReviewState(editor: EditorLike, documentId: string): DocAIReviewState {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubs = [subscribeDocAIInFlight(onChange)];
+      const forkStore = getForkStore(editor);
+      if (forkStore?.subscribe) unsubs.push(forkStore.subscribe(onChange));
+      const menuStore = getDocAIMenuStore(editor);
+      if (menuStore?.subscribe) unsubs.push(menuStore.subscribe(onChange));
+      return () => {
+        for (const unsub of unsubs) unsub();
+      };
+    },
+    [editor]
+  );
+
+  const isForked = useSyncExternalStore(
+    subscribe,
+    useCallback(() => getForkStore(editor)?.state?.isForked ?? false, [editor])
+  );
+  const menuOpen = useSyncExternalStore(
+    subscribe,
+    useCallback(() => {
+      const state = getDocAIMenuStore(editor)?.state?.aiMenuState;
+      return state !== undefined && state !== 'closed';
+    }, [editor])
+  );
+  const isStreaming = useSyncExternalStore(
+    subscribe,
+    useCallback(() => isDocAIInvocationInFlight(documentId), [documentId])
+  );
+
+  return { isPendingReview: isForked && !menuOpen, isStreaming };
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -52,6 +52,7 @@ export {
 } from './hooks/useDocuments';
 export { useResolveUsers } from './hooks/useResolveUsers';
 export { usePendingDocAI } from './hooks/usePendingDocAI';
+export { useDocAIReviewState, type DocAIReviewState } from './hooks/useDocAIReviewState';
 export { useIsTouchDevice } from '@gruenerator/shared/hooks';
 export { useVersionHistoryShortcut } from './hooks/useVersionHistoryShortcut';
 
@@ -81,7 +82,11 @@ export {
   MAX_FILE_SIZE,
 } from './lib/blockNoteUtils';
 export { defaultDocumentContent } from './lib/defaultContent';
-export { invokeDocumentAI } from './lib/invokeDocumentAI';
+export {
+  invokeDocumentAI,
+  isDocAIInvocationInFlight,
+  subscribeDocAIInFlight,
+} from './lib/invokeDocumentAI';
 export {
   acceptDocumentAI,
   rejectDocumentAI,

--- a/packages/docs/src/lib/aiExtension.ts
+++ b/packages/docs/src/lib/aiExtension.ts
@@ -53,3 +53,22 @@ export function isDocAIForked(documentId: string): boolean {
   if (!editor) return false;
   return getForkExtensionForEditor(editor)?.store?.state?.isForked ?? false;
 }
+
+/**
+ * The xl-ai extension's own store. `aiMenuState` is `'closed'` unless the user
+ * opened the AI popover (toolbar / slash menu) — chat-triggered invocations
+ * never open it. Both this and the fork store come from BlockNote's
+ * `createStore` and share the same `state`/`subscribe` API.
+ */
+export type DocAIMenuStore = {
+  state?: { aiMenuState?: unknown };
+  subscribe?: (listener: () => void) => () => void;
+};
+
+export function getDocAIMenuStore(editor: unknown): DocAIMenuStore | null {
+  if (!editor) return null;
+  const ext = (editor as EditorWithExtensions).getExtension?.(AIExtension) as
+    | { store?: DocAIMenuStore }
+    | undefined;
+  return ext?.store ?? null;
+}

--- a/packages/docs/src/lib/invokeDocumentAI.ts
+++ b/packages/docs/src/lib/invokeDocumentAI.ts
@@ -1,5 +1,30 @@
 import { getDocAIExtension } from './aiExtension';
 
+// In-flight invocation registry. The fork store flips `isForked` at fork time —
+// before the LLM streams — and with the AI menu closed the extension's own
+// status/abort APIs are no-ops, so review UIs need an independent signal to
+// know streaming is still in progress (accept/reject mid-stream would merge or
+// discard a fork the stream keeps writing into).
+const inFlight = new Set<string>();
+const inFlightListeners = new Set<() => void>();
+
+function notifyInFlight() {
+  for (const cb of inFlightListeners) cb();
+}
+
+/** Whether an AI invocation is currently streaming for a document. */
+export function isDocAIInvocationInFlight(documentId: string): boolean {
+  return inFlight.has(documentId);
+}
+
+/** Subscribe to in-flight changes (useSyncExternalStore-compatible). */
+export function subscribeDocAIInFlight(cb: () => void): () => void {
+  inFlightListeners.add(cb);
+  return () => {
+    inFlightListeners.delete(cb);
+  };
+}
+
 /**
  * Programmatically trigger BlockNote's AI extension for a given document. Used
  * by the docs-chat surface to dispatch `trigger_doc_edit` SSE events from the
@@ -29,12 +54,21 @@ export async function invokeDocumentAI(opts: {
   // review UX is rendered natively (DocAiReviewBar → accept/rejectDocumentAI).
   // `invokeAI` still applies the diff as ProseMirror suggestions regardless of
   // menu state — the suggestion plugin is independent of the menu.
-  await ext.invokeAI({
-    userPrompt: opts.userPrompt,
-    useSelection: opts.useSelection ?? false,
-    ...(opts.referenceContent
-      ? { chatRequestOptions: { body: { referenceContent: opts.referenceContent } } }
-      : {}),
-  });
+  inFlight.add(opts.documentId);
+  notifyInFlight();
+  try {
+    // invokeAI resolves only after the response stream completes, so the
+    // in-flight window covers the whole fork-and-stream phase.
+    await ext.invokeAI({
+      userPrompt: opts.userPrompt,
+      useSelection: opts.useSelection ?? false,
+      ...(opts.referenceContent
+        ? { chatRequestOptions: { body: { referenceContent: opts.referenceContent } } }
+        : {}),
+    });
+  } finally {
+    inFlight.delete(opts.documentId);
+    notifyInFlight();
+  }
   return true;
 }


### PR DESCRIPTION
## Problem

When the docs chatbot (right sidebar) edits a document, BlockNote applies AI diff marks (strikethrough deletions, highlighted insertions) — but on web there was **no way to accept or reject** the suggestion. The forked Y.Doc stayed pending indefinitely; the only related behavior was a beforeunload warning.

Root cause: `invokeDocumentAI` deliberately never opens BlockNote's AI popover (which hosts Accept/Reject on web) — a decision made for mobile, which renders its own native `DocAiReviewBar`. Web never got an equivalent.

Opening the popover programmatically instead was rejected: it sets the editor read-only for the whole streaming+review window, anchors to a block a whole-doc edit may delete, and `AIMenuController` auto-calls `rejectChanges()` when the popover closes — risking silent discard.

## Changes

- **`packages/docs` `invokeDocumentAI.ts`** — in-flight invocation registry (`isDocAIInvocationInFlight` / `subscribeDocAIInFlight`). The fork flag flips *before* streaming finishes, and with the menu closed the extension's abort/status APIs are no-ops, so review UIs need this signal to block accept/reject mid-stream.
- **`packages/docs` `useDocAIReviewState`** (new hook) — `{ isPendingReview, isStreaming }`; pending = forked **and** AI popover closed, so the bar never doubles BlockNote's own review popover for toolbar/slash-menu AI.
- **`apps/web` `DocAiReviewBar.tsx`** (new) — floating pill (web counterpart to mobile's native bar): "KI-Vorschlag" with **Verwerfen** / **Übernehmen**, "KI schreibt …" + spinner with disabled buttons while streaming. Calls existing `acceptDocumentAI` / `rejectDocumentAI`; surfaces a toast when the merge doesn't broadcast to collaborators (`not-broadcast`).
- **`apps/web` `DocsEditorPage.tsx`** — mounts the bar sticky at the bottom of the editor scroll container.

Mobile is untouched (it never renders `DocsEditorPage`; the shared change is additive).

## Testing

- `pnpm typecheck` + `pnpm lint` clean on `@gruenerator/docs` and `web`
- Manual: chat edit → bar appears (disabled while streaming) → Übernehmen merges + syncs to a second session / Verwerfen reverts; toolbar AI still uses BlockNote's popover without the bar appearing