### PR TITLE
feat(chat): route Gemma lane via verdigado-think alias

### DIFF
--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -76,7 +76,7 @@ const GPT_OSS_OVERFLOW: ModelConfigOverflow = {
 
 const GEMMA_4_OVERFLOW: ModelConfigOverflow = {
   kind: 'overflow',
-  primary: { provider: 'litellm', model: 'gemma' },
+  primary: { provider: 'litellm', model: 'verdigado-think' },
   overflow: { provider: 'regolo', model: 'gemma4-31b' },
   contextWindow: 32768,
 };

--- a/apps/api/services/ai/litellmThinkingFetch.ts
+++ b/apps/api/services/ai/litellmThinkingFetch.ts
@@ -1,14 +1,15 @@
 /**
  * LiteLLM (Ollama-backed) at Verdigado serves gemma4 models which default to
- * thinking mode: the OpenAI-compat layer streams long `reasoning` deltas with
- * empty `content` until the budget runs out. The Vercel AI SDK only reads
- * `delta.content`, so chat UIs see 0 chars before `finish_reason: length`.
+ * thinking mode. Historically the OpenAI-compat layer streamed long
+ * `reasoning` deltas with empty `content` until the budget ran out, and
+ * setting Ollama's top-level `think: false` made gemma4 emit directly into
+ * `content`.
  *
- * Ollama exposes a top-level `think` parameter on chat completions. Setting it
- * to `false` makes gemma4 emit content directly into `content` (after a brief
- * upstream reasoning preamble that the SDK silently drops). Models that don't
- * support thinking ignore the flag, so it's a safe no-op elsewhere on the
- * proxy.
+ * The proxy now ignores `think: false` on think-enabled aliases (e.g.
+ * `verdigado-think`) and returns reasoning in a separate `reasoning` field
+ * that no longer blocks `content` — the streaming layer surfaces it via
+ * fullStream as reasoning deltas. The wrapper stays as a harmless no-op
+ * safeguard for models/aliases that still honor the flag.
  */
 export const litellmFetchWithThinkingDisabled: typeof fetch = async (input, init) => {
   if (init?.body && typeof init.body === 'string') {

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -41,10 +41,13 @@ const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision:
   'mistral-small-latest': { name: 'Mistral Small', reasoning: false, vision: false },
   'mistral-small-2503': { name: 'Mistral Small (Vision)', reasoning: false, vision: true },
   'gemma4-31b': { name: 'Gemma 4 31B', reasoning: true, vision: true },
-  // Verdigado/LiteLLM serves Gemma 4 under the bare alias 'gemma' (resolves
-  // server-side to gemma4:26b-ctx16k). Without this entry, isVisionCapable
-  // would return false and the vision-override would hijack every image
-  // request on the gemma-4 overflow lane to Regolo, defeating alternation.
+  // Verdigado/LiteLLM serves Gemma 4 under the 'verdigado-think' alias
+  // (resolves server-side to gemma4:31b-ctx128k); the legacy bare alias
+  // 'gemma' (gemma4:26b-ctx16k) is kept during rollout. Without these
+  // entries, isVisionCapable would return false and the vision-override
+  // would hijack every image request on the gemma-4 overflow lane to
+  // Regolo, defeating alternation.
+  'verdigado-think': { name: 'Gemma 4', reasoning: true, vision: true },
   gemma: { name: 'Gemma 4', reasoning: true, vision: true },
   'mistral-medium-latest': { name: 'Mistral Medium', reasoning: false, vision: false },
   'pixtral-large-latest': { name: 'Pixtral Large', reasoning: false, vision: true },

--- a/packages/core/src/models/catalog.ts
+++ b/packages/core/src/models/catalog.ts
@@ -64,7 +64,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     id: 'gemma-litellm',
     name: '🌳 Gemma 4',
     description: 'Am besten für Kreativtexte',
-    model: 'gemma',
+    model: 'verdigado-think',
     provider: 'litellm',
     icon: 'zap',
     region: 'self-hosted',


### PR DESCRIPTION
## Why

verdigado asked us to stop using the hardcoded `gemma` LiteLLM alias and switch to the official `verdigado-think` alias, which is more stable.

Verified live against `litellm.netzbegruenung.verdigado.net`:

| Alias | Resolves to | Note |
|---|---|---|
| `verdigado-think` | `gemma4:31b-ctx128k` | new official alias, this PR |
| `gemma` (old) | `gemma4:26b-ctx16k` | smaller model, only 16k ctx (code assumed 32k) |
| `verdigado-pro` | `gpt-oss:120b-ctx128k` | follow-up, see below |

The proxy now ignores `think: false`; reasoning arrives in a separate `reasoning` field that no longer blocks `content`. Our streaming layer already handles this (fullStream → `reasoning_delta`, 30s LiteLLM first-token deadline).

## Changes

- `GEMMA_4_OVERFLOW.primary`: `gemma` → `verdigado-think` (single source the chat backend sends to LiteLLM; all gemma model IDs resolve through it)
- `modelDiscovery.ts`: add `verdigado-think` metadata entry so `isVisionCapable()` keeps working (legacy `gemma` entry kept during rollout)
- `catalog.ts`: informational `model` field on the `gemma-litellm` entry updated
- `litellmThinkingFetch.ts`: comment-only update reflecting current proxy behavior

User-facing model ID (`gemma-litellm`), display name (🌳 Gemma 4) and `contextWindow: 32768` unchanged.

## Out of scope (follow-ups)

- `gpt-oss:120b` → `verdigado-pro` migration (~12 call sites; hidden alias still works)
- contextWindow bump to 128k (blocked on verifying Regolo `gemma4-31b` limit — overflow sibling shares the value)

## Verification

- Live smoke test: `POST /v1/chat/completions` with `model: verdigado-think` returns content correctly (reasoning in separate field)
- `pnpm typecheck` clean for `@gruenerator/core` + `@gruenerator/api`