### PR TITLE
feat(contracts,api,canvas): close chat-edit surface gaps across all sharepic templates

### DIFF
--- a/apps/api/routes/chat/services/sharepicEditLlm.ts
+++ b/apps/api/routes/chat/services/sharepicEditLlm.ts
@@ -93,20 +93,26 @@ export function buildOperationCatalog(descriptor: SharepicTemplateDescriptor): s
   }
   if (supported.has('update-element') && descriptor.elements.length > 0) {
     lines.push(
-      '  - { "kind": "update-element", "elementId": "<id>", "patch": { "x"?: Zahl, "y"?: Zahl, "scale"?: Zahl } }'
+      '  - { "kind": "update-element", "elementId": "<id>", "patch": { "x"?: Zahl, "y"?: Zahl, "scale"?: Zahl, "opacity"?: 0..1 } }'
     );
     for (const el of descriptor.elements) {
-      const scalePart = el.scale ? `, scale ${el.scale.min}–${el.scale.max}` : '';
-      // Offset elements (bounds spanning negative y) move relative to their
-      // anchor; absolute elements use canvas coordinates where smaller y is
-      // higher up. The wrong hint sends the model in the wrong direction.
-      const directionHint =
-        el.bounds.minY < 0
-          ? 'Negative y = nach oben.'
-          : 'Absolute Position: kleinere y-Werte = weiter oben.';
-      lines.push(
-        `    elementId "${el.id}" (${el.label}): x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY}${scalePart}. ${directionHint}`
-      );
+      const caps: string[] = [];
+      let directionHint = '';
+      if (el.positionStateKey && el.bounds) {
+        caps.push(`x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY}`);
+        // Offset elements (bounds spanning negative y) move relative to their
+        // anchor; absolute elements use canvas coordinates where smaller y is
+        // higher up. The wrong hint sends the model in the wrong direction.
+        directionHint =
+          el.bounds.minY < 0
+            ? ' Negative y = nach oben.'
+            : ' Absolute Position: kleinere y-Werte = weiter oben.';
+      } else {
+        caps.push('nicht verschiebbar');
+      }
+      if (el.scale) caps.push(`scale ${el.scale.min}–${el.scale.max}`);
+      if (el.opacity) caps.push(`opacity ${el.opacity.min}–${el.opacity.max} (0 = unsichtbar)`);
+      lines.push(`    elementId "${el.id}" (${el.label}): ${caps.join(', ')}.${directionHint}`);
     }
   }
   if (supported.has('set-background-image')) {

--- a/apps/web/src/features/docs/DocAiReviewBar.tsx
+++ b/apps/web/src/features/docs/DocAiReviewBar.tsx
@@ -1,0 +1,87 @@
+import { useDocAIReviewState, acceptDocumentAI, rejectDocumentAI } from '@gruenerator/docs';
+import { useState } from 'react';
+import { PiSparkle, PiSpinner } from 'react-icons/pi';
+
+import type { BlockNoteEditor } from '@blocknote/core';
+
+/**
+ * Floating review bar for chat-triggered AI suggestions — the web counterpart
+ * to mobile's native DocAiReviewBar. Chat edits apply diff marks without ever
+ * opening BlockNote's AI popover (the popover would lock the editor and anchor
+ * to a block the edit may delete), so this bar hosts Accept/Reject instead.
+ * Hidden while the popover is open (toolbar/slash-menu AI reviews itself).
+ */
+export function DocAiReviewBar({
+  documentId,
+  editor,
+}: {
+  documentId: string;
+  editor: BlockNoteEditor | null;
+}) {
+  const { isPendingReview, isStreaming } = useDocAIReviewState(editor, documentId);
+  const [busy, setBusy] = useState(false);
+
+  if (!isPendingReview) return null;
+
+  const handleAccept = () => {
+    setBusy(true);
+    try {
+      const result = acceptDocumentAI(documentId);
+      if (result === 'not-broadcast') {
+        void import('sonner').then(({ toast }) =>
+          toast.error(
+            'Änderung übernommen, aber nicht an Mitarbeitende übertragen. Bitte Verbindung prüfen und das Dokument neu laden.'
+          )
+        );
+      } else if (result === 'no-extension') {
+        void import('sonner').then(({ toast }) =>
+          toast.error('Übernehmen fehlgeschlagen — der Editor ist nicht bereit.')
+        );
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleReject = () => {
+    rejectDocumentAI(documentId);
+  };
+
+  const disabled = isStreaming || busy;
+
+  return (
+    <div className="flex items-center gap-3 rounded-full bg-white/85 dark:bg-grey-900/85 backdrop-blur-xl border border-black/8 dark:border-white/10 shadow-lg px-4 py-2">
+      <span className="flex items-center gap-1.5 text-sm font-semibold text-grey-800 dark:text-grey-200">
+        {isStreaming ? (
+          <>
+            <PiSpinner size={16} className="animate-spin text-secondary-600" />
+            KI schreibt …
+          </>
+        ) : (
+          <>
+            <PiSparkle size={16} className="text-secondary-600" />
+            KI-Vorschlag
+          </>
+        )}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleReject}
+          disabled={disabled}
+          className="px-3 py-1.5 text-sm font-medium rounded-lg border border-grey-300 dark:border-grey-600 text-grey-700 dark:text-grey-300 transition-colors hover:bg-grey-100 dark:hover:bg-grey-800 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="KI-Vorschlag verwerfen"
+        >
+          Verwerfen
+        </button>
+        <button
+          onClick={handleAccept}
+          disabled={disabled}
+          className="px-3 py-1.5 text-sm font-semibold rounded-lg bg-primary-600 text-white transition-colors hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="KI-Vorschlag übernehmen"
+        >
+          Übernehmen
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/docs/DocsEditorPage.tsx
+++ b/apps/web/src/features/docs/DocsEditorPage.tsx
@@ -57,6 +57,7 @@ import { useDocumentTitle } from '../../components/hooks/useDocumentTitle';
 import { useAuth } from '../../hooks/useAuth';
 import { useCollaborationConfig } from '../../hooks/useCollaborationConfig';
 
+import { DocAiReviewBar } from './DocAiReviewBar';
 import { webAppDocsAdapter } from './docsAdapter';
 import { GuestBadge, GUEST_ANIMALS } from './GuestBadge';
 import { useDocsLiveWolkeSync } from './useDocsLiveWolkeSync';
@@ -758,6 +759,9 @@ function EditorContent() {
             commentsPortalTarget={commentsPortalTarget}
             onEditorReady={handleEditorReady}
           />
+          <div className="sticky bottom-4 z-[150] flex justify-center pointer-events-none [&>*]:pointer-events-auto">
+            <DocAiReviewBar documentId={id!} editor={editor} />
+          </div>
         </main>
 
         {hasOpenedChat && id && (

--- a/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
+++ b/packages/canvas-editor/src/ai/sharepicDescriptorParity.vitest.ts
@@ -116,6 +116,59 @@ describe('sharepicOpsToStatePatch', () => {
     );
   });
 
+  it('clamps element opacity to descriptor bounds (balken)', () => {
+    const result = sharepicOpsToStatePatch(
+      dreizeilen,
+      [{ kind: 'update-element', elementId: 'balken', patch: { opacity: 0.05 } }],
+      {}
+    );
+    expect(result.patch.balkenOpacity).toBe(0.2);
+  });
+
+  it('gates background-image pan/zoom on an existing image', () => {
+    const noImage = sharepicOpsToStatePatch(
+      dreizeilen,
+      [{ kind: 'update-element', elementId: 'hintergrundbild', patch: { scale: 1.5 } }],
+      {}
+    );
+    expect(noImage.rejected).toHaveLength(1);
+
+    const withImage = sharepicOpsToStatePatch(
+      dreizeilen,
+      [{ kind: 'update-element', elementId: 'hintergrundbild', patch: { scale: 1.5, y: -200 } }],
+      { currentImageSrc: '/api/image-picker/stock-image/x.jpg' }
+    );
+    expect(withImage.patch.imageScale).toBe(1.5);
+    expect(withImage.patch.imageOffset).toEqual({ x: 0, y: -200 });
+  });
+
+  it('hides the info arrow via opacity but rejects moving it', () => {
+    const info = getSharepicTemplateDescriptor('info')!;
+    const hide = sharepicOpsToStatePatch(
+      info,
+      [{ kind: 'update-element', elementId: 'pfeil', patch: { opacity: 0 } }],
+      {}
+    );
+    expect(hide.patch.arrowOpacity).toBe(0);
+
+    const move = sharepicOpsToStatePatch(
+      info,
+      [{ kind: 'update-element', elementId: 'pfeil', patch: { y: 100 } }],
+      {}
+    );
+    expect(move.rejected[0].reason).toContain('nicht verschiebbar');
+  });
+
+  it('rejects color/rotation-only patches instead of silently applying nothing', () => {
+    const result = sharepicOpsToStatePatch(
+      dreizeilen,
+      [{ kind: 'update-element', elementId: 'balken', patch: { color: '#ff0000' } }],
+      {}
+    );
+    expect(result.applied).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+  });
+
   it('rejects set-color-scheme with unknown scheme ids', () => {
     const ops: CanvasAiOperation[] = [{ kind: 'set-color-scheme', schemeId: 'neon-pink' }];
     const result = sharepicOpsToStatePatch(dreizeilen, ops, {});
@@ -177,5 +230,29 @@ describe('buildSharepicSnapshot', () => {
     const balken = snapshot.elementsSummary.find((e) => e.id === 'balken');
     expect(balken?.label).toContain('x=12');
     expect(balken?.label).toContain('y=-48');
+  });
+
+  it('surfaces current font size, sunflower visibility and image presence', () => {
+    const descriptor = getSharepicTemplateDescriptor('dreizeilen')!;
+    const snapshot = buildSharepicSnapshot(descriptor, {
+      line1: 'GRÜN',
+      fontSize: 80,
+      sunflowerVisible: false,
+      balkenOpacity: 0.5,
+    });
+    expect(snapshot.textFields[0].label).toContain('80px');
+    expect(snapshot.elementsSummary.find((e) => e.id === 'sunflower')?.label).toContain(
+      'ausgeblendet'
+    );
+    expect(snapshot.elementsSummary.find((e) => e.id === 'balken')?.label).toContain('50%');
+    expect(snapshot.elementsSummary.find((e) => e.id === 'hintergrundbild')?.label).toContain(
+      'kein Bild'
+    );
+
+    const zitatSnapshot = buildSharepicSnapshot(getSharepicTemplateDescriptor('zitat-pure')!, {
+      quote: 'Q',
+      name: 'N',
+    });
+    expect(zitatSnapshot.textFields[0].label).toContain('automatisch');
   });
 });

--- a/packages/canvas-editor/src/configs/info_full.config.tsx
+++ b/packages/canvas-editor/src/configs/info_full.config.tsx
@@ -155,6 +155,7 @@ const baseInfoConfig = createColorTwoTextCanvas({
   textColorMap: TEXT_COLORS,
   backgroundImageMap: BACKGROUND_IMAGES,
   calculateLayout,
+  passthroughStateKeys: ['arrowOpacity'],
   elements: [sunflowerElement, headerTextElement, arrowElement, bodyTextElement],
   features: { icons: true, shapes: true, illustrations: true },
   getCanvasText: (state) => {

--- a/packages/canvas-editor/src/configs/zitat_pure_full.config.tsx
+++ b/packages/canvas-editor/src/configs/zitat_pure_full.config.tsx
@@ -150,7 +150,7 @@ const baseZitatPureConfig = createColorTwoTextCanvas({
   defaultBackgroundColor: ZITAT_PURE_CONFIG.background.color,
   textColorMap: FONT_COLORS,
   calculateLayout,
-  passthroughStateKeys: ['namePosition'],
+  passthroughStateKeys: ['namePosition', 'quoteMarkOffset', 'quoteMarkOpacity'],
   elements: [sunflowerElement, quoteMarkElement, quoteTextElement, nameTextElement],
   features: { icons: true, shapes: true, illustrations: true },
   getCanvasText: (state) => {

--- a/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
+++ b/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
@@ -36,12 +36,20 @@ export interface SharepicElementDescriptor {
   id: string;
   label: string;
   kind: 'balken' | 'asset';
-  /** State key holding `{ x, y }` for this element. */
-  positionStateKey: string;
-  /** Allowed range for x/y values (canvas-relative). */
-  bounds: { minX: number; maxX: number; minY: number; maxY: number };
+  /** State key holding `{ x, y }`; omit for elements that cannot move (pfeil). */
+  positionStateKey?: string;
+  /** Allowed range for x/y values (canvas-relative). Required with positionStateKey. */
+  bounds?: { minX: number; maxX: number; minY: number; maxY: number };
   /** State key + clamp bounds for `patch.scale`, when scalable. */
   scale?: { stateKey: string; min: number; max: number };
+  /** State key + clamp bounds for `patch.opacity` (0–1), when supported. */
+  opacity?: { stateKey: string; min: number; max: number };
+  /**
+   * State key whose truthiness gates position/scale edits (dreizeilen
+   * background: panning/zooming a non-existent image is meaningless).
+   * Also surfaces as "vorhanden/keins" in the snapshot label.
+   */
+  presenceStateKey?: string;
 }
 
 export interface SharepicTemplateDescriptor {
@@ -123,6 +131,7 @@ const DREIZEILEN_DESCRIPTOR: SharepicTemplateDescriptor = {
       positionStateKey: 'balkenOffset',
       bounds: { minX: -300, maxX: 300, minY: -300, maxY: 300 },
       scale: { stateKey: 'balkenScale', min: 0.5, max: 2 },
+      opacity: { stateKey: 'balkenOpacity', min: 0.2, max: 1 },
     },
     {
       id: 'sunflower',
@@ -130,6 +139,20 @@ const DREIZEILEN_DESCRIPTOR: SharepicTemplateDescriptor = {
       kind: 'asset',
       positionStateKey: 'sunflowerPos',
       bounds: { minX: 0, maxX: 1080, minY: 0, maxY: 1350 },
+      opacity: { stateKey: 'sunflowerOpacity', min: 0.05, max: 1 },
+    },
+    {
+      // Background photo pan/zoom/opacity. Offset semantics: {0,0} = centered
+      // crop, negative y shifts the visible cutout up. Gated on an existing
+      // image via presenceStateKey.
+      id: 'hintergrundbild',
+      label: 'Hintergrundbild (Ausschnitt)',
+      kind: 'asset',
+      positionStateKey: 'imageOffset',
+      bounds: { minX: -540, maxX: 540, minY: -675, maxY: 675 },
+      scale: { stateKey: 'imageScale', min: 0.5, max: 3 },
+      opacity: { stateKey: 'backgroundImageOpacity', min: 0.2, max: 1 },
+      presenceStateKey: 'currentImageSrc',
     },
   ],
   defaultState: { colorSchemeId: 'tanne-sand', fontSize: 60, sunflowerVisible: true },
@@ -173,6 +196,16 @@ const ZITAT_PURE_DESCRIPTOR: SharepicTemplateDescriptor = {
       positionStateKey: 'namePosition',
       bounds: { minX: 75, maxX: 500, minY: 120, maxY: 1250 },
     },
+    {
+      // Decorative quotation mark above the quote. Offset relative to its
+      // auto-layout anchor; opacity 0 hides it.
+      id: 'anfuehrungszeichen',
+      label: 'Anführungszeichen',
+      kind: 'asset',
+      positionStateKey: 'quoteMarkOffset',
+      bounds: { minX: -400, maxX: 400, minY: -400, maxY: 400 },
+      opacity: { stateKey: 'quoteMarkOpacity', min: 0, max: 1 },
+    },
   ],
   layoutResets: [{ onFields: ['quote'], clearStateKey: 'namePosition' }],
   defaultState: { backgroundColor: '#6CCD87' },
@@ -182,7 +215,7 @@ const INFO_DESCRIPTOR: SharepicTemplateDescriptor = {
   id: 'info',
   label: 'Info',
   canvas: { width: 1080, height: 1350 },
-  supportedOperations: ['set-text', 'set-font-size', 'set-background-color'],
+  supportedOperations: ['set-text', 'set-font-size', 'set-background-color', 'update-element'],
   textFields: [
     {
       field: 'header',
@@ -204,7 +237,16 @@ const INFO_DESCRIPTOR: SharepicTemplateDescriptor = {
       { id: 'sand', label: 'Sand', color: '#F5F1E9' },
     ],
   },
-  elements: [],
+  elements: [
+    {
+      // The arrow between header and body. Not movable (auto layout) —
+      // opacity 0 hides it.
+      id: 'pfeil',
+      label: 'Pfeil',
+      kind: 'asset',
+      opacity: { stateKey: 'arrowOpacity', min: 0, max: 1 },
+    },
+  ],
   defaultState: { backgroundColor: '#005538' },
 };
 
@@ -223,14 +265,32 @@ export function getSharepicTemplateDescriptor(
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
 const clamp = (v: number, min: number, max: number): number => Math.min(max, Math.max(min, v));
 
-function elementPositionLabel(
+function elementSummaryLabel(
   el: SharepicElementDescriptor,
+  descriptor: SharepicTemplateDescriptor,
   state: Record<string, unknown>
 ): string {
-  const pos = state[el.positionStateKey] as { x?: number; y?: number } | null | undefined;
-  const x = typeof pos?.x === 'number' ? Math.round(pos.x) : 0;
-  const y = typeof pos?.y === 'number' ? Math.round(pos.y) : 0;
-  return `${el.label} — Position x=${x}, y=${y} (erlaubt: x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY})`;
+  const parts: string[] = [el.label];
+  if (el.positionStateKey && el.bounds) {
+    const pos = state[el.positionStateKey] as { x?: number; y?: number } | null | undefined;
+    const x = typeof pos?.x === 'number' ? Math.round(pos.x) : 0;
+    const y = typeof pos?.y === 'number' ? Math.round(pos.y) : 0;
+    parts.push(
+      `Position x=${x}, y=${y} (erlaubt: x ${el.bounds.minX}..${el.bounds.maxX}, y ${el.bounds.minY}..${el.bounds.maxY})`
+    );
+  }
+  if (el.opacity) {
+    const raw = state[el.opacity.stateKey];
+    const current = typeof raw === 'number' ? raw : 1;
+    parts.push(`Transparenz ${Math.round(current * 100)}%`);
+  }
+  if (el.presenceStateKey) {
+    parts.push(state[el.presenceStateKey] ? 'Bild vorhanden' : 'kein Bild gesetzt');
+  }
+  if (el.id === 'sunflower' && descriptor.sunflowerVisibleStateKey) {
+    parts.push(state[descriptor.sunflowerVisibleStateKey] === false ? 'ausgeblendet' : 'sichtbar');
+  }
+  return `${parts[0]} — ${parts.slice(1).join(', ')}`;
 }
 
 /** Compact LLM-facing snapshot of the current sharepic state (~200 tokens). */
@@ -240,15 +300,25 @@ export function buildSharepicSnapshot(
 ): CanvasAiSnapshot {
   const snapshot: CanvasAiSnapshot = {
     template: descriptor.id,
-    textFields: descriptor.textFields.map((f) => ({
-      field: f.field,
-      label: f.label,
-      value: str(state[f.stateKey]),
-    })),
+    // Current font size rides along in the label so the LLM can judge
+    // "größer/kleiner" relative to the actual value instead of guessing.
+    textFields: descriptor.textFields.map((f) => {
+      const size = f.fontSize ? state[f.fontSize.stateKey] : undefined;
+      const sizeInfo = f.fontSize
+        ? typeof size === 'number'
+          ? ` (Schrift: ${Math.round(size)}px)`
+          : ' (Schrift: automatisch)'
+        : '';
+      return {
+        field: f.field,
+        label: `${f.label}${sizeInfo}`,
+        value: str(state[f.stateKey]),
+      };
+    }),
     elementsSummary: descriptor.elements.map((el) => ({
       id: el.id,
       kind: el.kind,
-      label: elementPositionLabel(el, state),
+      label: elementSummaryLabel(el, descriptor, state),
     })),
   };
   if (descriptor.colorSchemes) {
@@ -356,11 +426,24 @@ export function sharepicOpsToStatePatch(
         rejected.push({ op, reason: `Unbekanntes Element "${op.elementId}"` });
         continue;
       }
-      const prev = (state[el.positionStateKey] as { x?: number; y?: number } | null) ?? null;
+      if (el.presenceStateKey && !state[el.presenceStateKey]) {
+        rejected.push({
+          op,
+          reason: `"${el.label}" ist nicht gesetzt — es gibt nichts zu verändern`,
+        });
+        continue;
+      }
+      let landed = false;
       if (op.patch.x != null || op.patch.y != null) {
+        if (!el.positionStateKey || !el.bounds) {
+          rejected.push({ op, reason: `Element "${op.elementId}" ist nicht verschiebbar` });
+          continue;
+        }
+        const prev = (state[el.positionStateKey] as { x?: number; y?: number } | null) ?? null;
         const x = clamp(op.patch.x ?? prev?.x ?? 0, el.bounds.minX, el.bounds.maxX);
         const y = clamp(op.patch.y ?? prev?.y ?? 0, el.bounds.minY, el.bounds.maxY);
         patch[el.positionStateKey] = { x, y };
+        landed = true;
       }
       if (op.patch.scale != null) {
         if (!el.scale) {
@@ -368,6 +451,26 @@ export function sharepicOpsToStatePatch(
           continue;
         }
         patch[el.scale.stateKey] = clamp(op.patch.scale, el.scale.min, el.scale.max);
+        landed = true;
+      }
+      if (op.patch.opacity != null) {
+        if (!el.opacity) {
+          rejected.push({
+            op,
+            reason: `Element "${op.elementId}" unterstützt keine Transparenz`,
+          });
+          continue;
+        }
+        patch[el.opacity.stateKey] = clamp(op.patch.opacity, el.opacity.min, el.opacity.max);
+        landed = true;
+      }
+      if (!landed) {
+        // color/rotation (or an empty patch) — nothing this surface supports.
+        rejected.push({
+          op,
+          reason: 'Für Elemente werden nur x/y, scale und opacity unterstützt',
+        });
+        continue;
       }
       applied.push(op);
     } else if (op.kind === 'set-background-image') {

--- a/packages/docs/src/hooks/useDocAIReviewState.ts
+++ b/packages/docs/src/hooks/useDocAIReviewState.ts
@@ -1,0 +1,71 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { ForkYDocExtension } from '@blocknote/core/extensions';
+
+import { getDocAIMenuStore } from '../lib/aiExtension';
+import { isDocAIInvocationInFlight, subscribeDocAIInFlight } from '../lib/invokeDocumentAI';
+
+/**
+ * Review state for AI suggestions that were applied without opening the AI
+ * popover — i.e. chat-triggered edits via {@link invokeDocumentAI}.
+ *
+ * - `isPendingReview`: the doc is forked AND the AI menu is closed. When the
+ *   user invokes AI through the toolbar/slash menu, BlockNote's own popover
+ *   hosts Accept/Reject, so external review UI must stay hidden.
+ * - `isStreaming`: an invocation is still writing into the fork. Accept/reject
+ *   must be blocked during this window — with the menu closed the extension's
+ *   abort is a no-op, and merging mid-stream would let the rest of the stream
+ *   land in the live doc.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EditorLike = { getExtension?: (factory: any) => unknown } | null | undefined;
+type ForkStore = {
+  store?: {
+    state?: { isForked?: boolean };
+    subscribe?: (listener: () => void) => () => void;
+  };
+};
+
+function getForkStore(editor: EditorLike): ForkStore['store'] | null {
+  if (!editor) return null;
+  const fork = editor.getExtension?.(ForkYDocExtension) as ForkStore | undefined;
+  return fork?.store ?? null;
+}
+
+export interface DocAIReviewState {
+  isPendingReview: boolean;
+  isStreaming: boolean;
+}
+
+export function useDocAIReviewState(editor: EditorLike, documentId: string): DocAIReviewState {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const unsubs = [subscribeDocAIInFlight(onChange)];
+      const forkStore = getForkStore(editor);
+      if (forkStore?.subscribe) unsubs.push(forkStore.subscribe(onChange));
+      const menuStore = getDocAIMenuStore(editor);
+      if (menuStore?.subscribe) unsubs.push(menuStore.subscribe(onChange));
+      return () => {
+        for (const unsub of unsubs) unsub();
+      };
+    },
+    [editor]
+  );
+
+  const isForked = useSyncExternalStore(
+    subscribe,
+    useCallback(() => getForkStore(editor)?.state?.isForked ?? false, [editor])
+  );
+  const menuOpen = useSyncExternalStore(
+    subscribe,
+    useCallback(() => {
+      const state = getDocAIMenuStore(editor)?.state?.aiMenuState;
+      return state !== undefined && state !== 'closed';
+    }, [editor])
+  );
+  const isStreaming = useSyncExternalStore(
+    subscribe,
+    useCallback(() => isDocAIInvocationInFlight(documentId), [documentId])
+  );
+
+  return { isPendingReview: isForked && !menuOpen, isStreaming };
+}

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -52,6 +52,7 @@ export {
 } from './hooks/useDocuments';
 export { useResolveUsers } from './hooks/useResolveUsers';
 export { usePendingDocAI } from './hooks/usePendingDocAI';
+export { useDocAIReviewState, type DocAIReviewState } from './hooks/useDocAIReviewState';
 export { useIsTouchDevice } from '@gruenerator/shared/hooks';
 export { useVersionHistoryShortcut } from './hooks/useVersionHistoryShortcut';
 
@@ -81,7 +82,11 @@ export {
   MAX_FILE_SIZE,
 } from './lib/blockNoteUtils';
 export { defaultDocumentContent } from './lib/defaultContent';
-export { invokeDocumentAI } from './lib/invokeDocumentAI';
+export {
+  invokeDocumentAI,
+  isDocAIInvocationInFlight,
+  subscribeDocAIInFlight,
+} from './lib/invokeDocumentAI';
 export {
   acceptDocumentAI,
   rejectDocumentAI,

--- a/packages/docs/src/lib/aiExtension.ts
+++ b/packages/docs/src/lib/aiExtension.ts
@@ -53,3 +53,22 @@ export function isDocAIForked(documentId: string): boolean {
   if (!editor) return false;
   return getForkExtensionForEditor(editor)?.store?.state?.isForked ?? false;
 }
+
+/**
+ * The xl-ai extension's own store. `aiMenuState` is `'closed'` unless the user
+ * opened the AI popover (toolbar / slash menu) — chat-triggered invocations
+ * never open it. Both this and the fork store come from BlockNote's
+ * `createStore` and share the same `state`/`subscribe` API.
+ */
+export type DocAIMenuStore = {
+  state?: { aiMenuState?: unknown };
+  subscribe?: (listener: () => void) => () => void;
+};
+
+export function getDocAIMenuStore(editor: unknown): DocAIMenuStore | null {
+  if (!editor) return null;
+  const ext = (editor as EditorWithExtensions).getExtension?.(AIExtension) as
+    | { store?: DocAIMenuStore }
+    | undefined;
+  return ext?.store ?? null;
+}

--- a/packages/docs/src/lib/invokeDocumentAI.ts
+++ b/packages/docs/src/lib/invokeDocumentAI.ts
@@ -1,5 +1,30 @@
 import { getDocAIExtension } from './aiExtension';
 
+// In-flight invocation registry. The fork store flips `isForked` at fork time —
+// before the LLM streams — and with the AI menu closed the extension's own
+// status/abort APIs are no-ops, so review UIs need an independent signal to
+// know streaming is still in progress (accept/reject mid-stream would merge or
+// discard a fork the stream keeps writing into).
+const inFlight = new Set<string>();
+const inFlightListeners = new Set<() => void>();
+
+function notifyInFlight() {
+  for (const cb of inFlightListeners) cb();
+}
+
+/** Whether an AI invocation is currently streaming for a document. */
+export function isDocAIInvocationInFlight(documentId: string): boolean {
+  return inFlight.has(documentId);
+}
+
+/** Subscribe to in-flight changes (useSyncExternalStore-compatible). */
+export function subscribeDocAIInFlight(cb: () => void): () => void {
+  inFlightListeners.add(cb);
+  return () => {
+    inFlightListeners.delete(cb);
+  };
+}
+
 /**
  * Programmatically trigger BlockNote's AI extension for a given document. Used
  * by the docs-chat surface to dispatch `trigger_doc_edit` SSE events from the
@@ -29,12 +54,21 @@ export async function invokeDocumentAI(opts: {
   // review UX is rendered natively (DocAiReviewBar → accept/rejectDocumentAI).
   // `invokeAI` still applies the diff as ProseMirror suggestions regardless of
   // menu state — the suggestion plugin is independent of the menu.
-  await ext.invokeAI({
-    userPrompt: opts.userPrompt,
-    useSelection: opts.useSelection ?? false,
-    ...(opts.referenceContent
-      ? { chatRequestOptions: { body: { referenceContent: opts.referenceContent } } }
-      : {}),
-  });
+  inFlight.add(opts.documentId);
+  notifyInFlight();
+  try {
+    // invokeAI resolves only after the response stream completes, so the
+    // in-flight window covers the whole fork-and-stream phase.
+    await ext.invokeAI({
+      userPrompt: opts.userPrompt,
+      useSelection: opts.useSelection ?? false,
+      ...(opts.referenceContent
+        ? { chatRequestOptions: { body: { referenceContent: opts.referenceContent } } }
+        : {}),
+    });
+  } finally {
+    inFlight.delete(opts.documentId);
+    notifyInFlight();
+  }
   return true;
 }


### PR DESCRIPTION
## Was

Zwei Themen (beide unmerged Arbeit aus der gestrigen Session):

1. **Chat-Edit-Surface-Erweiterung für alle Sharepic-Templates** (`969af7d15`, Details unten)
2. **Docs: Accept/Reject-Review-Bar für chat-getriggerte KI-Edits** (`a029928a6`)

---

## 1. Chat-Edit-Surface: Audit & Lückenschluss

Systematisches Audit aller drei chat-editierbaren Sharepic-Templates (dreizeilen / zitat-pure / info): Was rendert das Template, was liefert die Generierung, was konnte der Chat davon editieren? Alle sinnvollen Lücken sind jetzt geschlossen — **ohne neue Op-Kinds**: `update-element` trug `opacity` längst im Zod-Schema, der Server-Interpreter hat es nur ignoriert.

### Neue Edit-Fähigkeiten pro Template

| Template | Neu im Chat |
| --- | --- |
| **dreizeilen** | Balken-Transparenz · Sonnenblumen-Transparenz · **Hintergrundbild als Element**: Ausschnitt verschieben (Pan), zoomen (0.5–3×), Transparenz — mit Presence-Gate (ohne gesetztes Bild kommt eine klare Ablehnung statt sinnlosem State) |
| **zitat-pure** | **Anführungszeichen**: verschieben (Offset ±400) und ausblenden (opacity 0) |
| **info** | `update-element` überhaupt erst aktiviert; **Pfeil** ausblendbar (opacity 0), bewusst nicht verschiebbar (Auto-Layout) — x/y wird mit Begründung abgelehnt |

### Der LLM sieht jetzt, was ist (Snapshot-Lücken)

Bisher musste das Modell raten — jetzt stehen im Snapshot: aktuelle Schriftgröße pro Textfeld („80px" / „automatisch"), Sonnenblume sichtbar/ausgeblendet, Element-Transparenzen in %, Hintergrundbild vorhanden/keins. „Mach die Schrift größer" entscheidet damit relativ zum Ist-Wert statt blind.

### Robustheit

- Elemente ohne Position (`pfeil`) sind im Descriptor abbildbar (`positionStateKey`/`bounds` optional); x/y darauf → saubere Ablehnung.
- Color-/Rotation-only-Patches wurden bisher **stillschweigend als „applied" gezählt, ohne irgendetwas zu tun** — jetzt explizite Ablehnung mit Grund (Selbstkorrektur-Futter für den Loop).
- Prompt-Katalog listet pro Element die echten Fähigkeiten (verschiebbar/scale/opacity).
- `passthroughStateKeys` erweitert (zitat-pure: quoteMarkOffset/-Opacity; info: arrowOpacity), damit die Werte Karten-Render und Remote-Sync überleben.

### Verifikation

`pnpm typecheck` 20/20, Parity-Suite 21/21 (neu: Opacity-Clamping, Presence-Gate, Pfeil opacity-only, Color-only-Reject, Snapshot-Infos). Manuell: „mach das hintergrundbild dunkler/größer", „blende den pfeil aus", „sonnenblume halbtransparent".