### PR TITLE
feat(ai): route GPT-OSS lane via verdigado-pro alias

### DIFF
--- a/apps/api/agents/langgraph/WebSearchGraph/nodes/DossierNode.ts
+++ b/apps/api/agents/langgraph/WebSearchGraph/nodes/DossierNode.ts
@@ -119,7 +119,7 @@ ${refsSummary}`;
         messages: [{ role: 'user', content: enhancedUserPrompt }],
         options: {
           provider: 'litellm',
-          model: 'gpt-oss:120b',
+          model: 'verdigado-pro',
           max_tokens: 6000,
           temperature: 0.3,
         },

--- a/apps/api/agents/langgraph/WebSearchGraph/nodes/IntelligentCrawlerNode.ts
+++ b/apps/api/agents/langgraph/WebSearchGraph/nodes/IntelligentCrawlerNode.ts
@@ -100,7 +100,7 @@ Respond with JSON:
         ],
         options: {
           provider: 'litellm',
-          model: 'gpt-oss:120b',
+          model: 'verdigado-pro',
           max_tokens: 600,
           temperature: 0.1,
         },

--- a/apps/api/agents/langgraph/WebSearchGraph/nodes/SummaryNode.ts
+++ b/apps/api/agents/langgraph/WebSearchGraph/nodes/SummaryNode.ts
@@ -124,7 +124,7 @@ Crawl-Statistik: ${state.crawlMetadata?.crawledUrls || 0} erfolgreich gecrawlt`;
         messages: [{ role: 'user', content: userPrompt }],
         options: {
           provider: 'litellm',
-          model: 'gpt-oss:120b',
+          model: 'verdigado-pro',
           max_tokens: 500,
           temperature: 0.2,
         },

