### PR TITLE
feat(workplace): redesign notebook cards + refresh /notebooks gallery

### DIFF
--- a/apps/web/src/features/notebook/components/NotebookGalleryCard.tsx
+++ b/apps/web/src/features/notebook/components/NotebookGalleryCard.tsx
@@ -1,0 +1,87 @@
+import { cn } from '@gruenerator/ui';
+import { memo, type ReactNode } from 'react';
+import { FiFolder, FiLayers } from 'react-icons/fi';
+
+import type { IconType } from 'react-icons';
+
+export interface NotebookGalleryCardProps {
+  title: string;
+  /** Sub-line, e.g. "3 Programme", "542 Artikel", "Eigenes Notebook". */
+  meta?: string;
+  icon?: IconType;
+  /** Small icon shown before `meta`. Defaults to a "layers" (sources) glyph. */
+  metaIcon?: IconType;
+  onActivate: () => void;
+  /**
+   * Footer actions (a menu trigger). Rendered hover-revealed in the footer; the
+   * card stops click propagation around it, so the node only needs to render its
+   * own trigger/menu — it won't navigate the card.
+   */
+  menu?: ReactNode;
+  className?: string;
+}
+
+/**
+ * The shared notebook card: a neutral `aspect-[5/4]` preview zone with a ghost
+ * icon (no fill/colour) over a footer of title + meta. Mirrors the Zuletzt
+ * activity cards so notebooks read as one system across the workplace and the
+ * /notebooks gallery.
+ */
+const NotebookGalleryCard = memo(
+  ({ title, meta, icon, metaIcon, onActivate, menu, className }: NotebookGalleryCardProps) => {
+    const Icon = icon ?? FiFolder;
+    const MetaIcon = metaIcon ?? FiLayers;
+
+    return (
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onActivate}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onActivate();
+          }
+        }}
+        className={cn(
+          'group relative flex flex-col overflow-hidden rounded-xl border border-grey-200/80 bg-background text-left no-underline',
+          'cursor-pointer transition-all duration-200 ease-out',
+          'hover:-translate-y-0.5 hover:border-secondary-300 hover:shadow-md',
+          'dark:border-grey-700/60 dark:hover:border-secondary-700',
+          className
+        )}
+      >
+        <div className="flex aspect-[5/4] items-center justify-center bg-grey-50 dark:bg-grey-800/40">
+          <Icon className="size-9 text-grey-400 dark:text-grey-500" />
+        </div>
+
+        <div className="flex items-start gap-2 border-t border-grey-100 px-3 py-2.5 dark:border-grey-700/60">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <h3 className="m-0 min-w-0 truncate text-sm font-medium text-foreground-heading">
+              {title}
+            </h3>
+            {meta && (
+              <p className="m-0 flex min-w-0 items-center gap-1 truncate text-xs text-grey-500 dark:text-grey-400">
+                <MetaIcon className="size-3 shrink-0" />
+                <span className="truncate">{meta}</span>
+              </p>
+            )}
+          </div>
+          {menu && (
+            <div
+              className="-mr-1 shrink-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 max-sm:opacity-100"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+            >
+              {menu}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+NotebookGalleryCard.displayName = 'NotebookGalleryCard';
+
+export default NotebookGalleryCard;

--- a/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
+++ b/apps/web/src/features/notebook/components/NotebooksIndexPage.tsx
@@ -30,10 +30,16 @@ import {
   type NotebookConfigEntry,
 } from '../config/notebooksConfig';
 
+import NotebookGalleryCard from './NotebookGalleryCard';
 import { NotebookPageContent } from './NotebookPage';
 import { VonDerBasisSection } from './VonDerBasisSection';
 
 import type { NotebookCollection } from '../../../types/notebook';
+
+// Responsive grid of the tall notebook cards — shared by the system and the
+// "Eigene" sections so both read as one gallery.
+const NOTEBOOK_GRID_CLASS =
+  'grid grid-cols-[repeat(auto-fill,minmax(11rem,1fr))] gap-md max-sm:grid-cols-2';
 
 const EMPTY_COLLECTIONS: NotebookCollection[] = [];
 
@@ -71,62 +77,57 @@ const NotebookCard = memo(
       }
     };
 
+    const hasMenu = canStar || groups.length > 0;
+
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        className="group flex items-center gap-sm bg-background border border-grey-200 dark:border-grey-700 rounded-md px-md py-md min-h-[4rem] cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
-        onClick={() => navigate(notebook.path, { state: { freshConversation: true } })}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            void navigate(notebook.path, { state: { freshConversation: true } });
-          }
-        }}
-      >
-        <notebook.icon className="text-base text-secondary-600 shrink-0" />
-        <span className="text-sm font-medium text-foreground-heading flex-1">{notebook.title}</span>
-        <div
-          className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="flex items-center justify-center w-6 h-6 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
-                aria-label="Aktionen"
-              >
-                <HiDotsVertical size={14} />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {canStar && (
-                <DropdownMenuItem onClick={() => toggleFavourite(notebook.id)}>
-                  {starred ? <PiStarFill /> : <PiStar />}
-                  {starred ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
-                </DropdownMenuItem>
-              )}
-              {groups.length > 0 && (
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <HiShare />
-                    Teilen
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {groups.map((group) => (
-                      <DropdownMenuItem key={group.id} onClick={() => handleShareToGroup(group.id)}>
-                        <HiUserGroup />
-                        {sharedGroupId === group.id ? 'Geteilt!' : group.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
+      <NotebookGalleryCard
+        title={notebook.title}
+        meta={notebook.meta}
+        icon={notebook.icon}
+        onActivate={() => navigate(notebook.path, { state: { freshConversation: true } })}
+        menu={
+          hasMenu ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center justify-center size-7 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
+                  aria-label="Aktionen"
+                >
+                  <HiDotsVertical size={14} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {canStar && (
+                  <DropdownMenuItem onClick={() => toggleFavourite(notebook.id)}>
+                    {starred ? <PiStarFill /> : <PiStar />}
+                    {starred ? 'Aus Favoriten entfernen' : 'Zu Favoriten hinzufügen'}
+                  </DropdownMenuItem>
+                )}
+                {groups.length > 0 && (
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <HiShare />
+                      Teilen
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      {groups.map((group) => (
+                        <DropdownMenuItem
+                          key={group.id}
+                          onClick={() => handleShareToGroup(group.id)}
+                        >
+                          <HiUserGroup />
+                          {sharedGroupId === group.id ? 'Geteilt!' : group.name}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : undefined
+        }
+      />
     );
   }
 );
@@ -136,12 +137,10 @@ const NotebookSection = memo(
   ({
     title,
     notebooks,
-    columns = 1,
     groups = [],
   }: {
     title: string;
     notebooks: NotebookConfigEntry[];
-    columns?: 1 | 2;
     groups?: GroupSummary[];
   }) => {
     const filtered = notebooks.filter((nb) => !HIDDEN_NOTEBOOK_IDS.includes(nb.id));
@@ -150,13 +149,7 @@ const NotebookSection = memo(
     return (
       <section className="mt-xl">
         <SectionHeader title={title} />
-        <div
-          className={
-            columns === 2
-              ? 'grid grid-cols-4 max-lg:grid-cols-3 max-md:grid-cols-2 max-sm:grid-cols-1 gap-sm'
-              : 'flex flex-col gap-sm'
-          }
-        >
+        <div className={NOTEBOOK_GRID_CLASS}>
           {filtered.map((notebook) => (
             <NotebookCard key={notebook.id} notebook={notebook} groups={groups} />
           ))}
@@ -246,14 +239,17 @@ const EigeneNotebooks = memo(
       <div className="mt-xl">
         <SectionHeader title="Eigene" onCreate={onCreate} createLabel="Notebook erstellen" />
         {loading ? (
-          <div className="flex flex-col gap-sm">
+          <div className={NOTEBOOK_GRID_CLASS}>
             {Array.from({ length: 3 }, (_, i) => (
               <div
                 key={i}
-                className="flex items-center gap-sm border border-grey-200 dark:border-grey-700 rounded-md px-md py-md min-h-[4rem] max-w-[14rem]"
+                className="overflow-hidden rounded-xl border border-grey-200/80 dark:border-grey-700/60"
               >
-                <Skeleton className="size-5 rounded shrink-0" />
-                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="aspect-[5/4] rounded-none" />
+                <div className="px-3 py-2.5">
+                  <Skeleton className="h-4 w-3/4" />
+                  <Skeleton className="mt-1.5 h-3 w-1/2" />
+                </div>
               </div>
             ))}
           </div>
@@ -263,34 +259,20 @@ const EigeneNotebooks = memo(
           </p>
         ) : (
           <>
-            <div className="flex flex-col gap-sm">
+            <div className={NOTEBOOK_GRID_CLASS}>
               {visible.map((c) => (
-                <div
+                <NotebookGalleryCard
                   key={c.id}
-                  role="button"
-                  tabIndex={0}
-                  className="group flex items-center gap-sm bg-background border border-grey-200 dark:border-grey-700 rounded-md px-md py-md min-h-[4rem] max-w-[14rem] cursor-pointer transition-all duration-300 ease-out hover:-translate-y-0.5 hover:shadow-md"
-                  onClick={() => onView(c.id)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      onView(c.id);
-                    }
-                  }}
-                >
-                  <NotebookIcon className="text-base text-secondary-600 shrink-0" />
-                  <span className="text-sm font-medium text-foreground-heading truncate flex-1">
-                    {c.name}
-                  </span>
-                  <div
-                    className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
-                    onClick={(e) => e.stopPropagation()}
-                  >
+                  title={c.name}
+                  meta={c.description || 'Eigenes Notebook'}
+                  icon={NotebookIcon}
+                  onActivate={() => onView(c.id)}
+                  menu={
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button
                           type="button"
-                          className="flex items-center justify-center w-6 h-6 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
+                          className="flex items-center justify-center size-7 rounded-full text-grey-400 hover:text-foreground transition-colors cursor-pointer"
                           aria-label="Aktionen"
                         >
                           <HiDotsVertical size={14} />
@@ -349,8 +331,8 @@ const EigeneNotebooks = memo(
                         )}
                       </DropdownMenuContent>
                     </DropdownMenu>
-                  </div>
-                </div>
+                  }
+                />
               ))}
             </div>
             {shouldCollapse && (
@@ -456,28 +438,18 @@ function NotebooksIndexFooter() {
 
   return (
     <section className="mt-xl">
-      <div className="flex flex-wrap gap-xl max-md:flex-col">
-        <div className="flex-1 min-w-0">
-          <NotebookSection
-            title="Notebooks"
-            notebooks={allNotebooks}
-            columns={2}
-            groups={stableGroups}
-          />
-        </div>
-        <div>
-          <EigeneNotebooks
-            qaCollections={qaCollections}
-            onView={handleView}
-            onEdit={handleEdit}
-            onDelete={handleDelete}
-            onShare={handleShare}
-            onCreate={handleCreate}
-            loading={collectionsLoading}
-            copiedId={copiedId}
-          />
-        </div>
-      </div>
+      <NotebookSection title="Notebooks" notebooks={allNotebooks} groups={stableGroups} />
+
+      <EigeneNotebooks
+        qaCollections={qaCollections}
+        onView={handleView}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onShare={handleShare}
+        onCreate={handleCreate}
+        loading={collectionsLoading}
+        copiedId={copiedId}
+      />
 
       <VonDerBasisSection />
     </section>

--- a/apps/web/src/features/workplace/components/NotebookCard.tsx
+++ b/apps/web/src/features/workplace/components/NotebookCard.tsx
@@ -1,0 +1,60 @@
+import { CardActionsMenu, DropdownMenuItem } from '@gruenerator/ui';
+import { memo } from 'react';
+import { PiStar, PiStarFill } from 'react-icons/pi';
+import { useNavigate } from 'react-router-dom';
+
+import useSidebarFavouritesStore, { useIsFavourite } from '../../../stores/sidebarFavouritesStore';
+import NotebookGalleryCard from '../../notebook/components/NotebookGalleryCard';
+
+import type { IconType } from 'react-icons';
+
+export interface NotebookCardModel {
+  id: string;
+  title: string;
+  /** Source-count badge, e.g. "3 Programme", "542 Artikel", "Archiv". */
+  meta: string;
+  path: string;
+  icon?: IconType;
+  /** Member-owned notebook → exposes share/delete; system notebooks don't. */
+  isUser: boolean;
+}
+
+const NotebookCard = memo(
+  ({
+    item,
+    onShare,
+    onDelete,
+  }: {
+    item: NotebookCardModel;
+    onShare?: (id: string) => void;
+    onDelete?: (id: string) => void;
+  }) => {
+    const navigate = useNavigate();
+    const starred = useIsFavourite(item.id);
+    const toggleFavourite = useSidebarFavouritesStore((s) => s.toggleFavourite);
+
+    return (
+      <NotebookGalleryCard
+        title={item.title}
+        meta={item.meta}
+        icon={item.icon}
+        onActivate={() => void navigate(item.path)}
+        menu={
+          <CardActionsMenu
+            {...(item.isUser && onShare ? { onShare: () => onShare(item.id) } : {})}
+            {...(item.isUser && onDelete ? { onDelete: () => onDelete(item.id) } : {})}
+          >
+            <DropdownMenuItem onClick={() => toggleFavourite(item.id)}>
+              {starred ? <PiStarFill className="text-primary-600" /> : <PiStar />}
+              {starred ? 'Aus Favoriten entfernen' : 'Zu Favoriten'}
+            </DropdownMenuItem>
+          </CardActionsMenu>
+        }
+      />
+    );
+  }
+);
+
+NotebookCard.displayName = 'NotebookCard';
+
+export default NotebookCard;

--- a/apps/web/src/features/workplace/components/NotebooksSection.tsx
+++ b/apps/web/src/features/workplace/components/NotebooksSection.tsx
@@ -1,9 +1,8 @@
 import { type NotebookEditorSavePayload } from '@gruenerator/contracts';
-import { Dialog, DialogContent, DialogTitle, SectionHeader } from '@gruenerator/ui';
+import { cn, Dialog, DialogContent, DialogTitle, SectionHeader } from '@gruenerator/ui';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import ToolGrid from '../../../components/common/ToolGrid';
 import { useAuthStore } from '../../../stores/authStore';
 import { useNotebookCollections } from '../../auth/hooks/useProfileData';
 import NotebookCreationProgress from '../../notebook/components/NotebookCreationProgress';
@@ -11,13 +10,22 @@ import NotebookEditor from '../../notebook/components/NotebookEditor';
 import {
   getAustrianNotebooks,
   getNotebooksByCategory,
-  SYSTEM_NOTEBOOKS,
 } from '../../notebook/config/notebooksConfig';
 
-import type { ToolEntry } from '../../../components/common/ToolGrid';
+import NotebookCard, { type NotebookCardModel } from './NotebookCard';
+
 import type { NotebookCollection } from '../../../types/notebook';
 
-const INITIAL_COUNT = 5;
+// Single horizontally-scrollable row at every breakpoint — the notebooks read as
+// "one line" of cards (≈5 visible on desktop, the rest peeking/scrollable),
+// mirroring the Zuletzt row rather than a wrapping grid.
+const NOTEBOOK_ROW_CLASS = cn(
+  // `overflow-x-auto` also clips vertically, so the cards' upward hover-lift +
+  // shadow would be cut off — `pt-2` (matching `pb-2`) gives them room.
+  'grid grid-flow-col gap-md overflow-x-auto pt-2 pb-2',
+  'auto-cols-[68%] sm:auto-cols-[40%] md:auto-cols-[30%] lg:auto-cols-[19%]',
+  '-mx-4 px-4 lg:mx-0 lg:px-0'
+);
 
 type CreationPhase =
   | { kind: 'closed' }
@@ -32,7 +40,6 @@ type CreationPhase =
 const NotebooksSection: React.FC = memo(() => {
   const navigate = useNavigate();
   const [phase, setPhase] = useState<CreationPhase>({ kind: 'closed' });
-  const [showAll, setShowAll] = useState(false);
   const locale = useAuthStore((state) => state.locale);
   const isAustrian = locale === 'de-AT';
 
@@ -41,7 +48,7 @@ const NotebooksSection: React.FC = memo(() => {
   });
   const qaCollections = query.data ?? [];
 
-  const systemTools: ToolEntry[] = useMemo(
+  const systemCards: NotebookCardModel[] = useMemo(
     () =>
       (isAustrian
         ? getAustrianNotebooks()
@@ -50,30 +57,30 @@ const NotebooksSection: React.FC = memo(() => {
             ...getNotebooksByCategory('landesebene'),
             ...getNotebooksByCategory('weitere'),
           ]
-      )
-        .slice(0, showAll ? undefined : INITIAL_COUNT)
-        .map((nb) => ({
-          id: nb.id,
-          title: nb.title.replace(/^Frag\s+/i, ''),
-          description: nb.description,
-          path: nb.path,
-          icon: nb.icon,
-        })),
-    [isAustrian, showAll]
+      ).map((nb) => ({
+        id: nb.id,
+        title: nb.title.replace(/^Frag\s+/i, ''),
+        meta: nb.meta,
+        path: nb.path,
+        icon: nb.icon,
+        isUser: false,
+      })),
+    [isAustrian]
   );
 
-  const userTools: ToolEntry[] = useMemo(
+  const userCards: NotebookCardModel[] = useMemo(
     () =>
       qaCollections.slice(0, 3).map((c: NotebookCollection) => ({
         id: c.id,
         title: c.name,
-        description: c.description || 'Eigenes Notebook',
+        meta: 'Eigenes Notebook',
         path: `/notebook/${c.id}`,
+        isUser: true,
       })),
     [qaCollections]
   );
 
-  const allTools = useMemo(() => [...userTools, ...systemTools], [userTools, systemTools]);
+  const allCards = useMemo(() => [...userCards, ...systemCards], [userCards, systemCards]);
 
   const handleCreate = useCallback(() => setPhase({ kind: 'editing' }), []);
   const handleClose = useCallback(() => setPhase({ kind: 'closed' }), []);
@@ -123,23 +130,23 @@ const NotebooksSection: React.FC = memo(() => {
         onCreate={handleCreate}
         createLabel="Eigenes Notebook erstellen"
       />
-      <ToolGrid
-        tools={allTools}
-        columns={5}
-        compact
-        showFavourites
-        onShare={handleShare}
-        onDelete={handleDelete}
-      />
-      {SYSTEM_NOTEBOOKS.length > INITIAL_COUNT && (
-        <button
-          type="button"
-          onClick={() => setShowAll((v) => !v)}
-          className="mt-sm text-sm text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer bg-transparent border-none transition-colors"
-        >
-          {showAll ? 'Weniger anzeigen' : 'Weitere Notebooks'}
-        </button>
-      )}
+      <div className={NOTEBOOK_ROW_CLASS}>
+        {allCards.map((card) => (
+          <NotebookCard
+            key={card.id}
+            item={card}
+            onShare={handleShare}
+            onDelete={handleDelete}
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => navigate('/notebooks')}
+        className="mt-sm text-sm text-primary-600 hover:text-primary-500 dark:text-primary-400 dark:hover:text-primary-300 cursor-pointer bg-transparent border-none transition-colors"
+      >
+        Mehr anzeigen
+      </button>
 
       <Dialog
         open={dialogOpen}

--- a/apps/web/src/features/workplace/components/ToolsSection.tsx
+++ b/apps/web/src/features/workplace/components/ToolsSection.tsx
@@ -118,9 +118,16 @@ function filterTools(tools: ToolItem[]): ToolItem[] {
   return tools.filter((tool) => !tool.devOnly || import.meta.env.DEV);
 }
 
+// Uniform tool cells: reserve a fixed two-line label height and clamp to two
+// lines (targets the IconButton's label span — its only direct `span` child; the
+// icon span is nested inside the circle). Without this, labels wrap to 1–3 lines
+// and the round buttons end up at different heights. `max-w-32` lets the longest
+// labels ("Audio mit KI transkribieren") fit two lines instead of three.
+const TOOL_LABEL_CLASS = '[&>span]:line-clamp-2 [&>span]:min-h-[2.5rem] [&>span]:max-w-32';
+
 function IconGrid({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(6rem,1fr))] justify-items-center gap-lg px-md md:px-lg">
+    <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] justify-items-center gap-xl px-md md:px-lg">
       {children}
     </div>
   );
@@ -138,6 +145,7 @@ function ToolIconRow({ tools }: { tools: ToolItem[] }) {
             size="lg"
             icon={<Icon />}
             label={tool.title}
+            className={TOOL_LABEL_CLASS}
             onClick={() => navigate(tool.path)}
           />
         );
@@ -157,6 +165,7 @@ function FavoriteIconRow({ favorites }: { favorites: FavoriteItem[] }) {
             size="lg"
             icon={<Icon />}
             label={fav.title}
+            className={TOOL_LABEL_CLASS}
             onClick={() => window.open(fav.href, '_blank', 'noopener,noreferrer')}
           />
         );


### PR DESCRIPTION
## Summary

Redesigns the notebook cards so they read as one system with the **Zuletzt** activity cards, and refreshes the `/notebooks` gallery and the workplace tool rows.

### What changed
- **New shared `NotebookGalleryCard`** — a tall `aspect-[5/4]` preview zone with a neutral **ghost icon** (no fill/colour, no hover shift) over a `title + meta` footer, reusing the exact Zuletzt card shell (border, hover-lift, dark variants). Single source of truth for both surfaces.
- **Workplace "Notebooks"** — single horizontally-scrollable row of the new cards (one line, ~5 visible with the rest peeking), plus a **"Mehr anzeigen"** link to the full gallery.
- **`/notebooks` gallery** — system notebooks and **"Eigene"** notebooks now render as a responsive **card grid** (was a small row-card list); all existing menu actions preserved (favourite, share-to-group, edit, delete, collapse/"weitere anzeigen").
- **Tool rows ("Weitere Tools" / Favoriten)** — uniform cell height (reserve a 2-line label area, clamp to 2 lines so the longest labels stop wrapping to 3) and a bit more gap, so the round icon buttons line up. Scoped to the workplace rows; the shared `IconButton` is untouched.

### Notes
- Design iterated with the user from a mockup: started with category-coloured tiles, landed on the neutral ghost treatment per their feedback.
- `pnpm typecheck` (web) passes; touched files lint clean.

### Test plan
- [ ] `/workplace` — notebook row is a single scrollable line of the new cards; "Mehr anzeigen" navigates to `/notebooks`.
- [ ] `/notebooks` — system + Eigene render as the new card grid; menus (favourite/share/edit/delete) work.
- [ ] Tool rows align uniformly with 2-line labels.
- [ ] Light + dark mode.