### PR TITLE
feat(bilder): unify toolbar settings behind a single gear menu

### DIFF
--- a/apps/api/routes/flux/imageEditContractRouter.ts
+++ b/apps/api/routes/flux/imageEditContractRouter.ts
@@ -116,8 +116,9 @@ export const imageEditContractRouter = s.router(imageEditContract, {
         safety_tolerance: 2,
       });
 
-      const labeledBuffer = await addKiLabel(Buffer.from(stored.base64, 'base64'));
-      fs.writeFileSync(stored.filePath, labeledBuffer);
+      const rawBuffer = Buffer.from(stored.base64, 'base64');
+      const outputBuffer = body.kiLabel === false ? rawBuffer : await addKiLabel(rawBuffer);
+      fs.writeFileSync(stored.filePath, outputBuffer);
 
       const incrementResult = await imageCounter.incrementCount(
         userId,
@@ -129,7 +130,7 @@ export const imageEditContractRouter = s.router(imageEditContract, {
         body: {
           success: true as const,
           image: {
-            base64: labeledBuffer.toString('base64'),
+            base64: outputBuffer.toString('base64'),
             filename: stored.filename,
           },
           prompt,

--- a/apps/api/routes/flux/imageEditContractRouter.ts
+++ b/apps/api/routes/flux/imageEditContractRouter.ts
@@ -117,7 +117,10 @@ export const imageEditContractRouter = s.router(imageEditContract, {
       });
 
       const rawBuffer = Buffer.from(stored.base64, 'base64');
-      const outputBuffer = body.kiLabel === false ? rawBuffer : await addKiLabel(rawBuffer);
+      const outputBuffer =
+        body.kiLabel === 'none'
+          ? rawBuffer
+          : await addKiLabel(rawBuffer, body.kiLabel === 'short' ? 'short' : 'full');
       fs.writeFileSync(stored.filePath, outputBuffer);
 
       const incrementResult = await imageCounter.incrementCount(

--- a/apps/api/routes/flux/imaginePure.ts
+++ b/apps/api/routes/flux/imaginePure.ts
@@ -35,6 +35,9 @@ const imaginePureSchema = z.object({
   seed: z.number().nullish(),
   width: z.number().nullish(),
   height: z.number().nullish(),
+  // Burn the "KI-Generiert mit dem Grünerator" label into the result.
+  // Defaults to true; users can opt out to apply their own AI labeling.
+  kiLabel: z.boolean().nullish(),
 });
 
 type ImaginePureRequestBody = z.infer<typeof imaginePureSchema>;
@@ -231,9 +234,12 @@ router.post(
 
       const fluxImageBuffer = fs.readFileSync(fluxResult.filePath);
 
-      const labeledBuffer = await addKiLabel(fluxImageBuffer);
+      const labeledBuffer =
+        req.body.kiLabel === false ? fluxImageBuffer : await addKiLabel(fluxImageBuffer);
 
-      log.debug(`[ImaginePure] KI label added, final size: ${labeledBuffer.length} bytes`);
+      log.debug(
+        `[ImaginePure] KI label ${req.body.kiLabel === false ? 'skipped' : 'added'}, final size: ${labeledBuffer.length} bytes`
+      );
 
       const now = new Date();
       const today = now.toISOString().split('T')[0];

--- a/apps/api/routes/flux/imaginePure.ts
+++ b/apps/api/routes/flux/imaginePure.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { kiLabelModeSchema } from '@gruenerator/contracts';
 import { IMAGE_MODEL_BY_ID, IMAGE_MODEL_IDS, type ImageModelId } from '@gruenerator/shared/models';
 import express, { type Response } from 'express';
 import { z } from 'zod';
@@ -35,9 +36,10 @@ const imaginePureSchema = z.object({
   seed: z.number().nullish(),
   width: z.number().nullish(),
   height: z.number().nullish(),
-  // Burn the "KI-Generiert mit dem Grünerator" label into the result.
-  // Defaults to true; users can opt out to apply their own AI labeling.
-  kiLabel: z.boolean().nullish(),
+  // Which AI label to burn into the result: 'full' ("KI-Generiert mit dem
+  // Grünerator", default), 'short' ("KI-Generiert"), or 'none' so users can
+  // apply their own AI labeling.
+  kiLabel: kiLabelModeSchema.nullish(),
 });
 
 type ImaginePureRequestBody = z.infer<typeof imaginePureSchema>;
@@ -234,12 +236,11 @@ router.post(
 
       const fluxImageBuffer = fs.readFileSync(fluxResult.filePath);
 
+      const kiLabel = req.body.kiLabel ?? 'full';
       const labeledBuffer =
-        req.body.kiLabel === false ? fluxImageBuffer : await addKiLabel(fluxImageBuffer);
+        kiLabel === 'none' ? fluxImageBuffer : await addKiLabel(fluxImageBuffer, kiLabel);
 
-      log.debug(
-        `[ImaginePure] KI label ${req.body.kiLabel === false ? 'skipped' : 'added'}, final size: ${labeledBuffer.length} bytes`
-      );
+      log.debug(`[ImaginePure] KI label (${kiLabel}), final size: ${labeledBuffer.length} bytes`);
 
       const now = new Date();
       const today = now.toISOString().split('T')[0];

--- a/apps/api/routes/flux/outpaint.ts
+++ b/apps/api/routes/flux/outpaint.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
+import { kiLabelModeSchema } from '@gruenerator/contracts';
 import express, { type Response } from 'express';
 import multer from 'multer';
 import { z } from 'zod';
@@ -23,9 +24,10 @@ type PresetAspect = z.infer<typeof presetAspectSchema>;
 
 const MAX_AREA_PIXELS = 4_194_304; // BFL's 4MP cap
 
-// Multipart form field, so booleans arrive as strings. Defaults to labeling;
-// 'false' skips the burned-in KI label so users can apply their own.
-const kiLabelFieldSchema = z.enum(['true', 'false']).nullish();
+// Multipart form field: which AI label to burn into the result — 'full'
+// ("KI-Generiert mit dem Grünerator", default), 'short' ("KI-Generiert"),
+// or 'none' so users can apply their own labeling.
+const kiLabelFieldSchema = kiLabelModeSchema.nullish();
 
 const bodySchema = z.union([
   z.object({ aspectRatio: presetAspectSchema, kiLabel: kiLabelFieldSchema }),
@@ -101,8 +103,8 @@ router.post(
       });
 
       const fluxBuffer = fs.readFileSync(stored.filePath);
-      const labeledBuffer =
-        parsed.data.kiLabel === 'false' ? fluxBuffer : await addKiLabel(fluxBuffer);
+      const kiLabel = parsed.data.kiLabel ?? 'full';
+      const labeledBuffer = kiLabel === 'none' ? fluxBuffer : await addKiLabel(fluxBuffer, kiLabel);
       const labeledBase64 = labeledBuffer.toString('base64');
 
       const now = new Date();

--- a/apps/api/routes/flux/outpaint.ts
+++ b/apps/api/routes/flux/outpaint.ts
@@ -23,13 +23,18 @@ type PresetAspect = z.infer<typeof presetAspectSchema>;
 
 const MAX_AREA_PIXELS = 4_194_304; // BFL's 4MP cap
 
+// Multipart form field, so booleans arrive as strings. Defaults to labeling;
+// 'false' skips the burned-in KI label so users can apply their own.
+const kiLabelFieldSchema = z.enum(['true', 'false']).nullish();
+
 const bodySchema = z.union([
-  z.object({ aspectRatio: presetAspectSchema }),
+  z.object({ aspectRatio: presetAspectSchema, kiLabel: kiLabelFieldSchema }),
   z
     .object({
       aspectRatio: z.literal('custom'),
       width: z.coerce.number().int().min(256).max(2048),
       height: z.coerce.number().int().min(256).max(2048),
+      kiLabel: kiLabelFieldSchema,
     })
     .refine((d) => d.width * d.height <= MAX_AREA_PIXELS, {
       message: `Bild zu groß — maximal ${MAX_AREA_PIXELS / 1_000_000} Megapixel (Breite × Höhe).`,
@@ -96,7 +101,8 @@ router.post(
       });
 
       const fluxBuffer = fs.readFileSync(stored.filePath);
-      const labeledBuffer = await addKiLabel(fluxBuffer);
+      const labeledBuffer =
+        parsed.data.kiLabel === 'false' ? fluxBuffer : await addKiLabel(fluxBuffer);
       const labeledBase64 = labeledBuffer.toString('base64');
 
       const now = new Date();

--- a/apps/api/routes/sharepic/sharepic_canvas/imagine_label_canvas.ts
+++ b/apps/api/routes/sharepic/sharepic_canvas/imagine_label_canvas.ts
@@ -18,13 +18,19 @@ const log = createLogger('imagine_label_c');
 const router: Router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
-const LABEL_TEXT = 'KI-Generiert mit dem Grünerator';
+const LABEL_TEXTS = {
+  full: 'KI-Generiert mit dem Grünerator',
+  short: 'KI-Generiert',
+} as const;
+
+type KiLabelVariant = keyof typeof LABEL_TEXTS;
 
 interface MulterRequest extends Request {
   file?: Express.Multer.File;
 }
 
-async function addKiLabel(imageBuffer: Buffer): Promise<Buffer> {
+async function addKiLabel(imageBuffer: Buffer, variant: KiLabelVariant = 'full'): Promise<Buffer> {
+  const labelText = LABEL_TEXTS[variant];
   await checkFiles();
   registerFonts();
 
@@ -43,7 +49,7 @@ async function addKiLabel(imageBuffer: Buffer): Promise<Buffer> {
   ctx.font = fontFamily;
   ctx.textBaseline = 'middle';
 
-  const textMetrics = ctx.measureText(LABEL_TEXT);
+  const textMetrics = ctx.measureText(labelText);
   const textWidth = textMetrics.width;
   const rectHorizontalPadding = Math.round(fontSize * 0.6);
   const rectVerticalPadding = Math.round(fontSize * 0.35);
@@ -66,7 +72,7 @@ async function addKiLabel(imageBuffer: Buffer): Promise<Buffer> {
   ctx.save();
   ctx.globalAlpha = 0.85;
   ctx.fillStyle = '#FFFFFF';
-  ctx.fillText(LABEL_TEXT, rectX + rectHorizontalPadding, rectY + rectHeight / 2);
+  ctx.fillText(labelText, rectX + rectHorizontalPadding, rectY + rectHeight / 2);
   ctx.restore();
 
   const rawBuffer = canvas.toBuffer('image/png');

--- a/apps/api/services/flux/RegoloImageService.ts
+++ b/apps/api/services/flux/RegoloImageService.ts
@@ -21,6 +21,17 @@ import type {
 const REGOLO_BASE_URL = 'https://api.regolo.ai/v1';
 const DEFAULT_MODEL = 'Qwen-Image';
 
+// Qwen-Image via Regolo only supports square sizes (per Regolo docs:
+// 256x256, 512x512, 1024x1024). Requested dimensions — variant defaults or
+// user formats — are snapped to the nearest supported square.
+const REGOLO_SUPPORTED_SIDES = [256, 512, 1024] as const;
+
+function snapToSupportedSize(width?: number, height?: number): string {
+  const target = Math.max(width ?? 1024, height ?? 1024);
+  const side = REGOLO_SUPPORTED_SIDES.find((s) => target <= s) ?? 1024;
+  return `${side}x${side}`;
+}
+
 interface RegoloImageResponse {
   data: Array<{
     b64_json?: string;
@@ -53,9 +64,7 @@ class RegoloImageService {
       throw new Error('REGOLO_API_KEY is not configured');
     }
 
-    const width = options.width || 1024;
-    const height = options.height || 1024;
-    const size = `${width}x${height}`;
+    const size = snapToSupportedSize(options.width, options.height);
 
     console.log(`[RegoloImageService] Generating image: ${prompt.substring(0, 80)}...`);
 

--- a/apps/web/src/features/image-studio/services/imageEditingService.ts
+++ b/apps/web/src/features/image-studio/services/imageEditingService.ts
@@ -98,7 +98,8 @@ export async function editAiImage(
   image: File | File[],
   instruction: string,
   editType: ImageEditType = 'universal',
-  imageModel?: ImageModelId
+  imageModel?: ImageModelId,
+  options?: { kiLabel?: boolean }
 ): Promise<{ file: File; objectUrl: string; base64: string }> {
   const files = Array.isArray(image) ? image : [image];
   if (files.length === 0) throw new Error('Kein Bild ausgewählt');
@@ -113,6 +114,7 @@ export async function editAiImage(
       editType,
       precision: true,
       ...(imageModel && { imageModel }),
+      ...(options?.kiLabel === false && { kiLabel: false }),
     },
   });
 

--- a/apps/web/src/features/image-studio/services/imageEditingService.ts
+++ b/apps/web/src/features/image-studio/services/imageEditingService.ts
@@ -1,4 +1,4 @@
-import { type ImageEditReference } from '@gruenerator/contracts';
+import { type ImageEditReference, type KiLabelMode } from '@gruenerator/contracts';
 import { getContractsClient } from '@gruenerator/shared/api';
 
 import apiClient from '../../../components/utils/apiClient';
@@ -99,7 +99,7 @@ export async function editAiImage(
   instruction: string,
   editType: ImageEditType = 'universal',
   imageModel?: ImageModelId,
-  options?: { kiLabel?: boolean }
+  options?: { kiLabel?: KiLabelMode }
 ): Promise<{ file: File; objectUrl: string; base64: string }> {
   const files = Array.isArray(image) ? image : [image];
   if (files.length === 0) throw new Error('Kein Bild ausgewählt');
@@ -114,7 +114,7 @@ export async function editAiImage(
       editType,
       precision: true,
       ...(imageModel && { imageModel }),
-      ...(options?.kiLabel === false && { kiLabel: false }),
+      ...(options?.kiLabel && options.kiLabel !== 'full' && { kiLabel: options.kiLabel }),
     },
   });
 

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -323,6 +323,68 @@ function BilderSettingsMenu({
   );
 }
 
+// One "add image" button with a source dropdown (device upload / media
+// library) instead of two side-by-side buttons.
+function AddImageMenu({
+  label,
+  onUpload,
+  onPickFromLibrary,
+}: {
+  label: string;
+  onUpload: () => void;
+  onPickFromLibrary: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const select = (action: () => void) => {
+    setOpen(false);
+    action();
+  };
+  const sources = [
+    {
+      key: 'upload',
+      icon: <ImagePlus className="size-4" />,
+      label: 'Vom Gerät hochladen',
+      action: onUpload,
+    },
+    {
+      key: 'library',
+      icon: <ImageIcon className="size-4" />,
+      label: 'Aus der Mediathek',
+      action: onPickFromLibrary,
+    },
+  ];
+
+  return (
+    <ResponsiveMenu
+      open={open}
+      onOpenChange={setOpen}
+      sheetTitle="Bild hinzufügen"
+      dropdownSide="bottom"
+      dropdownAlign="start"
+      trigger={
+        <button
+          type="button"
+          className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
+        >
+          <ImagePlus className="size-3.5" />
+          {label}
+        </button>
+      }
+      desktopContent={sources.map((s) => (
+        <DropdownMenuItem key={s.key} onSelect={() => select(s.action)}>
+          {s.icon}
+          {s.label}
+        </DropdownMenuItem>
+      ))}
+      mobileContent={sources.map((s) => (
+        <ResponsiveMenuItem key={s.key} icon={s.icon} onClick={() => select(s.action)}>
+          {s.label}
+        </ResponsiveMenuItem>
+      ))}
+    />
+  );
+}
+
 type AspectRatio = '16:9' | '4:3' | '1:1' | '3:4' | '9:16' | 'custom';
 
 const ASPECT_RATIO_CONFIG: SettingConfig = {
@@ -1194,24 +1256,11 @@ const BilderInner: React.FC = memo(() => {
           </div>
         ))}
         {all.length < maxRefs && (
-          <>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
-            >
-              <ImagePlus className="size-3.5" />
-              {all.length === 0 ? 'Bild hochladen' : '+ Bild'}
-            </button>
-            <button
-              type="button"
-              onClick={handlePickFromLibrary}
-              className="flex items-center gap-1.5 text-xs text-grey-500 dark:text-grey-400 hover:text-grey-700 dark:hover:text-grey-200 px-2 py-1 rounded-md hover:bg-grey-100 dark:hover:bg-grey-800 transition-colors"
-            >
-              <ImageIcon className="size-3.5" />
-              Mediathek
-            </button>
-          </>
+          <AddImageMenu
+            label={all.length === 0 ? 'Bild hinzufügen' : '+ Bild'}
+            onUpload={() => fileInputRef.current?.click()}
+            onPickFromLibrary={handlePickFromLibrary}
+          />
         )}
         {all.length >= 2 && (
           <span className="text-[11px] text-grey-400 dark:text-grey-500">

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -12,14 +12,17 @@ import { useShareStore } from '@gruenerator/shared/share';
 import {
   AIPromptInput,
   Button,
+  DropdownMenuCheckboxItem,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   ResponsiveMenu,
   ResponsiveMenuItem,
   ResponsiveMenuSection,
+  ResponsiveMenuToggle,
   SettingsDropdown,
   pillBase,
   pillInactive,
@@ -98,6 +101,8 @@ function BilderSettingsMenu({
   onModelChange,
   aspectRatio,
   onAspectRatioChange,
+  kiLabel,
+  onKiLabelChange,
 }: {
   settings: SettingConfig[];
   settingsValues: Record<string, unknown>;
@@ -106,9 +111,12 @@ function BilderSettingsMenu({
   onModelChange: (id: ImageModelId) => void;
   aspectRatio: AspectRatio | null;
   onAspectRatioChange: (aspect: AspectRatio) => void;
+  kiLabel: boolean | null;
+  onKiLabelChange: (value: boolean) => void;
 }) {
   const [open, setOpen] = useState(false);
-  if (settings.length === 0 && modelValue === null && aspectRatio === null) return null;
+  const hasSelectSections = settings.length > 0 || modelValue !== null || aspectRatio !== null;
+  if (!hasSelectSections && kiLabel === null) return null;
 
   const selectModel = (id: ImageModelId) => {
     onModelChange(id);
@@ -199,6 +207,18 @@ function BilderSettingsMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
       )}
+      {kiLabel !== null && (
+        <>
+          {hasSelectSections && <DropdownMenuSeparator />}
+          <DropdownMenuCheckboxItem
+            checked={kiLabel}
+            onCheckedChange={(checked) => onKiLabelChange(checked === true)}
+            onSelect={(e) => e.preventDefault()}
+          >
+            KI-Kennzeichnung im Bild
+          </DropdownMenuCheckboxItem>
+        </>
+      )}
     </>
   );
 
@@ -258,6 +278,15 @@ function BilderSettingsMenu({
           ))}
         </ResponsiveMenuSection>
       )}
+      {kiLabel !== null && (
+        <ResponsiveMenuSection title="Kennzeichnung">
+          <ResponsiveMenuToggle
+            label="KI-Kennzeichnung im Bild"
+            checked={kiLabel}
+            onCheckedChange={onKiLabelChange}
+          />
+        </ResponsiveMenuSection>
+      )}
     </>
   );
 
@@ -270,7 +299,11 @@ function BilderSettingsMenu({
       dropdownAlign="start"
       dropdownClassName="min-w-[14rem]"
       trigger={
-        <button type="button" aria-label="Bild-Einstellungen" className={cn(pillBase, pillInactive)}>
+        <button
+          type="button"
+          aria-label="Bild-Einstellungen"
+          className={cn(pillBase, pillInactive)}
+        >
           <Settings className="size-3.5" />
         </button>
       }
@@ -299,6 +332,18 @@ const ASPECT_RATIO_CONFIG: SettingConfig = {
 const MIN_CUSTOM_SIDE = 256;
 const MAX_CUSTOM_SIDE = 2048;
 const MAX_CUSTOM_AREA = 4_194_304;
+
+// Persists the opt-out of the burned-in "KI-Generiert mit dem Grünerator"
+// label across sessions (users may want to apply their own AI labeling).
+const KI_LABEL_STORAGE_KEY = 'gruenerator-bilder-ki-label';
+
+function readStoredKiLabel(): boolean {
+  try {
+    return localStorage.getItem(KI_LABEL_STORAGE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
 
 const ASPECT_RATIO_VALUE: Record<Exclude<AspectRatio, 'custom'>, number> = {
   '16:9': 16 / 9,
@@ -426,6 +471,16 @@ const BilderInner: React.FC = memo(() => {
     customHeight <= MAX_CUSTOM_SIDE &&
     customArea <= MAX_CUSTOM_AREA;
   const [outpaintError, setOutpaintError] = useState<string | null>(null);
+
+  const [kiLabel, setKiLabelState] = useState<boolean>(readStoredKiLabel);
+  const setKiLabel = useCallback((value: boolean) => {
+    setKiLabelState(value);
+    try {
+      localStorage.setItem(KI_LABEL_STORAGE_KEY, String(value));
+    } catch {
+      // Storage unavailable (e.g. private mode) — keep the in-memory value.
+    }
+  }, []);
 
   const { state: modeState, updateField } = useModeState(ERSTELLEN_MODE_ID);
 
@@ -646,6 +701,7 @@ const BilderInner: React.FC = memo(() => {
       const payload: Record<string, unknown> = { prompt: trimmed };
       if (modeState.variant) payload.variant = modeState.variant;
       if (modeState.imageModel) payload.imageModel = modeState.imageModel;
+      if (!kiLabel) payload.kiLabel = false;
       const result = await submitForm(payload);
       const usageFromResponse = (result as { usage?: UsageStatus })?.usage;
       if (usageFromResponse) setUsage(usageFromResponse);
@@ -671,6 +727,7 @@ const BilderInner: React.FC = memo(() => {
     submitForm,
     modeState.variant,
     modeState.imageModel,
+    kiLabel,
     setResult,
     createImageShare,
     queryClient,
@@ -687,7 +744,8 @@ const BilderInner: React.FC = memo(() => {
         files,
         trimmed,
         'universal',
-        selectedImageModel ?? undefined
+        selectedImageModel ?? undefined,
+        { kiLabel }
       );
       setResult(objectUrl, true);
       createImageShare({
@@ -717,6 +775,7 @@ const BilderInner: React.FC = memo(() => {
     sourceFile,
     extraSourceFiles,
     selectedImageModel,
+    kiLabel,
     editLoading,
     setResult,
     createImageShare,
@@ -729,7 +788,15 @@ const BilderInner: React.FC = memo(() => {
     setGreenEditLoading(true);
     setGreenEditError(null);
     try {
-      const { objectUrl, base64 } = await editAiImage(sourceFile, trimmed, 'green-edit');
+      const { objectUrl, base64 } = await editAiImage(
+        sourceFile,
+        trimmed,
+        'green-edit',
+        undefined,
+        {
+          kiLabel,
+        }
+      );
       setResult(objectUrl, true);
       createImageShare({
         imageData: base64,
@@ -750,7 +817,7 @@ const BilderInner: React.FC = memo(() => {
     } finally {
       setGreenEditLoading(false);
     }
-  }, [prompt, sourceFile, greenEditLoading, setResult, createImageShare, queryClient]);
+  }, [prompt, sourceFile, kiLabel, greenEditLoading, setResult, createImageShare, queryClient]);
 
   const handleSubmitRemoveBg = useCallback(
     async (fileOverride?: File) => {
@@ -834,6 +901,7 @@ const BilderInner: React.FC = memo(() => {
       form.append('aspectRatio', 'custom');
       form.append('width', String(targetW));
       form.append('height', String(targetH));
+      if (!kiLabel) form.append('kiLabel', 'false');
       const res = await getGlobalApiClient().post<{
         success: boolean;
         image?: { base64?: string };
@@ -883,6 +951,7 @@ const BilderInner: React.FC = memo(() => {
     customWidth,
     customHeight,
     customSizeValid,
+    kiLabel,
     setResult,
     createImageShare,
     queryClient,
@@ -1092,6 +1161,8 @@ const BilderInner: React.FC = memo(() => {
           onModelChange={handleModelChange}
           aspectRatio={isVergroessern ? aspectRatio : null}
           onAspectRatioChange={setAspectRatio}
+          kiLabel={isHintergrund ? null : kiLabel}
+          onKiLabelChange={setKiLabel}
         />
         {isBearbeiten && referencePillRow}
         {(isBegruenen || isHintergrund) && filePickerPill}
@@ -1151,6 +1222,8 @@ const BilderInner: React.FC = memo(() => {
       filePickerPill,
       referencePillRow,
       aspectRatio,
+      kiLabel,
+      setKiLabel,
       usage,
     ]
   );

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -13,6 +13,7 @@ import {
   AIPromptInput,
   Button,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -20,13 +21,13 @@ import {
   ResponsiveMenuItem,
   ResponsiveMenuSection,
   SettingsDropdown,
-  pillActive,
   pillBase,
+  pillInactive,
   type SettingConfig,
 } from '@gruenerator/ui';
 import { useVoxtralDictation } from '@gruenerator/voice';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Check, ChevronDown, Download, Image as ImageIcon, ImagePlus, X } from 'lucide-react';
+import { Check, Download, Image as ImageIcon, ImagePlus, Settings, X } from 'lucide-react';
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import useApiSubmit from '../../../components/hooks/useApiSubmit';
@@ -84,98 +85,193 @@ const MODELS_BY_FAMILY = IMAGE_FAMILIES.map((family) => ({
       : IMAGE_MODELS.filter((m) => m.family === family.id),
 }));
 
-function ImageModelDropdown({
-  value,
-  onChange,
+const itemSelectedClass = 'text-primary-700 dark:text-primary-300';
+
+// One gear menu bundling all secondary image settings (Stil, Modell, Format),
+// mirroring the notebook composer's settings dropdown. The Modus pill stays
+// outside since it switches the entire input UI.
+function BilderSettingsMenu({
+  settings,
+  settingsValues,
+  onSettingChange,
+  modelValue,
+  onModelChange,
+  aspectRatio,
+  onAspectRatioChange,
 }: {
-  value: ImageModelId;
-  onChange: (id: ImageModelId) => void;
+  settings: SettingConfig[];
+  settingsValues: Record<string, unknown>;
+  onSettingChange: (key: string, value: string) => void;
+  modelValue: ImageModelId | null;
+  onModelChange: (id: ImageModelId) => void;
+  aspectRatio: AspectRatio | null;
+  onAspectRatioChange: (aspect: AspectRatio) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const selected = IMAGE_MODEL_BY_ID[value];
-  const select = (id: ImageModelId) => {
-    onChange(id);
+  if (settings.length === 0 && modelValue === null && aspectRatio === null) return null;
+
+  const selectModel = (id: ImageModelId) => {
+    onModelChange(id);
     setOpen(false);
   };
-  const itemSelectedClass = 'text-primary-700 dark:text-primary-300';
 
-  // Desktop: a Flux submenu nested under the model list; single-model families
-  // select directly.
-  const desktopContent = MODELS_BY_FAMILY.map(({ family, models }) => {
-    if (models.length === 1) {
-      const m = models[0];
-      const isSelected = m.id === value;
-      return (
-        <DropdownMenuItem
-          key={family.id}
-          onSelect={() => select(m.id)}
-          className={cn(isSelected && itemSelectedClass)}
-        >
-          <span className="flex-1">{m.name}</span>
-          {isSelected && <Check className="size-3.5 shrink-0 text-primary-500" />}
-        </DropdownMenuItem>
-      );
-    }
-    const familyActive = models.some((m) => m.id === value);
-    return (
-      <DropdownMenuSub key={family.id}>
-        <DropdownMenuSubTrigger className={cn(familyActive && itemSelectedClass)}>
-          {family.name}
-        </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent>
-          {models.map((m) => {
-            const isSelected = m.id === value;
-            return (
-              <DropdownMenuItem
-                key={m.id}
-                onSelect={() => select(m.id)}
-                className={cn(isSelected && itemSelectedClass)}
+  const subHint = (label: string | null) =>
+    label && <span className="ml-auto truncate pl-3 text-xs text-grey-500">{label}</span>;
+
+  const desktopItem = (
+    key: string,
+    label: React.ReactNode,
+    isSelected: boolean,
+    onSelect: () => void,
+    detail?: string
+  ) => (
+    <DropdownMenuItem key={key} onSelect={onSelect} className={cn(isSelected && itemSelectedClass)}>
+      <span className="flex-1">{label}</span>
+      {detail && <span className="text-xs text-grey-500">{detail}</span>}
+      {isSelected && <Check className="size-3.5 shrink-0 text-primary-500" />}
+    </DropdownMenuItem>
+  );
+
+  const desktopContent = (
+    <>
+      {settings.map((config) => {
+        const current = (settingsValues[config.key] as string) ?? '';
+        return (
+          <DropdownMenuSub key={config.key}>
+            <DropdownMenuSubTrigger>
+              {config.label ?? config.key}
+              {subHint(config.options.find((o) => o.id === current)?.label ?? null)}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {config.options.map((option) =>
+                desktopItem(option.id, option.label, option.id === current, () =>
+                  onSettingChange(config.key, option.id)
+                )
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        );
+      })}
+      {modelValue !== null && (
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            Modell
+            {subHint(IMAGE_MODEL_BY_ID[modelValue]?.name ?? null)}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {MODELS_BY_FAMILY.map(({ family, models }) =>
+              models.length === 1 ? (
+                desktopItem(family.id, models[0].name, models[0].id === modelValue, () =>
+                  selectModel(models[0].id)
+                )
+              ) : (
+                <React.Fragment key={family.id}>
+                  <DropdownMenuLabel className="text-xs text-grey-500">
+                    {family.name}
+                  </DropdownMenuLabel>
+                  {models.map((m) =>
+                    desktopItem(
+                      m.id,
+                      m.name.replace(FLUX_VARIANT_LABEL_RE, ''),
+                      m.id === modelValue,
+                      () => selectModel(m.id),
+                      shortCost(m.costMultiplier)
+                    )
+                  )}
+                </React.Fragment>
+              )
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      )}
+      {aspectRatio !== null && (
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            Format
+            {subHint(ASPECT_RATIO_CONFIG.options.find((o) => o.id === aspectRatio)?.label ?? null)}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {ASPECT_RATIO_CONFIG.options.map((option) =>
+              desktopItem(option.id, option.label, option.id === aspectRatio, () =>
+                onAspectRatioChange(option.id as AspectRatio)
+              )
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      )}
+    </>
+  );
+
+  // Mobile: flat titled sections in a bottom sheet (nested fly-outs are awkward
+  // on touch). Flux variants keep their full name to stay distinguishable.
+  const mobileContent = (
+    <>
+      {settings.map((config) => {
+        const current = (settingsValues[config.key] as string) ?? '';
+        return (
+          <ResponsiveMenuSection key={config.key} title={config.label ?? config.key}>
+            {config.options.map((option) => (
+              <ResponsiveMenuItem
+                key={option.id}
+                active={option.id === current}
+                onClick={() => {
+                  onSettingChange(config.key, option.id);
+                  setOpen(false);
+                }}
               >
-                <span className="flex-1">{m.name.replace(FLUX_VARIANT_LABEL_RE, '')}</span>
-                <span className="text-xs text-grey-500">{shortCost(m.costMultiplier)}</span>
-                {isSelected && <Check className="size-3.5 shrink-0 text-primary-500" />}
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuSubContent>
-      </DropdownMenuSub>
-    );
-  });
-
-  // Mobile: a flat bottom sheet — Flux variants grouped in a titled section,
-  // single-model families as loose rows. (Nested side fly-outs are awkward on touch.)
-  const mobileContent = MODELS_BY_FAMILY.map(({ family, models }) =>
-    models.length > 1 ? (
-      <ResponsiveMenuSection key={family.id} title={family.name}>
-        {models.map((m) => (
-          <ResponsiveMenuItem key={m.id} active={m.id === value} onClick={() => select(m.id)}>
-            {m.name.replace(FLUX_VARIANT_LABEL_RE, '')} · {shortCost(m.costMultiplier)}
-          </ResponsiveMenuItem>
-        ))}
-      </ResponsiveMenuSection>
-    ) : (
-      <ResponsiveMenuItem
-        key={family.id}
-        active={models[0].id === value}
-        onClick={() => select(models[0].id)}
-      >
-        {models[0].name}
-      </ResponsiveMenuItem>
-    )
+                {option.label}
+              </ResponsiveMenuItem>
+            ))}
+          </ResponsiveMenuSection>
+        );
+      })}
+      {modelValue !== null && (
+        <ResponsiveMenuSection title="Modell">
+          {MODELS_BY_FAMILY.flatMap(({ models }) =>
+            models.map((m) => (
+              <ResponsiveMenuItem
+                key={m.id}
+                active={m.id === modelValue}
+                onClick={() => selectModel(m.id)}
+              >
+                {models.length > 1
+                  ? `${m.name.replace(/^⭐\s+/, '')} · ${shortCost(m.costMultiplier)}`
+                  : m.name}
+              </ResponsiveMenuItem>
+            ))
+          )}
+        </ResponsiveMenuSection>
+      )}
+      {aspectRatio !== null && (
+        <ResponsiveMenuSection title="Format">
+          {ASPECT_RATIO_CONFIG.options.map((option) => (
+            <ResponsiveMenuItem
+              key={option.id}
+              active={option.id === aspectRatio}
+              onClick={() => {
+                onAspectRatioChange(option.id as AspectRatio);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+            </ResponsiveMenuItem>
+          ))}
+        </ResponsiveMenuSection>
+      )}
+    </>
   );
 
   return (
     <ResponsiveMenu
       open={open}
       onOpenChange={setOpen}
-      sheetTitle="Modell wählen"
+      sheetTitle="Bild-Einstellungen"
       dropdownSide="bottom"
       dropdownAlign="start"
-      dropdownClassName="min-w-[12rem]"
+      dropdownClassName="min-w-[14rem]"
       trigger={
-        <button type="button" className={cn(pillBase, pillActive, 'gap-1')}>
-          <span>{selected.name}</span>
-          <ChevronDown className={cn('size-3 transition-transform', open && 'rotate-180')} />
+        <button type="button" aria-label="Bild-Einstellungen" className={cn(pillBase, pillInactive)}>
+          <Settings className="size-3.5" />
         </button>
       }
       desktopContent={desktopContent}
@@ -986,30 +1082,19 @@ const BilderInner: React.FC = memo(() => {
           value={subMode}
           onChange={(val) => setSubMode(val as SubMode)}
         />
-        {isErstellen &&
-          erstellenDef?.settings?.map((config) => (
-            <SettingsDropdown
-              key={config.key}
-              config={config}
-              value={(modeState[config.key] as string) ?? ''}
-              onChange={(val) => updateField(config.key, val as string)}
-            />
-          ))}
-        {(isErstellen || isBearbeiten) && (
-          <ImageModelDropdown
-            value={selectedImageModel ?? DEFAULT_IMAGE_MODEL_ID}
-            onChange={handleModelChange}
-          />
-        )}
+        <BilderSettingsMenu
+          settings={isErstellen ? (erstellenDef?.settings ?? []) : []}
+          settingsValues={modeState}
+          onSettingChange={(key, val) => updateField(key, val)}
+          modelValue={
+            isErstellen || isBearbeiten ? (selectedImageModel ?? DEFAULT_IMAGE_MODEL_ID) : null
+          }
+          onModelChange={handleModelChange}
+          aspectRatio={isVergroessern ? aspectRatio : null}
+          onAspectRatioChange={setAspectRatio}
+        />
         {isBearbeiten && referencePillRow}
         {(isBegruenen || isHintergrund) && filePickerPill}
-        {isVergroessern && (
-          <SettingsDropdown
-            config={ASPECT_RATIO_CONFIG}
-            value={aspectRatio}
-            onChange={(val) => setAspectRatio(val as AspectRatio)}
-          />
-        )}
         {isVergroessern && isCustomAspect && (
           <span
             className={cn(

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -563,6 +563,10 @@ const BilderInner: React.FC = memo(() => {
   const selectedImageModel = (modeState.imageModel as ImageModelId | undefined) ?? null;
   const effectiveImageModel = selectedImageModel ?? defaultImageModel ?? DEFAULT_IMAGE_MODEL_ID;
   const maxRefs = IMAGE_MODEL_BY_ID[effectiveImageModel]?.maxReferenceImages ?? 1;
+  // Format presets/free px only make sense for models that honor width/height
+  // (Regolo/Qwen-Image always renders fixed squares).
+  const supportsCustomDims =
+    IMAGE_MODEL_BY_ID[effectiveImageModel]?.supportsCustomDimensions ?? false;
 
   const [usage, setUsage] = useState<UsageStatus | null>(null);
   const usageQuery = useQuery({
@@ -762,19 +766,21 @@ const BilderInner: React.FC = memo(() => {
       if (modeState.variant) payload.variant = modeState.variant;
       if (modeState.imageModel) payload.imageModel = modeState.imageModel;
       if (kiLabel !== 'full') payload.kiLabel = kiLabel;
-      if (createFormat === 'custom') {
-        if (!createCustomValid) {
-          setCreateSizeError(
-            `Ungültige Größe — ${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CREATE_AREA / 1_000_000} MP.`
-          );
-          return;
+      if (supportsCustomDims) {
+        if (createFormat === 'custom') {
+          if (!createCustomValid) {
+            setCreateSizeError(
+              `Ungültige Größe — ${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CREATE_AREA / 1_000_000} MP.`
+            );
+            return;
+          }
+          payload.width = roundTo16(customWidth);
+          payload.height = roundTo16(customHeight);
+        } else if (createFormat !== 'auto') {
+          const dims = CREATE_ASPECT_DIMENSIONS[createFormat];
+          payload.width = dims.width;
+          payload.height = dims.height;
         }
-        payload.width = roundTo16(customWidth);
-        payload.height = roundTo16(customHeight);
-      } else if (createFormat !== 'auto') {
-        const dims = CREATE_ASPECT_DIMENSIONS[createFormat];
-        payload.width = dims.width;
-        payload.height = dims.height;
       }
       setCreateSizeError(null);
       const result = await submitForm(payload);
@@ -807,6 +813,7 @@ const BilderInner: React.FC = memo(() => {
     createCustomValid,
     customWidth,
     customHeight,
+    supportsCustomDims,
     setResult,
     createImageShare,
     queryClient,
@@ -1239,7 +1246,7 @@ const BilderInner: React.FC = memo(() => {
           }
           onModelChange={handleModelChange}
           format={
-            isErstellen
+            isErstellen && supportsCustomDims
               ? {
                   config: CREATE_FORMAT_CONFIG,
                   value: createFormat,
@@ -1258,7 +1265,8 @@ const BilderInner: React.FC = memo(() => {
         />
         {isBearbeiten && referencePillRow}
         {(isBegruenen || isHintergrund) && filePickerPill}
-        {((isVergroessern && isCustomAspect) || (isErstellen && createFormat === 'custom')) && (
+        {((isVergroessern && isCustomAspect) ||
+          (isErstellen && supportsCustomDims && createFormat === 'custom')) && (
           <span
             className={cn(
               'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs',
@@ -1308,6 +1316,7 @@ const BilderInner: React.FC = memo(() => {
       customSizeValid,
       createFormat,
       createCustomValid,
+      supportsCustomDims,
       erstellenDef?.settings,
       modeState,
       updateField,

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -1,3 +1,4 @@
+import { type KiLabelMode } from '@gruenerator/contracts';
 import { getGlobalApiClient } from '@gruenerator/shared/api';
 import { useMediaPicker, type MediaItem } from '@gruenerator/shared/media-library';
 import {
@@ -12,7 +13,6 @@ import { useShareStore } from '@gruenerator/shared/share';
 import {
   AIPromptInput,
   Button,
-  DropdownMenuCheckboxItem,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -22,7 +22,6 @@ import {
   ResponsiveMenu,
   ResponsiveMenuItem,
   ResponsiveMenuSection,
-  ResponsiveMenuToggle,
   SettingsDropdown,
   pillBase,
   pillInactive,
@@ -111,8 +110,8 @@ function BilderSettingsMenu({
   onModelChange: (id: ImageModelId) => void;
   aspectRatio: AspectRatio | null;
   onAspectRatioChange: (aspect: AspectRatio) => void;
-  kiLabel: boolean | null;
-  onKiLabelChange: (value: boolean) => void;
+  kiLabel: KiLabelMode | null;
+  onKiLabelChange: (value: KiLabelMode) => void;
 }) {
   const [open, setOpen] = useState(false);
   const hasSelectSections = settings.length > 0 || modelValue !== null || aspectRatio !== null;
@@ -210,13 +209,19 @@ function BilderSettingsMenu({
       {kiLabel !== null && (
         <>
           {hasSelectSections && <DropdownMenuSeparator />}
-          <DropdownMenuCheckboxItem
-            checked={kiLabel}
-            onCheckedChange={(checked) => onKiLabelChange(checked === true)}
-            onSelect={(e) => e.preventDefault()}
-          >
-            KI-Kennzeichnung im Bild
-          </DropdownMenuCheckboxItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              Kennzeichnung
+              {subHint(KI_LABEL_OPTIONS.find((o) => o.id === kiLabel)?.label ?? null)}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              {KI_LABEL_OPTIONS.map((option) =>
+                desktopItem(option.id, option.label, option.id === kiLabel, () =>
+                  onKiLabelChange(option.id)
+                )
+              )}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         </>
       )}
     </>
@@ -280,11 +285,18 @@ function BilderSettingsMenu({
       )}
       {kiLabel !== null && (
         <ResponsiveMenuSection title="Kennzeichnung">
-          <ResponsiveMenuToggle
-            label="KI-Kennzeichnung im Bild"
-            checked={kiLabel}
-            onCheckedChange={onKiLabelChange}
-          />
+          {KI_LABEL_OPTIONS.map((option) => (
+            <ResponsiveMenuItem
+              key={option.id}
+              active={option.id === kiLabel}
+              onClick={() => {
+                onKiLabelChange(option.id);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+            </ResponsiveMenuItem>
+          ))}
         </ResponsiveMenuSection>
       )}
     </>
@@ -333,15 +345,24 @@ const MIN_CUSTOM_SIDE = 256;
 const MAX_CUSTOM_SIDE = 2048;
 const MAX_CUSTOM_AREA = 4_194_304;
 
-// Persists the opt-out of the burned-in "KI-Generiert mit dem Grünerator"
-// label across sessions (users may want to apply their own AI labeling).
+// Which AI label gets burned into generated images. Users may shorten or
+// drop it to apply their own AI labeling instead.
+const KI_LABEL_OPTIONS: Array<{ id: KiLabelMode; label: string }> = [
+  { id: 'full', label: '„KI-Generiert mit dem Grünerator“' },
+  { id: 'short', label: 'Nur „KI-Generiert“' },
+  { id: 'none', label: 'Keine Kennzeichnung' },
+];
+
+// Persists the label choice across sessions.
 const KI_LABEL_STORAGE_KEY = 'gruenerator-bilder-ki-label';
 
-function readStoredKiLabel(): boolean {
+function readStoredKiLabel(): KiLabelMode {
   try {
-    return localStorage.getItem(KI_LABEL_STORAGE_KEY) !== 'false';
+    const stored = localStorage.getItem(KI_LABEL_STORAGE_KEY);
+    if (stored === 'short' || stored === 'none') return stored;
+    return 'full';
   } catch {
-    return true;
+    return 'full';
   }
 }
 
@@ -472,11 +493,11 @@ const BilderInner: React.FC = memo(() => {
     customArea <= MAX_CUSTOM_AREA;
   const [outpaintError, setOutpaintError] = useState<string | null>(null);
 
-  const [kiLabel, setKiLabelState] = useState<boolean>(readStoredKiLabel);
-  const setKiLabel = useCallback((value: boolean) => {
+  const [kiLabel, setKiLabelState] = useState<KiLabelMode>(readStoredKiLabel);
+  const setKiLabel = useCallback((value: KiLabelMode) => {
     setKiLabelState(value);
     try {
-      localStorage.setItem(KI_LABEL_STORAGE_KEY, String(value));
+      localStorage.setItem(KI_LABEL_STORAGE_KEY, value);
     } catch {
       // Storage unavailable (e.g. private mode) — keep the in-memory value.
     }
@@ -701,7 +722,7 @@ const BilderInner: React.FC = memo(() => {
       const payload: Record<string, unknown> = { prompt: trimmed };
       if (modeState.variant) payload.variant = modeState.variant;
       if (modeState.imageModel) payload.imageModel = modeState.imageModel;
-      if (!kiLabel) payload.kiLabel = false;
+      if (kiLabel !== 'full') payload.kiLabel = kiLabel;
       const result = await submitForm(payload);
       const usageFromResponse = (result as { usage?: UsageStatus })?.usage;
       if (usageFromResponse) setUsage(usageFromResponse);
@@ -901,7 +922,7 @@ const BilderInner: React.FC = memo(() => {
       form.append('aspectRatio', 'custom');
       form.append('width', String(targetW));
       form.append('height', String(targetH));
-      if (!kiLabel) form.append('kiLabel', 'false');
+      if (kiLabel !== 'full') form.append('kiLabel', kiLabel);
       const res = await getGlobalApiClient().post<{
         success: boolean;
         image?: { base64?: string };

--- a/apps/web/src/features/workplace/components/BilderInner.tsx
+++ b/apps/web/src/features/workplace/components/BilderInner.tsx
@@ -98,8 +98,7 @@ function BilderSettingsMenu({
   onSettingChange,
   modelValue,
   onModelChange,
-  aspectRatio,
-  onAspectRatioChange,
+  format,
   kiLabel,
   onKiLabelChange,
 }: {
@@ -108,13 +107,12 @@ function BilderSettingsMenu({
   onSettingChange: (key: string, value: string) => void;
   modelValue: ImageModelId | null;
   onModelChange: (id: ImageModelId) => void;
-  aspectRatio: AspectRatio | null;
-  onAspectRatioChange: (aspect: AspectRatio) => void;
+  format: { config: SettingConfig; value: string; onChange: (value: string) => void } | null;
   kiLabel: KiLabelMode | null;
   onKiLabelChange: (value: KiLabelMode) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const hasSelectSections = settings.length > 0 || modelValue !== null || aspectRatio !== null;
+  const hasSelectSections = settings.length > 0 || modelValue !== null || format !== null;
   if (!hasSelectSections && kiLabel === null) return null;
 
   const selectModel = (id: ImageModelId) => {
@@ -191,16 +189,16 @@ function BilderSettingsMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
       )}
-      {aspectRatio !== null && (
+      {format !== null && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
-            Format
-            {subHint(ASPECT_RATIO_CONFIG.options.find((o) => o.id === aspectRatio)?.label ?? null)}
+            {format.config.label ?? format.config.key}
+            {subHint(format.config.options.find((o) => o.id === format.value)?.label ?? null)}
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent>
-            {ASPECT_RATIO_CONFIG.options.map((option) =>
-              desktopItem(option.id, option.label, option.id === aspectRatio, () =>
-                onAspectRatioChange(option.id as AspectRatio)
+            {format.config.options.map((option) =>
+              desktopItem(option.id, option.label, option.id === format.value, () =>
+                format.onChange(option.id)
               )
             )}
           </DropdownMenuSubContent>
@@ -267,14 +265,14 @@ function BilderSettingsMenu({
           )}
         </ResponsiveMenuSection>
       )}
-      {aspectRatio !== null && (
-        <ResponsiveMenuSection title="Format">
-          {ASPECT_RATIO_CONFIG.options.map((option) => (
+      {format !== null && (
+        <ResponsiveMenuSection title={format.config.label ?? format.config.key}>
+          {format.config.options.map((option) => (
             <ResponsiveMenuItem
               key={option.id}
-              active={option.id === aspectRatio}
+              active={option.id === format.value}
               onClick={() => {
-                onAspectRatioChange(option.id as AspectRatio);
+                format.onChange(option.id);
                 setOpen(false);
               }}
             >
@@ -340,6 +338,37 @@ const ASPECT_RATIO_CONFIG: SettingConfig = {
   ],
   multiple: false,
 };
+
+// Format for generation (erstellen): the variant's default size, a preset
+// ratio, or free pixel input.
+type CreateFormat = 'auto' | AspectRatio;
+
+const CREATE_FORMAT_CONFIG: SettingConfig = {
+  key: 'createFormat',
+  label: 'Format',
+  options: [{ id: 'auto', label: 'Automatisch' }, ...ASPECT_RATIO_CONFIG.options],
+  multiple: false,
+};
+
+// Pixel sizes per preset for /imagine/pure — multiples of 16 under its 4MP
+// cap; mirrors the outpaint target sizes on the server.
+const CREATE_ASPECT_DIMENSIONS: Record<
+  Exclude<AspectRatio, 'custom'>,
+  { width: number; height: number }
+> = {
+  '16:9': { width: 1600, height: 896 },
+  '4:3': { width: 1408, height: 1056 },
+  '1:1': { width: 1280, height: 1280 },
+  '3:4': { width: 1056, height: 1408 },
+  '9:16': { width: 896, height: 1600 },
+};
+
+// /imagine/pure rejects images over 4MP and requires sides in multiples of 16.
+const MAX_CREATE_AREA = 4_000_000;
+
+function roundTo16(n: number): number {
+  return Math.round(n / 16) * 16;
+}
 
 const MIN_CUSTOM_SIDE = 256;
 const MAX_CUSTOM_SIDE = 2048;
@@ -480,6 +509,7 @@ const BilderInner: React.FC = memo(() => {
           : hintergrundDef;
 
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
+  const [createFormat, setCreateFormat] = useState<CreateFormat>('auto');
   const [customWidth, setCustomWidth] = useState<number>(1280);
   const [customHeight, setCustomHeight] = useState<number>(1280);
   const [outpaintLoading, setOutpaintLoading] = useState(false);
@@ -491,7 +521,16 @@ const BilderInner: React.FC = memo(() => {
     customHeight >= MIN_CUSTOM_SIDE &&
     customHeight <= MAX_CUSTOM_SIDE &&
     customArea <= MAX_CUSTOM_AREA;
+  // Stricter than the outpaint rule: /imagine/pure caps at 4MP after the
+  // sides are rounded to multiples of 16.
+  const createCustomValid =
+    customWidth >= MIN_CUSTOM_SIDE &&
+    customWidth <= MAX_CUSTOM_SIDE &&
+    customHeight >= MIN_CUSTOM_SIDE &&
+    customHeight <= MAX_CUSTOM_SIDE &&
+    roundTo16(customWidth) * roundTo16(customHeight) <= MAX_CREATE_AREA;
   const [outpaintError, setOutpaintError] = useState<string | null>(null);
+  const [createSizeError, setCreateSizeError] = useState<string | null>(null);
 
   const [kiLabel, setKiLabelState] = useState<KiLabelMode>(readStoredKiLabel);
   const setKiLabel = useCallback((value: KiLabelMode) => {
@@ -723,6 +762,21 @@ const BilderInner: React.FC = memo(() => {
       if (modeState.variant) payload.variant = modeState.variant;
       if (modeState.imageModel) payload.imageModel = modeState.imageModel;
       if (kiLabel !== 'full') payload.kiLabel = kiLabel;
+      if (createFormat === 'custom') {
+        if (!createCustomValid) {
+          setCreateSizeError(
+            `Ungültige Größe — ${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CREATE_AREA / 1_000_000} MP.`
+          );
+          return;
+        }
+        payload.width = roundTo16(customWidth);
+        payload.height = roundTo16(customHeight);
+      } else if (createFormat !== 'auto') {
+        const dims = CREATE_ASPECT_DIMENSIONS[createFormat];
+        payload.width = dims.width;
+        payload.height = dims.height;
+      }
+      setCreateSizeError(null);
       const result = await submitForm(payload);
       const usageFromResponse = (result as { usage?: UsageStatus })?.usage;
       if (usageFromResponse) setUsage(usageFromResponse);
@@ -749,6 +803,10 @@ const BilderInner: React.FC = memo(() => {
     modeState.variant,
     modeState.imageModel,
     kiLabel,
+    createFormat,
+    createCustomValid,
+    customWidth,
+    customHeight,
     setResult,
     createImageShare,
     queryClient,
@@ -1180,22 +1238,35 @@ const BilderInner: React.FC = memo(() => {
             isErstellen || isBearbeiten ? (selectedImageModel ?? DEFAULT_IMAGE_MODEL_ID) : null
           }
           onModelChange={handleModelChange}
-          aspectRatio={isVergroessern ? aspectRatio : null}
-          onAspectRatioChange={setAspectRatio}
+          format={
+            isErstellen
+              ? {
+                  config: CREATE_FORMAT_CONFIG,
+                  value: createFormat,
+                  onChange: (val) => setCreateFormat(val as CreateFormat),
+                }
+              : isVergroessern
+                ? {
+                    config: ASPECT_RATIO_CONFIG,
+                    value: aspectRatio,
+                    onChange: (val) => setAspectRatio(val as AspectRatio),
+                  }
+                : null
+          }
           kiLabel={isHintergrund ? null : kiLabel}
           onKiLabelChange={setKiLabel}
         />
         {isBearbeiten && referencePillRow}
         {(isBegruenen || isHintergrund) && filePickerPill}
-        {isVergroessern && isCustomAspect && (
+        {((isVergroessern && isCustomAspect) || (isErstellen && createFormat === 'custom')) && (
           <span
             className={cn(
               'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs',
-              customSizeValid
+              (isErstellen ? createCustomValid : customSizeValid)
                 ? 'border-grey-200 dark:border-grey-700 text-grey-700 dark:text-grey-300'
                 : 'border-red-300 text-red-600 dark:border-red-700 dark:text-red-400'
             )}
-            title={`${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${MAX_CUSTOM_AREA / 1_000_000} MP`}
+            title={`${MIN_CUSTOM_SIDE}–${MAX_CUSTOM_SIDE}px pro Seite, max. ${(isErstellen ? MAX_CREATE_AREA : MAX_CUSTOM_AREA) / 1_000_000} MP`}
           >
             <input
               type="number"
@@ -1235,6 +1306,8 @@ const BilderInner: React.FC = memo(() => {
       customWidth,
       customHeight,
       customSizeValid,
+      createFormat,
+      createCustomValid,
       erstellenDef?.settings,
       modeState,
       updateField,
@@ -1261,7 +1334,9 @@ const BilderInner: React.FC = memo(() => {
   const error = isErstellen
     ? createError
       ? String(createError)
-      : null
+      : createFormat === 'custom' && !createCustomValid
+        ? createSizeError
+        : null
     : isBearbeiten
       ? editError
       : isBegruenen

--- a/packages/contracts/src/schemas/imageEdit.ts
+++ b/packages/contracts/src/schemas/imageEdit.ts
@@ -23,6 +23,9 @@ export const imageEditReferenceSchema = z.object({
 
 export const imageEditTypeSchema = z.enum(['universal', 'green-edit', 'ally-maker']);
 
+/** AI-label variants for generated/edited images (default: 'full'). */
+export const kiLabelModeSchema = z.enum(['full', 'short', 'none']);
+
 export const imageEditBodySchema = z.object({
   /** Natural-language edit instruction; may reference "Bild 1", "Bild 2", … */
   instruction: z.string().min(1).max(4000),
@@ -33,16 +36,17 @@ export const imageEditBodySchema = z.object({
   editType: imageEditTypeSchema.nullish(),
   precision: z.boolean().nullish(),
   /**
-   * Burn the "KI-Generiert mit dem Grünerator" label into the result.
-   * Defaults to true; users can opt out to apply their own AI labeling.
+   * Which AI label to burn into the result: 'full' ("KI-Generiert mit dem
+   * Grünerator", default), 'short' ("KI-Generiert"), or 'none' so users can
+   * apply their own AI labeling.
    */
-  kiLabel: z.boolean().nullish(),
+  kiLabel: kiLabelModeSchema.nullish(),
 });
 
 export const imageEditSuccessSchema = z.object({
   success: z.literal(true),
   image: z.object({
-    /** Base64-encoded JPEG result (no data-URL prefix), KI-labeled unless kiLabel=false. */
+    /** Base64-encoded JPEG result (no data-URL prefix), KI-labeled per kiLabel mode. */
     base64: z.string(),
     filename: z.string(),
   }),
@@ -75,3 +79,4 @@ export type ImageEditReference = z.infer<typeof imageEditReferenceSchema>;
 export type ImageEditBody = z.infer<typeof imageEditBodySchema>;
 export type ImageEditSuccess = z.infer<typeof imageEditSuccessSchema>;
 export type ImageEditType = z.infer<typeof imageEditTypeSchema>;
+export type KiLabelMode = z.infer<typeof kiLabelModeSchema>;

--- a/packages/contracts/src/schemas/imageEdit.ts
+++ b/packages/contracts/src/schemas/imageEdit.ts
@@ -32,12 +32,17 @@ export const imageEditBodySchema = z.object({
   imageModel: imageModelIdSchema.nullish(),
   editType: imageEditTypeSchema.nullish(),
   precision: z.boolean().nullish(),
+  /**
+   * Burn the "KI-Generiert mit dem Grünerator" label into the result.
+   * Defaults to true; users can opt out to apply their own AI labeling.
+   */
+  kiLabel: z.boolean().nullish(),
 });
 
 export const imageEditSuccessSchema = z.object({
   success: z.literal(true),
   image: z.object({
-    /** Base64-encoded JPEG result (no data-URL prefix), KI-labeled. */
+    /** Base64-encoded JPEG result (no data-URL prefix), KI-labeled unless kiLabel=false. */
     base64: z.string(),
     filename: z.string(),
   }),

--- a/packages/core/src/models/catalog.ts
+++ b/packages/core/src/models/catalog.ts
@@ -44,6 +44,12 @@ export interface ImageModelOption extends BaseModelOption {
   costMultiplier: number;
   /** Max reference images per edit (FLUX.2 multi-reference). Absent = 1. */
   maxReferenceImages?: number;
+  /**
+   * Whether generation honors free width/height (format presets, custom px).
+   * Absent = false: the backend snaps to the sizes the provider supports
+   * (e.g. Regolo/Qwen-Image only renders 256/512/1024 squares).
+   */
+  supportsCustomDimensions?: boolean;
 }
 
 export interface ImageFamilyOption {
@@ -84,7 +90,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     id: 'litellm',
     name: '🌳 GPT-OSS',
     description: 'Schnellstes Modell',
-    model: 'gpt-oss:120b',
+    model: 'verdigado-pro',
     provider: 'litellm',
     icon: 'server',
     region: 'self-hosted',
@@ -121,6 +127,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     modelPath: '/v1/flux-2-pro',
     costMultiplier: 1,
     maxReferenceImages: 8,
+    supportsCustomDimensions: true,
     icon: 'sparkles',
     region: 'eu',
   },
@@ -134,6 +141,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     modelPath: '/v1/flux-2-klein-9b',
     costMultiplier: 0.5,
     maxReferenceImages: 4,
+    supportsCustomDimensions: true,
     icon: 'zap',
     region: 'eu',
   },
@@ -147,6 +155,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     modelPath: '/v1/flux-2-max',
     costMultiplier: 2,
     maxReferenceImages: 8,
+    supportsCustomDimensions: true,
     icon: 'brain',
     region: 'eu',
   },
@@ -182,12 +191,15 @@ export const IMAGE_FAMILIES: ImageFamilyOption[] = [
     description: 'Selbst gehostet, klimaneutral',
     region: 'self-hosted',
   },
-  {
-    id: 'ionos',
-    name: '🌳 IONOS Schnell',
-    description: 'EU-Cloud, klimaneutral',
-    region: 'self-hosted',
-  },
+  // IONOS is hidden from the pickers for now (quality/availability issues).
+  // The 'ionos-image' model entry stays in IMAGE_MODELS so stored
+  // preferences keep resolving on the backend.
+  // {
+  //   id: 'ionos',
+  //   name: '🌳 IONOS Schnell',
+  //   description: 'EU-Cloud, klimaneutral',
+  //   region: 'self-hosted',
+  // },
 ];
 
 export const DEFAULT_FLUX_MODEL_ID: ImageModelId = 'flux-pro';


### PR DESCRIPTION
## Summary

The Bilder tab in the workplace page rendered up to four separate dropdown pills in the composer toolbar (Modus, Stil, Modell, Format), crowding it especially on mobile. This PR bundles the secondary settings behind a single gear icon, mirroring the notebook composer's settings dropdown pattern.

- **Modus stays visible** as its own pill — it switches the entire input UI.
- New `BilderSettingsMenu` (built on `ResponsiveMenu`) holds:
  - **Stil** (Erstellen only, driven by `erstellenDef.settings`)
  - **Modell** (Erstellen + Bearbeiten, replaces the standalone `ImageModelDropdown`)
  - **Format** (Erstellen + Vergrößern)
  - **Kennzeichnung** (all modes except Hintergrund)
- Desktop: nested dropdown submenus with current-value hints; Flux variants flattened under a label to avoid third-level nesting.
- Mobile: flat sectioned bottom sheet (nested fly-outs are awkward on touch).
- Custom pixel inputs, reference/file pills and the usage badge stay inline in the toolbar.

## Format for generation (Erstellen)

New Format choice when generating: **Automatisch** (the style variant's default size, default), the preset ratios **16:9 / 4:3 / 1:1 / 3:4 / 9:16**, or **Frei (Pixel)** with free width/height input.

- Presets map to the same multiple-of-16 pixel sizes the outpaint endpoint targets (e.g. 16:9 → 1600×896).
- Free input reuses the inline px fields, rounds to multiples of 16 and validates against the 4MP cap of `/imagine/pure` — which already accepted `width`/`height`, so no backend change.
- Vergrößern keeps its own Format selector; the menu section is generalized to a shared config/value/onChange prop.

## KI label (Kennzeichnung)

Generated images get a burned-in AI label. The **Kennzeichnung** section offers three choices so users can apply their own labeling instead:

- **„KI-Generiert mit dem Grünerator"** — full label, default
- **Nur „KI-Generiert"** — short label without the Grünerator branding
- **Keine Kennzeichnung** — no label

Implementation:
- `kiLabel` is a shared `full | short | none` enum (`kiLabelModeSchema` in `@gruenerator/contracts`), reused by the `/imagine/pure` Zod schema, the `imageEdit` ts-rest contract (Bearbeiten + Begrünen) and the `/imagine/outpaint` multipart form field.
- `addKiLabel` takes the variant; absent flag defaults to the full label, so chat image generation and other callers are unaffected.
- Preference persists in `localStorage`.

## Test plan

- [ ] Erstellen: gear shows Stil + Modell + Format + Kennzeichnung
- [ ] Erstellen Format 16:9 → generated image is 1600×896; Automatisch → variant default size
- [ ] Erstellen Format „Frei (Pixel)" → px inputs appear inline; odd values are rounded to multiples of 16; >4MP shows red border and an error on submit
- [ ] Bearbeiten: gear shows Modell + Kennzeichnung; reference pills still render
- [ ] Begrünen: gear shows only Kennzeichnung; file-picker pill still renders
- [ ] Vergrößern: gear shows Format + Kennzeichnung; „Frei (Pixel)" behaves as before
- [ ] Kennzeichnung „Nur KI-Generiert" → short label; „Keine" → no label, survives reload; default → full label
- [ ] Mobile viewport: gear opens a bottom sheet with flat sections

## Provider limits & IONOS

- **Regolo/Qwen-Image** only renders 256/512/1024 squares — `RegoloImageService` now snaps requested sizes to the nearest supported square (previously it forwarded raw `width x height`, including non-square variant defaults).
- New `supportsCustomDimensions` flag in the image-model catalog (Flux only): the Erstellen **Format** section hides for models that ignore dimensions, and no `width`/`height` is sent for them.
- **IONOS** is commented out of the pickers (quality issues); the model entry stays so stored preferences keep resolving.

## Real-world test (verified locally)

Generated via the UI with Flux Klein, Format 16:9, Kennzeichnung „Nur KI-Generiert": request body carried `width:1600, height:896, kiLabel:"short"`; the returned PNG is **1600×896** with a bottom-left badge reading only **„KI-Generiert"**. IONOS absent from the picker; selecting Qwen-Image hides the Format section.
