### PR TITLE
feat(chat): Instagram-Slider-Karusselle im Chat erstellen und bearbeiten

### DIFF
--- a/apps/api/routes/canvas/canvasContractRouter.ts
+++ b/apps/api/routes/canvas/canvasContractRouter.ts
@@ -32,7 +32,10 @@ import {
 } from '../../services/canvas/canvasRepository.js';
 import {
   applyCanvasStatePatch,
+  applyDeckChanges,
   getCurrentCanvasState,
+  getCurrentDeckState,
+  type CanvasPageDef,
 } from '../../services/canvas/canvasStateService.js';
 import {
   getCanvasVersion,
@@ -48,6 +51,17 @@ import { getServerFormat } from '../exports/pageConstants.js';
 import type { Application } from 'express';
 
 const log = createLogger('canvasContractRouter');
+
+const isCanvasPageDefArray = (v: unknown): v is CanvasPageDef[] =>
+  Array.isArray(v) &&
+  v.every(
+    (p) =>
+      !!p &&
+      typeof p === 'object' &&
+      typeof (p as CanvasPageDef).id === 'string' &&
+      typeof (p as CanvasPageDef).configId === 'string' &&
+      typeof (p as CanvasPageDef).state === 'object'
+  );
 
 const s = initServer();
 
@@ -155,9 +169,17 @@ export const canvasContractRouter = s.router(canvasContract, {
       }
       const current = await getCurrentCanvasState(args.params.id);
       const version = await getLatestCanvasVersionNumber(args.params.id);
+      // Deck canvases additionally expose their per-slide states.
+      const isDeck = access.canvas.template_type === 'slider';
+      const deckPages = isDeck ? (await getCurrentDeckState(args.params.id)).pages : [];
       return {
         status: 200 as const,
-        body: { state: current.state, source: current.source, version },
+        body: {
+          state: current.state,
+          source: current.source,
+          version,
+          ...(deckPages.length > 0 ? { pages: deckPages.map((p) => p.state) } : {}),
+        },
       };
     } catch (error) {
       const err = error as Error;
@@ -231,9 +253,19 @@ export const canvasContractRouter = s.router(canvasContract, {
         return { status: 404 as const, body: { error: 'Version not found' } };
       }
       // Re-apply the snapshot as a forward patch — never rewinds Yjs history.
-      await applyCanvasStatePatch(args.params.id, snapshot.state, {
-        seedState: snapshot.state,
-      });
+      // Deck versions ({ pages: [...] }) replace the page set instead.
+      const versionPages = (snapshot.state as { pages?: unknown }).pages;
+      if (isCanvasPageDefArray(versionPages) && versionPages.length > 0) {
+        await applyDeckChanges(args.params.id, {
+          seedPages: versionPages,
+          replacePages: versionPages,
+          newPages: versionPages,
+        });
+      } else {
+        await applyCanvasStatePatch(args.params.id, snapshot.state, {
+          seedState: snapshot.state,
+        });
+      }
       const newVersion = await insertCanvasVersion({
         canvasId: args.params.id,
         state: snapshot.state,

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -534,6 +534,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         ...(enabledTools != null && { enabledTools }),
         imageAttachments,
         req,
+        threadId: actualThreadId ?? null,
         ...(sharepicRefinement && { sharepicRefinement }),
       });
 
@@ -545,10 +546,14 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
         // already-finished sharepic. Emit a fixed confirmation instead so the user sees the
         // assistant knows the sharepic exists. Also covers the all-variants-failed case.
         const n = sharepicVariants.length;
+        const deckSlides = sharepicVariants[0]?.pages?.length;
         fullText =
           n > 0
-            ? `Ich habe dir ${n} Sharepic-${n === 1 ? 'Variante' : 'Varianten'} erstellt. ` +
-              `Wähle eine aus oder sag mir, was ich am Text oder Bild anpassen soll.`
+            ? deckSlides
+              ? `Ich habe dir ein Slider-Karussell mit ${deckSlides} Folien erstellt. ` +
+                `Sag mir, was ich an einzelnen Folien anpassen soll, oder öffne es im Studio.`
+              : `Ich habe dir ${n} Sharepic-${n === 1 ? 'Variante' : 'Varianten'} erstellt. ` +
+                `Wähle eine aus oder sag mir, was ich am Text oder Bild anpassen soll.`
             : `Die Sharepic-Erstellung hat leider nicht geklappt. Magst du es mit einem ` +
               `anderen Thema noch einmal versuchen?`;
         sse.send('response_start', { message: PROGRESS_MESSAGES.responseStart });

--- a/apps/api/routes/chat/services/intentExecutionService.ts
+++ b/apps/api/routes/chat/services/intentExecutionService.ts
@@ -29,6 +29,7 @@ import {
   type PriorSharepic,
   type SharepicVariant,
 } from './sharepicVariantHelpers.js';
+import { generateSliderDeckVariant } from './sliderDeckService.js';
 import { PROGRESS_MESSAGES } from './sseHelpers.js';
 import { createMessage, touchThread } from './threadPersistenceService.js';
 
@@ -440,6 +441,8 @@ export async function executeIntentPipeline(opts: {
   enabledTools?: Record<string, boolean>;
   imageAttachments: ImageAttachment[];
   req?: Request;
+  /** Thread id for deck mints (chat_thread_canvases binding). */
+  threadId?: string | null;
   /** When set, the sharepic branch refines the previous sharepic instead of starting fresh. */
   sharepicRefinement?: { instruction: string; prior: PriorSharepic };
 }): Promise<{
@@ -541,12 +544,28 @@ export async function executeIntentPipeline(opts: {
         );
 
         if (!opts.req) throw new Error('Express request required for sharepic generation');
-        const variants = await generateSharepicVariants({
-          req: opts.req as SharepicExpressRequest,
-          text: messageText,
-          ...(refinement ? { refinement } : preferredVariant ? { preferredVariant } : {}),
-          ...(authorName && { authorName }),
-        });
+        // Slider = multi-page deck, a different artifact: ONE deck variant,
+        // minted at generation time (studio open/editing need the pages).
+        let variants: SharepicVariant[];
+        if (preferredVariant === 'slider') {
+          const userId = classifiedState.agentConfig?.userId;
+          if (!userId) throw new Error('User required for slider deck creation');
+          variants = [
+            await generateSliderDeckVariant({
+              req: opts.req,
+              text: messageText,
+              threadId: opts.threadId ?? null,
+              userId,
+            }),
+          ];
+        } else {
+          variants = await generateSharepicVariants({
+            req: opts.req as SharepicExpressRequest,
+            text: messageText,
+            ...(refinement ? { refinement } : preferredVariant ? { preferredVariant } : {}),
+            ...(authorName && { authorName }),
+          });
+        }
 
         if (variants.length === 0) {
           sse.send('sharepic_complete', {

--- a/apps/api/routes/chat/services/sharepicAgenticGuards.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticGuards.ts
@@ -3,13 +3,18 @@
  * schemas and per-turn guard state. Separate file so unit tests don't import
  * the service's heavy transitive dependencies (DB, providers, env parsing).
  */
-import { canvasAiOperationSchema } from '@gruenerator/contracts';
+import { canvasAiOperationSchema, sliderDeckOperationSchema } from '@gruenerator/contracts';
 import { z } from 'zod';
 
 export const MAX_FAILURES_PER_TOOL = 2;
 
 export const applyOpsInputSchema = z.object({
   operations: z.array(canvasAiOperationSchema).min(1).max(8),
+  summary: z.string().min(1).max(120),
+});
+
+export const applySliderOpsInputSchema = z.object({
+  operations: z.array(sliderDeckOperationSchema).min(1).max(6),
   summary: z.string().min(1).max(120),
 });
 

--- a/apps/api/routes/chat/services/sharepicAgenticService.ts
+++ b/apps/api/routes/chat/services/sharepicAgenticService.ts
@@ -12,14 +12,21 @@
  * overall timeout. Tool results stay compact — full state travels via the
  * existing `sharepic_updated` SSE events only.
  */
-import { buildSharepicSnapshot, getSharepicTemplateDescriptor } from '@gruenerator/contracts';
+import {
+  buildSharepicSnapshot,
+  buildSliderDeckSnapshotLines,
+  getSharepicTemplateDescriptor,
+} from '@gruenerator/contracts';
 import { streamText, tool, stepCountIs, type ModelMessage } from 'ai';
 import { z } from 'zod';
 
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import {
-  getCurrentCanvasState,
   applyCanvasStatePatch,
+  applyDeckChanges,
+  getCurrentCanvasState,
+  getCurrentDeckState,
+  type CanvasPageDef,
 } from '../../../services/canvas/canvasStateService.js';
 import {
   getCanvasVersion,
@@ -31,12 +38,18 @@ import { getModel } from '../agents/providers.js';
 
 import {
   applyOpsInputSchema,
+  applySliderOpsInputSchema,
   createLoopGuards,
   restoreInputSchema,
 } from './sharepicAgenticGuards.js';
-import { buildOperationCatalog, buildSnapshotLines } from './sharepicEditLlm.js';
+import {
+  buildOperationCatalog,
+  buildSliderDeckOperationCatalog,
+  buildSnapshotLines,
+} from './sharepicEditLlm.js';
 import {
   applySharepicOpsToCanvas,
+  applySliderOpsToDeck,
   ensureMintedCanvas,
   resolveTarget,
   type HandleSharepicEditArgs,
@@ -89,11 +102,15 @@ function buildLoopSystemPrompt(args: {
   descriptor: NonNullable<ReturnType<typeof getSharepicTemplateDescriptor>>;
   snapshotLines: string[];
   recentEditSummaries: string[];
+  isDeck: boolean;
 }): string {
-  const { descriptor, snapshotLines, recentEditSummaries } = args;
+  const { descriptor, snapshotLines, recentEditSummaries, isDeck } = args;
+  const applyTool = isDeck ? 'apply_slider_ops' : 'apply_sharepic_ops';
+  const readTool = isDeck ? 'read_slider_deck' : 'read_sharepic_state';
+  const artifact = isDeck ? 'Folien-Karussell' : 'Sharepic';
   const lines: string[] = [
-    'Du bist der Bearbeitungs-Assistent für Sharepics der deutschen Grünen.',
-    'Der*die Nutzer*in beschreibt gewünschte Änderungen am aktuellen Sharepic.',
+    `Du bist der Bearbeitungs-Assistent für ${isDeck ? 'Instagram-Karussells' : 'Sharepics'} der deutschen Grünen.`,
+    `Der*die Nutzer*in beschreibt gewünschte Änderungen am aktuellen ${artifact}.`,
     'Du setzt sie mit deinen Tools um und bestätigst danach kurz im Chat.',
     '',
     'Sprachregeln: Du-Form, Genderstern (z.B. "Bürger*innen"), prägnante Kampagnen-Texte.',
@@ -111,20 +128,30 @@ function buildLoopSystemPrompt(args: {
 
   lines.push(
     '',
-    ...buildOperationCatalog(descriptor),
+    ...(isDeck ? buildSliderDeckOperationCatalog(descriptor) : buildOperationCatalog(descriptor)),
     '',
     'ARBEITSWEISE:',
-    '- Setze Änderungen SOFORT mit "apply_sharepic_ops" um. Stelle KEINE Rückfragen und beschreibe keine Entwürfe im Chat — bei Spielraum (z.B. "Text kürzen") entscheide selbst und formuliere kampagnentauglich.',
+    `- Setze Änderungen SOFORT mit "${applyTool}" um. Stelle KEINE Rückfragen und beschreibe keine Entwürfe im Chat — bei Spielraum (z.B. "Text kürzen") entscheide selbst und formuliere kampagnentauglich.`,
     '- Fasse zusammengehörige Operationen in EINEN Aufruf.',
-    '- Bestätigt der*die Nutzer*in einen früheren Vorschlag ("ja", "mach das so"), wende GENAU diesen Vorschlag aus der vorigen Antwort jetzt mit "apply_sharepic_ops" an.',
+    `- Bestätigt der*die Nutzer*in einen früheren Vorschlag ("ja", "mach das so"), wende GENAU diesen Vorschlag aus der vorigen Antwort jetzt mit "${applyTool}" an.`,
     '- Wird eine Operation abgelehnt (rejected), korrigiere sie EINMAL mit angepassten Werten.',
-    '- "read_sharepic_state" nur, wenn du den aktuellen Zustand wirklich brauchst (z.B. nach Ablehnungen).',
+    `- "${readTool}" nur, wenn du den aktuellen Zustand wirklich brauchst (z.B. nach Ablehnungen).`,
     '- "restore_version" nur auf ausdrücklichen Wunsch ("zurück zur vorherigen Version").',
     `- Du hast maximal ${MAX_STEPS} Schritte. Antworte am Ende IMMER mit 1–2 freundlichen Sätzen auf Deutsch.`,
     '- Ändere NUR, was verlangt wurde. Nutze nur die gelisteten Felder, IDs und Werte.',
     '- Bezieht sich die Nachricht auf Texte aus der vorigen Antwort ("setz das ein", "nimm Vorschlag 2"), übernimm sie sinngemäß in die passenden Felder — kürze auf die Feldlängen der Vorlage.',
-    '- NUR wenn die Nachricht erkennbar nichts mit dem Sharepic zu tun hat, antworte ohne Tool-Aufruf kurz im Chat.'
+    `- NUR wenn die Nachricht erkennbar nichts mit dem ${artifact} zu tun hat, antworte ohne Tool-Aufruf kurz im Chat.`
   );
+
+  if (isDeck) {
+    lines.push(
+      '',
+      'KARUSSELL-REGELN:',
+      '- Slides sind 1-basiert nummeriert: Slide 1 = Cover, letzte Slide = Abschluss.',
+      '- "Folie"/"Seite"/"Slide" + Zahl bezeichnet die Slide-Nummer aus dem Snapshot oben.',
+      '- Das Farbschema gilt immer für das ganze Karussell, nie für einzelne Folien.'
+    );
+  }
 
   return lines.join('\n');
 }
@@ -156,20 +183,35 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
       return false;
     }
 
+    const isDeck = Boolean(descriptor.deck);
+
     sse.send('progress_step', {
       stepId: `sharepic_agentic_${Date.now()}`,
       toolName: 'sharepic_edit',
-      title: 'Bearbeite Sharepic…',
+      title: isDeck ? 'Bearbeite Karussell…' : 'Bearbeite Sharepic…',
       status: 'in_progress',
     });
 
     const canvasId = await ensureMintedCanvas({ target, descriptor, threadId, userId, sse });
 
-    const current = await getCurrentCanvasState(canvasId);
+    let deckPages: CanvasPageDef[] = [];
+    if (isDeck) {
+      deckPages = (await getCurrentDeckState(canvasId)).pages;
+      if (deckPages.length === 0) {
+        await endTurn(
+          args,
+          [],
+          'Ich finde die Folien dieses Karussells gerade nicht. Öffne es einmal im Studio oder versuch es gleich noch einmal.'
+        );
+        return true;
+      }
+    }
+
+    const current = isDeck ? null : await getCurrentCanvasState(canvasId);
     const initialMergedState = {
       ...descriptor.defaultState,
       ...target.initialProps,
-      ...current.state,
+      ...(current?.state ?? {}),
     };
 
     const recentEditSummaries = (await listCanvasVersions(canvasId))
@@ -177,9 +219,9 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
       .slice(0, 2)
       .map((v) => v.summary as string);
 
-    // Mutable per-turn context — apply/restore update `state` so later steps
-    // (and the read tool) see their own effects without a DB round trip.
-    const ctx = { state: initialMergedState };
+    // Mutable per-turn context — apply/restore update `state`/`pages` so later
+    // steps (and the read tools) see their own effects without a DB round trip.
+    const ctx = { state: initialMergedState, pages: deckPages };
     const guards = createLoopGuards();
     const steps: PersistedStep[] = [];
 
@@ -192,7 +234,7 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
       steps.push({ toolCallId, toolName, args: input, result });
     };
 
-    const tools = {
+    const sharepicTools = {
       read_sharepic_state: tool({
         description:
           'Liest den aktuellen Zustand des Sharepics (Texte, Farben, Elemente). Nutze dies nach abgelehnten Operationen oder wenn du unsicher über den Ist-Zustand bist.',
@@ -313,11 +355,145 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
       }),
     };
 
+    const isPageDefArray = (v: unknown): v is CanvasPageDef[] =>
+      Array.isArray(v) &&
+      v.every(
+        (p) =>
+          !!p &&
+          typeof p === 'object' &&
+          typeof (p as CanvasPageDef).id === 'string' &&
+          typeof (p as CanvasPageDef).state === 'object'
+      );
+
+    const deckTools = {
+      read_slider_deck: tool({
+        description:
+          'Liest den aktuellen Zustand aller Folien des Karussells. Nutze dies nach abgelehnten Operationen oder wenn du unsicher über den Ist-Zustand bist.',
+        inputSchema: z.object({}),
+        execute: async (_input, { toolCallId }) => {
+          const fresh = await getCurrentDeckState(canvasId);
+          if (fresh.pages.length > 0) ctx.pages = fresh.pages;
+          recordStep(toolCallId, 'read_slider_deck', {}, { ok: true });
+          return { snapshot: buildSliderDeckSnapshotLines(descriptor, ctx.pages).join('\n') };
+        },
+      }),
+
+      apply_slider_ops: tool({
+        description:
+          'Wendet 1–6 Deck-Operationen auf das Karussell an (Folien-Texte/-Schriftgrößen ändern, Farbschema deck-weit wechseln, Folien hinzufügen/entfernen). Operationen werden validiert; abgelehnte kommen mit Begründung zurück.',
+        inputSchema: applySliderOpsInputSchema,
+        execute: async (input, { toolCallId }) => {
+          const guardError =
+            guards.checkFailureCap('apply_slider_ops') ??
+            guards.checkDuplicate('apply_slider_ops', input);
+          if (guardError) return { error: guardError };
+
+          const outcome = await applySliderOpsToDeck({
+            canvasId,
+            variantId: target.variantId,
+            descriptor,
+            pages: ctx.pages,
+            operations: input.operations,
+            summary: input.summary,
+            userId,
+            sse,
+          });
+
+          if (!outcome.ok) {
+            guards.noteFailure('apply_slider_ops');
+            recordStep(
+              toolCallId,
+              'apply_slider_ops',
+              { summary: input.summary },
+              { ok: false, reason: outcome.reason }
+            );
+            return {
+              error: `Keine Änderung angewendet: ${outcome.reason}`,
+              rejected: outcome.rejected,
+            };
+          }
+
+          ctx.pages = outcome.newPages;
+          recordStep(
+            toolCallId,
+            'apply_slider_ops',
+            { summary: input.summary },
+            {
+              canvasId,
+              variantId: target.variantId,
+              version: outcome.version,
+              summary: input.summary,
+              canvasType: target.canvasType,
+            }
+          );
+          return {
+            version: outcome.version,
+            applied: outcome.appliedKinds,
+            slideCount: ctx.pages.length,
+            ...(outcome.rejected.length > 0 ? { rejected: outcome.rejected } : {}),
+          };
+        },
+      }),
+
+      restore_version: tool({
+        description:
+          'Stellt eine frühere Version des Karussells wieder her (als neue Version, nichts geht verloren). Nur auf ausdrücklichen Nutzer*innen-Wunsch.',
+        inputSchema: restoreInputSchema,
+        execute: async (input, { toolCallId }) => {
+          const guardError =
+            guards.checkFailureCap('restore_version') ??
+            guards.checkDuplicate('restore_version', input);
+          if (guardError) return { error: guardError };
+
+          const snapshot = await getCanvasVersion(canvasId, input.version);
+          const restoredPages = snapshot ? (snapshot.state as { pages?: unknown }).pages : null;
+          if (!snapshot || !isPageDefArray(restoredPages) || restoredPages.length === 0) {
+            guards.noteFailure('restore_version');
+            recordStep(toolCallId, 'restore_version', input, { ok: false, reason: 'not_found' });
+            return { error: `Version ${input.version} existiert nicht oder ist kein Karussell.` };
+          }
+          await applyDeckChanges(canvasId, {
+            seedPages: ctx.pages,
+            replacePages: restoredPages,
+            newPages: restoredPages,
+          });
+          const newVersion = await insertCanvasVersion({
+            canvasId,
+            state: { pages: restoredPages },
+            summary: `Version ${snapshot.version} wiederhergestellt`,
+            origin: 'restore',
+            userId,
+          });
+          ctx.pages = restoredPages;
+          sse.send('sharepic_updated', {
+            variantId: target.variantId,
+            canvasId,
+            version: newVersion,
+            canvasType: target.canvasType,
+            pages: restoredPages.map((p) => p.state),
+            summary: `Version ${snapshot.version} wiederhergestellt`,
+          });
+          recordStep(toolCallId, 'restore_version', input, {
+            canvasId,
+            variantId: target.variantId,
+            version: newVersion,
+            canvasType: target.canvasType,
+          });
+          return { version: newVersion, restoredFrom: snapshot.version };
+        },
+      }),
+    };
+
+    const tools = isDeck ? deckTools : sharepicTools;
+
     const { provider, modelName } = resolveLoopModel();
     const system = buildLoopSystemPrompt({
       descriptor,
-      snapshotLines: buildSnapshotLines(buildSharepicSnapshot(descriptor, ctx.state)),
+      snapshotLines: isDeck
+        ? buildSliderDeckSnapshotLines(descriptor, ctx.pages)
+        : buildSnapshotLines(buildSharepicSnapshot(descriptor, ctx.state)),
       recentEditSummaries,
+      isDeck,
     });
 
     let text = '';
@@ -380,7 +556,9 @@ export async function handleSharepicAgenticEdit(args: HandleSharepicEditArgs): P
 
     // A model that only called tools still owes the user a confirmation.
     if (text.trim().length === 0) {
-      const lastApply = [...steps].reverse().find((s) => s.toolName === 'apply_sharepic_ops');
+      const lastApply = [...steps]
+        .reverse()
+        .find((s) => s.toolName === 'apply_sharepic_ops' || s.toolName === 'apply_slider_ops');
       text =
         typeof lastApply?.args.summary === 'string'
           ? `Erledigt: ${lastApply.args.summary}.`

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.ts
@@ -12,11 +12,11 @@ const EDIT_VERB_PATTERN =
   /(?<!\p{L})(änder|aender|mach|verschieb|beweg|setz|tausch|ersetz|wechsel|vergrößer|vergroesser|verklein|größer|groesser|kleiner|höher|hoeher|tiefer|kürz|kuerz|verläng|verlaeng|anpass|entfern|ausblend|einblend|zeig|versteck|nach\s+(?:oben|unten|links|rechts)|anderes?|neues?)/iu;
 
 const EDIT_NOUN_PATTERN =
-  /(?<!\p{L})(zeile\s*[123]?|text|balken|schrift|font|farb|hintergrund|bild|foto|motiv|sonnenblume|logo|zitat|überschrift|ueberschrift|header|sharepic|variante)/iu;
+  /(?<!\p{L})(zeile\s*[123]?|text|balken|schrift|font|farb|hintergrund|bild|foto|motiv|sonnenblume|logo|zitat|überschrift|ueberschrift|header|sharepic|variante|slides?|folien?|seite\s*\d*|karussell|slider|deck|cover|abschluss(folie)?|headline|untertext|zusatztext|label)/iu;
 
 /** Phrases that mean "generate fresh variants" — never treated as an edit. */
 const NEW_VARIANTS_PATTERN =
-  /(?<!\p{L})(neue?s?\s+(sharepic|varianten?)|noch\s*mal\s+(neu|von\s+vorn)|alle\s+varianten|drei\s+varianten)/iu;
+  /(?<!\p{L})(neue?[sn]?\s+(sharepic|varianten?|karussell|slider)|noch\s*mal\s+(neu|von\s+vorn)|alle\s+varianten|drei\s+varianten)/iu;
 
 /**
  * True when the message reads like an edit instruction for an existing

--- a/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
+++ b/apps/api/routes/chat/services/sharepicEditHeuristics.vitest.ts
@@ -36,6 +36,19 @@ describe('isSharepicEditInstruction', () => {
   it('requires an edit verb', () => {
     expect(isSharepicEditInstruction('was steht im wahlprogramm zum klimaschutz?')).toBe(false);
   });
+
+  it('matches slider-deck nouns (slide/folie/seite/karussell)', () => {
+    expect(isSharepicEditInstruction('mach die headline auf folie 2 kürzer')).toBe(true);
+    expect(isSharepicEditInstruction('ändere den text auf slide 3')).toBe(true);
+    expect(isSharepicEditInstruction('entferne seite 3')).toBe(true);
+    expect(isSharepicEditInstruction('mach das karussell dunkler')).toBe(true);
+    expect(isSharepicEditInstruction('ändere das cover')).toBe(true);
+  });
+
+  it('never fires on fresh-deck requests', () => {
+    expect(isSharepicEditInstruction('mach mir ein neues karussell')).toBe(false);
+    expect(isSharepicEditInstruction('erstelle einen neuen slider über klimaschutz')).toBe(false);
+  });
 });
 
 describe('hasSharepicEditVerb (relaxed Sharepic-Modus check)', () => {

--- a/apps/api/routes/chat/services/sharepicEditLlm.ts
+++ b/apps/api/routes/chat/services/sharepicEditLlm.ts
@@ -123,6 +123,29 @@ export function buildOperationCatalog(descriptor: SharepicTemplateDescriptor): s
   return lines;
 }
 
+/**
+ * Operation catalog for slider decks: the per-slide vocabulary above gets
+ * wrapped in deck operations that target slides by 1-based number.
+ */
+export function buildSliderDeckOperationCatalog(descriptor: SharepicTemplateDescriptor): string[] {
+  const fontBounds = descriptor.textFields
+    .filter((f) => f.fontSize)
+    .map((f) => `${f.field}: ${f.fontSize!.min}–${f.fontSize!.max}px`)
+    .join(', ');
+  const schemeIds =
+    descriptor.colorSchemes?.options.map((o) => `"${o.id}" (${o.label})`).join(', ') ?? '';
+  return [
+    'ERLAUBTE OPERATIONEN (genaue Schemas, Schlüssel ist "kind"):',
+    '  - { "kind": "edit-slide", "slide": <Nr>, "operations": [ ... ] } — ändert EINE Folie. Erlaubte innere Operationen:',
+    '      { "kind": "set-text", "field": "label" | "headline" | "subtext" | "subtext2", "label": "<Label>", "value": "<neuer Text>" }',
+    `      { "kind": "set-font-size", "field": "<field>", "label": "<Label>", "size": <Zahl> } (${fontBounds})`,
+    `      { "kind": "set-color-scheme", "schemeId": <id> } — nur: ${schemeIds}. Gilt IMMER für das GANZE Karussell.`,
+    '      Hinweis: "label" gibt es nur auf dem Cover (Slide 1), "subtext2" nur auf Inhalts-Folien.',
+    '  - { "kind": "add-slide", "afterSlide"?: <Nr>, "headline": "<Text>", "subtext"?: "<Text>", "subtext2"?: "<Text>" } — neue Inhalts-Folie (ohne afterSlide: vor der Abschluss-Folie).',
+    '  - { "kind": "remove-slide", "slide": <Nr> } — Cover (1) und Abschluss-Folie sind geschützt.',
+  ];
+}
+
 function buildSystemPrompt(
   descriptor: SharepicTemplateDescriptor,
   snapshot: CanvasAiSnapshot,

--- a/apps/api/routes/chat/services/sharepicEditService.ts
+++ b/apps/api/routes/chat/services/sharepicEditService.ts
@@ -17,15 +17,19 @@ import {
   buildSharepicSnapshot,
   getSharepicTemplateDescriptor,
   sharepicOpsToStatePatch,
+  sliderDeckOpsToPagePatches,
   type CanvasAiOperation,
   type SharepicTemplateDescriptor,
+  type SliderDeckOperation,
 } from '@gruenerator/contracts';
 
 import { getPostgresInstance } from '../../../database/services/PostgresService.js';
 import { createCanvas } from '../../../services/canvas/canvasRepository.js';
 import {
   applyCanvasStatePatch,
+  applyDeckChanges,
   getCurrentCanvasState,
+  type CanvasPageDef,
 } from '../../../services/canvas/canvasStateService.js';
 import {
   insertCanvasVersion,
@@ -273,6 +277,16 @@ export async function ensureMintedCanvas(args: {
     }
     sse.send('sharepic_minted', { variantId: target.variantId, canvasId });
     log.info(`[SharepicEdit] Minted canvas ${canvasId} for variant ${target.variantId}`);
+  } else {
+    // Pre-minted (decks mint at generation): make sure the thread binding
+    // exists — generation may have run without a thread id.
+    const pg = getPostgresInstance();
+    await pg.query(
+      `INSERT INTO chat_thread_canvases (thread_id, variant_id, canvas_id, canvas_type, is_active)
+       VALUES ($1, $2, $3, $4, TRUE)
+       ON CONFLICT (thread_id, variant_id) DO UPDATE SET updated_at = CURRENT_TIMESTAMP`,
+      [threadId, target.variantId, canvasId, target.canvasType]
+    );
   }
   await setActiveThreadCanvas(threadId, target.variantId);
   return canvasId;
@@ -379,6 +393,90 @@ export async function applySharepicOpsToCanvas(args: {
   };
 }
 
+export type ApplySliderOpsOutcome =
+  | {
+      ok: true;
+      version: number;
+      newPages: CanvasPageDef[];
+      appliedKinds: string[];
+      rejected: Array<{ kind: string; reason: string }>;
+    }
+  | { ok: false; reason: string; rejected: Array<{ kind: string; reason: string }> };
+
+/**
+ * Deck sibling of `applySharepicOpsToCanvas`: validate deck ops, write
+ * pageId-addressed patches / page ops through the Hocuspocus internal API
+ * (live-broadcasts into open studio tabs), snapshot a `{ pages }` version
+ * and emit `sharepic_updated` with the full page set.
+ */
+export async function applySliderOpsToDeck(args: {
+  canvasId: string;
+  variantId: string;
+  descriptor: SharepicTemplateDescriptor;
+  pages: CanvasPageDef[];
+  operations: SliderDeckOperation[];
+  summary: string;
+  userId: string;
+  sse: SSEWriter;
+}): Promise<ApplySliderOpsOutcome> {
+  const { canvasId, variantId, descriptor, pages, operations, summary, userId, sse } = args;
+
+  const result = sliderDeckOpsToPagePatches(descriptor, operations, pages);
+  const rejected = result.rejected.map((r) => ({ kind: r.op.kind, reason: r.reason }));
+  if (rejected.length > 0) {
+    log.warn(
+      `[SliderDeck] Rejected ops: ${rejected.map((r) => `${r.kind}: ${r.reason}`).join(' | ')}`
+    );
+  }
+
+  if (result.pagePatches.length === 0 && result.pageOps.length === 0) {
+    return {
+      ok: false,
+      reason: rejected[0]?.reason ?? 'Keine anwendbare Änderung',
+      rejected,
+    };
+  }
+
+  await applyDeckChanges(canvasId, {
+    // Always sent: re-seeds decks whose mint ran while Hocuspocus was down.
+    seedPages: pages,
+    pagePatches: result.pagePatches,
+    pageOps: result.pageOps,
+    newPages: result.newPages,
+  });
+
+  const version = await insertCanvasVersion({
+    canvasId,
+    state: { pages: result.newPages },
+    summary,
+    origin: 'chat-edit',
+    userId,
+  });
+
+  sse.send('sharepic_updated', {
+    variantId,
+    canvasId,
+    version,
+    canvasType: descriptor.id,
+    pages: result.newPages.map((p) => p.state),
+    summary,
+  });
+
+  log.info(
+    `[SliderDeck] Applied v${version} on ${canvasId} (${operations.length} op(s): ${operations
+      .map((o) => o.kind)
+      .join(', ')}, ${result.newPages.length} pages)`
+  );
+
+  return {
+    ok: true,
+    version,
+    newPages: result.newPages,
+    appliedKinds: result.applied.map((o) => o.kind),
+    rejected,
+  };
+}
+
 export interface HandleSharepicEditArgs {
   sse: SSEWriter;
   req: unknown;
@@ -453,6 +551,17 @@ export async function handleSharepicEdit(args: HandleSharepicEditArgs): Promise<
     if (!descriptor) {
       log.info(`[SharepicEdit] No descriptor for canvasType=${target.canvasType} — falling back`);
       return false;
+    }
+
+    if (descriptor.deck) {
+      // Deck NL-editing runs only on the agentic tool-loop path (v1). The
+      // single tool-forced call has no slide targeting — point at the Studio.
+      await finishWithText(
+        args,
+        'Folien-Karusselle kann ich hier gerade nicht direkt bearbeiten. ' +
+          'Öffne das Karussell im Studio, um einzelne Folien anzupassen.'
+      );
+      return true;
     }
 
     sse.send('progress_step', {

--- a/apps/api/routes/chat/services/sharepicVariantHelpers.ts
+++ b/apps/api/routes/chat/services/sharepicVariantHelpers.ts
@@ -9,7 +9,12 @@ import { createLogger } from '../../../utils/logger.js';
 const log = createLogger('SharepicVariants');
 
 export const SHAREPIC_VARIANT_TYPES = ['dreizeilen', 'zitat', 'info'] as const;
-export type SharepicVariantType = (typeof SHAREPIC_VARIANT_TYPES)[number];
+/**
+ * `slider` is requestable via keyword ("als Karussell") but deliberately NOT
+ * part of the generic 3-variant fanout — a deck is a different artifact and
+ * runs through `generateSliderDeckVariant` instead.
+ */
+export type SharepicVariantType = (typeof SHAREPIC_VARIANT_TYPES)[number] | 'slider';
 
 /**
  * Keyword patterns that pin a sharepic request to a SPECIFIC variant.
@@ -23,6 +28,11 @@ export type SharepicVariantType = (typeof SHAREPIC_VARIANT_TYPES)[number];
  * request, so chart terms like "balkendiagramm" never reach this map.
  */
 const VARIANT_KEYWORDS: ReadonlyArray<{ type: SharepicVariantType; pattern: RegExp }> = [
+  {
+    // Checked first: "slides"/"folien" must win over the dreizeilen fallback.
+    type: 'slider',
+    pattern: /\b(sliders?|karussells?|carousels?|slides?|folien|insta[\s-]?slides?)\b/i,
+  },
   {
     type: 'zitat',
     pattern: /\b(zitat\w*|quotes?|spruch\w*|spruchbild|zitatbild|aussage|statement)\b/i,
@@ -64,7 +74,7 @@ export function extractSharepicTopic(rawText: string): string {
     .replace(/\b(erstelle?|erstell|mache?|generiere?|baue?|gib|zeige?|entwirf|brauche?)\b/gi, ' ')
     .replace(/\b(mir|bitte|ein|eine|einen|einem|das|den|die)\b/gi, ' ')
     .replace(
-      /\b(share[\s-]?pics?|sharepics?|spruchbild\w*|zitatbild\w*|zitat\w*|spruch\w*|dreizeiler|dreizeilen|drei[\s-]?zeilen|info\w*|slogan|balken)\b/gi,
+      /\b(share[\s-]?pics?|sharepics?|spruchbild\w*|zitatbild\w*|zitat\w*|spruch\w*|dreizeiler|dreizeilen|drei[\s-]?zeilen|info\w*|slogan|balken|sliders?|karussells?|carousels?|slides?|folien)\b/gi,
       ' '
     )
     .replace(/\b(über|ueber|zum\s+thema|thema|zu|zum|zur|für|fuer)\b/gi, ' ')
@@ -142,6 +152,10 @@ export interface SharepicVariant {
   label?: string;
   /** Accessibility description generated alongside the sharepic text (for screen readers / social posts). */
   altText?: string;
+  /** Set for deck variants, which are minted at generation time. */
+  canvasId?: string;
+  /** Per-slide states for deck variants (slider); cover state doubles as initialProps. */
+  pages?: Array<Record<string, unknown>>;
 }
 
 const CANVAS_TYPE_BY_SHAREPIC: Record<string, string> = {

--- a/apps/api/routes/chat/services/sliderDeckService.ts
+++ b/apps/api/routes/chat/services/sliderDeckService.ts
@@ -1,0 +1,110 @@
+/**
+ * Slider deck creation for the chat: generate slide texts, mint a multi-page
+ * canvas document right away (unlike single sharepics, decks need their
+ * server-seeded pages for studio open, editing and versions), and return the
+ * variant payload for the chat card.
+ */
+import { randomUUID } from 'crypto';
+
+import { getSharepicTemplateDescriptor } from '@gruenerator/contracts';
+
+import { getPostgresInstance } from '../../../database/services/PostgresService.js';
+import { createCanvas } from '../../../services/canvas/canvasRepository.js';
+import {
+  applyDeckChanges,
+  type CanvasPageDef,
+} from '../../../services/canvas/canvasStateService.js';
+import { insertCanvasVersion } from '../../../services/canvas/canvasVersionRepository.js';
+import {
+  generateSliderDeckForChat,
+  type SliderSlide,
+} from '../../../services/chat/sliderGenerationService.js';
+import { createLogger } from '../../../utils/logger.js';
+
+import { extractSharepicTopic, type SharepicVariant } from './sharepicVariantHelpers.js';
+
+import type { Request } from 'express';
+
+const log = createLogger('SliderDeck');
+
+const DEFAULT_SCHEME = 'sand-tanne';
+
+/** Map generated slide texts to page defs (partial props, like the studio seeds). */
+export function slidesToPages(slides: SliderSlide[]): CanvasPageDef[] {
+  const descriptor = getSharepicTemplateDescriptor('slider');
+  const background = descriptor?.deck?.schemeColors[DEFAULT_SCHEME]?.background;
+  return slides.map((slide, i) => ({
+    id: randomUUID(),
+    configId: 'slider',
+    state: {
+      label: i === 0 ? slide.label || 'Wusstest du?' : slide.label,
+      headline: slide.headline,
+      subtext: slide.subtext,
+      subtext2: slide.subtext2,
+      slideVariant: i === 0 ? 'cover' : i === slides.length - 1 ? 'last' : 'content',
+      colorScheme: DEFAULT_SCHEME,
+      ...(background ? { backgroundColor: background } : {}),
+    },
+  }));
+}
+
+export async function generateSliderDeckVariant(args: {
+  req: Request;
+  text: string;
+  threadId: string | null;
+  userId: string;
+}): Promise<SharepicVariant> {
+  const { req, text, threadId, userId } = args;
+  const thema = extractSharepicTopic(text) || text;
+
+  const { slides } = await generateSliderDeckForChat(req, { thema });
+  const pages = slidesToPages(slides);
+  const variantId = randomUUID();
+
+  const title = slides[0].headline.slice(0, 80) || 'Slider-Karussell';
+  const canvas = await createCanvas(userId, {
+    title,
+    template_type: 'slider',
+    // Flat cover keys alongside `pages` keep gallery/thumbnail readers and
+    // the Hocuspocus-down fallback rendering something.
+    initial_state: { ...pages[0].state, pages },
+    page_count: pages.length,
+  });
+
+  try {
+    await applyDeckChanges(canvas.id, { seedPages: pages, newPages: pages });
+  } catch (err) {
+    // Tolerated: applyDeckChanges always re-sends seedPages, so the first
+    // edit re-seeds a deck whose mint happened while Hocuspocus was down.
+    log.warn(`[SliderDeck] Seeding ${canvas.id} failed (retried on first edit): ${err}`);
+  }
+
+  if (threadId) {
+    const pg = getPostgresInstance();
+    await pg.query(
+      `INSERT INTO chat_thread_canvases (thread_id, variant_id, canvas_id, canvas_type, is_active)
+       VALUES ($1, $2, $3, $4, TRUE)
+       ON CONFLICT (thread_id, variant_id) DO UPDATE SET updated_at = CURRENT_TIMESTAMP`,
+      [threadId, variantId, canvas.id, 'slider']
+    );
+  }
+
+  await insertCanvasVersion({
+    canvasId: canvas.id,
+    state: { pages },
+    summary: 'Aus dem Chat erstellt',
+    origin: 'mint',
+    userId,
+  });
+
+  log.info(`[SliderDeck] Minted deck ${canvas.id} (${pages.length} slides) for "${title}"`);
+
+  return {
+    id: variantId,
+    canvasType: 'slider',
+    canvasId: canvas.id,
+    initialProps: pages[0].state,
+    pages: pages.map((p) => p.state),
+    label: 'Slider',
+  };
+}

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -171,7 +171,9 @@ export interface SSEEventPayloads {
     canvasId: string;
     version: number;
     canvasType: string;
-    state: Record<string, unknown>;
+    /** Single sharepics send `state`; decks send `pages` instead. */
+    state?: Record<string, unknown>;
+    pages?: Array<Record<string, unknown>>;
     summary: string;
   };
   sharepic_edit_error: { variantId?: string; error: string };

--- a/apps/api/routes/sharepic/sharepic_claude/unifiedHandler.ts
+++ b/apps/api/routes/sharepic/sharepic_claude/unifiedHandler.ts
@@ -113,23 +113,45 @@ function mapToResponseFormat(
   }
 }
 
-export async function handleUnifiedRequest(
+export interface UnifiedTextBody {
+  thema?: string | undefined;
+  details?: string | undefined;
+  quote?: string | undefined;
+  name?: string | undefined;
+  count?: number | undefined;
+  _campaignPrompt?: unknown;
+}
+
+export type UnifiedTextResult =
+  | {
+      success: true;
+      mainKey: string;
+      main: Record<string, unknown> | string;
+      alternatives: Array<Record<string, unknown> | string>;
+      searchTerms: string[];
+    }
+  | { success: false; status: 400 | 500; error: string };
+
+/**
+ * Core of the unified sharepic text generation, extracted from the Express
+ * handler so the chat pipeline can call it without an HTTP round-trip. `req`
+ * is only used for worker-pool access (`getAIWorkerPool`).
+ */
+export async function generateUnifiedTexts(
   req: SharepicRequest,
-  res: Response,
-  type: string
-): Promise<void> {
+  type: string,
+  body: UnifiedTextBody
+): Promise<UnifiedTextResult> {
   const config = TYPE_CONFIGS[type];
   if (!config) {
-    res.status(400).json({ success: false, error: `Unknown type: ${type}` });
-    return;
+    return { success: false, status: 400, error: `Unknown type: ${type}` };
   }
 
-  const { thema, details, quote, name, count = 1 } = req.body;
-  const rawPromptConfig = req.body._campaignPrompt || prompts[type as keyof typeof prompts];
+  const { thema, details, quote, name, count = 1 } = body;
+  const rawPromptConfig = body._campaignPrompt || prompts[type as keyof typeof prompts];
 
   if (!rawPromptConfig) {
-    res.status(400).json({ success: false, error: `No prompt config for type: ${type}` });
-    return;
+    return { success: false, status: 400, error: `No prompt config for type: ${type}` };
   }
 
   const promptConfig = rawPromptConfig as PromptConfig;
@@ -239,21 +261,14 @@ export async function handleUnifiedRequest(
         searchTerms = processedData.suchbegriff ? [processedData.suchbegriff] : [];
       }
 
-      const response: Record<string, unknown> = {
+      log.info(`[${type}] Success on attempt ${attempts}`);
+      return {
         success: true,
-        [config.mainKey]: mainData,
+        mainKey: config.mainKey,
+        main: mainData,
         alternatives,
         searchTerms,
       };
-
-      if (type === 'zitat' || type === 'zitat_pure') {
-        response.quote = mainData;
-        response.name = name || '';
-      }
-
-      log.info(`[${type}] Success on attempt ${attempts}`);
-      res.json(response);
-      return;
     } catch (error) {
       lastError = (error as Error).message;
       log.error(`[${type}] Attempt ${attempts} exception:`, error);
@@ -261,8 +276,37 @@ export async function handleUnifiedRequest(
   }
 
   log.error(`[${type}] Failed after ${maxAttempts} attempts:`, lastError);
-  res.status(500).json({
+  return {
     success: false,
+    status: 500,
     error: `Failed after ${maxAttempts} attempts: ${lastError}`,
-  });
+  };
+}
+
+/** Thin Express wrapper around `generateUnifiedTexts` — response JSON unchanged. */
+export async function handleUnifiedRequest(
+  req: SharepicRequest,
+  res: Response,
+  type: string
+): Promise<void> {
+  const result = await generateUnifiedTexts(req, type, req.body);
+
+  if (!result.success) {
+    res.status(result.status).json({ success: false, error: result.error });
+    return;
+  }
+
+  const response: Record<string, unknown> = {
+    success: true,
+    [result.mainKey]: result.main,
+    alternatives: result.alternatives,
+    searchTerms: result.searchTerms,
+  };
+
+  if (type === 'zitat' || type === 'zitat_pure') {
+    response.quote = result.main;
+    response.name = req.body.name || '';
+  }
+
+  res.json(response);
 }

--- a/apps/api/services/canvas/canvasStateService.ts
+++ b/apps/api/services/canvas/canvasStateService.ts
@@ -20,8 +20,15 @@ const FETCH_TIMEOUT_MS = 5000;
 
 const db = getPostgresInstance();
 
+export interface CanvasPageDef {
+  id: string;
+  configId: string;
+  state: Record<string, unknown>;
+}
+
 interface InternalStateResponse {
   state: Record<string, unknown>;
+  pages?: CanvasPageDef[];
   hasYState: boolean;
 }
 
@@ -126,4 +133,113 @@ export async function applyCanvasStatePatch(
   );
 
   log.info(`Patched canvas ${canvasId} (${Object.keys(patch).length} key(s), yjs=${internalOk})`);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-page (slider deck) variants of the read/write paths. Deck state lives
+// per page in the Yjs `pages` array; root formState is never used for decks.
+// ---------------------------------------------------------------------------
+
+const isPageDefArray = (v: unknown): v is CanvasPageDef[] =>
+  Array.isArray(v) &&
+  v.every(
+    (p) =>
+      !!p &&
+      typeof p === 'object' &&
+      typeof (p as CanvasPageDef).id === 'string' &&
+      typeof (p as CanvasPageDef).configId === 'string' &&
+      typeof (p as CanvasPageDef).state === 'object'
+  );
+
+export interface CurrentDeckState {
+  pages: CanvasPageDef[];
+  source: 'yjs' | 'initial_state';
+}
+
+export async function getCurrentDeckState(canvasId: string): Promise<CurrentDeckState> {
+  try {
+    const res = await internalFetch(`/internal/canvas/${encodeURIComponent(canvasId)}/state`);
+    if (res.ok) {
+      const body = (await res.json()) as InternalStateResponse;
+      if (body.hasYState && isPageDefArray(body.pages) && body.pages.length > 0) {
+        return { pages: body.pages, source: 'yjs' };
+      }
+    } else {
+      log.warn(`internal GET state for ${canvasId} returned ${res.status}`);
+    }
+  } catch (err) {
+    log.warn(`internal GET state for ${canvasId} failed: ${err}`);
+  }
+  const initial = await readInitialState(canvasId);
+  const pages = initial?.pages;
+  return { pages: isPageDefArray(pages) ? pages : [], source: 'initial_state' };
+}
+
+export interface DeckChangesInput {
+  /**
+   * Full page set to seed a never-seeded Yjs doc with. Always sent — the
+   * Hocuspocus side ignores it when pages already exist, so this doubles as
+   * the retry-seed for decks whose mint happened while Hocuspocus was down.
+   */
+  seedPages: CanvasPageDef[];
+  pagePatches?: Array<{ pageId: string; patch: Record<string, unknown> }>;
+  pageOps?: Array<
+    { op: 'add'; index: number; page: CanvasPageDef } | { op: 'remove'; pageId: string }
+  >;
+  replacePages?: CanvasPageDef[];
+  /** Resulting full deck after the changes — mirrored into canvas_documents. */
+  newPages: CanvasPageDef[];
+}
+
+/**
+ * Apply deck changes (per-page patches, add/remove, restore). Mirrors the
+ * resulting deck into `canvas_documents.initial_state` as a FULL replace —
+ * jsonb `||` cannot deep-merge the pages array. Flat cover keys are kept
+ * alongside `pages` so gallery/thumbnail readers and the Hocuspocus-down
+ * fallback keep rendering something.
+ */
+export async function applyDeckChanges(canvasId: string, changes: DeckChangesInput): Promise<void> {
+  let internalOk = false;
+  try {
+    const res = await internalFetch(`/internal/canvas/${encodeURIComponent(canvasId)}/state`, {
+      method: 'POST',
+      body: JSON.stringify({
+        seedPages: changes.seedPages,
+        ...(changes.pagePatches ? { pagePatches: changes.pagePatches } : {}),
+        ...(changes.pageOps ? { pageOps: changes.pageOps } : {}),
+        ...(changes.replacePages ? { replacePages: changes.replacePages } : {}),
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`internal POST returned ${res.status}: ${text.slice(0, 200)}`);
+    }
+    internalOk = true;
+  } catch (err) {
+    if (await hasYjsRows(canvasId)) {
+      throw new Error(
+        `Folien konnten nicht aktualisiert werden (Collab-Dienst nicht erreichbar): ${err}`
+      );
+    }
+    log.warn(
+      `Hocuspocus unreachable for ${canvasId}; doc has no Yjs state — ` +
+        `updating initial_state only (${err})`
+    );
+  }
+
+  const coverState = changes.newPages[0]?.state ?? {};
+  await db.query(
+    `UPDATE canvas_documents
+     SET initial_state = $2::jsonb,
+         page_count = $3::int,
+         updated_at = CURRENT_TIMESTAMP
+     WHERE document_id = $1`,
+    [canvasId, JSON.stringify({ ...coverState, pages: changes.newPages }), changes.newPages.length]
+  );
+
+  log.info(
+    `Applied deck changes to canvas ${canvasId} ` +
+      `(pages=${changes.newPages.length}, patches=${changes.pagePatches?.length ?? 0}, ` +
+      `ops=${changes.pageOps?.length ?? 0}, restore=${changes.replacePages ? 'yes' : 'no'}, yjs=${internalOk})`
+  );
 }

--- a/apps/api/services/chat/sliderGenerationService.ts
+++ b/apps/api/services/chat/sliderGenerationService.ts
@@ -1,0 +1,64 @@
+/**
+ * Slider deck text generation for the chat pipeline. Reuses the image-studio
+ * slider stack without an HTTP round-trip: AI-determined slide count
+ * (`analyzeSlideCount`) → unified multi-slide prompt (`generateUnifiedTexts`).
+ */
+import { analyzeSlideCount } from '../../routes/sharepic/sharepic_claude/sliderSmartHandler.js';
+import { generateUnifiedTexts } from '../../routes/sharepic/sharepic_claude/unifiedHandler.js';
+import { createLogger } from '../../utils/logger.js';
+
+import type { SharepicRequest } from '../../routes/sharepic/sharepic_claude/types.js';
+import type { Request } from 'express';
+
+const log = createLogger('SliderGeneration');
+
+export interface SliderSlide {
+  label: string;
+  headline: string;
+  subtext: string;
+  subtext2: string;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+
+function toSlide(raw: Record<string, unknown> | string): SliderSlide {
+  const data = typeof raw === 'string' ? { headline: raw } : raw;
+  return {
+    label: str(data.label),
+    headline: str(data.headline),
+    subtext: str(data.subtext),
+    subtext2: str(data.subtext2),
+  };
+}
+
+/**
+ * Generate a full slider deck (cover + 1–3 content slides + closing slide)
+ * for a chat request. Throws on generation failure — the caller surfaces the
+ * error through the regular sharepic SSE error path.
+ */
+export async function generateSliderDeckForChat(
+  req: Request,
+  args: { thema: string; details?: string }
+): Promise<{ slides: SliderSlide[] }> {
+  const sharepicReq = req as SharepicRequest;
+  const contentSlides = await analyzeSlideCount(sharepicReq, args.thema, args.details ?? '');
+  const count = contentSlides + 2;
+
+  log.info(`[SliderGeneration] Generating ${count} slides for "${args.thema.slice(0, 60)}"`);
+
+  const result = await generateUnifiedTexts(sharepicReq, 'slider', {
+    thema: args.thema,
+    details: args.details ?? '',
+    count,
+  });
+
+  if (!result.success) {
+    throw new Error(`Slider-Generierung fehlgeschlagen: ${result.error}`);
+  }
+
+  const slides = [result.main, ...result.alternatives].map(toSlide);
+  if (slides.length < 2 || !slides[0].headline) {
+    throw new Error(`Slider-Generierung lieferte zu wenig Folien (${slides.length})`);
+  }
+  return { slides };
+}

--- a/apps/web/src/providers/GlobalChatProvider.tsx
+++ b/apps/web/src/providers/GlobalChatProvider.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import apiClient from '../components/utils/apiClient';
 import { renderSharepicToImage } from '../features/image-studio/renderSharepicToImage';
 import { uploadBlobToMediaLibrary } from '../features/image-studio/services/mediaUploadService';
 import { useModelPreferences } from '../features/models/hooks/useModelPreferences';
@@ -152,7 +153,26 @@ export function GlobalChatProvider({ children }: GlobalChatProviderProps) {
       fetchSharepicState: async (canvasId: string) => {
         const result = await getContractsClient().canvas.getState({ params: { id: canvasId } });
         if (result.status !== 200) return null;
-        return { state: result.body.state, version: result.body.version };
+        return {
+          state: result.body.state,
+          version: result.body.version,
+          ...(result.body.pages ? { pages: result.body.pages } : {}),
+        };
+      },
+      downloadSharepicZip: async (images: string[], canvasType: string) => {
+        const response = await apiClient.post(
+          '/exports/zip',
+          { images, canvasType },
+          { responseType: 'blob' }
+        );
+        const url = URL.createObjectURL(response.data as Blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `gruenerator-${canvasType}-${Date.now()}.zip`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
       },
       fetchSharepicVersions: async (canvasId: string) => {
         const result = await getContractsClient().canvas.listVersions({

--- a/packages/canvas-editor/src/ai/sliderDeckDescriptorParity.vitest.ts
+++ b/packages/canvas-editor/src/ai/sliderDeckDescriptorParity.vitest.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildSliderDeckSnapshotLines,
+  getSharepicTemplateDescriptor,
+  sliderDeckOpsToPagePatches,
+  type SliderDeckOperation,
+  type SliderDeckPage,
+} from '@gruenerator/contracts';
+
+import { sliderFullConfig } from '../configs/slider_full.config';
+import { getPillBadgeColorsForScheme } from '../utils/pillBadgeUtils';
+import { getSliderColors } from '../utils/sliderLayout';
+
+const descriptor = getSharepicTemplateDescriptor('slider')!;
+
+// The server-safe slider descriptor in @gruenerator/contracts duplicates the
+// editable surface of slider_full.config.tsx (API cannot import .tsx configs).
+describe('slider deck descriptor parity', () => {
+  it('exists and is the only deck descriptor', () => {
+    expect(descriptor).not.toBeNull();
+    expect(descriptor.deck).toBeDefined();
+    for (const type of ['dreizeilen', 'zitat-pure', 'info']) {
+      expect(getSharepicTemplateDescriptor(type)?.deck).toBeUndefined();
+    }
+  });
+
+  it('canvas dimensions match the config', () => {
+    expect(descriptor.canvas).toEqual(sliderFullConfig.canvas);
+  });
+
+  it('color scheme ids match the config AI capabilities', () => {
+    expect(descriptor.colorSchemes?.options.map((o) => o.id)).toEqual(
+      sliderFullConfig.ai?.colorSchemes?.map((s) => s.id)
+    );
+  });
+
+  it('scheme colors match getSliderColors + getPillBadgeColorsForScheme', () => {
+    for (const schemeId of ['sand-tanne', 'tanne-sand'] as const) {
+      const expected = getSliderColors(schemeId);
+      const pill = getPillBadgeColorsForScheme(schemeId);
+      expect(descriptor.deck!.schemeColors[schemeId]).toEqual({
+        background: expected.background,
+        pillBackground: pill.backgroundColor,
+        pillText: pill.textColor,
+        arrow: expected.arrowFill,
+      });
+    }
+  });
+
+  it('deck limits match the multiPage config', () => {
+    expect(descriptor.deck!.maxSlides).toBe(sliderFullConfig.multiPage?.maxPages);
+    expect(descriptor.deck!.defaultNewSlideState.slideVariant).toBe(
+      sliderFullConfig.multiPage?.defaultNewPageState?.slideVariant
+    );
+  });
+
+  it('text field state keys exist in the config initial state', () => {
+    const state = sliderFullConfig.createInitialState({}) as Record<string, unknown>;
+    for (const f of descriptor.textFields) {
+      expect(f.stateKey in state, f.stateKey).toBe(true);
+      if (f.fontSize) expect(f.fontSize.stateKey in state, f.fontSize.stateKey).toBe(true);
+    }
+    expect(descriptor.colorSchemes!.stateKey in state).toBe(true);
+  });
+});
+
+const makeDeck = (): SliderDeckPage[] => [
+  {
+    id: 'page-1',
+    configId: 'slider',
+    state: {
+      label: 'Wusstest du?',
+      headline: 'Cover-Headline',
+      subtext: 'Cover-Subtext',
+      subtext2: '',
+      slideVariant: 'cover',
+      colorScheme: 'sand-tanne',
+      backgroundColor: '#F5F1E9',
+      pillBadgeInstances: [
+        { id: 'pill-1', text: 'Wusstest du?', backgroundColor: '#005538', textColor: '#FFFFFF' },
+      ],
+      iconStates: { 'hi-chevronright': { x: 900, y: 1200, color: '#005538' } },
+    },
+  },
+  {
+    id: 'page-2',
+    configId: 'slider',
+    state: {
+      label: '',
+      headline: 'Fakt 1',
+      subtext: 'Inhalt 1',
+      subtext2: 'Quelle 1',
+      slideVariant: 'content',
+      colorScheme: 'sand-tanne',
+    },
+  },
+  {
+    id: 'page-3',
+    configId: 'slider',
+    state: {
+      label: '',
+      headline: 'Fakt 2',
+      subtext: 'Inhalt 2',
+      subtext2: '',
+      slideVariant: 'content',
+      colorScheme: 'sand-tanne',
+    },
+  },
+  {
+    id: 'page-4',
+    configId: 'slider',
+    state: {
+      label: '',
+      headline: 'Mehr dazu',
+      subtext: 'gruene.de',
+      subtext2: '',
+      slideVariant: 'last',
+      colorScheme: 'sand-tanne',
+    },
+  },
+];
+
+describe('sliderDeckOpsToPagePatches', () => {
+  it('edit-slide patches only the targeted page', () => {
+    const ops: SliderDeckOperation[] = [
+      {
+        kind: 'edit-slide',
+        slide: 2,
+        operations: [{ kind: 'set-text', field: 'headline', label: 'Headline', value: 'Neu' }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.pagePatches).toEqual([{ pageId: 'page-2', patch: { headline: 'Neu' } }]);
+    expect(result.pageOps).toHaveLength(0);
+    expect(result.newPages[1].state.headline).toBe('Neu');
+    expect(result.newPages[0].state.headline).toBe('Cover-Headline');
+  });
+
+  it('clamps font sizes via the shared single-page interpreter', () => {
+    const ops: SliderDeckOperation[] = [
+      {
+        kind: 'edit-slide',
+        slide: 2,
+        operations: [{ kind: 'set-font-size', field: 'headline', label: 'Headline', size: 500 }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.pagePatches[0].patch.customHeadlineFontSize).toBe(150);
+  });
+
+  it('expands set-color-scheme deck-wide with derived colors', () => {
+    const ops: SliderDeckOperation[] = [
+      {
+        kind: 'edit-slide',
+        slide: 3,
+        operations: [{ kind: 'set-color-scheme', schemeId: 'tanne-sand' }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.pagePatches).toHaveLength(4);
+    for (const { patch } of result.pagePatches) {
+      expect(patch.colorScheme).toBe('tanne-sand');
+      expect(patch.backgroundColor).toBe('#005538');
+    }
+    const coverPatch = result.pagePatches.find((p) => p.pageId === 'page-1')!.patch;
+    expect((coverPatch.pillBadgeInstances as Array<{ backgroundColor: string }>)[0]).toMatchObject({
+      backgroundColor: '#F5F1E9',
+      textColor: '#005538',
+      text: 'Wusstest du?',
+    });
+    expect(
+      (coverPatch.iconStates as Record<string, { color: string }>)['hi-chevronright'].color
+    ).toBe('#F5F1E9');
+  });
+
+  it('keeps the cover pill text in sync when the label changes', () => {
+    const ops: SliderDeckOperation[] = [
+      {
+        kind: 'edit-slide',
+        slide: 1,
+        operations: [{ kind: 'set-text', field: 'label', label: 'Label', value: 'Schon gewusst?' }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    const patch = result.pagePatches[0].patch;
+    expect(patch.label).toBe('Schon gewusst?');
+    expect((patch.pillBadgeInstances as Array<{ text: string }>)[0].text).toBe('Schon gewusst?');
+  });
+
+  it('add-slide inserts before the closing slide and inherits the scheme', () => {
+    const ops: SliderDeckOperation[] = [
+      { kind: 'add-slide', headline: 'Fakt 3', subtext: 'Inhalt 3' },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.pageOps).toHaveLength(1);
+    const add = result.pageOps[0];
+    if (add.op !== 'add') throw new Error('expected add op');
+    expect(add.index).toBe(3);
+    expect(add.page.state).toMatchObject({
+      headline: 'Fakt 3',
+      slideVariant: 'content',
+      colorScheme: 'sand-tanne',
+      backgroundColor: '#F5F1E9',
+    });
+    expect(result.newPages.map((p) => p.state.headline)).toEqual([
+      'Cover-Headline',
+      'Fakt 1',
+      'Fakt 2',
+      'Fakt 3',
+      'Mehr dazu',
+    ]);
+  });
+
+  it('folds edits to a freshly added slide into the add op', () => {
+    const ops: SliderDeckOperation[] = [
+      { kind: 'add-slide', headline: 'Fakt 3' },
+      {
+        kind: 'edit-slide',
+        slide: 4,
+        operations: [{ kind: 'set-text', field: 'subtext', label: 'Untertext', value: 'Spät' }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.pagePatches).toHaveLength(0);
+    const add = result.pageOps[0];
+    if (add.op !== 'add') throw new Error('expected add op');
+    expect(add.page.state.subtext).toBe('Spät');
+  });
+
+  it('remove-slide rejects cover, closing slide and the minimum', () => {
+    const cover = sliderDeckOpsToPagePatches(
+      descriptor,
+      [{ kind: 'remove-slide', slide: 1 } as never],
+      makeDeck()
+    );
+    expect(cover.rejected).toHaveLength(1);
+
+    const last = sliderDeckOpsToPagePatches(
+      descriptor,
+      [{ kind: 'remove-slide', slide: 4 }],
+      makeDeck()
+    );
+    expect(last.rejected[0].reason).toContain('Abschluss');
+
+    const three = makeDeck().slice(0, 2).concat(makeDeck()[3]);
+    const min = sliderDeckOpsToPagePatches(descriptor, [{ kind: 'remove-slide', slide: 2 }], three);
+    expect(min.rejected[0].reason).toContain('Mindestens');
+
+    const ok = sliderDeckOpsToPagePatches(
+      descriptor,
+      [{ kind: 'remove-slide', slide: 3 }],
+      makeDeck()
+    );
+    expect(ok.pageOps).toEqual([{ op: 'remove', pageId: 'page-3' }]);
+    expect(ok.newPages).toHaveLength(3);
+  });
+
+  it('rejects per-slide ops the slider does not support', () => {
+    const ops: SliderDeckOperation[] = [
+      {
+        kind: 'edit-slide',
+        slide: 2,
+        operations: [{ kind: 'toggle-sunflower', visible: false }],
+      },
+    ];
+    const result = sliderDeckOpsToPagePatches(descriptor, ops, makeDeck());
+    expect(result.applied).toHaveLength(0);
+    expect(result.rejected).toHaveLength(1);
+  });
+});
+
+describe('buildSliderDeckSnapshotLines', () => {
+  it('reports scheme, variants and per-slide texts', () => {
+    const lines = buildSliderDeckSnapshotLines(descriptor, makeDeck());
+    expect(lines[0]).toContain('4 Slides');
+    expect(lines[0]).toContain('sand-tanne');
+    expect(lines[1]).toContain('(Cover)');
+    expect(lines[1]).toContain('Wusstest du?');
+    expect(lines[2]).toContain('(Inhalt)');
+    expect(lines[2]).toContain('Quelle 1');
+    expect(lines[4]).toContain('(Abschluss)');
+    // Cover has no Zusatztext, content slides no Label
+    expect(lines[1]).not.toContain('Zusatztext');
+    expect(lines[2]).not.toContain('Label');
+  });
+});

--- a/packages/chat/src/components/SharepicArtifactPanel.tsx
+++ b/packages/chat/src/components/SharepicArtifactPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 
 import { useSharepicArtifact } from '../hooks/useSharepicArtifact';
+import { useSliderDeckArtifact } from '../hooks/useSliderDeckArtifact';
 import { useSharepicLiveStore, type ActiveSharepic } from '../stores/sharepicLiveStore';
 
 import type { SharepicVariant } from '../hooks/useChatGraphStream';
@@ -39,6 +40,9 @@ export function SharepicArtifactPanel({ className }: { className?: string }) {
   const active = useSharepicLiveStore((s) => s.activeVariant);
   if (!active) return null;
   // Key by variant so stepper/preview state never leaks across sharepics.
+  if (active.pages && active.pages.length > 0) {
+    return <DeckPanelInner key={active.variantId} active={active} className={className} />;
+  }
   return <PanelInner key={active.variantId} active={active} className={className} />;
 }
 
@@ -197,6 +201,222 @@ function PanelInner({ active, className }: { active: ActiveSharepic; className?:
 
         <p className="text-xs text-foreground-muted">
           Beschreibe Änderungen einfach im Chat — sie landen direkt auf diesem Sharepic.
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+function DeckPanelInner({ active, className }: { active: ActiveSharepic; className?: string }) {
+  const variant = useMemo<SharepicVariant>(
+    () => ({
+      id: active.variantId,
+      canvasType: active.canvasType,
+      initialProps: active.initialProps,
+      ...(active.pages ? { pages: active.pages } : {}),
+      ...(active.label ? { label: active.label } : {}),
+      ...(active.canvasId ? { canvasId: active.canvasId } : {}),
+    }),
+    [active]
+  );
+
+  const {
+    imageBase64,
+    isRendering,
+    renderError,
+    isExporting,
+    slideCount,
+    selectedIndex,
+    selectSlide,
+    headVersion,
+    viewVersion,
+    showStepper,
+    canDownloadZip,
+    stepToVersion,
+    restoreViewVersion,
+    downloadZip,
+    openInStudio,
+  } = useSliderDeckArtifact(variant);
+
+  const close = () => useSharepicLiveStore.getState().setActiveVariant(null);
+
+  return (
+    <aside
+      className={
+        className ??
+        'flex w-[24rem] shrink-0 flex-col overflow-hidden border-l border-border bg-background-alt'
+      }
+      aria-label="Aktives Karussell"
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
+            <SquarePen className="h-3 w-3" />
+            Sharepic-Modus
+          </span>
+          <span className="truncate text-sm font-medium text-foreground">
+            Slider · {slideCount} Folien
+          </span>
+        </div>
+        <button
+          onClick={close}
+          className="rounded p-1 text-foreground-muted hover:bg-primary/10 hover:text-foreground"
+          aria-label="Sharepic-Modus beenden"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3">
+        {renderError ? (
+          <div className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
+            Karussell-Vorschau konnte nicht gerendert werden.
+            <button onClick={openInStudio} className="ml-2 text-primary hover:underline">
+              Im Editor öffnen
+            </button>
+          </div>
+        ) : (
+          <div className="group/panelimg relative overflow-hidden rounded-lg border border-border bg-background">
+            {isRendering && !imageBase64 && (
+              <div className="flex h-72 items-center justify-center">
+                <div className="flex flex-col items-center gap-2">
+                  <Loader2 className="h-8 w-8 animate-spin text-foreground-muted" />
+                  <span className="text-xs text-foreground-muted">Rendere Karussell...</span>
+                </div>
+              </div>
+            )}
+            {imageBase64 && (
+              <img
+                src={imageBase64}
+                alt={`Karussell-Folie ${selectedIndex + 1} von ${slideCount}`}
+                className={
+                  isRendering
+                    ? 'mx-auto w-full opacity-50 transition-opacity'
+                    : 'mx-auto w-full opacity-100 transition-opacity'
+                }
+              />
+            )}
+            {imageBase64 && slideCount > 1 && (
+              <span className="absolute bottom-2 right-2 rounded-full bg-black/50 px-2 py-0.5 text-xs font-medium text-white">
+                {selectedIndex + 1}/{slideCount}
+              </span>
+            )}
+            {imageBase64 && !isRendering && (
+              <div className="absolute inset-0 flex items-center justify-center gap-3 bg-black/0 opacity-0 transition-opacity group-hover/panelimg:bg-black/30 group-hover/panelimg:opacity-100 focus-within:bg-black/30 focus-within:opacity-100">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <button
+                      className="flex size-11 items-center justify-center rounded-full bg-white text-grey-900 shadow-lg transition-transform hover:scale-105"
+                      aria-label="Karussell im Studio bearbeiten"
+                    >
+                      <Pencil className="h-5 w-5" />
+                    </button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Im Studio öffnen?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Das Karussell öffnet sich im Studio-Editor in einem neuen Tab. Änderungen
+                        bleiben synchron — du kannst danach hier im Chat weiterarbeiten.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+                      <AlertDialogAction onClick={openInStudio}>Im Studio öffnen</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+                {canDownloadZip && (
+                  <button
+                    onClick={() => void downloadZip()}
+                    disabled={isExporting}
+                    className="flex size-11 items-center justify-center rounded-full bg-white text-grey-900 shadow-lg transition-transform hover:scale-105 disabled:opacity-50"
+                    aria-label="Alle Folien als ZIP herunterladen"
+                  >
+                    {isExporting ? (
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                    ) : (
+                      <Download className="h-5 w-5" />
+                    )}
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {slideCount > 1 && (
+          <div className="flex items-center justify-center gap-1">
+            <button
+              onClick={() => selectSlide(selectedIndex - 1)}
+              disabled={selectedIndex === 0}
+              className="rounded p-1 text-foreground-muted hover:bg-primary/10 hover:text-foreground disabled:opacity-30"
+              aria-label="Vorherige Folie"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            {Array.from({ length: slideCount }, (_, i) => (
+              <button
+                key={i}
+                onClick={() => selectSlide(i)}
+                className={
+                  i === selectedIndex
+                    ? 'h-6 min-w-6 rounded bg-primary px-1 text-xs font-medium text-white'
+                    : 'h-6 min-w-6 rounded px-1 text-xs font-medium text-foreground-muted hover:bg-primary/10 hover:text-foreground'
+                }
+                aria-label={`Folie ${i + 1} anzeigen`}
+                aria-current={i === selectedIndex}
+              >
+                {i + 1}
+              </button>
+            ))}
+            <button
+              onClick={() => selectSlide(selectedIndex + 1)}
+              disabled={selectedIndex >= slideCount - 1}
+              className="rounded p-1 text-foreground-muted hover:bg-primary/10 hover:text-foreground disabled:opacity-30"
+              aria-label="Nächste Folie"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          {showStepper ? (
+            <span className="inline-flex items-center gap-0.5 text-xs text-foreground-muted">
+              <button
+                onClick={() => void stepToVersion(-1)}
+                className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                aria-label="Vorherige Version anzeigen"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </button>
+              v{viewVersion ?? headVersion}/{headVersion}
+              <button
+                onClick={() => void stepToVersion(1)}
+                className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                aria-label="Nächste Version anzeigen"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </button>
+            </span>
+          ) : (
+            <span />
+          )}
+          {viewVersion != null && (
+            <button
+              onClick={() => void restoreViewVersion()}
+              className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
+              aria-label={`Version ${viewVersion} wiederherstellen`}
+            >
+              <History className="h-3.5 w-3.5" />
+              <span>Wiederherstellen</span>
+            </button>
+          )}
+        </div>
+
+        <p className="text-xs text-foreground-muted">
+          Beschreibe Änderungen einfach im Chat — z.B. „kürze die Headline auf Folie 2".
         </p>
       </div>
     </aside>

--- a/packages/chat/src/components/message-parts/SharepicVariantStack.tsx
+++ b/packages/chat/src/components/message-parts/SharepicVariantStack.tsx
@@ -1,4 +1,5 @@
 import { SharepicVariantCard } from './SharepicVariantCard';
+import { SliderDeckCard } from './SliderDeckCard';
 
 import type { SharepicData } from '../../hooks/useChatGraphStream';
 
@@ -17,9 +18,13 @@ export function SharepicVariantStack({ data }: SharepicVariantStackProps) {
 
   return (
     <div className="mb-3 space-y-3">
-      {data.variants.map((variant) => (
-        <SharepicVariantCard key={variant.id} variant={variant} />
-      ))}
+      {data.variants.map((variant) =>
+        variant.pages && variant.pages.length > 0 ? (
+          <SliderDeckCard key={variant.id} variant={variant} />
+        ) : (
+          <SharepicVariantCard key={variant.id} variant={variant} />
+        )
+      )}
     </div>
   );
 }

--- a/packages/chat/src/components/message-parts/SliderDeckCard.tsx
+++ b/packages/chat/src/components/message-parts/SliderDeckCard.tsx
@@ -1,0 +1,237 @@
+import { useCallback } from 'react';
+import {
+  Loader2,
+  Pencil,
+  Download,
+  ExternalLink,
+  ChevronLeft,
+  ChevronRight,
+  SquarePen,
+  History,
+} from 'lucide-react';
+import { cn } from '../../lib/utils';
+import { useSliderDeckArtifact } from '../../hooks/useSliderDeckArtifact';
+
+import type { SharepicVariant } from '../../hooks/useChatGraphStream';
+
+interface SliderDeckCardProps {
+  variant: SharepicVariant;
+}
+
+/** Chat card for a multi-page slider deck: slide pager + deck actions. */
+export function SliderDeckCard({ variant }: SliderDeckCardProps) {
+  const {
+    imageBase64,
+    isRendering,
+    renderError,
+    isExporting,
+    slideCount,
+    selectedIndex,
+    selectSlide,
+    headVersion,
+    viewVersion,
+    isActiveForChat,
+    showStepper,
+    canDownloadZip,
+    stepToVersion,
+    restoreViewVersion,
+    toggleActive,
+    downloadZip,
+    openInStudio,
+  } = useSliderDeckArtifact(variant);
+
+  const handleZip = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      void downloadZip();
+    },
+    [downloadZip]
+  );
+
+  if (renderError) {
+    return (
+      <div className="rounded-lg border border-border p-4 text-sm text-foreground-muted">
+        Karussell-Vorschau konnte nicht gerendert werden.
+        <button onClick={openInStudio} className="ml-2 text-primary hover:underline">
+          Im Editor öffnen
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'group/sliderdeck relative overflow-hidden rounded-lg border bg-background-alt transition-all hover:shadow-md',
+        isActiveForChat
+          ? 'border-primary ring-1 ring-primary'
+          : 'border-border hover:border-primary'
+      )}
+    >
+      <div className="relative">
+        <button
+          type="button"
+          onClick={openInStudio}
+          className="block w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          aria-label="Slider-Karussell im Editor öffnen"
+        >
+          {isRendering && !imageBase64 && (
+            <div className="flex h-64 items-center justify-center">
+              <div className="flex flex-col items-center gap-2">
+                <Loader2 className="h-8 w-8 animate-spin text-foreground-muted" />
+                <span className="text-xs text-foreground-muted">Rendere Karussell...</span>
+              </div>
+            </div>
+          )}
+          {imageBase64 && (
+            <img
+              src={imageBase64}
+              alt={`Karussell-Folie ${selectedIndex + 1} von ${slideCount}`}
+              className={cn(
+                'mx-auto max-h-[420px] w-auto transition-opacity',
+                isRendering ? 'opacity-50' : 'opacity-100'
+              )}
+            />
+          )}
+          {imageBase64 && !isRendering && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/0 opacity-0 transition-opacity group-hover/sliderdeck:bg-black/30 group-hover/sliderdeck:opacity-100">
+              <div className="flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-medium text-white shadow-lg">
+                <ExternalLink className="h-4 w-4" />
+                <span>Im Studio öffnen</span>
+              </div>
+            </div>
+          )}
+        </button>
+
+        {slideCount > 1 && imageBase64 && (
+          <>
+            <button
+              onClick={() => selectSlide(selectedIndex - 1)}
+              disabled={selectedIndex === 0}
+              className="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-1.5 text-white transition-opacity hover:bg-black/60 disabled:opacity-30"
+              aria-label="Vorherige Folie"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => selectSlide(selectedIndex + 1)}
+              disabled={selectedIndex >= slideCount - 1}
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-black/40 p-1.5 text-white transition-opacity hover:bg-black/60 disabled:opacity-30"
+              aria-label="Nächste Folie"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+            <span className="absolute bottom-2 right-2 rounded-full bg-black/50 px-2 py-0.5 text-xs font-medium text-white">
+              {selectedIndex + 1}/{slideCount}
+            </span>
+          </>
+        )}
+      </div>
+
+      {slideCount > 1 && imageBase64 && (
+        <div className="flex items-center justify-center gap-1 border-t border-border px-3 py-1.5">
+          {Array.from({ length: slideCount }, (_, i) => (
+            <button
+              key={i}
+              onClick={() => selectSlide(i)}
+              className={cn(
+                'h-6 min-w-6 rounded px-1 text-xs font-medium transition-colors',
+                i === selectedIndex
+                  ? 'bg-primary text-white'
+                  : 'text-foreground-muted hover:bg-primary/10 hover:text-foreground'
+              )}
+              aria-label={`Folie ${i + 1} anzeigen`}
+              aria-current={i === selectedIndex}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {imageBase64 && (
+        <div className="flex flex-wrap items-center justify-between gap-1 border-t border-border px-3 py-2">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+              Slider · {slideCount} Folien
+            </span>
+            {isActiveForChat && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-white">
+                <SquarePen className="h-3 w-3" />
+                Aktiv im Chat
+              </span>
+            )}
+            {showStepper && (
+              <span className="inline-flex items-center gap-0.5 text-xs text-foreground-muted">
+                <button
+                  onClick={() => void stepToVersion(-1)}
+                  className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                  aria-label="Vorherige Version anzeigen"
+                >
+                  <ChevronLeft className="h-3 w-3" />
+                </button>
+                v{viewVersion ?? headVersion}/{headVersion}
+                <button
+                  onClick={() => void stepToVersion(1)}
+                  className="rounded p-0.5 hover:bg-primary/10 hover:text-foreground"
+                  aria-label="Nächste Version anzeigen"
+                >
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              </span>
+            )}
+            {viewVersion != null && (
+              <button
+                onClick={() => void restoreViewVersion()}
+                className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
+                aria-label={`Version ${viewVersion} wiederherstellen`}
+              >
+                <History className="h-3 w-3" />
+                <span>Wiederherstellen</span>
+              </button>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={toggleActive}
+              className={cn(
+                'flex items-center gap-1 rounded-lg px-2 py-1 text-xs',
+                isActiveForChat
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-foreground-muted hover:bg-primary/10 hover:text-foreground'
+              )}
+              aria-pressed={isActiveForChat}
+              aria-label="Dieses Karussell per Chat bearbeiten"
+            >
+              <SquarePen className="h-3 w-3" />
+              <span>{isActiveForChat ? 'Im Chat aktiv' : 'Im Chat bearbeiten'}</span>
+            </button>
+            {canDownloadZip && (
+              <button
+                onClick={handleZip}
+                disabled={isExporting}
+                className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-foreground-muted hover:bg-primary/10 hover:text-foreground disabled:opacity-50"
+                aria-label="Alle Folien als ZIP herunterladen"
+              >
+                {isExporting ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Download className="h-3 w-3" />
+                )}
+                <span>Als ZIP</span>
+              </button>
+            )}
+            <button
+              onClick={openInStudio}
+              className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-primary hover:bg-primary/10"
+              aria-label="Karussell im Studio bearbeiten"
+            >
+              <Pencil className="h-3 w-3" />
+              <span>Studio</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/chat/src/hooks/useChatGraphStream.ts
+++ b/packages/chat/src/hooks/useChatGraphStream.ts
@@ -38,6 +38,8 @@ export interface SharepicVariant {
   label?: string;
   /** Set once the variant has been minted into a canvas document (chat editing). */
   canvasId?: string;
+  /** Per-slide states for deck variants (slider carousel). */
+  pages?: Array<Record<string, unknown>>;
 }
 
 export interface SharepicData {

--- a/packages/chat/src/hooks/useSliderDeckArtifact.ts
+++ b/packages/chat/src/hooks/useSliderDeckArtifact.ts
@@ -3,66 +3,30 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { useChatConfigStore } from '../stores/chatConfigStore';
 import { useSharepicLiveStore } from '../stores/sharepicLiveStore';
 
+import { maybeUploadThumbnail, type SharepicVersionEntry } from './useSharepicArtifact';
+
 import type { SharepicVariant } from './useChatGraphStream';
 
-export interface SharepicVersionEntry {
-  version: number;
-  summary: string | null;
-}
-
-const FALLBACK_LABELS: Record<string, string> = {
-  dreizeilen: 'Dreizeiler',
-  'zitat-pure': 'Zitat',
-  zitat: 'Zitat',
-  info: 'Info',
-  simple: 'Sharepic',
-  veranstaltung: 'Veranstaltung',
-  slider: 'Slider',
-  freeform: 'Freeform',
-};
-
-export function sharepicLabel(variant: Pick<SharepicVariant, 'label' | 'canvasType'>): string {
-  return variant.label ?? FALLBACK_LABELS[variant.canvasType] ?? 'Sharepic';
-}
-
 /**
- * After a real edit (entry is thumbnail-dirty) the freshly rendered head PNG
- * doubles as the canvas thumbnail. Version previews never qualify, and the
- * flag is cleared up front — a failed upload is not worth a retry loop.
- * Clearing is synchronous, so when card and panel render the same variant
- * concurrently only the first completed render uploads.
+ * Deck sibling of useSharepicArtifact: live rendering, slide pager, version
+ * stepping and ZIP download for a multi-page slider variant. Card and docked
+ * panel share the same sharepicLiveStore entry, so SSE updates reach both.
  */
-export function maybeUploadThumbnail(
-  variantId: string,
-  dataUrl: string,
-  isVersionPreview: boolean
-) {
-  if (isVersionPreview) return;
-  const store = useSharepicLiveStore.getState();
-  const entry = store.entries[variantId];
-  if (!entry?.thumbnailDirty || !entry.canvasId) return;
-  const upload = useChatConfigStore.getState().updateSharepicThumbnail;
-  if (!upload) return;
-  store.clearThumbnailDirty(variantId);
-  upload(entry.canvasId, dataUrl).catch((err) => {
-    console.warn('[useSharepicArtifact] Thumbnail-Update fehlgeschlagen:', err);
-  });
-}
-
-/**
- * Shared live-rendering + version logic for a chat sharepic variant. Used by
- * the inline message card AND the docked artifact panel — both render from
- * the same sharepicLiveStore entry, so SSE updates reach them identically.
- */
-export function useSharepicArtifact(variant: SharepicVariant) {
+export function useSliderDeckArtifact(variant: SharepicVariant) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [imageBase64, setImageBase64] = useState<string | null>(null);
   const [isRendering, setIsRendering] = useState(true);
   const [renderError, setRenderError] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [versions, setVersions] = useState<SharepicVersionEntry[] | null>(null);
   /** Version being previewed via the stepper; null = current head. */
   const [viewVersion, setViewVersion] = useState<number | null>(null);
-  const [viewState, setViewState] = useState<Record<string, unknown> | null>(null);
-  const versionStateCache = useRef(new Map<number, Record<string, unknown>>());
+  const [viewPages, setViewPages] = useState<Array<Record<string, unknown>> | null>(null);
+  // Render cache: epoch bumps whenever the page set changes, invalidating
+  // all cached slide renders at once.
+  const renderCache = useRef(new Map<string, string>());
+  const epochRef = useRef(0);
+  const versionPagesCache = useRef(new Map<number, Array<Record<string, unknown>>>());
   const hydratedRef = useRef(false);
 
   const live = useSharepicLiveStore((s) => s.entries[variant.id]);
@@ -70,27 +34,48 @@ export function useSharepicArtifact(variant: SharepicVariant) {
 
   const canvasId = live?.canvasId ?? variant.canvasId ?? null;
   const headVersion = live?.version ?? null;
-  const renderInput = viewState ?? live?.state ?? variant.initialProps;
+  const livePages = live?.pages ?? null;
+  const headPages = livePages ?? variant.pages ?? [];
+  const pages = viewPages ?? headPages;
+  const slideCount = pages.length;
+  const safeIndex = Math.min(selectedIndex, Math.max(0, slideCount - 1));
 
-  // Render (and re-render after each chat edit / version step). renderInput
-  // is the full flat state — StandaloneCanvas's createInitialState accepts it
-  // in place of the original initialProps.
+  useEffect(() => {
+    epochRef.current += 1;
+  }, [pages]);
+
+  const renderSlide = useCallback(
+    async (index: number): Promise<string | null> => {
+      const pageState = pages[index];
+      if (!pageState) return null;
+      const key = `${epochRef.current}:${index}`;
+      const cached = renderCache.current.get(key);
+      if (cached) return cached;
+      const renderFn = useChatConfigStore.getState().renderSharepic;
+      if (!renderFn) return null;
+      const dataUrl = await renderFn(variant.canvasType, pageState);
+      if (dataUrl) renderCache.current.set(key, dataUrl);
+      return dataUrl;
+    },
+    [pages, variant.canvasType]
+  );
+
+  // Render the selected slide (and re-render after chat edits / version steps).
   useEffect(() => {
     let cancelled = false;
-    const renderFn = useChatConfigStore.getState().renderSharepic;
-    if (!renderFn) {
+    if (slideCount === 0) {
       setRenderError(true);
       setIsRendering(false);
       return undefined;
     }
     setIsRendering(true);
-    renderFn(variant.canvasType, renderInput)
+    renderSlide(safeIndex)
       .then((dataUrl) => {
         if (cancelled) return;
         if (dataUrl) {
           setImageBase64(dataUrl);
           setRenderError(false);
-          maybeUploadThumbnail(variant.id, dataUrl, viewState != null);
+          if (safeIndex === 0) maybeUploadThumbnail(variant.id, dataUrl, viewPages != null);
         } else {
           setRenderError(true);
         }
@@ -104,32 +89,40 @@ export function useSharepicArtifact(variant: SharepicVariant) {
     return () => {
       cancelled = true;
     };
-  }, [variant.canvasType, variant.id, renderInput, viewState]);
+  }, [renderSlide, safeIndex, slideCount, variant.id, viewPages]);
 
-  // Thread-reload rehydration: a minted variant renders its CURRENT state
-  // (which may have changed in the studio), not the stale initialProps.
+  // Thread-reload rehydration: a deck renders its CURRENT pages (which may
+  // have changed in the studio), not the stale generation-time pages.
   useEffect(() => {
-    if (!canvasId || hydratedRef.current || live?.state) return;
+    if (!canvasId || hydratedRef.current || livePages) return;
     const fetchState = useChatConfigStore.getState().fetchSharepicState;
     if (!fetchState) return;
     hydratedRef.current = true;
     void fetchState(canvasId).then((result) => {
-      if (!result) return;
+      if (!result?.pages || result.pages.length === 0) return;
       useSharepicLiveStore.getState().upsertEntry(variant.id, {
         canvasId,
         canvasType: variant.canvasType,
         version: result.version,
-        state: result.state,
+        state: null,
+        pages: result.pages,
       });
     });
-  }, [canvasId, live?.state, variant.id, variant.canvasType]);
+  }, [canvasId, livePages, variant.id, variant.canvasType]);
 
   // New head version (chat edit applied) → drop any stale version preview.
   useEffect(() => {
     setViewVersion(null);
-    setViewState(null);
+    setViewPages(null);
     setVersions(null);
   }, [headVersion]);
+
+  const selectSlide = useCallback(
+    (index: number) => {
+      setSelectedIndex(Math.min(Math.max(index, 0), Math.max(0, slideCount - 1)));
+    },
+    [slideCount]
+  );
 
   const loadVersions = useCallback(async (): Promise<SharepicVersionEntry[]> => {
     if (versions) return versions;
@@ -140,6 +133,19 @@ export function useSharepicArtifact(variant: SharepicVariant) {
     setVersions(entries);
     return entries;
   }, [canvasId, versions]);
+
+  const extractVersionPages = (
+    state: Record<string, unknown> | null
+  ): Array<Record<string, unknown>> | null => {
+    const raw = state?.pages;
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    // Version snapshots store full PageDefs ({id, configId, state}).
+    return raw.map((p) =>
+      p && typeof p === 'object' && 'state' in (p as object)
+        ? ((p as { state: Record<string, unknown> }).state ?? {})
+        : ((p as Record<string, unknown>) ?? {})
+    );
+  };
 
   const stepToVersion = useCallback(
     async (direction: -1 | 1) => {
@@ -156,22 +162,23 @@ export function useSharepicArtifact(variant: SharepicVariant) {
       if (!target) return;
       if (nextIdx === ordered.length - 1) {
         setViewVersion(null);
-        setViewState(null);
+        setViewPages(null);
         return;
       }
-      const cached = versionStateCache.current.get(target.version);
+      const cached = versionPagesCache.current.get(target.version);
       if (cached) {
         setViewVersion(target.version);
-        setViewState(cached);
+        setViewPages(cached);
         return;
       }
       const fetchVersionState = useChatConfigStore.getState().fetchSharepicVersionState;
       if (!fetchVersionState) return;
       const state = await fetchVersionState(canvasId, target.version).catch(() => null);
-      if (state) {
-        versionStateCache.current.set(target.version, state);
+      const versionPages = extractVersionPages(state);
+      if (versionPages) {
+        versionPagesCache.current.set(target.version, versionPages);
         setViewVersion(target.version);
-        setViewState(state);
+        setViewPages(versionPages);
       }
     },
     [canvasId, loadVersions, viewVersion]
@@ -183,11 +190,13 @@ export function useSharepicArtifact(variant: SharepicVariant) {
     if (!restore) return;
     const result = await restore(canvasId, viewVersion).catch(() => null);
     if (result) {
+      const restoredPages = extractVersionPages(result.state);
       useSharepicLiveStore.getState().upsertEntry(variant.id, {
         canvasId,
         canvasType: variant.canvasType,
         version: result.version,
-        state: result.state,
+        state: null,
+        ...(restoredPages ? { pages: restoredPages } : {}),
         thumbnailDirty: true,
       });
     }
@@ -203,28 +212,36 @@ export function useSharepicArtifact(variant: SharepicVariant) {
         canvasId,
         canvasType: variant.canvasType,
         initialProps: variant.initialProps,
+        pages: headPages,
         ...(variant.label ? { label: variant.label } : {}),
       });
     }
-  }, [variant.id, variant.canvasType, variant.initialProps, variant.label, canvasId]);
+  }, [variant.id, variant.canvasType, variant.initialProps, variant.label, canvasId, headPages]);
 
-  const download = useCallback(() => {
-    if (!imageBase64) return;
-    const link = document.createElement('a');
-    link.href = imageBase64;
-    link.download = `sharepic-${variant.canvasType}.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  }, [imageBase64, variant.canvasType]);
+  const downloadZip = useCallback(async () => {
+    const zip = useChatConfigStore.getState().downloadSharepicZip;
+    if (!zip || slideCount === 0 || isExporting) return;
+    setIsExporting(true);
+    try {
+      const images: string[] = [];
+      for (let i = 0; i < slideCount; i++) {
+        const dataUrl = await renderSlide(i);
+        if (dataUrl) images.push(dataUrl);
+      }
+      if (images.length > 0) await zip(images, variant.canvasType);
+    } catch (err) {
+      console.warn('[useSliderDeckArtifact] ZIP-Export fehlgeschlagen:', err);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [slideCount, isExporting, renderSlide, variant.canvasType]);
 
   const openInStudio = useCallback(() => {
     useChatConfigStore.getState().onEditSharepic?.({
       ...variant,
-      initialProps: live?.state ?? variant.initialProps,
       ...(canvasId ? { canvasId } : {}),
     });
-  }, [variant, live?.state, canvasId]);
+  }, [variant, canvasId]);
 
   const showStepper = canvasId != null && headVersion != null && headVersion > 1;
 
@@ -232,16 +249,20 @@ export function useSharepicArtifact(variant: SharepicVariant) {
     imageBase64,
     isRendering,
     renderError,
+    isExporting,
     canvasId,
+    slideCount,
+    selectedIndex: safeIndex,
+    selectSlide,
     headVersion,
     viewVersion,
     isActiveForChat,
     showStepper,
-    label: sharepicLabel(variant),
+    canDownloadZip: useChatConfigStore.getState().downloadSharepicZip != null,
     stepToVersion,
     restoreViewVersion,
     toggleActive,
-    download,
+    downloadZip,
     openInStudio,
   };
 }

--- a/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
+++ b/packages/chat/src/runtime/GrueneratorModelAdapter/parseSSEStream.ts
@@ -443,14 +443,17 @@ export async function* parseSSEStream(
             canvasId: string;
             version: number;
             canvasType: string;
-            state: Record<string, unknown>;
+            /** Single sharepics send `state`, decks send `pages` instead. */
+            state?: Record<string, unknown>;
+            pages?: Array<Record<string, unknown>>;
             summary: string;
           };
           useSharepicLiveStore.getState().upsertEntry(payload.variantId, {
             canvasId: payload.canvasId,
             canvasType: payload.canvasType,
             version: payload.version,
-            state: payload.state,
+            state: payload.state ?? null,
+            ...(payload.pages ? { pages: payload.pages } : {}),
             summary: payload.summary,
             thumbnailDirty: true,
           });

--- a/packages/chat/src/stores/chatConfigStore.ts
+++ b/packages/chat/src/stores/chatConfigStore.ts
@@ -36,9 +36,12 @@ export interface ChatConfig {
     initialProps: Record<string, unknown>
   ) => Promise<string | null>;
   /** Current state of a chat-edited sharepic canvas (GET /api/canvas/:id/state). */
-  fetchSharepicState?: (
-    canvasId: string
-  ) => Promise<{ state: Record<string, unknown>; version: number | null } | null>;
+  fetchSharepicState?: (canvasId: string) => Promise<{
+    state: Record<string, unknown>;
+    version: number | null;
+    /** Per-slide states for multi-page (deck) canvases. */
+    pages?: Array<Record<string, unknown>> | null;
+  } | null>;
   /** Chat-edit version history of a canvas, newest first. */
   fetchSharepicVersions?: (
     canvasId: string
@@ -59,6 +62,11 @@ export interface ChatConfig {
    * state. Best-effort — failures must not surface in the chat UI.
    */
   updateSharepicThumbnail?: (canvasId: string, imageDataUrl: string) => Promise<void>;
+  /**
+   * Bundles rendered slide PNGs (data URLs) into a ZIP download (deck
+   * variants). Platform-specific — web posts to /api/exports/zip.
+   */
+  downloadSharepicZip?: (images: string[], canvasType: string) => Promise<void>;
   /**
    * URL the @wolke picker links to when the user hasn't connected any
    * Nextcloud share link yet. Platform-specific (web: `/wolke`, native: a deep
@@ -169,6 +177,7 @@ interface ChatConfigStore extends ResolvedChatConfig {
   fetchSharepicVersionState?: ChatConfig['fetchSharepicVersionState'];
   restoreSharepicVersion?: ChatConfig['restoreSharepicVersion'];
   updateSharepicThumbnail?: ChatConfig['updateSharepicThumbnail'];
+  downloadSharepicZip?: ChatConfig['downloadSharepicZip'];
   /** URL the @wolke empty-state CTA opens (new tab). Hidden when unset. */
   wolkeConnectUrl?: string;
   /** threadId → context-getter, populated by host surfaces (e.g. docs editor). */
@@ -259,6 +268,7 @@ export const useChatConfigStore = create<ChatConfigStore>((set, get) => ({
       fetchSharepicVersionState: config?.fetchSharepicVersionState,
       restoreSharepicVersion: config?.restoreSharepicVersion,
       updateSharepicThumbnail: config?.updateSharepicThumbnail,
+      downloadSharepicZip: config?.downloadSharepicZip,
       wolkeConnectUrl: config?.wolkeConnectUrl,
     });
   },

--- a/packages/chat/src/stores/sharepicLiveStore.ts
+++ b/packages/chat/src/stores/sharepicLiveStore.ts
@@ -14,6 +14,8 @@ export interface SharepicLiveEntry {
   version: number | null;
   /** Full flat state of the latest version; null until first fetch/update. */
   state: Record<string, unknown> | null;
+  /** Per-slide states for deck variants (slider); null for single sharepics. */
+  pages?: Array<Record<string, unknown>> | null;
   summary?: string;
   /**
    * Set when the state changed through a real edit (SSE update / restore) —
@@ -34,6 +36,8 @@ export interface ActiveSharepic {
    */
   initialProps: Record<string, unknown>;
   label?: string;
+  /** Per-slide render seeds for deck variants (slider). */
+  pages?: Array<Record<string, unknown>>;
 }
 
 interface SharepicLiveStore {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -108,6 +108,7 @@ export * from './schemas/userAgents.js';
 export * from './schemas/canvasAi.js';
 export * from './schemas/canvas.js';
 export * from './schemas/canvasTemplateDescriptors.js';
+export * from './schemas/sliderDeck.js';
 export * from './schemas/skill.js';
 export * from './schemas/groups.js';
 export * from './schemas/contentSync.js';

--- a/packages/contracts/src/schemas/canvas.ts
+++ b/packages/contracts/src/schemas/canvas.ts
@@ -114,6 +114,8 @@ export const canvasStateResponseSchema = z.object({
   state: z.record(z.unknown()),
   source: z.enum(['yjs', 'initial_state']),
   version: z.number().int().nullable(),
+  /** Per-slide states for multi-page (deck) canvases, in page order. */
+  pages: z.array(z.record(z.unknown())).nullish(),
 });
 
 export type CanvasStateResponse = z.infer<typeof canvasStateResponseSchema>;

--- a/packages/contracts/src/schemas/canvasAi.ts
+++ b/packages/contracts/src/schemas/canvasAi.ts
@@ -279,3 +279,36 @@ export const sharepicEditResponseSchema = z.object({
 });
 
 export type SharepicEditResponse = z.infer<typeof sharepicEditResponseSchema>;
+
+// ── Slider deck operations (multi-page chat editing) ────────────────────────
+
+/**
+ * Deck-level wrapper around the single-page operation vocabulary: slider
+ * carousels are edited per slide (1-based, slide 1 = cover, last slide =
+ * closing). `edit-slide` reuses `canvasAiOperationSchema` unchanged, so the
+ * per-page interpreter (`sharepicOpsToStatePatch`) keeps doing the
+ * clamping/rejecting.
+ */
+export const sliderDeckOperationSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('edit-slide'),
+    /** 1-based slide number as shown in the snapshot. */
+    slide: z.number().int().min(1).max(10),
+    operations: z.array(canvasAiOperationSchema).min(1).max(6),
+  }),
+  z.object({
+    kind: z.literal('add-slide'),
+    /** Insert after this 1-based slide; defaults to before the closing slide. */
+    afterSlide: z.number().int().min(1).max(9).nullish(),
+    headline: z.string().min(1),
+    subtext: z.string().nullish(),
+    subtext2: z.string().nullish(),
+  }),
+  z.object({
+    kind: z.literal('remove-slide'),
+    /** 1-based; cover (1) and the closing slide cannot be removed. */
+    slide: z.number().int().min(2).max(10),
+  }),
+]);
+
+export type SliderDeckOperation = z.infer<typeof sliderDeckOperationSchema>;

--- a/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
+++ b/packages/contracts/src/schemas/canvasTemplateDescriptors.ts
@@ -17,7 +17,7 @@ import {
   type CanvasAiSnapshot,
 } from './canvasAi.js';
 
-export const SHAREPIC_EDITABLE_TEMPLATES = ['dreizeilen', 'zitat-pure', 'info'] as const;
+export const SHAREPIC_EDITABLE_TEMPLATES = ['dreizeilen', 'zitat-pure', 'info', 'slider'] as const;
 export type SharepicEditableTemplate = (typeof SHAREPIC_EDITABLE_TEMPLATES)[number];
 
 export interface SharepicTextFieldDescriptor {
@@ -52,10 +52,34 @@ export interface SharepicElementDescriptor {
   presenceStateKey?: string;
 }
 
+/** Per-scheme colors the studio's `setColorScheme` action derives together. */
+export interface SliderSchemeColors {
+  background: string;
+  pillBackground: string;
+  pillText: string;
+  arrow: string;
+}
+
+export interface SharepicDeckDescriptor {
+  maxSlides: number;
+  /** Cover + at least one content slide + closing slide. */
+  minSlides: number;
+  /** Base state for `add-slide` (before headline/subtext are merged in). */
+  defaultNewSlideState: Record<string, unknown>;
+  /**
+   * `set-color-scheme` is deck-wide and, unlike the studio action, reaches the
+   * state as a raw patch — so the interpreter must mirror the derived colors
+   * (backgroundColor, pill badge, arrow icon) itself using this map.
+   */
+  schemeColors: Record<string, SliderSchemeColors>;
+}
+
 export interface SharepicTemplateDescriptor {
   id: SharepicEditableTemplate;
   label: string;
   canvas: { width: number; height: number };
+  /** Present only for multi-page (deck) templates such as the slider. */
+  deck?: SharepicDeckDescriptor;
   supportedOperations: string[];
   textFields: SharepicTextFieldDescriptor[];
   /** Color schemes for `set-color-scheme` (dreizeilen). */
@@ -250,10 +274,78 @@ const INFO_DESCRIPTOR: SharepicTemplateDescriptor = {
   defaultState: { backgroundColor: '#005538' },
 };
 
+const SLIDER_DESCRIPTOR: SharepicTemplateDescriptor = {
+  id: 'slider',
+  label: 'Slider-Karussell',
+  canvas: { width: 1080, height: 1350 },
+  deck: {
+    maxSlides: 10,
+    minSlides: 3,
+    defaultNewSlideState: {
+      label: '',
+      headline: '',
+      subtext: '',
+      subtext2: '',
+      slideVariant: 'content',
+    },
+    schemeColors: {
+      'sand-tanne': {
+        background: '#F5F1E9',
+        pillBackground: '#005538',
+        pillText: '#FFFFFF',
+        arrow: '#005538',
+      },
+      'tanne-sand': {
+        background: '#005538',
+        pillBackground: '#F5F1E9',
+        pillText: '#005538',
+        arrow: '#F5F1E9',
+      },
+    },
+  },
+  supportedOperations: ['set-text', 'set-font-size', 'set-color-scheme'],
+  textFields: [
+    {
+      field: 'label',
+      label: 'Label (Pill-Badge, nur Cover)',
+      stateKey: 'label',
+      fontSize: { stateKey: 'customLabelFontSize', min: 20, max: 80 },
+    },
+    {
+      field: 'headline',
+      label: 'Headline',
+      stateKey: 'headline',
+      fontSize: { stateKey: 'customHeadlineFontSize', min: 30, max: 150 },
+    },
+    {
+      field: 'subtext',
+      label: 'Untertext',
+      stateKey: 'subtext',
+      fontSize: { stateKey: 'customSubtextFontSize', min: 20, max: 90 },
+    },
+    {
+      field: 'subtext2',
+      label: 'Zusatztext (nur Content-Slides)',
+      stateKey: 'subtext2',
+      fontSize: { stateKey: 'customSubtext2FontSize', min: 20, max: 90 },
+    },
+  ],
+  colorSchemes: {
+    stateKey: 'colorScheme',
+    options: [
+      { id: 'sand-tanne', label: 'Sand & Tanne (heller Hintergrund)' },
+      { id: 'tanne-sand', label: 'Tanne & Sand (dunkler Hintergrund)' },
+    ],
+  },
+  elements: [],
+  defaultState: { colorScheme: 'sand-tanne' },
+};
+
 const DESCRIPTORS: Record<SharepicEditableTemplate, SharepicTemplateDescriptor> = {
   dreizeilen: DREIZEILEN_DESCRIPTOR,
   'zitat-pure': ZITAT_PURE_DESCRIPTOR,
   info: INFO_DESCRIPTOR,
+  slider: SLIDER_DESCRIPTOR,
 };
 
 export function getSharepicTemplateDescriptor(

--- a/packages/contracts/src/schemas/sliderDeck.ts
+++ b/packages/contracts/src/schemas/sliderDeck.ts
@@ -1,0 +1,272 @@
+/**
+ * Slider-deck interpreter: translates validated `SliderDeckOperation`s into
+ * pageId-addressed patches and structural page ops for the Hocuspocus
+ * internal API. Per-slide edits delegate to `sharepicOpsToStatePatch`, so all
+ * single-page clamping/rejecting applies unchanged.
+ */
+import { type CanvasAiOperation, type SliderDeckOperation } from './canvasAi.js';
+import {
+  sharepicOpsToStatePatch,
+  type SharepicTemplateDescriptor,
+} from './canvasTemplateDescriptors.js';
+
+export interface SliderDeckPage {
+  id: string;
+  configId: string;
+  state: Record<string, unknown>;
+}
+
+export type SliderDeckPageOp =
+  | { op: 'add'; index: number; page: SliderDeckPage }
+  | { op: 'remove'; pageId: string };
+
+export interface SliderDeckOpsResult {
+  pagePatches: Array<{ pageId: string; patch: Record<string, unknown> }>;
+  pageOps: SliderDeckPageOp[];
+  /** Resulting full deck (version snapshot + DB mirror). */
+  newPages: SliderDeckPage[];
+  applied: SliderDeckOperation[];
+  rejected: Array<{ op: SliderDeckOperation | CanvasAiOperation; reason: string }>;
+}
+
+const newPageId = (): string =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `p-${Math.random().toString(36).slice(2, 11)}`;
+
+const SLIDE_VARIANT_LABELS: Record<string, string> = {
+  cover: 'Cover',
+  content: 'Inhalt',
+  last: 'Abschluss',
+};
+
+/** The slider config keys its arrow decoration under this icon id. */
+const ARROW_ICON_ID = 'hi-chevronright';
+
+interface PillBadgeLike {
+  backgroundColor?: string;
+  textColor?: string;
+  text?: string;
+}
+
+/**
+ * Mirror of the studio's `setColorScheme` action: alongside `colorScheme`
+ * the derived backgroundColor, pill badge colors and arrow icon color must
+ * change too — a raw state patch bypasses the action coupling.
+ */
+function buildSchemePatch(
+  descriptor: SharepicTemplateDescriptor,
+  schemeId: string,
+  state: Record<string, unknown>
+): Record<string, unknown> {
+  const colors = descriptor.deck?.schemeColors[schemeId];
+  const stateKey = descriptor.colorSchemes?.stateKey ?? 'colorScheme';
+  const patch: Record<string, unknown> = { [stateKey]: schemeId };
+  if (!colors) return patch;
+  patch['backgroundColor'] = colors.background;
+
+  const pills = state['pillBadgeInstances'];
+  if (Array.isArray(pills) && pills.length > 0) {
+    patch['pillBadgeInstances'] = pills.map((p: PillBadgeLike) => ({
+      ...p,
+      backgroundColor: colors.pillBackground,
+      textColor: colors.pillText,
+    }));
+  }
+  const icons = state['iconStates'];
+  if (icons && typeof icons === 'object' && ARROW_ICON_ID in (icons as object)) {
+    const iconStates = icons as Record<string, Record<string, unknown>>;
+    patch['iconStates'] = {
+      ...iconStates,
+      [ARROW_ICON_ID]: { ...iconStates[ARROW_ICON_ID], color: colors.arrow },
+    };
+  }
+  return patch;
+}
+
+/**
+ * The visible pill text on mounted cover slides lives in
+ * `pillBadgeInstances[0].text`, not in `state.label` — keep both in sync.
+ */
+function withPillText(
+  patch: Record<string, unknown>,
+  state: Record<string, unknown>
+): Record<string, unknown> {
+  if (!('label' in patch)) return patch;
+  const pills = state['pillBadgeInstances'];
+  if (!Array.isArray(pills) || pills.length === 0) return patch;
+  return {
+    ...patch,
+    pillBadgeInstances: pills.map((p: PillBadgeLike, i: number) =>
+      i === 0 ? { ...p, text: patch['label'] } : p
+    ),
+  };
+}
+
+export function sliderDeckOpsToPagePatches(
+  descriptor: SharepicTemplateDescriptor,
+  ops: SliderDeckOperation[],
+  pages: SliderDeckPage[]
+): SliderDeckOpsResult {
+  const deck = descriptor.deck;
+  const pagePatchById = new Map<string, Record<string, unknown>>();
+  const pageOps: SliderDeckPageOp[] = [];
+  const applied: SliderDeckOperation[] = [];
+  const rejected: SliderDeckOpsResult['rejected'] = [];
+  // Pages added in this batch don't exist in Yjs when pagePatches apply
+  // (patches run before pageOps) — fold their edits into the add op instead.
+  const addedPages = new Map<string, SliderDeckPage>();
+
+  const working: SliderDeckPage[] = pages.map((p) => ({ ...p, state: { ...p.state } }));
+
+  const mergePatch = (page: SliderDeckPage, patch: Record<string, unknown>): void => {
+    if (Object.keys(patch).length === 0) return;
+    page.state = { ...page.state, ...patch };
+    const added = addedPages.get(page.id);
+    if (added) {
+      added.state = { ...added.state, ...patch };
+      return;
+    }
+    pagePatchById.set(page.id, { ...(pagePatchById.get(page.id) ?? {}), ...patch });
+  };
+
+  if (!deck) {
+    return {
+      pagePatches: [],
+      pageOps: [],
+      newPages: working,
+      applied,
+      rejected: ops.map((op) => ({ op, reason: `${descriptor.id} ist kein Folien-Deck` })),
+    };
+  }
+
+  for (const op of ops) {
+    if (op.kind === 'edit-slide') {
+      const idx = op.slide - 1;
+      const page = working[idx];
+      if (!page) {
+        rejected.push({ op, reason: `Slide ${op.slide} existiert nicht (1–${working.length})` });
+        continue;
+      }
+      const result = sharepicOpsToStatePatch(descriptor, op.operations, page.state);
+      rejected.push(...result.rejected);
+      if (result.applied.length === 0) continue;
+
+      const schemeOp = result.applied.find((o) => o.kind === 'set-color-scheme');
+      if (schemeOp && schemeOp.kind === 'set-color-scheme') {
+        // Color scheme is a deck-wide property — expand to every slide with
+        // the derived colors, regardless of which slide the LLM targeted.
+        for (const p of working) {
+          mergePatch(p, buildSchemePatch(descriptor, schemeOp.schemeId, p.state));
+        }
+        const stateKey = descriptor.colorSchemes?.stateKey ?? 'colorScheme';
+        delete result.patch[stateKey];
+      }
+      mergePatch(page, withPillText(result.patch, page.state));
+      applied.push(op);
+    } else if (op.kind === 'add-slide') {
+      if (working.length >= deck.maxSlides) {
+        rejected.push({ op, reason: `Maximal ${deck.maxSlides} Slides` });
+        continue;
+      }
+      // Default: before the closing slide. afterSlide is clamped so nothing
+      // can land before the cover or after the closing slide.
+      const insertAfter = Math.min(op.afterSlide ?? working.length - 1, working.length - 1);
+      const index = Math.max(1, insertAfter);
+      const coverState = working[0]?.state ?? {};
+      const schemeId =
+        typeof coverState['colorScheme'] === 'string' ? coverState['colorScheme'] : 'sand-tanne';
+      const page: SliderDeckPage = {
+        id: newPageId(),
+        configId: descriptor.id,
+        state: {
+          ...deck.defaultNewSlideState,
+          headline: op.headline,
+          subtext: op.subtext ?? '',
+          subtext2: op.subtext2 ?? '',
+          colorScheme: schemeId,
+          ...(deck.schemeColors[schemeId]
+            ? { backgroundColor: deck.schemeColors[schemeId].background }
+            : {}),
+        },
+      };
+      working.splice(index, 0, page);
+      addedPages.set(page.id, page);
+      pageOps.push({ op: 'add', index, page });
+      applied.push(op);
+    } else {
+      const idx = op.slide - 1;
+      const page = working[idx];
+      if (!page) {
+        rejected.push({ op, reason: `Slide ${op.slide} existiert nicht (1–${working.length})` });
+        continue;
+      }
+      if (idx === 0) {
+        rejected.push({ op, reason: 'Das Cover (Slide 1) kann nicht entfernt werden' });
+        continue;
+      }
+      if (idx === working.length - 1) {
+        rejected.push({ op, reason: 'Die Abschluss-Folie kann nicht entfernt werden' });
+        continue;
+      }
+      if (working.length <= deck.minSlides) {
+        rejected.push({ op, reason: `Mindestens ${deck.minSlides} Slides nötig` });
+        continue;
+      }
+      working.splice(idx, 1);
+      if (addedPages.has(page.id)) {
+        // Added and removed in the same batch — drop the pending add op.
+        addedPages.delete(page.id);
+        const addIdx = pageOps.findIndex((o) => o.op === 'add' && o.page.id === page.id);
+        if (addIdx >= 0) pageOps.splice(addIdx, 1);
+      } else {
+        pagePatchById.delete(page.id);
+        pageOps.push({ op: 'remove', pageId: page.id });
+      }
+      applied.push(op);
+    }
+  }
+
+  return {
+    pagePatches: [...pagePatchById.entries()].map(([pageId, patch]) => ({ pageId, patch })),
+    pageOps,
+    newPages: working,
+    applied,
+    rejected,
+  };
+}
+
+const trim = (v: unknown, max = 90): string => {
+  const s = typeof v === 'string' ? v : '';
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+};
+
+/** Compact per-slide snapshot lines for the LLM (~40 tokens per slide). */
+export function buildSliderDeckSnapshotLines(
+  descriptor: SharepicTemplateDescriptor,
+  pages: SliderDeckPage[]
+): string[] {
+  const schemeKey = descriptor.colorSchemes?.stateKey ?? 'colorScheme';
+  const scheme = pages[0]?.state[schemeKey];
+  const lines: string[] = [
+    `Karussell mit ${pages.length} Slides (max. ${descriptor.deck?.maxSlides ?? 10})` +
+      (typeof scheme === 'string' ? ` — Farbschema: ${scheme} (gilt für alle Slides)` : ''),
+  ];
+  pages.forEach((page, i) => {
+    const rawVariant = page.state['slideVariant'];
+    const variant = typeof rawVariant === 'string' ? rawVariant : '';
+    const variantLabel = SLIDE_VARIANT_LABELS[variant] ?? variant;
+    const parts: string[] = [];
+    for (const f of descriptor.textFields) {
+      // Cover-only / content-only fields stay out of irrelevant slides.
+      if (f.field === 'label' && variant !== 'cover') continue;
+      if (f.field === 'subtext2' && variant !== 'content') continue;
+      const value = trim(page.state[f.stateKey]);
+      const size = f.fontSize ? page.state[f.fontSize.stateKey] : undefined;
+      const sizeInfo = typeof size === 'number' ? ` [${Math.round(size)}px]` : '';
+      parts.push(`${f.label.replace(/ \(.*\)$/, '')}${sizeInfo}: "${value}"`);
+    }
+    lines.push(`Slide ${i + 1}/${pages.length} (${variantLabel}) — ${parts.join(' | ')}`);
+  });
+  return lines;
+}

--- a/services/hocuspocus/src/internalApi.ts
+++ b/services/hocuspocus/src/internalApi.ts
@@ -14,6 +14,8 @@ const log = createLogger('InternalApi');
 const KEY_FORM_STATE = 'formState';
 const KEY_PAGES = 'pages';
 const KEY_STATE = 'state';
+const KEY_ID = 'id';
+const KEY_CONFIG_ID = 'configId';
 
 const TRANSACT_ORIGIN = 'gruenerator-internal-canvas-api';
 
@@ -22,8 +24,50 @@ interface InternalApiDeps {
   persistence: PostgresPersistence;
 }
 
+export interface PageDef {
+  id: string;
+  configId: string;
+  state: Record<string, unknown>;
+}
+
+export interface DeckChanges {
+  /** Seed the pages array — applied only when the doc has no pages yet. */
+  seedPages?: PageDef[];
+  /** Per-page state patches, addressed by page id (stable under reorders). */
+  pagePatches?: Array<{ pageId: string; patch: Record<string, unknown> }>;
+  /** Structural changes, applied after patches. */
+  pageOps?: Array<{ op: 'add'; index: number; page: PageDef } | { op: 'remove'; pageId: string }>;
+  /** Restore: replace the whole pages array. Applied last, wins over the rest. */
+  replacePages?: PageDef[];
+}
+
+// Mirrors buildPageYMap in packages/canvas-editor/src/collab/useYjsPages.ts:
+// layers & config maps are created on demand when the page first mounts.
+function buildPageYMap(def: PageDef): Y.Map<unknown> {
+  const page = new Y.Map<unknown>();
+  page.set(KEY_ID, def.id);
+  page.set(KEY_CONFIG_ID, def.configId);
+  const state = new Y.Map<unknown>();
+  for (const [k, v] of Object.entries(def.state)) state.set(k, v);
+  page.set(KEY_STATE, state);
+  return page;
+}
+
+function readPageDef(yMap: Y.Map<unknown>): PageDef | null {
+  const id = yMap.get(KEY_ID);
+  const configId = yMap.get(KEY_CONFIG_ID);
+  if (typeof id !== 'string' || typeof configId !== 'string') return null;
+  const state: Record<string, unknown> = {};
+  const yState = yMap.get(KEY_STATE);
+  if (yState instanceof Y.Map) {
+    for (const [k, v] of (yState as Y.Map<unknown>).entries()) state[k] = v;
+  }
+  return { id, configId, state };
+}
+
 export function readMergedState(doc: Y.Doc): {
   state: Record<string, unknown>;
+  pages: PageDef[];
   hasYState: boolean;
 } {
   const formState = doc.getMap<unknown>(KEY_FORM_STATE);
@@ -40,7 +84,122 @@ export function readMergedState(doc: Y.Doc): {
     merged[key] = value;
   });
 
-  return { state: merged, hasYState: formState.size > 0 || pages.length > 0 };
+  const pageDefs: PageDef[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const def = readPageDef(pages.get(i));
+    if (def) pageDefs.push(def);
+  }
+
+  return {
+    state: merged,
+    pages: pageDefs,
+    hasYState: formState.size > 0 || pages.length > 0,
+  };
+}
+
+/**
+ * Multi-page (deck) writes. Never touches root formState — decks keep their
+ * authoritative state per page; the single-page patch path (applyPatchToDoc)
+ * stays untouched for sharepics.
+ */
+export function applyDeckChangesToDoc(doc: Y.Doc, changes: DeckChanges): void {
+  doc.transact(() => {
+    const pages = doc.getArray<Y.Map<unknown>>(KEY_PAGES);
+
+    if (changes.seedPages && changes.seedPages.length > 0 && pages.length === 0) {
+      pages.push(changes.seedPages.map(buildPageYMap));
+    }
+
+    const findIndexById = (pageId: string): number => {
+      for (let i = 0; i < pages.length; i++) {
+        if (pages.get(i).get(KEY_ID) === pageId) return i;
+      }
+      return -1;
+    };
+
+    if (changes.pagePatches) {
+      for (const { pageId, patch } of changes.pagePatches) {
+        const idx = findIndexById(pageId);
+        if (idx < 0) continue;
+        const yState = pages.get(idx).get(KEY_STATE);
+        if (yState instanceof Y.Map) {
+          for (const [k, v] of Object.entries(patch)) (yState as Y.Map<unknown>).set(k, v);
+        }
+      }
+    }
+
+    if (changes.pageOps) {
+      for (const op of changes.pageOps) {
+        if (op.op === 'add') {
+          const index = Math.max(0, Math.min(op.index, pages.length));
+          pages.insert(index, [buildPageYMap(op.page)]);
+        } else {
+          const idx = findIndexById(op.pageId);
+          if (idx >= 0) pages.delete(idx, 1);
+        }
+      }
+    }
+
+    if (changes.replacePages && changes.replacePages.length > 0) {
+      if (pages.length > 0) pages.delete(0, pages.length);
+      pages.push(changes.replacePages.map(buildPageYMap));
+    }
+  }, TRANSACT_ORIGIN);
+}
+
+function hasDeckKeys(body: Record<string, unknown>): boolean {
+  return Boolean(body.seedPages || body.pagePatches || body.pageOps || body.replacePages);
+}
+
+const isPageDef = (v: unknown): v is PageDef => {
+  if (!v || typeof v !== 'object') return false;
+  const p = v as Record<string, unknown>;
+  return (
+    typeof p.id === 'string' &&
+    typeof p.configId === 'string' &&
+    typeof p.state === 'object' &&
+    p.state !== null &&
+    !Array.isArray(p.state)
+  );
+};
+
+function validateDeckChanges(body: Record<string, unknown>): string | null {
+  if (body.seedPages !== undefined) {
+    if (!Array.isArray(body.seedPages) || !body.seedPages.every(isPageDef))
+      return 'seedPages must be an array of {id, configId, state}';
+  }
+  if (body.replacePages !== undefined) {
+    if (!Array.isArray(body.replacePages) || !body.replacePages.every(isPageDef))
+      return 'replacePages must be an array of {id, configId, state}';
+  }
+  if (body.pagePatches !== undefined) {
+    if (
+      !Array.isArray(body.pagePatches) ||
+      !body.pagePatches.every(
+        (p: unknown) =>
+          !!p &&
+          typeof p === 'object' &&
+          typeof (p as Record<string, unknown>).pageId === 'string' &&
+          typeof (p as Record<string, unknown>).patch === 'object' &&
+          (p as Record<string, unknown>).patch !== null
+      )
+    )
+      return 'pagePatches must be an array of {pageId, patch}';
+  }
+  if (body.pageOps !== undefined) {
+    if (
+      !Array.isArray(body.pageOps) ||
+      !body.pageOps.every((o: unknown) => {
+        if (!o || typeof o !== 'object') return false;
+        const op = o as Record<string, unknown>;
+        if (op.op === 'add') return typeof op.index === 'number' && isPageDef(op.page);
+        if (op.op === 'remove') return typeof op.pageId === 'string';
+        return false;
+      })
+    )
+      return 'pageOps must be add {index, page} or remove {pageId} operations';
+  }
+  return null;
 }
 
 export function applyPatchToDoc(
@@ -121,27 +280,51 @@ export function registerInternalApi(app: express.Express, deps: InternalApiDeps)
 
   router.post('/canvas/:documentId/state', async (req, res) => {
     const { documentId } = req.params;
-    const body = req.body as {
+    const body = (req.body ?? {}) as Record<string, unknown> & {
       patch?: Record<string, unknown>;
       seedState?: Record<string, unknown>;
-    };
-    if (!body?.patch || typeof body.patch !== 'object' || Array.isArray(body.patch)) {
-      res.status(400).json({ error: 'patch (object) is required' });
+    } & DeckChanges;
+
+    const isFlatPatch = body.patch !== undefined;
+    const isDeck = hasDeckKeys(body);
+    if (isFlatPatch && isDeck) {
+      res.status(400).json({ error: 'use either patch (single-page) or deck keys, not both' });
+      return;
+    }
+    if (isFlatPatch) {
+      if (!body.patch || typeof body.patch !== 'object' || Array.isArray(body.patch)) {
+        res.status(400).json({ error: 'patch (object) is required' });
+        return;
+      }
+    } else if (isDeck) {
+      const validationError = validateDeckChanges(body);
+      if (validationError) {
+        res.status(400).json({ error: validationError });
+        return;
+      }
+    } else {
+      res.status(400).json({ error: 'patch (object) or deck keys are required' });
       return;
     }
 
     try {
       const connection = await deps.server.hocuspocus.openDirectConnection(documentId);
       try {
-        let result: { state: Record<string, unknown>; hasYState: boolean } | null = null;
+        let result: ReturnType<typeof readMergedState> | null = null;
         await connection.transact((doc) => {
-          applyPatchToDoc(doc, body.patch!, body.seedState ?? null);
+          if (isFlatPatch) {
+            applyPatchToDoc(doc, body.patch!, body.seedState ?? null);
+          } else {
+            applyDeckChangesToDoc(doc, body);
+          }
           result = readMergedState(doc);
         });
         log.info(
-          `Applied canvas patch to ${documentId} (${Object.keys(body.patch).length} key(s))`
+          isFlatPatch
+            ? `Applied canvas patch to ${documentId} (${Object.keys(body.patch!).length} key(s))`
+            : `Applied deck changes to ${documentId} (seed=${body.seedPages?.length ?? 0}, patches=${body.pagePatches?.length ?? 0}, ops=${body.pageOps?.length ?? 0}, replace=${body.replacePages?.length ?? 0})`
         );
-        res.json({ ok: true, ...(result ?? { state: {}, hasYState: false }) });
+        res.json({ ok: true, ...(result ?? { state: {}, pages: [], hasYState: false }) });
       } finally {
         await connection.disconnect();
       }

--- a/services/hocuspocus/src/internalApi.vitest.ts
+++ b/services/hocuspocus/src/internalApi.vitest.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import * as Y from 'yjs';
 
-import { applyPatchToDoc, readMergedState } from './internalApi.js';
+import {
+  applyDeckChangesToDoc,
+  applyPatchToDoc,
+  readMergedState,
+  type PageDef,
+} from './internalApi.js';
 
 function buildPage(state: Record<string, unknown>): Y.Map<unknown> {
   const page = new Y.Map<unknown>();
@@ -56,5 +61,86 @@ describe('internal canvas API doc helpers', () => {
   it('reports hasYState=false for an empty doc', () => {
     const doc = new Y.Doc();
     expect(readMergedState(doc).hasYState).toBe(false);
+  });
+});
+
+const deckPages = (): PageDef[] => [
+  { id: 'p1', configId: 'slider', state: { headline: 'Cover', slideVariant: 'cover' } },
+  { id: 'p2', configId: 'slider', state: { headline: 'Fakt 1', slideVariant: 'content' } },
+  { id: 'p3', configId: 'slider', state: { headline: 'Ende', slideVariant: 'last' } },
+];
+
+describe('applyDeckChangesToDoc', () => {
+  it('seeds pages only when the doc has none', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    expect(readMergedState(doc).pages.map((p) => p.id)).toEqual(['p1', 'p2', 'p3']);
+
+    // Re-seeding with different content is a no-op.
+    applyDeckChangesToDoc(doc, {
+      seedPages: [{ id: 'x', configId: 'slider', state: {} }],
+    });
+    expect(readMergedState(doc).pages.map((p) => p.id)).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('patches a single page by id and leaves the others untouched', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    applyDeckChangesToDoc(doc, {
+      pagePatches: [{ pageId: 'p2', patch: { headline: 'Gepatcht' } }],
+    });
+
+    const { pages } = readMergedState(doc);
+    expect(pages[1].state.headline).toBe('Gepatcht');
+    expect(pages[0].state.headline).toBe('Cover');
+    expect(pages[2].state.headline).toBe('Ende');
+  });
+
+  it('never touches formState (deck writes are page-scoped)', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    applyDeckChangesToDoc(doc, {
+      pagePatches: [{ pageId: 'p1', patch: { headline: 'Neu' } }],
+    });
+    expect(doc.getMap<unknown>('formState').size).toBe(0);
+  });
+
+  it('adds and removes pages by id', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    applyDeckChangesToDoc(doc, {
+      pageOps: [
+        {
+          op: 'add',
+          index: 2,
+          page: { id: 'p4', configId: 'slider', state: { headline: 'Fakt 2' } },
+        },
+        { op: 'remove', pageId: 'p2' },
+      ],
+    });
+
+    const { pages } = readMergedState(doc);
+    expect(pages.map((p) => p.id)).toEqual(['p1', 'p4', 'p3']);
+  });
+
+  it('replacePages swaps the whole deck (restore)', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    applyDeckChangesToDoc(doc, {
+      replacePages: [{ id: 'r1', configId: 'slider', state: { headline: 'Restored' } }],
+    });
+
+    const { pages } = readMergedState(doc);
+    expect(pages).toHaveLength(1);
+    expect(pages[0].state.headline).toBe('Restored');
+  });
+
+  it('flat-patch regression: applyPatchToDoc still mirrors into every page', () => {
+    const doc = new Y.Doc();
+    applyDeckChangesToDoc(doc, { seedPages: deckPages() });
+    applyPatchToDoc(doc, { headline: 'Überall' }, null);
+
+    const { pages } = readMergedState(doc);
+    for (const p of pages) expect(p.state.headline).toBe('Überall');
   });
 });


### PR DESCRIPTION
## Was

Der Chat kann jetzt **Instagram-Slider-Karusselle** erzeugen und per natürlicher Sprache bearbeiten — über das bestehende `@sharepic`-Mention plus Keyword (kein neues Mention):

> `@sharepic Klimaschutz in der Kommune als Slider/Karussell`

→ KI bestimmt die Folienanzahl (3–5: Cover + Inhalte + Abschluss, bestehender `sliderSmartHandler`-Stack), das Deck wird **direkt bei der Generierung** als Multi-Page-Canvas-Dokument gemintet und erscheint als Karte mit Folien-Pager im Chat.

Danach (agentic Tool-Loop, `CHAT_TOOL_LOOP=true`):
- „kürze die Headline auf Folie 2"
- „Farbschema dunkel" (deck-weit, inkl. Pill-Badge- und Pfeil-Farben)
- „füge eine Folie über X hinzu" / „lösche Folie 3"
- „zurück zur vorherigen Version"

## Architektur

**Hocuspocus internal API — Multi-Page-Server-Autorität (Kern der PR):**
- `seedPages` (idempotent), pageId-adressierte `pagePatches`, `pageOps` (add/remove), `replacePages` (Restore); GET liefert `pages[]`
- Der flache Single-Page-Pfad (`patch` + Mirror in alle Seiten) bleibt byte-identisch — regression-getestet
- Spike manuell verifiziert: servergeseedete 4 Folien → Studio rendert alle, kein Doppel-Seed, kein Heal-Konflikt; pageId-Patch bei offenem Studio-Tab → Live-Update

**Contracts:**
- `SLIDER_DESCRIPTOR` (Registrierung unter `slider`) mit `deck`-Erweiterung: min/max Slides, `defaultNewSlideState`, Farbschema-Map (Hintergrund/Pill/Pfeil) — Parity-Tests gegen `slider_full.config.tsx` (`getSliderColors`/`getPillBadgeColorsForScheme`/multiPage)
- `sliderDeckOperationSchema`: `edit-slide {slide, operations}` | `add-slide` | `remove-slide` — wraps das unveränderte `canvasAiOperationSchema`
- Interpreter `sliderDeckOpsToPagePatches` delegiert pro Folie an `sharepicOpsToStatePatch` (volle Clamp/Reject-Wiederverwendung); `set-color-scheme` expandiert deck-weit und spiegelt die abgeleiteten Farben (Server-Patch umgeht die Studio-Action-Kopplung); Cover-Pill-Text bleibt mit `label` synchron; Edits auf frisch hinzugefügte Folien werden in die Add-Op gefaltet (Patches laufen vor Ops)

**API:**
- `generateUnifiedTexts` aus `handleUnifiedRequest` extrahiert (Express-Wrapper liefert byte-identisches JSON, `/api/sharepic`-Routen unverändert)
- `sliderGenerationService` (analyzeSlideCount → unified texts) + `sliderDeckService` (Mint-at-Generation: createCanvas mit `initial_state = {Cover-Keys, pages}`, Deck-Seed, `chat_thread_canvases`, Mint-Version)
- Agentic Loop: Deck-Branch mit `read_slider_deck` / `apply_slider_ops` / deck-aware `restore_version` + Karussell-Systemprompt; Single-Call-Pfad antwortet mit Studio-Hinweis (v1: Deck-Editing nur im Loop)
- REST `restoreVersion` + `getState` deck-aware (`{pages}`-Versionen → `replacePages`; getState liefert `pages` für Slider)
- Edit-Heuristik: neue Nomen (slide/folie/seite/karussell/slider/deck/cover/headline/…), `NEW_VARIANTS_PATTERN` deckt „neuen Slider/Karussell" ab

**Frontend:**
- `SliderDeckCard`: Folien-Pager (Pfeile + Nummern), „Im Chat bearbeiten", Version-Stepper (Preview = Cover der Version), „Als ZIP" (bestehender `/api/exports/zip`), „Im Studio öffnen" (canvasId ab Generierung)
- `SharepicArtifactPanel`: Deck-Variante mit Folien-Pager im Sharepic-Modus
- `sharepicLiveStore`/`parseSSEStream`/`SharepicVariant` tragen `pages`; `sharepic_updated` sendet für Decks `pages` statt `state`
- packages/chat bleibt produkt-agnostisch: ZIP über neuen injizierten `downloadSharepicZip`-Callback (GlobalChatProvider)

## Tests

- 10/10 hocuspocus (`internalApi.vitest.ts` inkl. Flat-Patch-Regression)
- 36/36 canvas-editor (neue `sliderDeckDescriptorParity` + bestehende Sharepic-Parity)
- 98/98 apps/api chat-services (inkl. neue Heuristik-Fälle)
- `pnpm typecheck` 20/20, Lint clean (nur Bestands-Warnings)

## Manuelle E2E (dev, CHAT_TOOL_LOOP=true) — Checkliste

1. [ ] `@sharepic <Thema> als Karussell` → Deck-Karte mit 3–5 Folien, cover/content/last korrekt
2. [ ] „Im Studio öffnen" → alle Folien da; Folie im Studio editieren; danach Chat-Edit auf andere Folie → baut auf Studio-Stand auf
3. [ ] Chat-Edits: Folientext, „Farbschema dunkel" (Pill/Pfeil nach Studio-Reload korrekt), Folie hinzufügen/löschen, Version-Restore
4. [ ] Live-Sync: offener Studio-Tab bei Chat-Edit
5. [ ] ZIP-Download, Version-Stepper, Artifact-Panel-Pager, Thread-Reload-Rehydration
6. [ ] Regression: dreizeilen/zitat/info Generierung + Edit unverändert

## Offene Punkte / Follow-ups

- Slide-Reorder-Op (bewusst vertagt)
- Deck-Editing im Single-Call-Pfad (falls CHAT_TOOL_LOOP irgendwo aus bleibt)
- Prod-Envs unverändert nötig: `HOCUSPOCUS_INTERNAL_TOKEN/URL`, `CHAT_TOOL_LOOP`