### PR TITLE
feat(boards): gate AI features behind expert mode

### DIFF
--- a/apps/web/src/features/boards/BoardPage.tsx
+++ b/apps/web/src/features/boards/BoardPage.tsx
@@ -390,6 +390,7 @@ function BoardViewContent({
           currentUserId={currentUserId}
           boardId={boardId}
           provider={provider}
+          expertMode={expertMode}
         />
       )}
 
@@ -442,11 +443,12 @@ function BoardViewContent({
           onUpdateField={boardState.updateField}
           boardId={boardId}
           currentUserId={currentUserId}
+          expertMode={expertMode}
         />
       )}
 
-      {/* AI assistant — only once the board state is synced and a user is present. */}
-      {isSynced && userId && (
+      {/* AI assistant — expert-only, and only once the board state is synced and a user is present. */}
+      {isSynced && userId && expertMode && (
         <>
           {/* Hidden while the panel is open — the fixed panel overlays the FAB's
               corner (composer/send button), and the panel has its own close button. */}

--- a/apps/web/src/features/boards/components/CardDetailPanel.tsx
+++ b/apps/web/src/features/boards/components/CardDetailPanel.tsx
@@ -155,6 +155,8 @@ interface CardDetailPanelProps {
   currentUserAvatarRobotId?: number;
   onPrevCard?: () => void;
   onNextCard?: () => void;
+  // Grünerator-Spalte run button is expert-only.
+  expertMode?: boolean;
 }
 
 export const CardDetailPanel = memo(function CardDetailPanel({
@@ -173,6 +175,7 @@ export const CardDetailPanel = memo(function CardDetailPanel({
   currentUserAvatarRobotId = 1,
   onPrevCard,
   onNextCard,
+  expertMode = false,
 }: CardDetailPanelProps) {
   const navigate = useNavigate();
 
@@ -855,8 +858,8 @@ export const CardDetailPanel = memo(function CardDetailPanel({
             </div>
 
             {/* Grünerator-Spalte — runs the configured Grünerator agent on this card.
-                Renders nothing unless the card's status column carries an aiTask. */}
-            {row && (
+                Expert-only; renders nothing unless the card's status column carries an aiTask. */}
+            {row && expertMode && (
               <AgentRunButton
                 boardId={boardId}
                 row={row}

--- a/apps/web/src/features/boards/components/PlannerKanban.tsx
+++ b/apps/web/src/features/boards/components/PlannerKanban.tsx
@@ -99,6 +99,8 @@ interface ColumnBoardProps {
   onCardClick: (row: Row) => void;
   onRenameCard: (rowId: string, title: string) => void;
   fields: Field[];
+  // When false, the AI-column menu actions are hidden (expert-only).
+  expertMode: boolean;
 }
 
 const ColumnBoard = memo(function ColumnBoard({
@@ -124,6 +126,7 @@ const ColumnBoard = memo(function ColumnBoard({
   onCardClick,
   onRenameCard,
   fields,
+  expertMode,
 }: ColumnBoardProps) {
   const onRename = useCallback(
     (name: string) => onRenameGroup(groupId, name),
@@ -180,8 +183,8 @@ const ColumnBoard = memo(function ColumnBoard({
           onColorChange={onColor}
           onDuplicate={onDuplicate}
           hasAiTask={hasAiTask}
-          onConfigureAi={onConfigureAi}
-          onRemoveAi={onRemoveAi}
+          onConfigureAi={expertMode ? onConfigureAi : undefined}
+          onRemoveAi={expertMode ? onRemoveAi : undefined}
           onSetLimit={isRealColumn ? onSetLimitCb : undefined}
           onMoveLeft={isRealColumn && canMoveLeft ? onMoveLeft : undefined}
           onMoveRight={isRealColumn && canMoveRight ? onMoveRight : undefined}
@@ -225,6 +228,8 @@ interface PlannerKanbanProps {
   currentUserId: string;
   boardId?: string;
   provider?: HocuspocusProvider | null;
+  // Grünerator-Spalten (AI columns) are expert-only; gates creation + run buttons.
+  expertMode?: boolean;
 }
 
 export function PlannerKanban({
@@ -243,6 +248,7 @@ export function PlannerKanban({
   currentUserId,
   boardId,
   provider,
+  expertMode = false,
 }: PlannerKanbanProps) {
   const { userName, userAvatarRobotId } = useAuthStore(
     useShallow((s) => ({
@@ -654,10 +660,12 @@ export function PlannerKanban({
                     <FiPlus className="mr-2" size={14} />
                     Neue Spalte
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={openAiDialogForNew}>
-                    <FiZap className="mr-2" size={14} />
-                    Neue Grünerator-Spalte
-                  </DropdownMenuItem>
+                  {expertMode && (
+                    <DropdownMenuItem onClick={openAiDialogForNew}>
+                      <FiZap className="mr-2" size={14} />
+                      Neue Grünerator-Spalte
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
               {laneHiddenGroups.length > 0 && (
@@ -716,6 +724,7 @@ export function PlannerKanban({
               onCardClick={handleCardClick}
               onRenameCard={handleRenameCard}
               fields={fields}
+              expertMode={expertMode}
             />
           );
         }}
@@ -781,6 +790,7 @@ export function PlannerKanban({
         currentUserAvatarRobotId={userAvatarRobotId}
         onPrevCard={handlePrevCard}
         onNextCard={handleNextCard}
+        expertMode={expertMode}
       />
     </BoardAwarenessProvider>
   );

--- a/apps/web/src/features/workplace/components/BoardsInner.tsx
+++ b/apps/web/src/features/workplace/components/BoardsInner.tsx
@@ -1,10 +1,12 @@
 import { AIPromptInput } from '@gruenerator/ui';
 import { useVoxtralDictation } from '@gruenerator/voice';
 import React, { memo, useCallback, useState } from 'react';
+import { FiPlus } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 
 import FeatureIcons from '../../../components/common/FeatureIcons';
 import { useBoardsTyped } from '../../../hooks/useBoardsTyped';
+import useUserDefaults from '../../../hooks/useUserDefaults';
 import { MODE_MAP } from '../../texte/modes';
 
 const BOARD_MODE_ID = 'boards';
@@ -12,8 +14,12 @@ const BOARD_MODE_ID = 'boards';
 const BoardsInner: React.FC = memo(() => {
   const [prompt, setPrompt] = useState('');
   const navigate = useNavigate();
-  const { generateBoard } = useBoardsTyped();
+  const { generateBoard, createBoard } = useBoardsTyped();
   const def = MODE_MAP[BOARD_MODE_ID];
+  // AI board generation is expert-only. Non-experts get a plain "empty board" path
+  // and can enable the assistant via the Expert*innenmodus toggle inside a board.
+  const { get: getBoardsDefault } = useUserDefaults<boolean>('boards');
+  const expertMode = getBoardsDefault('expertMode', false);
 
   const handleSubmit = useCallback(() => {
     const trimmed = prompt.trim();
@@ -29,6 +35,41 @@ const BoardsInner: React.FC = memo(() => {
   }, [prompt, generateBoard, navigate]);
 
   const onSubmit = useCallback(() => void handleSubmit(), [handleSubmit]);
+
+  const handleCreateEmpty = useCallback(() => {
+    if (createBoard.isPending) return;
+    createBoard.mutate(
+      { title: 'Neues Board', boardType: 'kanban' },
+      {
+        onSuccess: (board) => {
+          void navigate(`/boards/${board.id}`);
+        },
+      }
+    );
+  }, [createBoard, navigate]);
+
+  if (!expertMode) {
+    return (
+      <div className="w-full max-w-xl mx-auto flex flex-col items-center gap-sm text-center">
+        <button
+          onClick={handleCreateEmpty}
+          disabled={createBoard.isPending}
+          className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-lg border-none cursor-pointer transition-all bg-primary-600 text-white hover:bg-primary-700 shadow-sm disabled:opacity-60"
+        >
+          {createBoard.isPending ? (
+            <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+          ) : (
+            <FiPlus size={16} />
+          )}
+          Neues Board erstellen
+        </button>
+        <p className="text-xs text-grey-400">
+          KI-Board-Generierung ist im Expert*innenmodus verfügbar (im Board oben rechts
+          aktivierbar).
+        </p>
+      </div>
+    );
+  }
 
   return (
     <AIPromptInput


### PR DESCRIPTION
## Summary

Restricts all AI-powered board features to users who have enabled the **Expert\*innenmodus** toggle (the existing per-user \`boards\` default, toggled from the board header dropdown). Non-experts get a clean, AI-free board experience.

## What's gated behind \`expertMode\`

- **KI-Board-Assistent (bottom-right Fab + side panel)** — the floating assistant in `BoardPage` only mounts when expert mode is on. This also implicitly gates the *Bearbeiten an/aus* AI-edit toggle, which lives inside the panel.
- **Grünerator-Spalten (AI columns)** in `PlannerKanban` / `ColumnHeader`:
  - the *Neue Grünerator-Spalte* add-column menu item
  - the per-column *In Grünerator-Spalte umwandeln* / *bearbeiten* / *entfernen* actions
  - the per-card `AgentRunButton` in `CardDetailPanel`
- **Workplace board creator** (`BoardsInner`) — AI generation (`AIPromptInput` → `/api/boards/generate`) is expert-only. Non-experts get a plain **Neues Board erstellen** button instead, with a hint that AI generation lives in expert mode.

## Chicken-and-egg note

The expert toggle is reachable from inside any board, and non-experts can still create empty boards (workplace fallback + the existing manual paths), so they can always opt in.

## Test plan

- [x] `pnpm --filter @gruenerator/web typecheck`
- [x] eslint on changed files (0 errors)
- [ ] Manual: with expert mode **off**, confirm no Fab, no AI column menu/run buttons, workplace shows the empty-board button
- [ ] Manual: enable expert mode → all AI surfaces reappear