### PR TITLE
feat(monitor): merge Bundesländer tab into Umfragen

### DIFF
--- a/apps/web/src/features/monitor/MonitorPage.tsx
+++ b/apps/web/src/features/monitor/MonitorPage.tsx
@@ -8,7 +8,6 @@ import PageContainer from '../../components/common/PageContainer';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import { useAuthStore } from '../../stores/authStore';
 
-import { BundeslandView } from './components/BundeslandView';
 import { KeywordInsightsCard } from './components/KeywordInsightsCard';
 import { KeywordRanking } from './components/KeywordRanking';
 import { MonitorOverview } from './components/MonitorOverview';
@@ -35,7 +34,6 @@ type MonitorTab =
   | 'keywords'
   | 'social'
   | 'umfragen'
-  | 'bundesland'
   | 'watcher'
   | 'whatHappened'
   | 'details';
@@ -109,7 +107,6 @@ function MonitorPage() {
                   <TabsTrigger value="overview">Überblick</TabsTrigger>
                   <TabsTrigger value="topics">Themen</TabsTrigger>
                   <TabsTrigger value="umfragen">Umfragen</TabsTrigger>
-                  {locale === 'de' && <TabsTrigger value="bundesland">Bundesländer</TabsTrigger>}
                   <TabsTrigger value="watcher">Watcher</TabsTrigger>
                   <TabsTrigger value="whatHappened">Was ist passiert</TabsTrigger>
                 </TabsList>
@@ -129,8 +126,6 @@ function MonitorPage() {
             )}
 
             {tab === 'umfragen' && <UmfragenView locale={locale} />}
-
-            {tab === 'bundesland' && <BundeslandView />}
 
             {tab === 'watcher' && <WatcherView locale={locale} />}
 

