### PR TITLE
fix(content-sync): add Hessen (HE) to landesverband sync matrix

### DIFF
--- a/.github/workflows/content-sync.yml
+++ b/.github/workflows/content-sync.yml
@@ -11,7 +11,7 @@ on:
         required: false
         type: string
       landesverband:
-        description: 'Single Landesverband shortName prefix (BB, BE, HH, LSA, MV, TH). Mutually exclusive with source.'
+        description: 'Single Landesverband shortName prefix (BB, BE, BY, HE, HH, LSA, MV, TH). Mutually exclusive with source.'
         required: false
         type: string
       dry_run:
@@ -48,7 +48,7 @@ jobs:
           INPUT_SOURCE: ${{ inputs.source }}
           INPUT_LV: ${{ inputs.landesverband }}
         run: |
-          ALL_LVS='["BB","BE","BY","HH","LSA","MV","TH"]'
+          ALL_LVS='["BB","BE","BY","HE","HH","LSA","MV","TH"]'
           ALL_SOURCES='["gruenblog","gruene-at","kommunalwiki","boell-stiftung","bundestag"]'
           EMPTY='[]'
 


### PR DESCRIPTION
## Problem

The Hessen notebook only held **128 documents** — and that number is the *real* Qdrant count (verified directly against production), not a frontend display bug.

Breaking it down by source:

| Source | Stored (unique docs) | Available within 5yr | Status |
|---|---|---|---|
| \`hessen-lv\` Presse | 125 (2021–2026) | ~125 | ✅ healthy |
| \`hessen-lv\` Beschlüsse | **3** | ~50 | ❌ |
| \`hessen-fraktion\` (HE-F) | **0** | ~1700 | ❌ |

## Root cause

The daily content-sync matrix listed every configured Landesverband base code **except HE**:

\`\`\`
ALL_LVS='["BB","BE","BY","HH","LSA","MV","TH"]'
\`\`\`

Hessen was set up as a notebook + scraper config (\`scrape-hessen.ts\`, \`hessen-lv\` / \`hessen-fraktion\` sources) but never added to the rotation. The 128 docs came from a single partial manual run that captured LV presse + 3 Beschlüsse and never completed the Fraktion. The scraper config itself is fine — selectors, pagination, date parsing, and the 5-year freshness window all verified working against the live site.

## Fix

Add \`HE\` to \`ALL_LVS\` (and refresh the stale dispatch-input hint). The daily job now runs \`--landesverband HE\`, which prefix-matches both \`hessen-lv\` (presse + beschluss) and \`hessen-fraktion\`, keeping all three paths fresh.

## Backfill follow-up (not in this PR)

This fixes future runs only. To fill the existing gap (~1700 Fraktion + ~45 Beschluss docs) once merged, trigger a one-off run:

\`\`\`bash
gh workflow run content-sync.yml -f landesverband=HE -f force=true
\`\`\`