### PR TITLE
feat(notebook): surface LV agents as a category on notebook pages

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookAgentsSection.tsx
+++ b/apps/web/src/features/notebook/components/NotebookAgentsSection.tsx
@@ -1,0 +1,48 @@
+import { getAgentSlug, getSystemAgentsForLocale } from '@gruenerator/shared/agents';
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuthStore } from '../../../stores/authStore';
+import { AgentCard } from '../../agentura/components/cards';
+
+interface NotebookAgentsSectionProps {
+  /** Canonical notebook id, e.g. `brandenburg-notebook`. */
+  notebookId: string;
+  title?: string;
+}
+
+// LV agents pin themselves to their Landesverband notebook via `defaultNotebookId`,
+// so the notebook's own agents are exactly the system agents whose
+// `defaultNotebookId` matches. Matching on the notebook id (not the identifier)
+// also covers the Austria suffix quirk (identifier `…-at`, notebook
+// `oesterreich-notebook`). Self-hides when nothing matches — user notebooks (UUID
+// id) and Bundes notebooks without agents simply render nothing.
+export function NotebookAgentsSection({
+  notebookId,
+  title = 'Agenten für diesen Landesverband',
+}: NotebookAgentsSectionProps) {
+  const navigate = useNavigate();
+  const locale = useAuthStore((s) => s.locale) ?? 'de-DE';
+
+  const agents = useMemo(
+    () => getSystemAgentsForLocale(locale).filter((a) => a.defaultNotebookId === notebookId),
+    [locale, notebookId]
+  );
+
+  if (agents.length === 0) return null;
+
+  return (
+    <section className="w-full">
+      <h2 className="mt-xl mb-md text-xl font-semibold text-foreground-heading">{title}</h2>
+      <div className="grid gap-sm md:grid-cols-2">
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.identifier}
+            agent={agent}
+            onSelect={(a) => void navigate(`/agents/${getAgentSlug(a.identifier)}`)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/notebook/components/NotebookPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookPage.tsx
@@ -332,6 +332,11 @@ export const NotebookPageContent = ({
     return entry?.mention ?? null;
   }, [config.id]);
 
+  // Canonical notebook id (matches LV agents' `defaultNotebookId`). For dynamic
+  // user notebooks `config.id` is a UUID, so this matches no agent and the
+  // agents section self-hides.
+  const notebookId = `${config.id}-notebook`;
+
   const chatContent = (
     <NotebookChatProvider
       collections={providerCollections}
@@ -371,6 +376,7 @@ export const NotebookPageContent = ({
                     hideGlobalChat={hideGlobalChat}
                     manualSearchNotebookId={manualSearchNotebookId}
                     notebookMention={notebookMention}
+                    notebookId={notebookId}
                     footer={startpageFooter}
                   />
                 </div>

--- a/apps/web/src/features/notebook/components/NotebookStartpage.tsx
+++ b/apps/web/src/features/notebook/components/NotebookStartpage.tsx
@@ -10,6 +10,7 @@ import { memo, useState, type ReactNode } from 'react';
 import PageContainer from '../../../components/common/PageContainer';
 
 import { LastAddedSection } from './LastAddedSection';
+import { NotebookAgentsSection } from './NotebookAgentsSection';
 import { NotebookGlobalChatLauncher } from './NotebookGlobalChatLauncher';
 import { NotebookManualSearch } from './NotebookManualSearch';
 import { StatisticsSection } from './StatisticsSection';
@@ -52,6 +53,9 @@ interface NotebookStartpageProps {
   manualSearchNotebookId?: string;
   /** Mention slug for the global-chat tab (e.g. 'berlin'). Null hides the tab. */
   notebookMention?: string | null;
+  /** Canonical notebook id (e.g. 'brandenburg-notebook') used to surface the
+   *  notebook's LV agents. The agents section self-hides when none match. */
+  notebookId?: string;
   footer?: ReactNode;
 }
 
@@ -94,6 +98,7 @@ export function NotebookStartpage({
   hideGlobalChat = false,
   manualSearchNotebookId,
   notebookMention,
+  notebookId,
   footer,
 }: NotebookStartpageProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('ki');
@@ -119,7 +124,7 @@ export function NotebookStartpage({
             {sources.map(
               (s, i) =>
                 s.name && (
-                  <span key={i} className="inline-flex items-center gap-1">
+                  <span key={s.name} className="inline-flex items-center gap-1">
                     <span>{s.name}</span>
                     {s.count && <span className="text-grey-400">· {s.count}</span>}
                     {i < sources.length - 1 && <span className="mx-xs">·</span>}
@@ -175,8 +180,8 @@ export function NotebookStartpage({
             />
             {exampleQuestions.length > 0 && (
               <div className="mt-md grid grid-cols-1 gap-sm md:grid-cols-3">
-                {exampleQuestions.map((q, i) => (
-                  <ExampleChip key={i} question={q} />
+                {exampleQuestions.map((q) => (
+                  <ExampleChip key={q.text} question={q} />
                 ))}
               </div>
             )}
@@ -188,6 +193,8 @@ export function NotebookStartpage({
               showSourceLabel={showRecentSourceLabel}
             />
           )}
+
+          {notebookId && <NotebookAgentsSection notebookId={notebookId} />}
 
           {showStats && recentCollectionIds.length > 0 && (
             <StatisticsSection collectionIds={recentCollectionIds} />


### PR DESCRIPTION
## What

Adds a new card category on each Landesverband notebook page (e.g. `/notebooks/brandenburg`) that surfaces the LV's specialist agents — the `Öffentlichkeitsarbeit` (PR) and `Bürger*innenanfragen` agents — **between** the "Zuletzt hinzugefügt" section and the statistics section.

Previously these agents existed but were never surfaced on the very notebook pages they're tuned for.

## How

- New `NotebookAgentsSection` filters `getSystemAgentsForLocale(locale)` by `defaultNotebookId === \`\${config.id}-notebook\`` and renders each as the existing `AgentCard`, linking to `/agents/<slug>`.
- Wired through `NotebookStartpage` (new optional `notebookId` prop) and `NotebookPage` (reuses the existing `\${config.id}-notebook` derivation).
- Matching on the **notebook id** (not the agent identifier) auto-handles the Austria quirk (identifier `…-at` vs notebook `oesterreich-notebook`).
- Self-hides when nothing matches, so user notebooks (UUID id) and Bundes notebooks without agents render nothing — no extra gating.

## Drive-by

Fixes two preexisting `react/no-array-index-key` warnings in `NotebookStartpage.tsx` (sources + example-question maps).

## Test plan

- [ ] de-DE user: `/notebooks/brandenburg` and `/notebooks/berlin` show the new "Agenten für diesen Landesverband" section between "Zuletzt hinzugefügt" and the statistics section; cards open `/agents/<slug>`.
- [ ] de-AT user: `/notebooks/oesterreich` shows the Austrian LV agents.
- [ ] User notebook (UUID) and a Bundes notebook with no agents: section does not render.