### PR TITLE
fix(notebook): raise output-token budgets so reasoning no longer truncates answers

### DIFF
--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -620,7 +620,9 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
               return streamForResolution({
                 resolution: r,
                 messages: messagesForAI as Parameters<typeof streamForResolution>[0]['messages'],
-                maxTokens: isReasoning ? Math.max(baseMaxTokens, 9000) : baseMaxTokens,
+                maxTokens: isReasoning
+                  ? Math.max(baseMaxTokens, 16000)
+                  : Math.max(baseMaxTokens, 8000),
                 temperature: finalState.agentConfig.params.temperature,
                 sse,
                 logPrefix: '[ChatGraph]',

--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -289,7 +289,7 @@ export async function handleNotebookStream(
     log.debug(`⏱ Model setup: ${t2 - t1}ms`);
 
     // Reasoning models need extra room for the <think> block before content.
-    const baseMaxOutput = isFast ? 3000 : 16000;
+    const baseMaxOutput = isFast ? 8000 : 16000;
 
     sse.send('response_start', { message: 'Generiere Antwort...' });
 

--- a/apps/api/routes/chat/services/resumePipeline.ts
+++ b/apps/api/routes/chat/services/resumePipeline.ts
@@ -261,7 +261,7 @@ export async function runChatGraphResume({
           return streamForResolution({
             resolution: r,
             messages: messagesForAI,
-            maxTokens: isReasoning ? Math.max(baseMaxTokens, 9000) : baseMaxTokens,
+            maxTokens: isReasoning ? Math.max(baseMaxTokens, 16000) : Math.max(baseMaxTokens, 8000),
             temperature: finalState.agentConfig.params.temperature,
             sse,
             logPrefix: '[ChatGraph:Resume]',

--- a/apps/api/services/notebook/NotebookQAService.ts
+++ b/apps/api/services/notebook/NotebookQAService.ts
@@ -922,7 +922,7 @@ export class NotebookQAService {
       type: 'qa_draft',
       messages: [{ role: 'user', content: userPrompt }],
       systemPrompt,
-      options: { max_tokens: 2500, temperature: 0.2, top_p: 0.8 },
+      options: { max_tokens: 16000, temperature: 0.2, top_p: 0.8 },
     });
 
     return (
@@ -965,7 +965,7 @@ export class NotebookQAService {
       type: 'qa_draft_fast',
       messages: [{ role: 'user', content: userPrompt }],
       systemPrompt,
-      options: { max_tokens: 2000, temperature: 0.3, top_p: 0.9 },
+      options: { max_tokens: 8000, temperature: 0.3, top_p: 0.9 },
     });
 
     return (
@@ -1197,7 +1197,7 @@ export class NotebookQAService {
       type: 'qa_draft',
       messages: [{ role: 'user', content: userPrompt }],
       systemPrompt,
-      options: { max_tokens: 2000, temperature: 0.3, top_p: 0.9 },
+      options: { max_tokens: 16000, temperature: 0.3, top_p: 0.9 },
     });
 
     return (

--- a/apps/api/workers/providers/litellmAdapter.ts
+++ b/apps/api/workers/providers/litellmAdapter.ts
@@ -150,6 +150,13 @@ async function execute(requestId: string, data: AIRequestData): Promise<AIWorker
     // Extract text content
     const textContent = result.text || null;
 
+    if (result.finishReason === 'length') {
+      console.warn(
+        `[litellmAdapter ${requestId}] Output token budget exhausted (finish_reason=length) for type=${type}, model=${model}. ` +
+          `Usage: ${JSON.stringify(result.usage)}. Reasoning tokens count against max_tokens — raise the budget if answers are truncated.`
+      );
+    }
+
     // Extract tool calls
     const toolCalls: ToolCall[] | undefined =
       result.toolCalls && result.toolCalls.length > 0
@@ -164,7 +171,10 @@ async function execute(requestId: string, data: AIRequestData): Promise<AIWorker
     const isToolUseResponse =
       result.finishReason === 'tool-calls' || (toolCalls && toolCalls.length > 0);
     if (!textContent && !isToolUseResponse) {
-      const errorMsg = `Empty response from LiteLLM model=${model}`;
+      const errorMsg =
+        result.finishReason === 'length'
+          ? `Empty response from LiteLLM model=${model}: output token budget exhausted by reasoning before any answer was emitted (finish_reason=length)`
+          : `Empty response from LiteLLM model=${model}`;
       console.error(`[litellmAdapter ${requestId}] ${errorMsg}`);
       throw new Error(errorMsg);
     }


### PR DESCRIPTION
## Problem

Notebook chat answers sometimes stop mid-sentence or come back empty when the model reasons a lot. Reasoning models (gpt-oss, Qwen) spend their thinking tokens against the same `max_tokens` budget as the visible answer, so small budgets get exhausted before or during the answer (`finish_reason=length`) — and nothing detected or logged this. Plain models (Mistral) also hit the 2000–4000 caps on long answers.

## Changes

**Path A — Notebook API (`POST /api/v1/notebooks/ask` → `NotebookQAService`):**
- `qa_draft` (gpt-oss reasoning): `max_tokens` 2500 → 16000
- person answers: 2000 → 16000
- fast mode (Mistral): 2000 → 8000

**Path B — Main chat (ChatGraph respond + resume):**
- `maxTokens` now floors at 16000 for reasoning models / 8000 for others instead of using raw `agentConfig.params.max_tokens` (2000–4000). The previous 9000 reasoning bump only fired for Regolo models.
- `notebookStreamCore` fast mode: 3000 → 8000

**Observability (`litellmAdapter`):**
- `finish_reason=length` now logs a warning with token usage instead of passing silently
- the empty-response error explains budget exhaustion by reasoning when that's the cause

Reasoning stays fully enabled — quality prioritized over cost/latency.

## Verification

- `pnpm --filter @gruenerator/api typecheck` ✅
- `responseStreamingService.vitest.ts` + `regoloThinkingFetch.vitest.ts` ✅ (18 passed, 2 skipped)