--- a/apps/web/src/features/monitor/bundeslaender.ts
+++ b/apps/web/src/features/monitor/bundeslaender.ts
@@ -48,6 +48,3 @@ export const BUNDESLAENDER: Bundesland[] = [
 
 export const bundeslandById = (id: string): Bundesland | undefined =>
   BUNDESLAENDER.find((b) => b.id === id);
-
-export const bundeslandByCode = (code: string): Bundesland | undefined =>
-  BUNDESLAENDER.find((b) => b.code === code);

--- a/apps/web/src/features/monitor/components/LandDetails.tsx
+++ b/apps/web/src/features/monitor/components/LandDetails.tsx
@@ -5,22 +5,14 @@ import {
   AccordionTrigger,
   Card,
   CardContent,
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
   LoadingSection,
 } from '@gruenerator/ui';
 import { ExternalLink } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
-import { bundeslandByCode, BUNDESLAENDER } from '../bundeslaender';
 import { useMeinungsbild, useStateElections } from '../hooks/useMonitor';
 import { estimateColor } from '../meinungsbildConfig';
-
-import { PARTY_COLORS, SonntagsfrageChart } from './UmfragenView';
+import { PARTY_COLORS } from '../partyColors';
 
 function partyColor(party: string): string {
   return PARTY_COLORS[party] ?? '#9ca3af';
@@ -65,7 +57,7 @@ function IssueBar({ label, estimate }: { label: string; estimate: number }) {
   );
 }
 
-function LandtagsergebnisCard({ code }: { code: string }) {
+export function LandtagsergebnisCard({ code }: { code: string }) {
   const { data, isLoading } = useStateElections();
   if (isLoading) return <LoadingSection />;
 
@@ -103,7 +95,7 @@ function LandtagsergebnisCard({ code }: { code: string }) {
   );
 }
 
-function MeinungsbildForState({ code }: { code: string }) {
+export function MeinungsbildForState({ code, stateName }: { code: string; stateName: string }) {
   const { data, isLoading } = useMeinungsbild();
 
   const ranked = useMemo(() => {
@@ -123,7 +115,7 @@ function MeinungsbildForState({ code }: { code: string }) {
   return (
     <div>
       <h3 className="text-base font-semibold text-foreground-heading mb-xs">
-        Meinungsbild — Was denkt das Land?
+        Meinungsbild — {stateName}
       </h3>
       <p className="text-xs text-grey-500 mb-md">
         MRP-Schätzung des Zustimmungsanteils zu politischen Aussagen, sortiert nach Zustimmung.
@@ -137,94 +129,39 @@ function MeinungsbildForState({ code }: { code: string }) {
   );
 }
 
-export function BundeslandView() {
-  const [code, setCode] = useState<string | null>(null);
-  const selected = code ? bundeslandByCode(code) : undefined;
-
-  // Combobox value is the state code; items sorted alphabetically by name.
-  const options = useMemo(
-    () => [...BUNDESLAENDER].sort((a, b) => a.name.localeCompare(b.name, 'de')),
-    []
-  );
-
+export function GerdaAttribution() {
   return (
-    <div>
-      <div className="mb-lg max-w-sm">
-        <label className="text-xs font-semibold text-foreground-heading uppercase tracking-wide mb-xs block">
-          Bundesland suchen
-        </label>
-        <Combobox value={code} onValueChange={(v) => setCode(v)}>
-          <ComboboxInput placeholder="Bundesland eingeben oder wählen..." />
-          <ComboboxContent>
-            <ComboboxList>
-              <ComboboxEmpty>Kein Bundesland gefunden</ComboboxEmpty>
-              {options.map((b) => (
-                <ComboboxItem key={b.code} value={b.code}>
-                  {b.name}
-                </ComboboxItem>
-              ))}
-            </ComboboxList>
-          </ComboboxContent>
-        </Combobox>
-      </div>
-
-      {!selected ? (
-        <Card>
-          <CardContent className="py-xl text-center text-sm text-grey-500">
-            Wähle ein Bundesland, um Wahlergebnisse, aktuelle Umfragen und das Meinungsbild
-            anzuzeigen.
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="space-y-xl">
-          <h2 className="text-lg font-bold text-foreground-heading">{selected.name}</h2>
-
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-lg items-start">
-            <LandtagsergebnisCard code={selected.code} />
-            <SonntagsfrageChart
-              key={selected.id}
-              parliament={selected.id}
-              title="Aktuelle Sonntagsfrage"
-              subtitle="Wenn am nächsten Sonntag Landtagswahl wäre… Wöchentlich aggregierter Durchschnitt."
-            />
+    <Accordion
+      type="single"
+      collapsible
+      className="border border-grey-200 dark:border-grey-700 rounded-lg overflow-hidden"
+    >
+      <AccordionItem value="gerda-info">
+        <AccordionTrigger className="px-md py-sm text-sm font-medium text-foreground hover:bg-grey-50 dark:hover:bg-grey-800/50 hover:no-underline">
+          Daten: GERDA — German Election Database & PolitPro
+        </AccordionTrigger>
+        <AccordionContent className="px-md">
+          <div className="text-xs text-foreground/80 space-y-sm">
+            <p>
+              Wahlergebnisse und Meinungsbild (MRP-Schätzung) stammen aus GERDA; die Sonntagsfrage
+              wird über PolitPro aggregiert.
+            </p>
+            <p>
+              Heddesheimer, V., Hilbig, H., Sichart, F. &amp; Wiedemann, A. (2025). GERDA: German
+              Election Database. <em>Nature: Scientific Data</em>, 12: 618.
+            </p>
+            <a
+              href="https://github.com/awiedem/german_election_data"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline"
+            >
+              github.com/awiedem/german_election_data
+              <ExternalLink className="h-3 w-3" />
+            </a>
           </div>
-
-          <MeinungsbildForState code={selected.code} />
-
-          <Accordion
-            type="single"
-            collapsible
-            className="border border-grey-200 dark:border-grey-700 rounded-lg overflow-hidden"
-          >
-            <AccordionItem value="gerda-info">
-              <AccordionTrigger className="px-md py-sm text-sm font-medium text-foreground hover:bg-grey-50 dark:hover:bg-grey-800/50 hover:no-underline">
-                Daten: GERDA — German Election Database & PolitPro
-              </AccordionTrigger>
-              <AccordionContent className="px-md">
-                <div className="text-xs text-foreground/80 space-y-sm">
-                  <p>
-                    Wahlergebnisse und Meinungsbild (MRP-Schätzung) stammen aus GERDA; die
-                    Sonntagsfrage wird über PolitPro aggregiert.
-                  </p>
-                  <p>
-                    Heddesheimer, V., Hilbig, H., Sichart, F. &amp; Wiedemann, A. (2025). GERDA:
-                    German Election Database. <em>Nature: Scientific Data</em>, 12: 618.
-                  </p>
-                  <a
-                    href="https://github.com/awiedem/german_election_data"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline"
-                  >
-                    github.com/awiedem/german_election_data
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        </div>
-      )}
-    </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/apps/web/src/features/monitor/components/UmfragenView.tsx
+++ b/apps/web/src/features/monitor/components/UmfragenView.tsx
@@ -10,9 +10,11 @@ import {
 import { ExternalLink, Minus, TrendingDown, TrendingUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
-import { BUNDESLAENDER } from '../bundeslaender';
+import { bundeslandById, BUNDESLAENDER } from '../bundeslaender';
 import { usePolls } from '../hooks/useMonitor';
+import { PARTY_COLORS } from '../partyColors';
 
+import { GerdaAttribution, LandtagsergebnisCard, MeinungsbildForState } from './LandDetails';
 import { MeinungsbildSection } from './MeinungsbildSection';
 
 import type { MonitorLocale } from '../hooks/useMonitor';
@@ -20,23 +22,6 @@ import type { MonitorLocale } from '../hooks/useMonitor';
 interface UmfragenViewProps {
   locale: MonitorLocale;
 }
-
-export const PARTY_COLORS: Record<string, string> = {
-  'CDU/CSU': '#000000',
-  AfD: '#009ee0',
-  SPD: '#e3000f',
-  GRÜNE: '#46962b',
-  Grüne: '#46962b',
-  'DIE LINKE': '#be3075',
-  Linke: '#be3075',
-  BSW: '#571D47',
-  FDP: '#ffed00',
-  Sonstige: '#aaaaaa',
-  ÖVP: '#63C3D0',
-  NEOS: '#E84188',
-  SPÖ: '#e3000f',
-  FPÖ: '#0E6EB8',
-};
 
 // Compact labels for the tight 2-column "Grüne in den Ländern" grid.
 const LAENDER = BUNDESLAENDER.map((b) => ({ id: b.id, name: b.display ?? b.name }));
@@ -377,6 +362,7 @@ export function UmfragenView({ locale }: UmfragenViewProps) {
     );
   }
 
+  const land = selectedLand ? bundeslandById(selectedLand) : undefined;
   const activeParliament = selectedLand ?? 'deutschland';
   const activeTitle = selectedLand
     ? `Sonntagsfrage — ${LAENDER.find((l) => l.id === selectedLand)?.name ?? selectedLand}`
@@ -388,13 +374,14 @@ export function UmfragenView({ locale }: UmfragenViewProps) {
   return (
     <div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-lg items-start">
-        <div>
+        <div className="space-y-xl">
           <SonntagsfrageChart
             key={activeParliament}
             parliament={activeParliament}
             title={activeTitle}
             subtitle={activeSubtitle}
           />
+          {land && <LandtagsergebnisCard code={land.code} />}
         </div>
 
         <div>
@@ -431,7 +418,14 @@ export function UmfragenView({ locale }: UmfragenViewProps) {
         </div>
       </div>
 
-      <MeinungsbildSection />
+      {land ? (
+        <div className="mt-xl border-t border-grey-200 dark:border-grey-700 pt-xl space-y-lg">
+          <MeinungsbildForState code={land.code} stateName={land.name} />
+          <GerdaAttribution />
+        </div>
+      ) : (
+        <MeinungsbildSection />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/monitor/partyColors.ts
+++ b/apps/web/src/features/monitor/partyColors.ts
@@ -1,0 +1,16 @@
+export const PARTY_COLORS: Record<string, string> = {
+  'CDU/CSU': '#000000',
+  AfD: '#009ee0',
+  SPD: '#e3000f',
+  GRÜNE: '#46962b',
+  Grüne: '#46962b',
+  'DIE LINKE': '#be3075',
+  Linke: '#be3075',
+  BSW: '#571D47',
+  FDP: '#ffed00',
+  Sonstige: '#aaaaaa',
+  ÖVP: '#63C3D0',
+  NEOS: '#E84188',
+  SPÖ: '#e3000f',
+  FPÖ: '#0E6EB8',
+};


### PR DESCRIPTION
## Was ändert sich

Die Monitor-Tabs **Umfragen** und **Bundesländer** sind zu einem Tab zusammengeführt (enrich-in-place):

- Die Land-Auswahl läuft jetzt ausschließlich über das bestehende „Grüne in den Ländern"-Grid im Umfragen-Tab.
- Bei ausgewähltem Land erscheinen zusätzlich zur Landtags-Sonntagsfrage (wie bisher) die **letzten Landtagswahl-Ergebnisse** unter dem Chart sowie das **Land-Meinungsbild** (ersetzt das nationale) mit GERDA-Attribution.
- Ohne Auswahl (Bundestrend) bleibt alles wie heute; Österreich-Ansicht unverändert.
- Der Bundesländer-Tab samt Combobox entfällt. Die Combobox war ohnehin unbenutzbar: `max-w-sm` löst in dieser App zu einem 12px-Spacing-Token auf, nicht zu einer Container-Breite.

## Code

- `BundeslandView.tsx` → `LandDetails.tsx`: nur noch die wiederverwendbaren Sektionen (`LandtagsergebnisCard`, `MeinungsbildForState`, `GerdaAttribution`), Wrapper/Combobox entfernt.
- `PARTY_COLORS` nach `partyColors.ts` verschoben (verhindert Importzyklus UmfragenView ↔ LandDetails).
- Ungenutztes `bundeslandByCode` entfernt; `bundeslandById` wird jetzt in UmfragenView genutzt.

## Verifiziert

- `pnpm typecheck` + `lint` clean (keine neuen Warnings).
- Manuell im Browser (Vite-Dev gegen diesen Stand): Default-Ansicht unverändert; Land-Klick zeigt Landtagswahl + Land-Meinungsbild; erneuter Klick/Bundestrend stellt nationale Ansicht wieder her; AT-Locale unverändert.

Hinweis: `max-w-sm/md/lg` (=12/16/24px) wird noch in ~8 Dialogen verwendet (AgentCard, IconPicker, ShareWolkeLinkDialog, AiColumnDialog, AllAgentsDialog, …) — separater Folge-Fix sinnvoll.