### PR TITLE
docs(monitor): LSR-Konformität der RSS-Erfassung festschreiben

### DIFF
--- a/apps/api/services/monitor/MonitorCollectorService.ts
+++ b/apps/api/services/monitor/MonitorCollectorService.ts
@@ -46,6 +46,9 @@ function getLocale(domain: string): MonitorLocale {
   return AT_DOMAINS.has(domain) ? 'at' : 'de';
 }
 
+// LSR-konform: nur Headline + Link aus RSS übernehmen. content/contentSnippet
+// werden bewusst NICHT gelesen — Textauszüge aus Presse-Feeds fallen unter das
+// Leistungsschutzrecht (§ 87f-h UrhG), Überschrift + Hyperlink sind ausgenommen.
 interface RSSItem {
   title?: string;
   link?: string;
@@ -87,7 +90,7 @@ async function fetchFeed(
       items.push({
         url: rssItem.link,
         title: rssItem.title || '',
-        excerpt: '',
+        excerpt: '', // immer leer für RSS — Volltext/Auszug kommt nur aus lizenzierten Quellen (EventRegistry)
         source: feed.title || domain,
         publishedAt: pubDate || null,
         locale,

--- a/apps/api/services/monitor/rssFeeds.ts
+++ b/apps/api/services/monitor/rssFeeds.ts
@@ -1,6 +1,13 @@
 /**
  * Known RSS feed URLs for German and Austrian news sources.
  * Used by Monitor for article collection.
+ *
+ * Rechtlicher Rahmen: Aus diesen Feeds wird ausschließlich Überschrift + Link
+ * gespeichert (siehe fetchFeed in MonitorCollectorService — excerpt bleibt leer).
+ * Überschrift + Hyperlink sind vom Leistungsschutzrecht für Presseverleger
+ * (§ 87f-h UrhG / Art. 15 DSM-RL) ausgenommen. Hier KEINE Volltexte oder
+ * Textauszüge ergänzen — Auszüge kommen nur aus lizenzierten Quellen.
+ *
  * Verified 2026-03-19.
  */
 export const KNOWN_RSS_FEEDS: Record<string, string> = {


### PR DESCRIPTION
## Worum geht's

Klarstellung/Absicherung der RSS-Nutzung im Monitor — **kein Verhaltenswechsel**, reine Doku/Kommentar-Änderung.

Hintergrund: Frage kam auf, ob RSS-Feeds rechtlich problematisch sind. Tatsächlich speichert der Monitor aus RSS **nur Überschrift + Link** (`excerpt` bleibt immer leer, siehe `fetchFeed`). Überschrift + Hyperlink sind vom **Leistungsschutzrecht für Presseverleger** (§ 87f-h UrhG / Art. 15 DSM-RL) ausgenommen — Volltexte/Auszüge kommen ausschließlich aus der lizenzierten **EventRegistry**-API.

## Änderungen

- `MonitorCollectorService.ts`: Kommentar am `RSSItem`-Interface erklärt, warum `content`/`contentSnippet` bewusst nicht aus dem Feed gelesen werden.
- `MonitorCollectorService.ts`: `excerpt: ''` mit Begründung markiert.
- `rssFeeds.ts`: Header-Doku mit rechtlichem Rahmen, damit beim Pflegen der Quellen klar ist: keine Volltexte ergänzen.

## Warum so

Statt RSS zu entfernen (deutlicher Funktionsverlust, ~79 Quellen) wird die `nur Headline+Link`-Garantie im Code festgeschrieben, damit niemand später versehentlich Textauszüge ergänzt.

> ⚠️ Keine Rechtsberatung — falls intern eine strengere Policy gilt, die über das LSR hinausgeht, kann RSS in einem Folge-PR sauber entfernt werden.