--- a/apps/api/agents/langgraph/WebSearchGraph/utilities/queryOptimizer.ts
+++ b/apps/api/agents/langgraph/WebSearchGraph/utilities/queryOptimizer.ts
@@ -67,7 +67,7 @@ Fokussiere dich auf externe Quellen und verschiedene Perspektiven.`;
         messages: [{ role: 'user', content: researchPrompt }],
         options: {
           provider: 'litellm',
-          model: 'gpt-oss:120b',
+          model: 'verdigado-pro',
           max_tokens: 300,
           temperature: 0.3,
         },

--- a/apps/api/routes/boards/boardAiService.ts
+++ b/apps/api/routes/boards/boardAiService.ts
@@ -27,7 +27,7 @@ const log = createLogger('BoardAI');
 // Mirror docs/aiController DOCS_AI_MODELS — these IDs are confirmed to return
 // finish_reason:tool_calls on their respective providers.
 const BOARD_AI_MODELS: Record<AgentConfig['provider'], string> = {
-  litellm: 'gpt-oss:120b',
+  litellm: 'verdigado-pro',
   regolo: 'mistral-small-4-119b',
   mistral: 'mistral-medium-2604',
   anthropic: 'mistral-medium-2604',

--- a/apps/api/routes/chat/agents/providers.ts
+++ b/apps/api/routes/chat/agents/providers.ts
@@ -18,7 +18,7 @@ import {
 import type { AgentConfig } from './types.js';
 import type { LanguageModel } from 'ai';
 
-const LITELLM_DEFAULT_MODEL = 'gpt-oss:120b';
+const LITELLM_DEFAULT_MODEL = 'verdigado-pro';
 
 export const VISION_MODEL = {
   provider: 'regolo' as const,
@@ -69,7 +69,7 @@ export type ModelConfig = ModelConfigSingle | ModelConfigOverflow;
 
 const GPT_OSS_OVERFLOW: ModelConfigOverflow = {
   kind: 'overflow',
-  primary: { provider: 'litellm', model: 'gpt-oss:120b' },
+  primary: { provider: 'litellm', model: 'verdigado-pro' },
   overflow: { provider: 'regolo', model: 'gpt-oss-120b' },
   contextWindow: 32768,
 };

--- a/apps/api/routes/docs/aiController.htmlFormat-eval.vitest.ts
+++ b/apps/api/routes/docs/aiController.htmlFormat-eval.vitest.ts
@@ -159,7 +159,7 @@ const MODELS: ModelConfig[] = [
     skip: () => !process.env.MISTRAL_API_KEY,
   },
   {
-    name: 'gpt-oss:120b (LiteLLM)',
+    name: 'verdigado-pro (LiteLLM)',
     shortName: 'gpt-oss',
     provider: () =>
       createOpenAI({
@@ -167,7 +167,7 @@ const MODELS: ModelConfig[] = [
         apiKey: process.env.LITELLM_API_KEY ?? '',
         name: 'litellm',
       }),
-    modelId: 'gpt-oss:120b',
+    modelId: 'verdigado-pro',
     skip: () => !process.env.LITELLM_BASE_URL || !process.env.LITELLM_API_KEY,
   },
 ];

--- a/apps/api/routes/docs/aiController.model-comparison.vitest.ts
+++ b/apps/api/routes/docs/aiController.model-comparison.vitest.ts
@@ -171,7 +171,7 @@ const MODELS: ModelConfig[] = [
   {
     name: 'GPT-OSS 120B (LiteLLM)',
     provider: litellmProvider,
-    modelId: 'gpt-oss:120b',
+    modelId: 'verdigado-pro',
     skip: () => !process.env.LITELLM_BASE_URL || !process.env.LITELLM_API_KEY,
   },
   {

--- a/apps/api/routes/docs/aiController.ts
+++ b/apps/api/routes/docs/aiController.ts
@@ -97,7 +97,7 @@ export type AiRequestBody = z.infer<typeof aiRequestBodySchema>;
 // reasoning into content (verified failure for tool calls). Each entry below was
 // probed against a tool-call request and confirmed to return finish_reason:tool_calls.
 const DOCS_AI_MODELS: Record<AgentConfig['provider'], string> = {
-  litellm: 'gpt-oss:120b',
+  litellm: 'verdigado-pro',
   regolo: 'mistral-small-4-119b',
   mistral: 'mistral-medium-2604',
   anthropic: 'mistral-medium-2604',

--- a/apps/api/routes/docs/aiController.vitest.ts
+++ b/apps/api/routes/docs/aiController.vitest.ts
@@ -113,7 +113,7 @@ function createMockReadableStream(chunks: string[] = ['data: test\n\n']) {
 
 function setupHappyPath() {
   mockIsProviderConfigured.mockReturnValue(true);
-  mockGetModel.mockReturnValue({ modelId: 'gpt-oss:120b' });
+  mockGetModel.mockReturnValue({ modelId: 'verdigado-pro' });
   mockInjectDocumentStateMessages.mockImplementation((msgs: unknown[]) => [...msgs]);
   mockToolDefinitionsToToolSet.mockReturnValue({ applyDocumentOperations: {} });
   mockConvertToModelMessages.mockResolvedValue([{ role: 'user', content: 'test' }]);
@@ -269,7 +269,7 @@ describe('aiController – POST /api/docs/ai', () => {
 
       await handleAiRequest(req, res);
 
-      expect(mockGetModel).toHaveBeenCalledWith('litellm', 'gpt-oss:120b');
+      expect(mockGetModel).toHaveBeenCalledWith('litellm', 'verdigado-pro');
     });
   });
 
@@ -329,7 +329,7 @@ describe('aiController – POST /api/docs/ai', () => {
 
       expect(mockStreamText).toHaveBeenCalledOnce();
       const opts = mockStreamText.mock.calls[0][0];
-      expect(opts.model).toEqual({ modelId: 'gpt-oss:120b' });
+      expect(opts.model).toEqual({ modelId: 'verdigado-pro' });
       expect(opts.system).toContain('You are a document editor.');
       expect(opts.system).toContain('VALID SHAPES');
       expect(opts.toolChoice).toBe('auto');

--- a/apps/api/routes/search/searchStreamController.ts
+++ b/apps/api/routes/search/searchStreamController.ts
@@ -327,7 +327,7 @@ export async function streamNormalSearch(req: AuthenticatedRequest, res: Respons
     const { systemPrompt, userPrompt, references } = promptResult;
 
     // Stream the AI summary
-    const model = getModel('litellm', 'gpt-oss:120b');
+    const model = getModel('litellm', 'verdigado-pro');
     const streamResult = streamText({
       model,
       messages: [
@@ -587,7 +587,7 @@ Verfügbare Quellenreferenzen:
 ${refsSummary}`;
 
     // Stream the dossier
