### PR TITLE
feat(notebook): Mistral Medium 3.5 as default model for notebooks

### DIFF
--- a/apps/api/routes/chat/notebookStreamCore.ts
+++ b/apps/api/routes/chat/notebookStreamCore.ts
@@ -41,8 +41,8 @@ import type express from 'express';
 const log = createLogger('NotebookStreamCore');
 const notebookHelper = new NotebookQdrantHelper();
 
-const DEFAULT_PROVIDER = 'litellm';
-const DEFAULT_MODEL = 'gpt-oss:120b';
+const DEFAULT_PROVIDER = 'mistral';
+const DEFAULT_MODEL = 'mistral-medium-2604';
 
 export interface NotebookStreamOptions {
   req: express.Request;

--- a/apps/api/services/providers/providerSelector.ts
+++ b/apps/api/services/providers/providerSelector.ts
@@ -120,10 +120,10 @@ export function selectProviderAndModel({
     provider = 'mistral';
     model = options.model || 'mistral-medium-2604';
   }
-  // QA draft (final answer) — GPT-OSS with reasoning
+  // QA draft (final answer) — Mistral Medium 3.5, the notebook default
   else if (type === 'qa_draft') {
-    provider = 'litellm';
-    model = options.model || 'gpt-oss:120b';
+    provider = 'mistral';
+    model = options.model || 'mistral-medium-2604';
   }
   // QA intermediate steps (planner, repair, tools) — fast model
   else if (type === 'qa_tools' || type === 'qa_planner' || type === 'qa_repair') {

--- a/apps/mobile/app/(tabs)/(chat)/index.tsx
+++ b/apps/mobile/app/(tabs)/(chat)/index.tsx
@@ -63,7 +63,7 @@ function SettingsBar({ onOpen }: { onOpen: () => void }) {
 
       <View style={[styles.settingsChip, { borderColor: theme.border }]}>
         <Text style={[styles.settingsChipText, { color: theme.textSecondary }]}>
-          {model?.name || 'Mistral'}
+          {model?.name || 'Automatisch'}
         </Text>
       </View>
 

--- a/apps/mobile/components/chat/ComposerActionSheet.tsx
+++ b/apps/mobile/components/chat/ComposerActionSheet.tsx
@@ -1,4 +1,10 @@
-import { useAgentStore, MODEL_OPTIONS, type ToolKey } from '@gruenerator/chat';
+import {
+  useAgentStore,
+  MODEL_OPTIONS,
+  AUTO_MODEL_ID,
+  AUTO_MODEL_OPTION,
+  type ToolKey,
+} from '@gruenerator/chat';
 import { QWEN_WARNING } from '@gruenerator/shared/models';
 import { Ionicons, type IoniconsIconName } from '@react-native-vector-icons/ionicons';
 import { memo, useCallback } from 'react';
@@ -107,6 +113,37 @@ export const ComposerActionSheet = memo(function ComposerActionSheet({
           Modell
         </Text>
         <View style={styles.chipRow}>
+          <Pressable
+            onPress={() => setSelectedModel(AUTO_MODEL_ID)}
+            style={[
+              styles.modelChip,
+              {
+                backgroundColor:
+                  selectedModel === AUTO_MODEL_ID ? colors.primary[600] : theme.surface,
+                borderColor: selectedModel === AUTO_MODEL_ID ? colors.primary[600] : theme.border,
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.modelChipText,
+                { color: selectedModel === AUTO_MODEL_ID ? colors.white : theme.text },
+              ]}
+            >
+              {AUTO_MODEL_OPTION.name}
+            </Text>
+            <Text
+              style={[
+                styles.modelChipDesc,
+                {
+                  color:
+                    selectedModel === AUTO_MODEL_ID ? colors.primary[200] : theme.textSecondary,
+                },
+              ]}
+            >
+              {AUTO_MODEL_OPTION.description}
+            </Text>
+          </Pressable>
           {MODEL_OPTIONS.map((model) => {
             const active = selectedModel === model.id;
             return (

--- a/packages/chat/src/lib/resolveAutoModel.ts
+++ b/packages/chat/src/lib/resolveAutoModel.ts
@@ -24,8 +24,11 @@ export interface AutoResolverContext {
 }
 
 export function resolveAutoModel(ctx: AutoResolverContext): TextModelId {
+  // Mistral Medium 3.5 is the notebook default; outside notebooks the
+  // previous defaults stay (Gemma general/creative, Mistral for
+  // instruction-heavy agents like the agent creator).
   if (ctx.threadMode === 'notebook') return 'mistral-medium-3.5';
   if (ctx.agent?.autoRoutingHint === 'precise') return 'mistral-medium-3.5';
   if (ctx.agent?.autoRoutingHint === 'creative') return 'gemma-litellm';
-  return 'mistral-medium-3.5';
+  return 'gemma-litellm';
 }

--- a/packages/chat/src/lib/resolveAutoModel.ts
+++ b/packages/chat/src/lib/resolveAutoModel.ts
@@ -25,9 +25,7 @@ export interface AutoResolverContext {
 
 export function resolveAutoModel(ctx: AutoResolverContext): TextModelId {
   if (ctx.threadMode === 'notebook') return 'mistral-medium-3.5';
-  // Mistral for instruction-heavy agents (e.g. the agent creator) so "auto"
-  // lands on a strong instruction-follower rather than the GPT-OSS default.
   if (ctx.agent?.autoRoutingHint === 'precise') return 'mistral-medium-3.5';
   if (ctx.agent?.autoRoutingHint === 'creative') return 'gemma-litellm';
-  return 'litellm';
+  return 'mistral-medium-3.5';
 }

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -145,8 +145,8 @@ export const useAgentStore = create<AgentState>()(
   persist(
     (set) => ({
       selectedAgentId: null,
-      selectedProvider: 'mistral',
-      selectedModel: 'mistral-medium-3.5',
+      selectedProvider: 'litellm',
+      selectedModel: AUTO_MODEL_ID,
       currentThreadId: null,
       currentThreadTitle: null,
       enabledTools: { ...DEFAULT_ENABLED_TOOLS },
@@ -425,11 +425,11 @@ export const useAgentStore = create<AgentState>()(
           state.enabledTools = { ...DEFAULT_ENABLED_TOOLS };
         }
         if (version < 12) {
-          // Mistral Medium 3.5 is the new default. Move users still on the old
-          // implicit default (gemma-litellm); explicit other choices stay.
+          // 'Automatisch' is the new default selection (notebooks resolve to
+          // Mistral Medium 3.5, general chat keeps Gemma). Move users still on
+          // the old implicit default (gemma-litellm); explicit choices stay.
           if (state.selectedModel === 'gemma-litellm') {
-            state.selectedModel = 'mistral-medium-3.5';
-            state.selectedProvider = 'mistral';
+            state.selectedModel = AUTO_MODEL_ID;
           }
         }
         return state;

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -145,8 +145,8 @@ export const useAgentStore = create<AgentState>()(
   persist(
     (set) => ({
       selectedAgentId: null,
-      selectedProvider: 'litellm',
-      selectedModel: 'gemma-litellm',
+      selectedProvider: 'mistral',
+      selectedModel: 'mistral-medium-3.5',
       currentThreadId: null,
       currentThreadTitle: null,
       enabledTools: { ...DEFAULT_ENABLED_TOOLS },
@@ -344,7 +344,7 @@ export const useAgentStore = create<AgentState>()(
           removeItem: (key: string) => mem.delete(key),
         };
       }),
-      version: 11,
+      version: 12,
       migrate: (persisted: unknown, version: number) => {
         const state = persisted as Record<string, unknown>;
         if (version === 0) {
@@ -423,6 +423,14 @@ export const useAgentStore = create<AgentState>()(
         }
         if (version < 11) {
           state.enabledTools = { ...DEFAULT_ENABLED_TOOLS };
+        }
+        if (version < 12) {
+          // Mistral Medium 3.5 is the new default. Move users still on the old
+          // implicit default (gemma-litellm); explicit other choices stay.
+          if (state.selectedModel === 'gemma-litellm') {
+            state.selectedModel = 'mistral-medium-3.5';
+            state.selectedProvider = 'mistral';
+          }
         }
         return state;
       },


### PR DESCRIPTION
Mistral Medium 3.5 (`mistral-medium-2604`) becomes the default model **for notebooks only** — general chat defaults are unchanged.

## How

- **Default selection is now „Automatisch"** (which the code already documented as the intended default): notebook surfaces resolve it to `mistral-medium-3.5`, general chat resolves it to Gemma — same model defaulted users had before, so outside notebooks nothing changes for them.
- **Existing users**: persist-version 12 migration moves users still on `gemma-litellm` (the old implicit default) to „Automatisch". Explicit model choices stay untouched.
- **Notebook QA pipeline** (`POST /api/v1/notebooks/ask`, `qa_draft` in `providerSelector`): switches from `gpt-oss:120b` to `mistral-medium-2604`. Fast mode already ran Mistral.
- **Backend stream fallback** (`notebookStreamCore`, when no model param is sent — e.g. MCP callers): `mistral-medium-2604` instead of `gpt-oss:120b`.
- **Mobile**: the composer model picker gets an „Automatisch" chip (it previously had no way to select auto), and the status chip label falls back to „Automatisch".

## Side effect to be aware of

The auto resolver's general-chat fallback changed `litellm` (GPT-OSS) → `gemma-litellm`. This keeps migrated users' general chat on Gemma (no change for them), but users who had **explicitly** selected „Automatisch" before will get Gemma instead of GPT-OSS in general chat. Notebook („Mistral") and creative-agent („Gemma") auto-routing are unchanged in nature.

## Verification
- `pnpm --filter @gruenerator/chat typecheck` ✅
- `pnpm --filter @gruenerator/api typecheck` ✅
- `pnpm --filter @gruenerator/mobile typecheck` ✅