### PR TITLE
feat: FLUX.2 multi-reference image editing (Bilder tab + chat)

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/imageEditNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/imageEditNode.ts
@@ -11,7 +11,9 @@ import {
   buildGreenEditPrompt,
   buildUniversalPrompt,
   type GenerateResult,
+  type ReferenceImage,
 } from '../../../../services/flux/index.js';
+import { MAX_REFERENCE_IMAGES, fitToBudget } from '../../../../services/flux/referenceImages.js';
 import { visionService } from '../../../../services/vision/VisionService.js';
 import { createLogger } from '../../../../utils/logger.js';
 import { redisClient } from '../../../../utils/redis/index.js';
@@ -84,23 +86,33 @@ export async function imageEditNode(state: ChatGraphState): Promise<Partial<Chat
         error: 'Bitte hänge ein Bild an, das bearbeitet werden soll.',
       };
     }
-    const imageBuffer = Buffer.from(attachment.data, 'base64');
+
+    // Multi-reference: all attached images go to FLUX.2 in order; the user can
+    // reference them as "Bild 1", "Bild 2", … One composited result comes back.
+    const references: ReferenceImage[] = imageAttachments
+      .slice(0, MAX_REFERENCE_IMAGES)
+      .map((a) => ({ buffer: Buffer.from(a.data, 'base64'), mimeType: a.type }));
+    const processed = await fitToBudget(references);
     const mimeType = attachment.type;
 
     // `imageEditStyle` is set by the controller from forcedTools (mention path)
     // or defaulted by the classifier route. `null` falls back to universal so a
     // raw `image_edit` intent without controller wiring still produces a sane
-    // edit driven by the user's instruction.
-    const editStyle: ImageEditStyle = state.imageEditStyle ?? 'universal';
+    // edit driven by the user's instruction. With multiple references the
+    // green-edit preset is skipped — compositing needs the universal prompt.
+    const editStyle: ImageEditStyle =
+      references.length > 1 ? 'universal' : (state.imageEditStyle ?? 'universal');
     const prompt =
       editStyle === 'green-edit'
         ? buildGreenEditPrompt(userContent)
-        : buildUniversalPrompt(userContent);
+        : buildUniversalPrompt(userContent, references.length);
     const resultStyle: ImageStyle = editStyle;
-    log.info(`[ImageEditNode] Built ${editStyle} prompt (${prompt.length} chars)`);
+    log.info(
+      `[ImageEditNode] Built ${editStyle} prompt (${prompt.length} chars, ${references.length} reference image(s))`
+    );
 
     const flux = await FluxImageService.create();