-    const model = getModel('litellm', 'gpt-oss:120b');
+    const model = getModel('litellm', 'verdigado-pro');
     const streamResult = streamText({
       model,
       messages: [

--- a/apps/api/services/ai/__tests__/aiService.vitest.ts
+++ b/apps/api/services/ai/__tests__/aiService.vitest.ts
@@ -69,7 +69,7 @@ describe('AIService', () => {
     vi.clearAllMocks();
     mockSelectProviderAndModel.mockReturnValue({
       provider: 'litellm',
-      model: 'gpt-oss:120b',
+      model: 'verdigado-pro',
     });
     mockExecuteProvider.mockResolvedValue(VALID_RESULT);
     service = new AIService();
@@ -129,7 +129,7 @@ describe('AIService', () => {
   it('routes pro mode to LiteLLM', async () => {
     mockSelectProviderAndModel.mockReturnValue({
       provider: 'litellm',
-      model: 'gpt-oss:120b',
+      model: 'verdigado-pro',
     });
     const data = makeRequest({ options: { useProMode: true } });
     await service.processRequest(data);

--- a/apps/api/services/ai/modelDiscovery.ts
+++ b/apps/api/services/ai/modelDiscovery.ts
@@ -52,6 +52,10 @@ const MODEL_METADATA: Record<string, { name: string; reasoning: boolean; vision:
   'mistral-medium-latest': { name: 'Mistral Medium', reasoning: false, vision: false },
   'pixtral-large-latest': { name: 'Pixtral Large', reasoning: false, vision: true },
   'gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
+  // Verdigado/LiteLLM official alias for GPT-OSS (resolves server-side to
+  // gpt-oss:120b-ctx128k); the hidden legacy alias 'gpt-oss:120b' is kept
+  // below during rollout.
+  'verdigado-pro': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'gpt-oss:120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'openai/gpt-oss-120b': { name: 'GPT-OSS 120B', reasoning: true, vision: false },
   'qwen3.5-122b': { name: 'Qwen 3.5 122B', reasoning: true, vision: true },
@@ -200,7 +204,7 @@ const FALLBACK_MODELS: PlaygroundModel[] = ['mistral-medium-2604', 'mistral-smal
       'gpt-oss-120b',
       'mistral-small3.2',
     ].map((id) => enrichModel(id, 'regolo')),
-    [enrichModel('gpt-oss:120b', 'litellm')],
+    [enrichModel('verdigado-pro', 'litellm')],
     [enrichModel('openai/gpt-oss-120b', 'ionos')]
   );
 

--- a/apps/api/services/ai/providers.ts
+++ b/apps/api/services/ai/providers.ts
@@ -23,7 +23,7 @@ export type ProviderName = 'mistral' | 'litellm' | 'ionos' | 'regolo';
 // Default models per provider
 const PROVIDER_DEFAULTS = {
   mistral: 'mistral-medium-2604',
-  litellm: 'gpt-oss:120b',
+  litellm: 'verdigado-pro',
   ionos: 'openai/gpt-oss-120b',
   regolo: env.REGOLO_DEFAULT_MODEL ?? 'qwen3.5-122b',
 } as const;

--- a/apps/api/services/providers/providerFallback.ts
+++ b/apps/api/services/providers/providerFallback.ts
@@ -39,13 +39,13 @@ export function getPrivacyModelForProvider(provider: ProviderName): ModelName {
     case 'ionos':
       return 'openai/gpt-oss-120b';
     case 'litellm':
-      return 'gpt-oss:120b';
+      return 'verdigado-pro';
     case 'mistral':
       return 'mistral-medium-2604';
     case 'regolo':
       return env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b';
     default:
-      return 'gpt-oss:120b';
+      return 'verdigado-pro';
   }
 }
 
@@ -59,7 +59,7 @@ export function getSharepicFallbackModel(provider: ProviderName): ModelName {
     case 'ionos':
       return 'openai/gpt-oss-120b';
     case 'litellm':
-      return 'gpt-oss:120b';
+      return 'verdigado-pro';
     case 'regolo':
       return env.REGOLO_DEFAULT_MODEL || 'qwen3.5-122b';
     default:

--- a/apps/api/services/providers/providerSelector.ts
+++ b/apps/api/services/providers/providerSelector.ts
@@ -18,8 +18,11 @@ import type {
  */
 export function isLiteLLMCompatibleModel(modelName: string = ''): boolean {
   const name = String(modelName || '').toLowerCase();
-  // LiteLLM models typically use prefixes like gpt-oss, or are mistral/mixtral variants
-  // Exclude Mistral API models (mistral-medium-2604, etc.)
+  // LiteLLM models are the official verdigado-* aliases, gpt-oss prefixes,
+  // or mistral/mixtral variants. Exclude Mistral API models (mistral-medium-2604, etc.)
+  if (name.includes('verdigado')) {
+    return true;
+  }
   if (name.includes('gpt-oss') || name.includes('gpt-4') || name.includes('gpt-3')) {
     return true;
   }
@@ -96,7 +99,7 @@ export function selectProviderAndModel({
 }: SelectProviderParams): ProviderResult {
   // Base defaults — GPT-OSS 120B via LiteLLM as primary model
   let provider: ProviderName = (options.provider as ProviderName) || 'litellm';
-  let model: ModelName = options.model || 'gpt-oss:120b';
+  let model: ModelName = options.model || 'verdigado-pro';
 
   // Ultra mode (useUltraMode flag) - routes to IONOS with high-quality model
   if (options.useUltraMode === true) {
@@ -106,7 +109,7 @@ export function selectProviderAndModel({
   // Pro mode (useProMode flag) - routes to high-quality reasoning model
   else if (options.useProMode === true) {
     provider = 'litellm';
-    model = options.model || 'gpt-oss:120b';
+    model = options.model || 'verdigado-pro';
   }
 
   // Type-based defaults
@@ -138,7 +141,7 @@ export function selectProviderAndModel({
     type === 'grosse_anfrage'
   ) {
     provider = 'litellm';
-    model = options.model || 'gpt-oss:120b';
+    model = options.model || 'verdigado-pro';
   }
   // Fast helper tasks — Intermediate model (Regolo)
   else if (
@@ -171,7 +174,7 @@ export function selectProviderAndModel({
     // When explicitly using litellm, ensure model is litellm-compatible
     if (provider === 'litellm' && !isLiteLLMCompatibleModel(model)) {
       // Use explicitly provided litellm model or default
-      model = isLiteLLMCompatibleModel(options.model) ? options.model! : 'gpt-oss:120b';
+      model = isLiteLLMCompatibleModel(options.model) ? options.model! : 'verdigado-pro';
     }
   }
 

--- a/apps/api/workers/providers/litellmAdapter.ts
+++ b/apps/api/workers/providers/litellmAdapter.ts
@@ -101,8 +101,8 @@ async function execute(requestId: string, data: AIRequestData): Promise<AIWorker
     );
   }
 
-  // LiteLLM only serves one model — always use it
-  const model = 'gpt-oss:120b';
+  // Always use verdigado's official gpt-oss alias for worker requests
+  const model = 'verdigado-pro';
 
   // Convert messages to Vercel AI SDK format
   const { system, messages: modelMessages } = convertMessages(messages, systemPrompt);

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -67,7 +67,7 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
     id: 'litellm',
     name: 'GPT-OSS',
     description: 'Selbst gehostet',
-    model: 'gpt-oss:120b',
+    model: 'verdigado-pro',
   },
 ];
 

--- a/packages/core/src/models/catalog.ts
+++ b/packages/core/src/models/catalog.ts
@@ -84,7 +84,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     id: 'litellm',
     name: '🌳 GPT-OSS',
     description: 'Schnellstes Modell',
-    model: 'gpt-oss:120b',
+    model: 'verdigado-pro',
     provider: 'litellm',
     icon: 'server',
     region: 'self-hosted',


### PR DESCRIPTION
## Why

Follow-up to #1241 (stacked on it — GitHub will retarget to `master` once #1241 merges). Completes the migration to verdigado's official LiteLLM aliases: the LiteLLM-bound `gpt-oss:120b` string only survives as a **hidden** legacy alias on the proxy (resolves to `gpt-oss:120b-ctx128k`, same as `verdigado-pro`) and could be dropped anytime.

## Changes

- All LiteLLM-bound `'gpt-oss:120b'` strings → `'verdigado-pro'`: chat `GPT_OSS_OVERFLOW` lane + `LITELLM_DEFAULT_MODEL`, WebSearchGraph nodes (crawler/summary/dossier/queryOptimizer), worker `litellmAdapter`, docs `aiController`, `boardAiService`, `searchStreamController`, `providerSelector` defaults, `providerFallback`, `services/ai/providers` default map, playground `modelDiscovery` (new metadata entry; legacy `gpt-oss:120b` entry kept during rollout), catalog + chatStore informational entries.
- `isLiteLLMCompatibleModel()` now recognizes `verdigado-*` aliases (otherwise the explicit-litellm path would have rerouted them back to a default).
- Test mocks/assertions and live-eval harnesses updated accordingly.

**Untouched (different providers/strings):** Regolo `gpt-oss-120b`, IONOS `openai/gpt-oss-120b`, historical regression-test comments, and `packages/shared` agents' `defaultModel: 'gpt-oss:120b'` (flows into the Mistral `getAgentLLM` path, not LiteLLM — pre-existing oddity, out of scope).

## Verification

- `pnpm typecheck` clean for core/chat/api
- `aiService.vitest.ts` 16/16 green; `aiController.vitest.ts` fails identically (30) on unmodified HEAD locally — pre-existing env-dependent failure, no regression
- Live dev-backend test: chat with `modelId: litellm` logs `litellm → litellm/verdigado-pro` and streams content (no fallback to Regolo)