### PR TITLE
feat(monitor): blog-style „Was ist passiert" feed with excerpts

### DIFF
--- a/apps/api/database/postgres/migrations/add_excerpt_to_content_sync_articles.sql
+++ b/apps/api/database/postgres/migrations/add_excerpt_to_content_sync_articles.sql
@@ -1,0 +1,3 @@
+-- Short article excerpt for the blog-style "Was ist passiert" feed cards,
+-- captured at sync time by the scrapers (first ~300 chars of the text).
+ALTER TABLE content_sync_articles ADD COLUMN IF NOT EXISTS excerpt TEXT;

--- a/apps/api/database/schema/contentSync.ts
+++ b/apps/api/database/schema/contentSync.ts
@@ -19,6 +19,7 @@ export const contentSyncArticles = pgTable(
     source_url: text('source_url').notNull(),
     source_group_id: text('source_group_id').$type<SyncArticleSourceGroup>().notNull(),
     source_name: text('source_name').notNull(),
+    excerpt: text('excerpt'),
     landesverband: text('landesverband'),
     collection: text('collection').notNull(),
     event_type: text('event_type').$type<SyncArticleEventType>().notNull(),

--- a/apps/api/services/monitor/ContentSyncEventsService.ts
+++ b/apps/api/services/monitor/ContentSyncEventsService.ts
@@ -86,17 +86,18 @@ export async function upsertSyncEvents(
     const params: unknown[] = [];
     for (let i = 0; i < chunk.length; i++) {
       const e = chunk[i];
-      const o = i * 11;
+      const o = i * 12;
       placeholders.push(
-        `($${o + 1}, $${o + 2}, $${o + 3}, $${o + 4}, $${o + 5}, $${o + 6}, $${o + 7}, ` +
-          `$${o + 8}::timestamptz, $${o + 9}::timestamptz, ` +
-          `($${o + 9}::timestamptz AT TIME ZONE 'UTC')::date, $${o + 10}, $${o + 11})`
+        `($${o + 1}, $${o + 2}, $${o + 3}, $${o + 4}, $${o + 5}, $${o + 6}, $${o + 7}, $${o + 8}, ` +
+          `$${o + 9}::timestamptz, $${o + 10}::timestamptz, ` +
+          `($${o + 10}::timestamptz AT TIME ZONE 'UTC')::date, $${o + 11}, $${o + 12})`
       );
       params.push(
         e.title,
         e.sourceUrl,
         e.sourceGroupId,
         e.sourceName,
+        e.excerpt,
         e.landesverband,
         e.collection,
         e.eventType,
@@ -109,11 +110,12 @@ export async function upsertSyncEvents(
 
     const result = await db().query(
       `INSERT INTO content_sync_articles
-         (title, source_url, source_group_id, source_name, landesverband, collection,
+         (title, source_url, source_group_id, source_name, excerpt, landesverband, collection,
           event_type, published_at, indexed_at, event_date, sync_run_id, sync_run_url)
        VALUES ${placeholders.join(', ')}
        ON CONFLICT (source_url, event_date) DO UPDATE SET
          title = EXCLUDED.title,
+         excerpt = COALESCE(EXCLUDED.excerpt, content_sync_articles.excerpt),
          event_type = CASE
            WHEN content_sync_articles.event_type = 'stored' THEN 'stored'
            ELSE EXCLUDED.event_type
@@ -286,7 +288,7 @@ async function buildDigestArticles(rows: ContentSyncArticleRow[]): Promise<Diges
     title: row.title,
     url: row.source_url,
     source: row.source_name,
-    excerpt: excerpts.get(row.source_url) ?? '',
+    excerpt: excerpts.get(row.source_url) ?? row.excerpt ?? '',
   }));
 }
 
@@ -296,6 +298,7 @@ function toArticle(row: ContentSyncArticleRow): WhatHappenedArticle {
     sourceUrl: row.source_url,
     sourceGroupId: row.source_group_id,
     sourceName: row.source_name,
+    excerpt: row.excerpt,
     landesverband: row.landesverband,
     collection: row.collection,
     eventType: row.event_type,

--- a/apps/api/services/scrapers/implementations/BoellStiftungScraper.ts
+++ b/apps/api/services/scrapers/implementations/BoellStiftungScraper.ts
@@ -19,7 +19,7 @@ import { chunkQualityService } from '../../ChunkQualityService/index.js';
 import { smartChunkDocument } from '../../document-services/index.js';
 import { mistralEmbeddingService } from '../../mistral/index.js';
 import { BaseScraper } from '../base/BaseScraper.js';
-import { recordSyncEvent } from '../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../syncEventRecorder.js';
 import { batchProcess } from '../utils/batchFetch.js';
 import { extractMainContent, extractDate } from '../utils/contentExtractor.js';
 import {
@@ -660,6 +660,7 @@ export class BoellStiftungScraper extends BaseScraper {
       sourceUrl: url,
       sourceGroupId: 'boell-stiftung',
       sourceName: 'Heinrich-Böll-Stiftung',
+      excerpt: toExcerpt(content.description || content.text),
       landesverband: null,
       collection: this.config.collectionName,
       eventType: existing ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/implementations/BundestagScraper/BundestagScraper.ts
+++ b/apps/api/services/scrapers/implementations/BundestagScraper/BundestagScraper.ts
@@ -10,7 +10,7 @@ import { createLogger } from '../../../../utils/logger.js';
 import BundestagContentProcessor from '../../../bundestag/BundestagContentProcessor.js';
 import { chunkQualityService } from '../../../ChunkQualityService/index.js';
 import { mistralEmbeddingService } from '../../../mistral/index.js';
-import { recordSyncEvent } from '../../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../../syncEventRecorder.js';
 import { WebsiteCrawler } from '../WebsiteCrawler.js';
 
 import {
@@ -187,6 +187,7 @@ export class BundestagScraper {
               sourceUrl: page.source_url,
               sourceGroupId: 'bundestag',
               sourceName: 'Bundestagsfraktion',
+              excerpt: toExcerpt(page.text),
               landesverband: null,
               collection: COLLECTION_NAME,
               eventType: existingHash ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/implementations/GruenblogScraper.ts
+++ b/apps/api/services/scrapers/implementations/GruenblogScraper.ts
@@ -19,7 +19,7 @@ import { chunkQualityService } from '../../ChunkQualityService/index.js';
 import { smartChunkDocument } from '../../document-services/index.js';
 import { mistralEmbeddingService } from '../../mistral/index.js';
 import { BaseScraper } from '../base/BaseScraper.js';
-import { recordSyncEvent } from '../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../syncEventRecorder.js';
 import { batchProcess } from '../utils/batchFetch.js';
 import { removeUnwantedElements } from '../utils/htmlCleaner.js';
 
@@ -432,6 +432,7 @@ export class GruenblogScraper extends BaseScraper {
       sourceUrl: url,
       sourceGroupId: 'gruenblog',
       sourceName: 'Grünblog',
+      excerpt: toExcerpt(content.description || content.text),
       landesverband: null,
       collection: this.config.collectionName,
       eventType: existing ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/implementations/GrueneAtScraper.ts
+++ b/apps/api/services/scrapers/implementations/GrueneAtScraper.ts
@@ -28,7 +28,7 @@ import { chunkQualityService } from '../../ChunkQualityService/index.js';
 import { smartChunkDocument } from '../../document-services/index.js';
 import { mistralEmbeddingService } from '../../mistral/index.js';
 import { BaseScraper } from '../base/BaseScraper.js';
-import { recordSyncEvent } from '../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../syncEventRecorder.js';
 import { batchProcess } from '../utils/batchFetch.js';
 import { removeUnwantedElements } from '../utils/htmlCleaner.js';
 
@@ -474,6 +474,7 @@ export class GrueneAtScraper extends BaseScraper {
       sourceUrl: url,
       sourceGroupId: 'gruene-at',
       sourceName: 'Grüne Österreich',
+      excerpt: toExcerpt(content.description || content.text),
       landesverband: null,
       collection: this.config.collectionName,
       eventType: existing ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/implementations/KommunalwikiScraper.ts
+++ b/apps/api/services/scrapers/implementations/KommunalwikiScraper.ts
@@ -8,7 +8,7 @@ import { chunkQualityService } from '../../ChunkQualityService/index.js';
 import { smartChunkDocument } from '../../document-services/index.js';
 import { mistralEmbeddingService } from '../../mistral/index.js';
 import { BaseScraper } from '../base/BaseScraper.js';
-import { recordSyncEvent } from '../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../syncEventRecorder.js';
 
 import type { ScraperConfig, ScraperResult, MediaWikiPage } from '../types.js';
 
@@ -506,6 +506,7 @@ export class KommunalwikiScraper extends BaseScraper {
                   sourceUrl: `${this.baseUrl}/index.php/${encodeURIComponent(article.title.replace(/ /g, '_'))}`,
                   sourceGroupId: 'kommunalwiki',
                   sourceName: 'KommunalWiki',
+                  excerpt: toExcerpt(this.cleanWikiContent(wikiContent)),
                   landesverband: null,
                   collection: this.config.collectionName,
                   eventType: wasExisting ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/processors/DocumentProcessor.ts
@@ -17,7 +17,7 @@ import {
 import { chunkQualityService } from '../../../../ChunkQualityService/index.js';
 import { smartChunkDocument } from '../../../../document-services/index.js';
 import { mistralEmbeddingService } from '../../../../mistral/index.js';
-import { recordSyncEvent } from '../../../syncEventRecorder.js';
+import { recordSyncEvent, toExcerpt } from '../../../syncEventRecorder.js';
 import { DateExtractor } from '../extractors/DateExtractor.js';
 
 import type { LandesverbandSource } from '../../../../../config/landesverbaendeConfig.js';
@@ -174,6 +174,7 @@ export class DocumentProcessor {
       sourceUrl: url,
       sourceGroupId: 'landesverbaende',
       sourceName: source.name,
+      excerpt: toExcerpt(text),
       landesverband: source.shortName,
       collection: targetCollection,
       eventType: existing ? 'updated' : 'stored',

--- a/apps/api/services/scrapers/syncEventRecorder.ts
+++ b/apps/api/services/scrapers/syncEventRecorder.ts
@@ -11,8 +11,17 @@
 import { type SyncEventInput } from '@gruenerator/contracts';
 
 const MAX_BUFFERED_EVENTS = 5000;
+const EXCERPT_MAX_CHARS = 300;
 
 let events: SyncEventInput[] = [];
+
+/** Normalize article text into a short single-line excerpt for the feed cards. */
+export function toExcerpt(text: string | null | undefined): string | null {
+  if (!text) return null;
+  const cleaned = text.replace(/\s+/g, ' ').trim();
+  if (!cleaned) return null;
+  return cleaned.length > EXCERPT_MAX_CHARS ? `${cleaned.slice(0, EXCERPT_MAX_CHARS)}…` : cleaned;
+}
 
 export function recordSyncEvent(event: Omit<SyncEventInput, 'indexedAt'>): void {
   if (events.length >= MAX_BUFFERED_EVENTS) return;

--- a/apps/web/src/features/monitor/components/WhatHappenedView.tsx
+++ b/apps/web/src/features/monitor/components/WhatHappenedView.tsx
@@ -130,8 +130,60 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
 
   return (
     <div>
-      <div className="flex items-center justify-end gap-sm mb-lg">
-        <label className="flex items-center gap-sm text-xs text-grey-400 cursor-pointer shrink-0">
+      <div className="flex flex-wrap items-center gap-sm mb-xl">
+        {expertMode && (
+          <>
+            <Select value={String(days)} onValueChange={(v) => setDays(Number(v))}>
+              <SelectTrigger className="w-[10rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="7">7 Tage</SelectItem>
+                <SelectItem value="14">14 Tage</SelectItem>
+                <SelectItem value="30">30 Tage</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={sourceGroup} onValueChange={setSourceGroup}>
+              <SelectTrigger className="w-[13rem]">
+                <SelectValue placeholder="Quelle" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>Alle Quellen</SelectItem>
+                {(data?.sourceGroups ?? []).map((g) => (
+                  <SelectItem key={g} value={g}>
+                    {SOURCE_GROUP_LABELS[g] ?? g}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {(data?.landesverbaende.length ?? 0) > 0 && (
+              <Select value={landesverband} onValueChange={setLandesverband}>
+                <SelectTrigger className="w-[13rem]">
+                  <SelectValue placeholder="Landesverband" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={ALL}>Alle Landesverbände</SelectItem>
+                  {(data?.landesverbaende ?? []).map((lv) => (
+                    <SelectItem key={lv} value={lv}>
+                      {LV_NAMES[lv] ?? lv}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <Select value={eventType} onValueChange={setEventType}>
+              <SelectTrigger className="w-[10rem]">
+                <SelectValue placeholder="Typ" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>Neu + aktualisiert</SelectItem>
+                <SelectItem value="stored">Nur neu</SelectItem>
+                <SelectItem value="updated">Nur aktualisiert</SelectItem>
+              </SelectContent>
+            </Select>
+          </>
+        )}
+        <label className="ml-auto flex items-center gap-sm text-xs text-grey-400 cursor-pointer shrink-0">
           Expertenmodus
           <Switch
             checked={expertMode}
@@ -139,59 +191,6 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
           />
         </label>
       </div>
-
-      {expertMode && (
-        <div className="flex flex-wrap gap-sm mb-xl">
-          <Select value={String(days)} onValueChange={(v) => setDays(Number(v))}>
-            <SelectTrigger className="w-[10rem]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="7">7 Tage</SelectItem>
-              <SelectItem value="14">14 Tage</SelectItem>
-              <SelectItem value="30">30 Tage</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={sourceGroup} onValueChange={setSourceGroup}>
-            <SelectTrigger className="w-[13rem]">
-              <SelectValue placeholder="Quelle" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL}>Alle Quellen</SelectItem>
-              {(data?.sourceGroups ?? []).map((g) => (
-                <SelectItem key={g} value={g}>
-                  {SOURCE_GROUP_LABELS[g] ?? g}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {(data?.landesverbaende.length ?? 0) > 0 && (
-            <Select value={landesverband} onValueChange={setLandesverband}>
-              <SelectTrigger className="w-[13rem]">
-                <SelectValue placeholder="Landesverband" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>Alle Landesverbände</SelectItem>
-                {(data?.landesverbaende ?? []).map((lv) => (
-                  <SelectItem key={lv} value={lv}>
-                    {LV_NAMES[lv] ?? lv}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-          <Select value={eventType} onValueChange={setEventType}>
-            <SelectTrigger className="w-[10rem]">
-              <SelectValue placeholder="Typ" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={ALL}>Neu + aktualisiert</SelectItem>
-              <SelectItem value="stored">Nur neu</SelectItem>
-              <SelectItem value="updated">Nur aktualisiert</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      )}
 
       {error && (
         <StatusBanner variant="error" className="mb-lg">

--- a/apps/web/src/features/monitor/components/WhatHappenedView.tsx
+++ b/apps/web/src/features/monitor/components/WhatHappenedView.tsx
@@ -1,10 +1,7 @@
 import {
-  Badge,
+  ArticleCard,
   Card,
   CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
   Select,
   SelectContent,
   SelectItem,
@@ -14,7 +11,7 @@ import {
   StatusBanner,
   Switch,
 } from '@gruenerator/ui';
-import { ChevronDown, ExternalLink, Inbox, Sparkles } from 'lucide-react';
+import { ChevronDown, Inbox, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
 import { Markdown } from '../../../components/common/Markdown/Markdown';
@@ -23,11 +20,7 @@ import { BUNDESLAENDER } from '../bundeslaender';
 import { useWhatHappened, useWhatHappenedSummary } from '../hooks/useMonitor';
 
 import type { MonitorLocale } from '../hooks/useMonitor';
-import type {
-  SyncArticleEventType,
-  SyncArticleSourceGroup,
-  WhatHappenedArticle,
-} from '@gruenerator/contracts';
+import type { SyncArticleEventType, SyncArticleSourceGroup } from '@gruenerator/contracts';
 
 interface WhatHappenedViewProps {
   locale: MonitorLocale;
@@ -58,85 +51,49 @@ function formatDay(date: string): string {
   });
 }
 
-function groupLabel(article: WhatHappenedArticle): string {
-  if (article.landesverband) return LV_NAMES[article.landesverband] ?? article.landesverband;
-  return SOURCE_GROUP_LABELS[article.sourceGroupId] ?? article.sourceName;
-}
-
-function ArticleRow({
-  article,
-  expertMode,
-}: {
-  article: WhatHappenedArticle;
-  expertMode: boolean;
-}) {
-  return (
-    <li className="flex items-start justify-between gap-sm py-xs">
-      <div className="min-w-0">
-        <a
-          href={article.sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-sm text-foreground hover:text-primary-600 hover:underline inline-flex items-start gap-xs"
-        >
-          <span className="leading-snug">{article.title}</span>
-          <ExternalLink className="h-3 w-3 mt-1 shrink-0 text-grey-400" />
-        </a>
-        {expertMode && (
-          <p className="text-[11px] text-grey-400 mt-0.5">
-            {article.collection}
-            {article.syncRunUrl && (
-              <>
-                {' · '}
-                <a
-                  href={article.syncRunUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="hover:underline"
-                >
-                  Sync-Lauf
-                </a>
-              </>
-            )}
-          </p>
-        )}
-      </div>
-      {article.eventType === 'updated' && (
-        <span className="text-[10px] text-grey-400 shrink-0 mt-1">aktualisiert</span>
-      )}
-    </li>
-  );
-}
-
+/** AI digest for one day, styled like the Überblick "KI-Einordnung" block. */
 function DaySummary({ date, locale }: { date: string; locale: MonitorLocale }) {
   const [open, setOpen] = useState(false);
   const { data, isLoading, error } = useWhatHappenedSummary(date, locale, open);
 
   return (
-    <div className="rounded-md border border-grey-100 dark:border-grey-800">
+    <div className="rounded-xl border border-grey-200 dark:border-grey-700 bg-background mb-md">
       <button
         onClick={() => setOpen(!open)}
-        className="flex w-full items-center justify-between gap-sm px-sm py-xs text-left hover:bg-grey-50 dark:hover:bg-grey-800/30 rounded-md"
+        className="flex w-full items-center justify-between gap-sm px-md py-sm text-left border-none bg-transparent cursor-pointer rounded-xl hover:bg-grey-50 dark:hover:bg-grey-800/30 transition-colors"
       >
-        <span className="inline-flex items-center gap-xs text-xs font-medium text-foreground">
+        <span className="inline-flex items-center gap-xs">
           <Sparkles className="h-3.5 w-3.5 text-primary-500" />
-          Grünerator-Zusammenfassung
+          <span className="text-xs font-semibold text-grey-500 uppercase tracking-wide">
+            KI-Zusammenfassung
+          </span>
+          {data?.generatedAt && (
+            <span className="text-[10px] text-grey-400">
+              ·{' '}
+              {new Date(data.generatedAt).toLocaleString('de-DE', {
+                day: 'numeric',
+                month: 'short',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          )}
         </span>
         <ChevronDown
           className={`h-4 w-4 text-grey-400 transition-transform ${open ? 'rotate-180' : ''}`}
         />
       </button>
       {open && (
-        <div className="px-sm pb-sm">
+        <div className="px-md pb-md border-t border-grey-100 dark:border-grey-800 pt-sm">
           {isLoading && (
-            <div className="space-y-2 pt-xs">
+            <div className="space-y-2">
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-[90%]" />
-              <Skeleton className="h-4 w-[75%]" />
+              <Skeleton className="h-4 w-[80%]" />
             </div>
           )}
           {error && (
-            <p className="text-xs text-grey-400 pt-xs">
+            <p className="text-xs text-grey-400 m-0">
               Zusammenfassung konnte nicht erstellt werden.
             </p>
           )}
@@ -173,15 +130,8 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
 
   return (
     <div>
-      <div className="flex items-start justify-between gap-sm mb-lg flex-wrap">
-        <div>
-          <h2 className="text-lg font-semibold text-foreground">Was ist passiert</h2>
-          <p className="text-sm text-grey-500">
-            Neue Inhalte, die der Content-Sync in die Notebooks aufgenommen hat — letzte{' '}
-            {expertMode ? days : 7} Tage.
-          </p>
-        </div>
-        <label className="flex items-center gap-sm text-sm text-grey-500 cursor-pointer mt-1">
+      <div className="flex items-center justify-end gap-sm mb-lg">
+        <label className="flex items-center gap-sm text-xs text-grey-400 cursor-pointer shrink-0">
           Expertenmodus
           <Switch
             checked={expertMode}
@@ -191,7 +141,7 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
       </div>
 
       {expertMode && (
-        <div className="flex flex-wrap gap-sm mb-lg">
+        <div className="flex flex-wrap gap-sm mb-xl">
           <Select value={String(days)} onValueChange={(v) => setDays(Number(v))}>
             <SelectTrigger className="w-[10rem]">
               <SelectValue />
@@ -251,10 +201,12 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
 
       {isLoading && (
         <div className="space-y-4">
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="h-24 w-full" />
-          <Skeleton className="h-5 w-48" />
-          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-6 w-56" />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-md">
+            <Skeleton className="h-36 w-full" />
+            <Skeleton className="h-36 w-full" />
+            <Skeleton className="h-36 w-full" />
+          </div>
         </div>
       )}
 
@@ -262,54 +214,39 @@ export function WhatHappenedView({ locale }: WhatHappenedViewProps) {
         <Card>
           <CardContent className="flex flex-col items-center gap-sm py-2xl text-grey-400">
             <Inbox className="h-8 w-8" />
-            <p className="text-sm">Im gewählten Zeitraum wurden keine neuen Inhalte aufgenommen.</p>
+            <p className="text-sm m-0">
+              Im gewählten Zeitraum wurden keine neuen Inhalte aufgenommen.
+            </p>
           </CardContent>
         </Card>
       )}
 
-      {data?.days.map((day) => {
-        const groups = new Map<string, WhatHappenedArticle[]>();
-        for (const article of day.articles) {
-          const label = groupLabel(article);
-          const list = groups.get(label) ?? [];
-          list.push(article);
-          groups.set(label, list);
-        }
+      {data?.days.map((day) => (
+        <section key={day.date} className="mb-2xl">
+          <div className="flex items-baseline justify-between gap-sm mb-md">
+            <h2 className="text-lg font-semibold text-foreground m-0">{formatDay(day.date)}</h2>
+            <span className="text-xs text-grey-400 shrink-0">
+              {day.counts.stored} neu
+              {day.counts.updated > 0 && `, ${day.counts.updated} aktualisiert`}
+            </span>
+          </div>
 
-        return (
-          <Card key={day.date} className="mb-lg">
-            <CardHeader>
-              <CardTitle className="text-base">{formatDay(day.date)}</CardTitle>
-              {expertMode && (
-                <CardDescription>
-                  {day.counts.stored} neu
-                  {day.counts.updated > 0 && `, ${day.counts.updated} aktualisiert`}
-                </CardDescription>
-              )}
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <DaySummary date={day.date} locale={locale} />
-              {[...groups.entries()].map(([label, articles]) => (
-                <div key={label}>
-                  <div className="flex items-center gap-sm mb-xs">
-                    <Badge variant="secondary">{label}</Badge>
-                    <span className="text-[11px] text-grey-400">{articles.length} Artikel</span>
-                  </div>
-                  <ul className="divide-y divide-grey-100 dark:divide-grey-800">
-                    {articles.map((article) => (
-                      <ArticleRow
-                        key={article.sourceUrl}
-                        article={article}
-                        expertMode={expertMode}
-                      />
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </CardContent>
-          </Card>
-        );
-      })}
+          <DaySummary date={day.date} locale={locale} />
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-md">
+            {day.articles.map((article) => (
+              <ArticleCard
+                key={article.sourceUrl}
+                url={article.sourceUrl}
+                title={article.title}
+                excerpt={article.excerpt ?? undefined}
+                source={article.sourceName}
+                publishedAt={article.publishedAt ?? article.indexedAt}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   );
 }

--- a/packages/contracts/src/schemas/monitor.ts
+++ b/packages/contracts/src/schemas/monitor.ts
@@ -316,6 +316,7 @@ export const whatHappenedArticleSchema = z.object({
   sourceUrl: z.string(),
   sourceGroupId: syncArticleSourceGroupSchema,
   sourceName: z.string(),
+  excerpt: z.string().nullable(),
   landesverband: z.string().nullable(),
   collection: z.string(),
   eventType: syncArticleEventTypeSchema,
@@ -348,6 +349,8 @@ export const syncEventInputSchema = z.object({
   sourceUrl: z.string().min(1),
   sourceGroupId: syncArticleSourceGroupSchema,
   sourceName: z.string().min(1),
+  /** First ~300 chars of the article text, for the blog-style feed cards. */
+  excerpt: z.string().max(500).nullable(),
   landesverband: z.string().nullable(),
   collection: z.string().min(1),
   eventType: syncArticleEventTypeSchema,


### PR DESCRIPTION
## Summary

UI rework of the „Was ist passiert" tab (follow-up to #1240), aligning it with the Überblick design language and giving the Beiträge a blog look.

### UI
- **Day sections like the Überblick:** plain `<section>` per day with `Freitag, 12. Juni` header and counts right-aligned — no more nested cards.
- **KI-Zusammenfassung** restyled as a collapsed bar matching the „KI-Einordnung" block (Sparkles + uppercase eyebrow + generated-at timestamp); still lazy + Redis-cached.
- **Beiträge as blog cards:** articles render via the shared `ArticleCard` (source eyebrow, title, excerpt, relative time, hover lift) in a responsive 3-column grid — same as the Top-Artikel section.
- Removed the technical caption (`collection · aktualisiert · Sync-Lauf`) and the description line per user feedback. Expert mode now adds the filter row only.

### Excerpts
- All six scrapers record a normalized ~300-char excerpt at their sync seam (`toExcerpt` in `syncEventRecorder.ts`).
- New nullable `excerpt` column via **separate migration** (`add_excerpt_to_content_sync_articles.sql`, idempotent `ADD COLUMN IF NOT EXISTS`) since the base table migration is already merged.
- Contract schemas (`syncEventInputSchema`, `whatHappenedArticleSchema`) carry the field; the upsert keeps an existing excerpt when a retry posts null (`COALESCE`).
- The day digest uses the stored excerpt as fallback when the Qdrant full-text fetch fails.

## Verification
- Migration re-applied locally; seeded two days of events with excerpts; feed + cards + collapsed digest verified in the browser (user-reviewed locally).
- `pnpm typecheck` clean; demo data and caches removed afterwards.