-    const { stored }: GenerateResult = await flux.generateFromImage(prompt, imageBuffer, mimeType, {
+    const { stored }: GenerateResult = await flux.generateFromImages(prompt, processed, {
       output_format: 'jpeg',
       safety_tolerance: 2,
     });

--- a/apps/api/agents/langgraph/ChatGraph/tools/editImage.ts
+++ b/apps/api/agents/langgraph/ChatGraph/tools/editImage.ts
@@ -10,12 +10,13 @@ import { z } from 'zod';
 
 import { ImageGenerationCounter } from '../../../../services/counters/index.js';
 import { buildGreenEditPrompt } from '../../../../services/flux/greenEditPrompt.js';
-import { FluxImageService } from '../../../../services/flux/index.js';
+import { FluxImageService, buildUniversalPrompt } from '../../../../services/flux/index.js';
+import { MAX_REFERENCE_IMAGES, fitToBudget } from '../../../../services/flux/referenceImages.js';
 import { createLogger } from '../../../../utils/logger.js';
 import { redisClient } from '../../../../utils/redis/index.js';
 
 import type { ToolDependencies } from './registry.js';
-import type { GenerateResult } from '../../../../services/flux/FluxImageService.js';
+import type { GenerateResult, ReferenceImage } from '../../../../services/flux/FluxImageService.js';
 import type { GeneratedImageResult } from '../types.js';
 
 const log = createLogger('Tool:EditImage');
@@ -58,20 +59,26 @@ export function createEditImageTool(deps: ToolDependencies): DynamicStructuredTo
       log.info(`[EditImage] instruction="${instruction.slice(0, 60)}"`);
 
       try {
-        const prompt = buildGreenEditPrompt(instruction);
-        const imageBuffer = Buffer.from(imageAttachment.data, 'base64');
-        const mimeType = imageAttachment.type || 'image/jpeg';
+        // All attached images go to FLUX.2 in order; with more than one
+        // reference the green-edit preset gives way to the universal prompt
+        // (compositing needs the user's instruction verbatim).
+        const references: ReferenceImage[] = (deps.imageAttachments ?? [])
+          .slice(0, MAX_REFERENCE_IMAGES)
+          .map((a) => ({
+            buffer: Buffer.from(a.data, 'base64'),
+            mimeType: a.type || 'image/jpeg',
+          }));
+        const processed = await fitToBudget(references);
+        const prompt =
+          references.length > 1
+            ? buildUniversalPrompt(instruction, references.length)
+            : buildGreenEditPrompt(instruction);
 
         const flux = await FluxImageService.create();
-        const { stored }: GenerateResult = await flux.generateFromImage(
-          prompt,
-          imageBuffer,
-          mimeType,
-          {
-            output_format: 'jpeg',
-            safety_tolerance: 2,
-          }
-        );
+        const { stored }: GenerateResult = await flux.generateFromImages(prompt, processed, {
+          output_format: 'jpeg',
+          safety_tolerance: 2,
+        });
 
         await imageCounter.incrementCount(userId);
 
@@ -82,7 +89,7 @@ export function createEditImageTool(deps: ToolDependencies): DynamicStructuredTo
           url: imageUrl,
           filename: stored.filename,
           prompt,
-          style: 'green-edit',
+          style: references.length > 1 ? 'universal' : 'green-edit',
           generationTimeMs: Date.now() - startTime,
         };
 

--- a/apps/api/routes.ts
+++ b/apps/api/routes.ts
@@ -278,6 +278,7 @@ export async function setupRoutes(app: Application): Promise<void> {
     await import('./routes/sites/index.js');
   const { default: flyerController } = await import('./routes/sites/flyerController.js');
   const { default: fluxImageEditingRoute } = await import('./routes/flux/imageEditing.js');
+  const { mountImageEditContractRouter } = await import('./routes/flux/imageEditContractRouter.js');
   const { default: unsplashRouter } = await import('./routes/unsplash/unsplashRoutes.js');
   const { default: docsRouter } = await import('./routes/docs/index.js');
 
@@ -739,6 +740,11 @@ export async function setupRoutes(app: Application): Promise<void> {
   mountSitesContractRouter(app);
   app.use('/api/sites', sitesRouter);
   app.use('/api/flux/green-edit', aiGenerationLimiter, fluxImageEditingRoute);
+  // ts-rest contract router for image editing (multi-reference). requireAuth +
+  // limiter run at the prefix because createExpressEndpoints registers
+  // handlers directly on the app.
+  app.use('/api/image-edit', requireAuth, aiGenerationLimiter);
+  mountImageEditContractRouter(app);
   app.use('/api/imagine/create', aiGenerationLimiter, imagineCreateRoute);
   app.use('/api/imagine/pure', aiGenerationLimiter, imaginePureRoute);
   app.use('/api/imagine/outpaint', aiGenerationLimiter, outpaintRoute);

--- a/apps/api/routes/flux/imageEditContractRouter.ts
+++ b/apps/api/routes/flux/imageEditContractRouter.ts
@@ -1,0 +1,158 @@
+/**
+ * ts-rest contract router for POST /api/image-edit — FLUX.2 image editing
+ * with 1–8 reference images (multi-reference).
+ *
+ * Replaces the legacy multipart POST /api/flux/green-edit/prompt for typed
+ * web clients; the legacy route stays mounted for old consumers. requireAuth
+ * runs at the mount prefix in routes.ts.
+ */
+import fs from 'fs';
+
+import { imageEditContract } from '@gruenerator/contracts';
+import { IMAGE_MODEL_BY_ID } from '@gruenerator/shared/models';
+import { createExpressEndpoints, initServer } from '@ts-rest/express';
+
+import { ImageGenerationCounter } from '../../services/counters/index.js';
+import {
+  FluxImageService,
+  buildUniversalPrompt,
+  type GenerateResult,
+  type ReferenceImage,
+} from '../../services/flux/index.js';
+import { fitToBudget } from '../../services/flux/referenceImages.js';
+import { getImageModelForUser } from '../../services/user/imageModelPreference.js';
+import { logContractValidationError } from '../../utils/contractValidationLogger.js';
+import { getAuthedUser } from '../../utils/getAuthedUser.js';
+import { createLogger } from '../../utils/logger.js';
+import { redisClient } from '../../utils/redis/index.js';
+import { addKiLabel } from '../sharepic/sharepic_canvas/imagine_label_canvas.js';
+
+import { buildGreenEditPrompt, buildAllyMakerPrompt } from './imageEditing.js';
+
+import type { ImageModelId } from '@gruenerator/shared/models';
+import type { Application } from 'express';
+
+const log = createLogger('imageEditContractRouter');
+
+const s = initServer();
+const imageCounter = new ImageGenerationCounter(redisClient);
+
+export const imageEditContractRouter = s.router(imageEditContract, {
+  edit: async ({ req, body }) => {
+    try {
+      const userId = getAuthedUser(req).id;
+
+      const limitStatus = await imageCounter.checkLimit(userId);
+      if (!limitStatus.canGenerate) {
+        return {
+          status: 429 as const,
+          body: {
+            success: false as const,
+            error: `Tageslimit von ${limitStatus.limit} Bildgenerierungen erreicht. Versuche es morgen wieder.`,
+            data: {
+              count: limitStatus.count,
+              remaining: limitStatus.remaining,
+              limit: limitStatus.limit,
+            },
+          },
+        };
+      }
+
+      const modelId: ImageModelId = body.imageModel ?? (await getImageModelForUser(userId));
+      const model = IMAGE_MODEL_BY_ID[modelId];
+      const maxRefs = model.maxReferenceImages ?? 1;
+
+      if (body.images.length > 1 && model.backend !== 'hosted') {
+        return {
+          status: 400 as const,
+          body: {
+            success: false as const,
+            error: `Mehrere Referenzbilder werden nur mit Flux-Modellen unterstützt. Bitte wähle Flux Klein, Pro oder Max als Bildmodell.`,
+          },
+        };
+      }
+      if (body.images.length > maxRefs) {
+        return {
+          status: 400 as const,
+          body: {
+            success: false as const,
+            error: `Maximal ${maxRefs} Referenzbilder für ${model.name}. Du hast ${body.images.length} übergeben.`,
+          },
+        };
+      }
+
+      const instruction = body.instruction.trim();
+      if (!instruction) {
+        return {
+          status: 400 as const,
+          body: { success: false as const, error: 'Bitte gib eine Bearbeitungsanweisung an.' },
+        };
+      }
+
+      const references: ReferenceImage[] = body.images.map((img) => ({
+        buffer: Buffer.from(img.data, 'base64'),
+        mimeType: img.type,
+      }));
+      const processed = await fitToBudget(references);
+
+      const editType = body.editType ?? 'universal';
+      const isPrecision = body.precision ?? true;
+      const prompt =
+        body.images.length > 1
+          ? buildUniversalPrompt(instruction, body.images.length)
+          : editType === 'ally-maker'
+            ? buildAllyMakerPrompt(instruction, isPrecision)
+            : editType === 'green-edit'
+              ? buildGreenEditPrompt(instruction, isPrecision)
+              : buildUniversalPrompt(instruction);
+
+      log.debug(
+        `[imageEdit] ${processed.length} reference image(s), model ${model.id}, type ${editType} (User: ${userId})`
+      );
+
+      const flux = await FluxImageService.create(model.backend, model.modelPath);
+      const { stored }: GenerateResult = await flux.generateFromImages(prompt, processed, {
+        output_format: 'jpeg',
+        safety_tolerance: 2,
+      });
+
+      const labeledBuffer = await addKiLabel(Buffer.from(stored.base64, 'base64'));
+      fs.writeFileSync(stored.filePath, labeledBuffer);
+
+      const incrementResult = await imageCounter.incrementCount(
+        userId,
+        Math.round(model.costMultiplier * 100)
+      );
+
+      return {
+        status: 200 as const,
+        body: {
+          success: true as const,
+          image: {
+            base64: labeledBuffer.toString('base64'),
+            filename: stored.filename,
+          },
+          prompt,
+          model: model.id,
+          usage: {
+            count: incrementResult.count,
+            remaining: incrementResult.remaining,
+            limit: incrementResult.limit,
+          },
+        },
+      };
+    } catch (error) {
+      log.error('[imageEditContract.edit] Error:', error);
+      return {
+        status: 500 as const,
+        body: { success: false as const, error: 'Bildbearbeitung fehlgeschlagen.' },
+      };
+    }
+  },
+});
+
+export function mountImageEditContractRouter(app: Application): void {
+  createExpressEndpoints(imageEditContract, imageEditContractRouter, app, {
+    requestValidationErrorHandler: logContractValidationError(log, 'imageEditContract'),
+  });
+}

--- a/apps/api/routes/flux/imageEditing.ts
+++ b/apps/api/routes/flux/imageEditing.ts
@@ -78,7 +78,7 @@ interface FluxGenerationResult {
 // Prompt Building Functions
 // ============================================================================
 
-function buildGreenEditPrompt(userText: string, isPrecision = false): string {
+export function buildGreenEditPrompt(userText: string, isPrecision = false): string {
   const trimmed = (userText || '').toString().trim();
   const hasUserInput = trimmed.length > 0;
   const lowerInput = trimmed.toLowerCase();
@@ -194,7 +194,7 @@ function buildGreenEditPrompt(userText: string, isPrecision = false): string {
   return JSON.stringify(promptStructure, null, 2);
 }
 
-function buildAllyMakerPrompt(placementText: string, _isPrecision = false): string {
+export function buildAllyMakerPrompt(placementText: string, _isPrecision = false): string {
   const trimmed = (placementText || '').toString().trim();
   const hasPlacement = trimmed.length > 0;
 

--- a/apps/api/services/flux/FluxImageService.ts
+++ b/apps/api/services/flux/FluxImageService.ts
@@ -114,6 +114,11 @@ export interface GenerateFromImageOptions extends SubmitOptions, PollOptions {
   seed?: number;
 }
 
+export interface ReferenceImage {
+  buffer: Buffer;
+  mimeType: string;
+}
+
 export interface OutpaintOptions extends PollOptions {
   width: number;
   height: number;
@@ -469,6 +474,22 @@ class FluxImageService {
     mimeType: string = 'image/jpeg',
     options: GenerateFromImageOptions = {}
   ): Promise<GenerateResult> {
+    return this.generateFromImages(prompt, [{ buffer: imageBuffer, mimeType }], options);
+  }
+
+  /**
+   * Image-to-image with one or more reference images (FLUX.2 multi-reference).
+   * The first image maps to `input_image`, further ones to `input_image_2`…
+   * `input_image_8` in the order given.
+   */
+  async generateFromImages(
+    prompt: string,
+    images: ReferenceImage[],
+    options: GenerateFromImageOptions = {}
+  ): Promise<GenerateResult> {
+    if (images.length === 0) {
+      throw new Error('generateFromImages requires at least one reference image');
+    }
     const modelPath = options.modelPathOverride || this.modelPath;
     const url = `${this.baseUrl}${modelPath}`;
     const headers = {
@@ -476,21 +497,23 @@ class FluxImageService {
       'Content-Type': 'application/json',
       'x-key': this.apiKey,
     };
-    const base64 = imageBuffer.toString('base64');
-    const imageDataUrl = `data:${mimeType};base64,${base64}`;
 
-    const body = {
+    const body: Record<string, unknown> = {
       prompt,
-      input_image: imageDataUrl,
       output_format: options.output_format || 'jpeg',
       safety_tolerance: options.safety_tolerance ?? 2,
       ...(options.width && { width: options.width }),
       ...(options.height && { height: options.height }),
       ...(options.seed && { seed: options.seed }),
     };
+    images.forEach((img, i) => {
+      const key = i === 0 ? 'input_image' : `input_image_${i + 1}`;
+      body[key] = `data:${img.mimeType};base64,${img.buffer.toString('base64')}`;
+    });
 
+    const totalKb = Math.round(images.reduce((sum, img) => sum + img.buffer.length, 0) / 1024);
     console.log(
-      `[FluxImageService] Submitting image-to-image request to ${url}, image size: ${Math.round(imageBuffer.length / 1024)}KB`
+      `[FluxImageService] Submitting image-to-image request to ${url}, ${images.length} reference image(s), total size: ${totalKb}KB`
     );
 
     const request = await this.executeWithRetry(async (family?: number) => {
@@ -502,7 +525,7 @@ class FluxImageService {
 
       const res = await axios.post<SubmitResponse>(url, body, axiosConfig);
       return res.data;
-    }, 'generateFromImage');
+    }, 'generateFromImages');
 
     const { id, polling_url } = request;
     console.log(`[FluxImageService] Image-to-image request submitted successfully, ID: ${id}`);

--- a/apps/api/services/flux/IonosImageService.ts
+++ b/apps/api/services/flux/IonosImageService.ts
@@ -17,6 +17,7 @@ import type {
   PollResponse,
   DownloadResult,
   GenerateFromImageOptions,
+  ReferenceImage,
 } from './FluxImageService.js';
 
 const IONOS_BASE_URL = 'https://openai.inference.de-txl.ionos.com/v1';
@@ -104,6 +105,15 @@ class IonosImageService {
     _mimeType: string = 'image/jpeg',
     options: GenerateFromImageOptions = {}
   ): Promise<GenerateResult> {
+    return this.generateFromPrompt(prompt, options);
+  }
+
+  async generateFromImages(
+    prompt: string,
+    _images: ReferenceImage[],
+    options: GenerateFromImageOptions = {}
+  ): Promise<GenerateResult> {
+    // No img2img support — same fallback as generateFromImage.
     return this.generateFromPrompt(prompt, options);
   }
 

--- a/apps/api/services/flux/RegoloImageService.ts
+++ b/apps/api/services/flux/RegoloImageService.ts
@@ -15,6 +15,7 @@ import type {
   PollResponse,
   DownloadResult,
   GenerateFromImageOptions,
+  ReferenceImage,
 } from './FluxImageService.js';
 
 const REGOLO_BASE_URL = 'https://api.regolo.ai/v1';
@@ -106,6 +107,15 @@ class RegoloImageService {
     _mimeType: string = 'image/jpeg',
     options: GenerateFromImageOptions = {}
   ): Promise<GenerateResult> {
+    return this.generateFromPrompt(prompt, options);
+  }
+
+  async generateFromImages(
+    prompt: string,
+    _images: ReferenceImage[],
+    options: GenerateFromImageOptions = {}
+  ): Promise<GenerateResult> {
+    // No img2img support — same fallback as generateFromImage.
     return this.generateFromPrompt(prompt, options);
   }
 

--- a/apps/api/services/flux/index.ts
+++ b/apps/api/services/flux/index.ts
@@ -15,6 +15,7 @@ export type {
   GenerateFromPromptOptions,
   GenerateResult,
   GenerateFromImageOptions,
+  ReferenceImage,
   OutpaintOptions,
 } from './FluxImageService.js';
 
@@ -43,3 +44,4 @@ export type {
 
 export { buildGreenEditPrompt } from './greenEditPrompt.js';
 export { buildUniversalPrompt } from './universalEditPrompt.js';
+export { fitToBudget, MAX_REFERENCE_IMAGES } from './referenceImages.js';

--- a/apps/api/services/flux/referenceImages.ts
+++ b/apps/api/services/flux/referenceImages.ts
@@ -1,0 +1,45 @@
+/**
+ * Reference-image preparation for FLUX.2 multi-reference editing.
+ *
+ * The BFL API caps input + output at 9 megapixels combined. We reserve
+ * ~1MP headroom for the output and split the remaining budget evenly
+ * across the reference images. Images already under their share pass
+ * through byte-identical; oversized ones are downscaled via sharp.
+ *
+ * Shared between the imageEdit contract router and the ChatGraph
+ * imageEditNode.
+ */
+
+import sharp from 'sharp';
+
+import type { ReferenceImage } from './FluxImageService.js';
+
+const TOTAL_INPUT_BUDGET_MP = 8;
+const MP = 1_000_000;
+
+export const MAX_REFERENCE_IMAGES = 8;
+
+export async function fitToBudget(images: ReferenceImage[]): Promise<ReferenceImage[]> {
+  if (images.length === 0) return images;
+  const capPx = Math.max(1, Math.floor(TOTAL_INPUT_BUDGET_MP / images.length)) * MP;
+
+  return Promise.all(
+    images.map(async (img) => {
+      const meta = await sharp(img.buffer).metadata();
+      const width = meta.width ?? 0;
+      const height = meta.height ?? 0;
+      if (!width || !height || width * height <= capPx) return img;
+
+      const scale = Math.sqrt(capPx / (width * height));
+      const buffer = await sharp(img.buffer)
+        .resize({
+          width: Math.max(1, Math.floor(width * scale)),
+          height: Math.max(1, Math.floor(height * scale)),
+          fit: 'inside',
+        })
+        .jpeg({ quality: 90 })
+        .toBuffer();
+      return { buffer, mimeType: 'image/jpeg' };
+    })
+  );
+}

--- a/apps/api/services/flux/universalEditPrompt.ts
+++ b/apps/api/services/flux/universalEditPrompt.ts
@@ -9,14 +9,20 @@
  * /flux/imageEditing REST route.
  */
 
-export function buildUniversalPrompt(userText: string): string {
+export function buildUniversalPrompt(userText: string, referenceCount = 1): string {
   const trimmed = (userText || '').toString().trim();
 
   const promptStructure = {
     edit: trimmed,
+    ...(referenceCount > 1 && {
+      references: `${referenceCount} input images provided. "Bild N" / "image N" in the edit instruction refers to the N-th input image in upload order; the first input image is the primary scene.`,
+    }),
     style: 'Photorealistic, maintaining original image quality',
     constraints: {
-      preserve: ['Aspects not mentioned in edit instruction'],
+      preserve:
+        referenceCount > 1
+          ? ['Aspects of the primary scene not mentioned in the edit instruction']
+          : ['Aspects not mentioned in edit instruction'],
       match: ['Original lighting, shadows, and textures'],
     },
     quality: 'Photorealistic edit',

--- a/apps/web/src/features/image-studio/services/imageEditingService.ts
+++ b/apps/web/src/features/image-studio/services/imageEditingService.ts
@@ -1,10 +1,72 @@
+import { type ImageEditReference } from '@gruenerator/contracts';
+import { getContractsClient } from '@gruenerator/shared/api';
+
 import apiClient from '../../../components/utils/apiClient';
 
-interface UniversalEditResponse {
-  image: string | { base64: string; filename?: string };
-}
+import type { ImageModelId } from '@gruenerator/shared/models';
 
 export type ImageEditType = 'universal' | 'green-edit';
+
+/**
+ * Per-image pixel cap mirroring the server-side budget (BFL caps input +
+ * output at 9MP combined; ~1MP is reserved for the output). Downscaling
+ * client-side keeps the base64 JSON payload well under the body limit.
+ */
+const TOTAL_INPUT_BUDGET_MP = 8;
+
+function isSupportedMimeType(type: string): type is ImageEditReference['type'] {
+  return type === 'image/jpeg' || type === 'image/png' || type === 'image/webp';
+}
+
+async function fileToReference(file: File, capPx: number): Promise<ImageEditReference> {
+  let bitmap: ImageBitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch {
+    throw new Error(`„${file.name}" konnte nicht gelesen werden. Bitte nutze JPEG, PNG oder WebP.`);
+  }
+
+  const pixels = bitmap.width * bitmap.height;
+
+  if (pixels <= capPx && isSupportedMimeType(file.type)) {
+    bitmap.close();
+    const data = await fileToBase64(file);
+    return { name: file.name, type: file.type, data };
+  }
+
+  const scale = pixels > capPx ? Math.sqrt(capPx / pixels) : 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.floor(bitmap.width * scale));
+  canvas.height = Math.max(1, Math.floor(bitmap.height * scale));
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Bildverarbeitung fehlgeschlagen');
+  ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+  bitmap.close();
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, 'image/jpeg', 0.9)
+  );
+  if (!blob) throw new Error('Bildverarbeitung fehlgeschlagen');
+
+  const data = await blobToBase64(blob);
+  return { name: file.name, type: 'image/jpeg', data };
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = () => reject(new Error('Bild konnte nicht gelesen werden'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return blobToBase64(file);
+}
 
 interface BackgroundRemovalResponse {
   image: string;
@@ -33,28 +95,44 @@ export async function removeImageBackground(
 }
 
 export async function editAiImage(
-  image: File,
+  image: File | File[],
   instruction: string,
-  editType: ImageEditType = 'universal'
+  editType: ImageEditType = 'universal',
+  imageModel?: ImageModelId
 ): Promise<{ file: File; objectUrl: string; base64: string }> {
-  const form = new FormData();
-  form.append('image', image);
-  form.append('text', instruction);
-  form.append('precision', 'true');
-  form.append('type', editType);
+  const files = Array.isArray(image) ? image : [image];
+  if (files.length === 0) throw new Error('Kein Bild ausgewählt');
 
-  const response = await apiClient.post<UniversalEditResponse>('/flux/green-edit/prompt', form, {
-    headers: { 'Content-Type': 'multipart/form-data' },
+  const capPx = Math.max(1, Math.floor(TOTAL_INPUT_BUDGET_MP / files.length)) * 1_000_000;
+  const images = await Promise.all(files.map((f) => fileToReference(f, capPx)));
+
+  const result = await getContractsClient().imageEdit.edit({
+    body: {
+      instruction,
+      images,
+      editType,
+      precision: true,
+      ...(imageModel && { imageModel }),
+    },
   });
 
-  const payload = response.data?.image;
-  if (!payload) throw new Error('Keine Bilddaten empfangen');
+  if (
+    result.status === 400 ||
+    result.status === 401 ||
+    result.status === 429 ||
+    result.status === 500
+  ) {
+    throw new Error(result.body.error);
+  }
+  if (result.status !== 200) {
+    throw new Error('Bearbeitung fehlgeschlagen');
+  }
 
-  const base64 = typeof payload === 'string' ? payload : payload.base64;
-  const filename = typeof payload === 'string' ? 'edited.png' : (payload.filename ?? 'edited.png');
+  const base64 = `data:image/jpeg;base64,${result.body.image.base64}`;
+  const filename = result.body.image.filename || 'edited.jpg';
 
   const blob = await (await fetch(base64)).blob();
-  const file = new File([blob], filename, { type: blob.type || 'image/png' });
+  const file = new File([blob], filename, { type: blob.type || 'image/jpeg' });
   const objectUrl = URL.createObjectURL(file);
 
   return { file, objectUrl, base64 };

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -1,4 +1,5 @@
 import { getGlobalApiClient } from '@gruenerator/shared/api';
+import { useMediaPicker, type MediaItem } from '@gruenerator/shared/media-library';
 import {
   DEFAULT_IMAGE_MODEL_ID,
   FLUX_VARIANT_ORDER,
@@ -35,6 +36,7 @@ import {
   editAiImage,
   removeImageBackground,
 } from '../../image-studio/services/imageEditingService';
+import MediaPickerModal from '../../media-library/components/MediaPickerModal';
 import { useImageModelPreference } from '../../models/hooks/useImageModelPreference';
 import { useModeState } from '../../texte/hooks/useModeState';
 import { MODE_MAP } from '../../texte/modes';
@@ -277,6 +279,11 @@ const BilderInner: React.FC = memo(() => {
   const [sourceFile, setSourceFile] = useState<File | null>(null);
   const [sourcePreviewUrl, setSourcePreviewUrl] = useState<string | null>(null);
   const [sourceDims, setSourceDims] = useState<{ width: number; height: number } | null>(null);
+  // Additional reference images for multi-reference editing (bearbeiten only).
+  // sourceFile stays the primary image; other sub-modes ignore the extras.
+  const [extraSourceFiles, setExtraSourceFiles] = useState<
+    Array<{ file: File; previewUrl: string }>
+  >([]);
 
   const [editError, setEditError] = useState<string | null>(null);
   const [editLoading, setEditLoading] = useState(false);
@@ -342,6 +349,10 @@ const BilderInner: React.FC = memo(() => {
     }
   }, [isPrefLoading, defaultImageModel, modeState.imageModel, updateField]);
 
+  const selectedImageModel = (modeState.imageModel as ImageModelId | undefined) ?? null;
+  const effectiveImageModel = selectedImageModel ?? defaultImageModel ?? DEFAULT_IMAGE_MODEL_ID;
+  const maxRefs = IMAGE_MODEL_BY_ID[effectiveImageModel]?.maxReferenceImages ?? 1;
+
   const [usage, setUsage] = useState<UsageStatus | null>(null);
   const usageQuery = useQuery({
     queryKey: ['image-generation-status'],
@@ -360,6 +371,15 @@ const BilderInner: React.FC = memo(() => {
       if (sourcePreviewUrl) URL.revokeObjectURL(sourcePreviewUrl);
     },
     [sourcePreviewUrl]
+  );
+
+  const extraSourceFilesRef = useRef(extraSourceFiles);
+  extraSourceFilesRef.current = extraSourceFiles;
+  useEffect(
+    () => () => {
+      extraSourceFilesRef.current.forEach((e) => URL.revokeObjectURL(e.previewUrl));
+    },
+    []
   );
 
   useEffect(
@@ -388,28 +408,54 @@ const BilderInner: React.FC = memo(() => {
   subModeRef.current = subMode;
   const removeBgHandlerRef = useRef<((file: File) => void) | null>(null);
 
-  const handleFileChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0] ?? null;
-      if (!file) return;
-      if (sourcePreviewUrl) URL.revokeObjectURL(sourcePreviewUrl);
-      const objectUrl = URL.createObjectURL(file);
-      setSourceFile(file);
-      setSourcePreviewUrl(objectUrl);
-      setSourceDims(null);
+  const addSourceFiles = useCallback(
+    (files: File[]) => {
+      if (files.length === 0) return;
       setEditError(null);
       setOutpaintError(null);
-      const img = new Image();
-      img.src = objectUrl;
-      img
-        .decode()
-        .then(() => setSourceDims({ width: img.naturalWidth, height: img.naturalHeight }))
-        .catch(() => {});
-      if (subModeRef.current === 'hintergrund') {
-        removeBgHandlerRef.current?.(file);
+      let rest = files;
+      const isBearbeitenMode = subModeRef.current === 'bearbeiten';
+      if (!sourceFile || !isBearbeitenMode) {
+        const first = files[0];
+        if (sourcePreviewUrl) URL.revokeObjectURL(sourcePreviewUrl);
+        const objectUrl = URL.createObjectURL(first);
+        setSourceFile(first);
+        setSourcePreviewUrl(objectUrl);
+        setSourceDims(null);
+        const img = new Image();
+        img.src = objectUrl;
+        img
+          .decode()
+          .then(() => setSourceDims({ width: img.naturalWidth, height: img.naturalHeight }))
+          .catch(() => {});
+        if (subModeRef.current === 'hintergrund') {
+          removeBgHandlerRef.current?.(first);
+        }
+        rest = files.slice(1);
       }
+      if (!isBearbeitenMode || rest.length === 0) return;
+      setExtraSourceFiles((prev) => {
+        const room = Math.max(0, maxRefs - 1 - prev.length);
+        if (rest.length > room) {
+          setEditError(`Maximal ${maxRefs} Bilder für dieses Modell.`);
+        }
+        const accepted = rest.slice(0, room);
+        return [
+          ...prev,
+          ...accepted.map((file) => ({ file, previewUrl: URL.createObjectURL(file) })),
+        ];
+      });
     },
-    [sourcePreviewUrl]
+    [sourceFile, sourcePreviewUrl, maxRefs]
+  );
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      e.target.value = '';
+      addSourceFiles(files);
+    },
+    [addSourceFiles]
   );
 
   const clearSource = useCallback(() => {
@@ -417,8 +463,85 @@ const BilderInner: React.FC = memo(() => {
     setSourceFile(null);
     setSourcePreviewUrl(null);
     setSourceDims(null);
+    setExtraSourceFiles((prev) => {
+      prev.forEach((e) => URL.revokeObjectURL(e.previewUrl));
+      return [];
+    });
     if (fileInputRef.current) fileInputRef.current.value = '';
   }, [sourcePreviewUrl]);
+
+  // Removes the i-th reference image; removing the primary promotes the next
+  // extra so the numbering users referenced in the prompt stays contiguous.
+  const removeSourceAt = useCallback(
+    (index: number) => {
+      if (index === 0) {
+        if (sourcePreviewUrl) URL.revokeObjectURL(sourcePreviewUrl);
+        const [next, ...restExtras] = extraSourceFiles;
+        if (next) {
+          setSourceFile(next.file);
+          setSourcePreviewUrl(next.previewUrl);
+          setSourceDims(null);
+          setExtraSourceFiles(restExtras);
+        } else {
+          setSourceFile(null);
+          setSourcePreviewUrl(null);
+          setSourceDims(null);
+          if (fileInputRef.current) fileInputRef.current.value = '';
+        }
+        return;
+      }
+      setExtraSourceFiles((prev) => {
+        const entry = prev[index - 1];
+        if (entry) URL.revokeObjectURL(entry.previewUrl);
+        return prev.filter((_, i) => i !== index - 1);
+      });
+    },
+    [sourcePreviewUrl, extraSourceFiles]
+  );
+
+  // Switching to a model with a lower reference limit trims surplus extras.
+  useEffect(() => {
+    if (extraSourceFiles.length <= maxRefs - 1) return;
+    const kept = extraSourceFiles.slice(0, Math.max(0, maxRefs - 1));
+    extraSourceFiles.slice(Math.max(0, maxRefs - 1)).forEach((e) => {
+      URL.revokeObjectURL(e.previewUrl);
+    });
+    setExtraSourceFiles(kept);
+    setEditError(`Maximal ${maxRefs} Bilder für dieses Modell — überzählige wurden entfernt.`);
+  }, [maxRefs, extraSourceFiles]);
+
+  const { openImagePicker, isOpen: isMediaPickerOpen } = useMediaPicker();
+
+  const importMediaItems = useCallback(
+    async (items: MediaItem[]) => {
+      try {
+        const files = await Promise.all(
+          items
+            .filter((item) => item.mediaType === 'image')
+            .map(async (item) => {
+              const res = await getGlobalApiClient().get<Blob>(
+                `/share/${item.shareToken}/download`,
+                { responseType: 'blob' }
+              );
+              return new File([res.data], item.originalFilename ?? item.title ?? 'bild.jpg', {
+                type: item.mimeType || res.data.type || 'image/jpeg',
+              });
+            })
+        );
+        addSourceFiles(files);
+      } catch (err) {
+        console.error('[BilderInner] Media library import failed:', err);
+        setEditError('Bild aus der Mediathek konnte nicht geladen werden.');
+      }
+    },
+    [addSourceFiles]
+  );
+
+  const handlePickFromLibrary = useCallback(() => {
+    openImagePicker((items) => {
+      void importMediaItems(items);
+    }, maxRefs > 1);
+  }, [openImagePicker, importMediaItems, maxRefs]);
 
   const handleSubmitCreate = useCallback(async () => {
     const trimmed = prompt.trim();
@@ -463,14 +586,27 @@ const BilderInner: React.FC = memo(() => {
     setEditLoading(true);
     setEditError(null);
     try {
-      const { objectUrl, base64 } = await editAiImage(sourceFile, trimmed);
+      const files = [sourceFile, ...extraSourceFiles.map((e) => e.file)];
+      const { objectUrl, base64 } = await editAiImage(
+        files,
+        trimmed,
+        'universal',
+        selectedImageModel ?? undefined
+      );
       setResult(objectUrl, true);
       createImageShare({
         imageData: base64,
         title: trimmed.slice(0, 100),
         imageType: 'edit',
         status: 'ready',
-        metadata: { prompt: trimmed, sourceFilename: sourceFile.name },
+        metadata: {
+          prompt: trimmed,
+          sourceFilename: sourceFile.name,
+          ...(files.length > 1 && {
+            sourceFilenames: files.map((f) => f.name),
+            referenceCount: files.length,
+          }),
+        },
       })
         .then(() => queryClient.invalidateQueries({ queryKey: ['recent-activity'] }))
         .catch(() => {});
@@ -480,7 +616,16 @@ const BilderInner: React.FC = memo(() => {
     } finally {
       setEditLoading(false);
     }
-  }, [prompt, sourceFile, editLoading, setResult, createImageShare, queryClient]);
+  }, [
+    prompt,
+    sourceFile,
+    extraSourceFiles,
+    selectedImageModel,
+    editLoading,
+    setResult,
+    createImageShare,
+    queryClient,
+  ]);
 
   const handleSubmitGreenEdit = useCallback(async () => {
     const trimmed = prompt.trim();
@@ -755,14 +900,83 @@ const BilderInner: React.FC = memo(() => {
     [sourcePreviewUrl, sourceFile, clearSource]
   );
 
-  const selectedImageModel = (modeState.imageModel as ImageModelId | undefined) ?? null;
-
   const handleModelChange = useCallback(
     (modelId: ImageModelId) => {
       updateField('imageModel', modelId);
     },
     [updateField]
   );
+
+  // Bearbeiten: numbered pill row for 1–N reference images, with upload and
+  // media-library sources. "Bild N" in the prompt refers to pill N.
+  const referencePillRow = useMemo(() => {
+    const all = [
+      ...(sourceFile && sourcePreviewUrl
+        ? [{ file: sourceFile, previewUrl: sourcePreviewUrl }]
+        : []),
+      ...extraSourceFiles,
+    ];
+    return (
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {all.map((entry, i) => (
+          <div
+            key={entry.previewUrl}
+            className="flex items-center gap-1.5 rounded-md border border-grey-200 dark:border-grey-700 bg-background-pure pl-1 pr-1.5 py-0.5"
+          >
+            {all.length > 1 && (
+              <span className="flex items-center justify-center size-4 rounded-full bg-grey-200 dark:bg-grey-700 text-[10px] font-semibold text-grey-700 dark:text-grey-200">
+                {i + 1}
+              </span>
+            )}
+            <img src={entry.previewUrl} alt="" className="size-6 object-cover rounded" />
+            <span className="text-xs text-grey-600 dark:text-grey-300 max-w-[100px] truncate">
+              {entry.file.name}
+            </span>
+            <button
+              type="button"
+              onClick={() => removeSourceAt(i)}
+              className="text-grey-400 hover:text-grey-600 dark:hover:text-grey-200"
+              aria-label={`Bild ${i + 1} entfernen`}
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        ))}
+        {all.length < maxRefs && (
+          <>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
+            >
+              <ImagePlus className="size-3.5" />
+              {all.length === 0 ? 'Bild hochladen' : '+ Bild'}
+            </button>
+            <button
+              type="button"
+              onClick={handlePickFromLibrary}
+              className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
+            >
+              <ImageIcon className="size-3.5" />
+              Mediathek
+            </button>
+          </>
+        )}
+        {all.length >= 2 && (
+          <span className="text-[11px] text-grey-400 dark:text-grey-500">
+            Beziehe dich im Text auf „Bild 1“, „Bild 2“ …
+          </span>
+        )}
+      </div>
+    );
+  }, [
+    sourceFile,
+    sourcePreviewUrl,
+    extraSourceFiles,
+    maxRefs,
+    removeSourceAt,
+    handlePickFromLibrary,
+  ]);
 
   const toolbar = useMemo(
     () => (
@@ -781,13 +995,14 @@ const BilderInner: React.FC = memo(() => {
               onChange={(val) => updateField(config.key, val as string)}
             />
           ))}
-        {isErstellen && (
+        {(isErstellen || isBearbeiten) && (
           <ImageModelDropdown
             value={selectedImageModel ?? DEFAULT_IMAGE_MODEL_ID}
             onChange={handleModelChange}
           />
         )}
-        {(isBearbeiten || isBegruenen || isHintergrund) && filePickerPill}
+        {isBearbeiten && referencePillRow}
+        {(isBegruenen || isHintergrund) && filePickerPill}
         {isVergroessern && (
           <SettingsDropdown
             config={ASPECT_RATIO_CONFIG}
@@ -849,6 +1064,7 @@ const BilderInner: React.FC = memo(() => {
       selectedImageModel,
       handleModelChange,
       filePickerPill,
+      referencePillRow,
       aspectRatio,
       usage,
     ]
@@ -890,6 +1106,7 @@ const BilderInner: React.FC = memo(() => {
         ref={fileInputRef}
         type="file"
         accept="image/*"
+        multiple={isBearbeiten && maxRefs > 1}
         onChange={handleFileChange}
         className="hidden"
       />
@@ -950,6 +1167,8 @@ const BilderInner: React.FC = memo(() => {
           altText={altText}
         />
       )}
+
+      {isMediaPickerOpen && <MediaPickerModal />}
     </div>
   );
 });

--- a/packages/contracts/src/contracts/imageEditContract.ts
+++ b/packages/contracts/src/contracts/imageEditContract.ts
@@ -1,0 +1,45 @@
+/**
+ * ts-rest contract for FLUX.2 image editing (single- and multi-reference).
+ *
+ * Covers:
+ * - POST /api/image-edit
+ *
+ * Auth: requireAuth is applied at the mount prefix in routes.ts. The legacy
+ * multipart route POST /api/flux/green-edit/prompt stays mounted for old
+ * clients; new web callers go through this contract.
+ */
+import { initContract } from '@ts-rest/core';
+import { z } from 'zod';
+
+import {
+  imageEditBodySchema,
+  imageEditSuccessSchema,
+  imageEditErrorSchema,
+  imageEditQuotaErrorSchema,
+} from '../schemas/imageEdit.js';
+
+const c = initContract();
+
+export const imageEditContract = c.router(
+  {
+    /**
+     * Edit an image with 1–8 reference images. images[0] is the primary
+     * image; the instruction may reference "Bild N" / "image N" for the
+     * N-th reference (FLUX.2 multi-reference editing).
+     */
+    edit: {
+      method: 'POST',
+      path: '/api/image-edit',
+      body: imageEditBodySchema,
+      responses: {
+        200: imageEditSuccessSchema,
+        400: imageEditErrorSchema,
+        401: imageEditErrorSchema,
+        429: imageEditQuotaErrorSchema,
+        500: z.object({ success: z.literal(false), error: z.string() }),
+      },
+      summary: 'Edit an image with one or more reference images (FLUX.2)',
+    },
+  },
+  { pathPrefix: '' }
+);

--- a/packages/contracts/src/contracts/index.ts
+++ b/packages/contracts/src/contracts/index.ts
@@ -36,6 +36,7 @@ export { notificationsContract } from './notificationsContract.js';
 export { emailContract } from './emailContract.js';
 export { modelPreferencesContract } from './modelPreferencesContract.js';
 export { imageModelPreferenceContract } from './imageModelPreferenceContract.js';
+export { imageEditContract } from './imageEditContract.js';
 export { adminVorlagenContract } from './adminVorlagenContract.js';
 export { userTemplatesContract } from './userTemplatesContract.js';
 export { templateInteractionsContract } from './templateInteractionsContract.js';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -53,6 +53,7 @@ export {
   emailContract,
   modelPreferencesContract,
   imageModelPreferenceContract,
+  imageEditContract,
   adminVorlagenContract,
   userTemplatesContract,
   templateInteractionsContract,
@@ -99,6 +100,7 @@ export * from './schemas/notifications.js';
 export * from './schemas/email.js';
 export * from './schemas/modelPreferences.js';
 export * from './schemas/imageModelPreference.js';
+export * from './schemas/imageEdit.js';
 export * from './schemas/adminVorlagen.js';
 export * from './schemas/userTemplates.js';
 export * from './schemas/templateInteractions.js';

--- a/packages/contracts/src/schemas/imageEdit.ts
+++ b/packages/contracts/src/schemas/imageEdit.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import { imageModelIdSchema } from './imageModelPreference.js';
+
+/**
+ * Schemas for POST /api/image-edit — FLUX.2 image editing with one or more
+ * reference images (multi-reference). Images travel as base64 in the JSON
+ * body (repo convention: ts-rest contracts don't model multipart; same
+ * pattern as chat attachments).
+ */
+
+export const IMAGE_EDIT_MAX_REFERENCES = 8;
+
+export const imageEditMimeTypeSchema = z.enum(['image/jpeg', 'image/png', 'image/webp']);
+
+export const imageEditReferenceSchema = z.object({
+  name: z.string().min(1).max(255),
+  /** MIME type of the encoded image. */
+  type: imageEditMimeTypeSchema,
+  /** Base64-encoded image bytes (no data-URL prefix). */
+  data: z.string().min(1),
+});
+
+export const imageEditTypeSchema = z.enum(['universal', 'green-edit', 'ally-maker']);
+
+export const imageEditBodySchema = z.object({
+  /** Natural-language edit instruction; may reference "Bild 1", "Bild 2", … */
+  instruction: z.string().min(1).max(4000),
+  /** Reference images in order: images[0] is the primary image. */
+  images: z.array(imageEditReferenceSchema).min(1).max(IMAGE_EDIT_MAX_REFERENCES),
+  /** Overrides the user's stored image-model preference for this edit. */
+  imageModel: imageModelIdSchema.nullish(),
+  editType: imageEditTypeSchema.nullish(),
+  precision: z.boolean().nullish(),
+});
+
+export const imageEditSuccessSchema = z.object({
+  success: z.literal(true),
+  image: z.object({
+    /** Base64-encoded JPEG result (no data-URL prefix), KI-labeled. */
+    base64: z.string(),
+    filename: z.string(),
+  }),
+  /** The structured prompt that was sent to the image model. */
+  prompt: z.string(),
+  model: imageModelIdSchema,
+  usage: z.object({
+    count: z.number(),
+    remaining: z.number(),
+    limit: z.number(),
+  }),
+});
+
+export const imageEditErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.string(),
+});
+
+export const imageEditQuotaErrorSchema = imageEditErrorSchema.extend({
+  data: z
+    .object({
+      count: z.number(),
+      remaining: z.number(),
+      limit: z.number(),
+    })
+    .nullish(),
+});
+
+export type ImageEditReference = z.infer<typeof imageEditReferenceSchema>;
+export type ImageEditBody = z.infer<typeof imageEditBodySchema>;
+export type ImageEditSuccess = z.infer<typeof imageEditSuccessSchema>;
+export type ImageEditType = z.infer<typeof imageEditTypeSchema>;

--- a/packages/core/src/models/catalog.ts
+++ b/packages/core/src/models/catalog.ts
@@ -42,6 +42,8 @@ export interface ImageModelOption extends BaseModelOption {
   backend: ImageBackend;
   modelPath?: string;
   costMultiplier: number;
+  /** Max reference images per edit (FLUX.2 multi-reference). Absent = 1. */
+  maxReferenceImages?: number;
 }
 
 export interface ImageFamilyOption {
@@ -118,6 +120,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     backend: 'hosted',
     modelPath: '/v1/flux-2-pro',
     costMultiplier: 1,
+    maxReferenceImages: 8,
     icon: 'sparkles',
     region: 'eu',
   },
@@ -130,6 +133,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     backend: 'hosted',
     modelPath: '/v1/flux-2-klein-9b',
     costMultiplier: 0.5,
+    maxReferenceImages: 4,
     icon: 'zap',
     region: 'eu',
   },
@@ -142,6 +146,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     backend: 'hosted',
     modelPath: '/v1/flux-2-max',
     costMultiplier: 2,
+    maxReferenceImages: 8,
     icon: 'brain',
     region: 'eu',
   },

--- a/packages/shared/src/api/contractsClient.ts
+++ b/packages/shared/src/api/contractsClient.ts
@@ -39,6 +39,7 @@ import {
   emailContract,
   modelPreferencesContract,
   imageModelPreferenceContract,
+  imageEditContract,
   adminVorlagenContract,
   userTemplatesContract,
   templateInteractionsContract,
@@ -166,6 +167,7 @@ const _notificationsClient = () => initClient(notificationsContract, CLIENT_OPTS
 const _emailClient = () => initClient(emailContract, CLIENT_OPTS);
 const _modelPreferencesClient = () => initClient(modelPreferencesContract, CLIENT_OPTS);
 const _imageModelPreferenceClient = () => initClient(imageModelPreferenceContract, CLIENT_OPTS);
+const _imageEditClient = () => initClient(imageEditContract, CLIENT_OPTS);
 const _adminVorlagenClient = () => initClient(adminVorlagenContract, CLIENT_OPTS);
 const _userTemplatesClient = () => initClient(userTemplatesContract, CLIENT_OPTS);
 const _templateInteractionsClient = () => initClient(templateInteractionsContract, CLIENT_OPTS);
@@ -201,6 +203,7 @@ export interface ContractsClient {
   email: ReturnType<typeof _emailClient>;
   modelPreferences: ReturnType<typeof _modelPreferencesClient>;
   imageModelPreference: ReturnType<typeof _imageModelPreferenceClient>;
+  imageEdit: ReturnType<typeof _imageEditClient>;
   adminVorlagen: ReturnType<typeof _adminVorlagenClient>;
   userTemplates: ReturnType<typeof _userTemplatesClient>;
   templateInteractions: ReturnType<typeof _templateInteractionsClient>;
@@ -253,6 +256,7 @@ export function getContractsClient(): ContractsClient {
     email: _emailClient(),
     modelPreferences: _modelPreferencesClient(),
     imageModelPreference: _imageModelPreferenceClient(),
+    imageEdit: _imageEditClient(),
     adminVorlagen: _adminVorlagenClient(),
     userTemplates: _userTemplatesClient(),
     templateInteractions: _templateInteractionsClient(),


### PR DESCRIPTION
## Was

Multi-Referenz-Bildbearbeitung mit FLUX.2: Nutzer:innen geben 1–8 Referenzbilder plus eine Anweisung an ("Setze die Person aus Bild 2 auf die Bank in Bild 1") und erhalten ein zusammengesetztes Ergebnis. Verfügbar im Bilder-Tab (Bearbeiten) und im Chat.

## Wie

**Vollständig contract-basiert** (4-Layer-Pass):
- **Zod-Schemas** (`packages/contracts/src/schemas/imageEdit.ts`): `imageEditBodySchema` mit 1–8 base64-Referenzen (`z.enum`-MIME-Types), `instruction`, `imageModel`-Override, `editType`; Response-Schemas pro Status, Typen via `z.infer`.
- **Contract** (`imageEditContract.ts`): `POST /api/image-edit` mit Status-Map 200/400/401/429/500.
- **Server** (`apps/api/routes/flux/imageEditContractRouter.ts`): Quota-Check, Modell-Auflösung (Body-Override → User-Preference), Validierung (hosted-only für Multi-Ref, `maxReferenceImages` pro Modell) mit deutschen Fehlermeldungen, sharp-basiertes Megapixel-Budget (BFL: 9MP input+output), KI-Label, Counter-Increment.
- **Client**: `editAiImage` läuft über `getContractsClient().imageEdit.edit(...)` mit Client-seitigem Canvas-Downscale vor der base64-Kodierung.

**Core**: `FluxImageService.generateFromImages()` mappt Referenzen auf `input_image`, `input_image_2`…`input_image_8` (BFL-API verifiziert); `generateFromImage` delegiert — bestehende Aufrufer unverändert. Katalog: `maxReferenceImages` (pro/max 8, klein 4); regolo/ionos bleiben Single-Image und werden serverseitig abgelehnt.

**Bilder-Tab UI**: Nummerierte Thumbnail-Pills (1…N) mit Einzel-Entfernen (Entfernen von #1 rückt nach, damit die Bild-N-Nummerierung im Prompt gültig bleibt), "+ Bild"-Upload und Mediathek-Picker (bestehendes `MediaPickerModal`/`useMediaPicker`-Multi-Select). Modell-Dropdown jetzt auch in Bearbeiten — steuert Modell pro Edit und Referenz-Limit (Wechsel zu Klein trimmt überzählige Bilder mit Hinweis). Hinweis ab 2 Bildern: „Beziehe dich im Text auf ‚Bild 1', ‚Bild 2' …“.

**Chat**: `imageEditNode` (und das ungenutzte `edit_image`-Tool) schickt alle angehängten Bilder statt nur `imageAttachments[0]`; bei >1 Referenz ersetzt der Universal-Prompt das Green-Edit-Preset. Output-Shape unverändert (ein Ergebnis).

Die Legacy-Multipart-Route `/flux/green-edit/prompt` bleibt für alte Clients gemountet; alle Web-Aufrufer (Bearbeiten, Begrünen, Canvas-Editor-AiEditTool) laufen jetzt über den typisierten Endpoint.

## Tests / Verifikation

- `pnpm typecheck` ✅, `pnpm lint` ✅ (0 errors)
- Flux-Service-Tests ✅; die 30 fehlschlagenden `aiController`-Doc-Tests sind pre-existing (schlagen identisch auf master fehl)
- ⚠️ Noch nicht gegen die Live-BFL-API getestet — braucht `BFL_API_KEY` + manuellen 2-3-Bild-Edit (im Log auf `input_image_2` achten)

## Out of scope (Follow-ups)

Multi-Ref auf `POST /generate`, Pill-Reordering, HEIC-Transcoding, Bild-Lineage in der DB, mehrere Output-Bilder im Chat.