### PR TITLE
feat(chat): unify Websuche and Recherche into one search tool

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/systemPrompt.ts
+++ b/apps/api/agents/langgraph/ChatGraph/systemPrompt.ts
@@ -39,8 +39,22 @@ function isToolEnabled(
   agentWhitelist: string[] | undefined,
   frontendToggles: Record<string, boolean>
 ): boolean {
-  if (agentWhitelist && !agentWhitelist.includes(key)) return false;
-  if (frontendToggles[key] === false) return false;
+  // 'web' and 'research' are the two depths of the single merged "Recherche"
+  // tool — whitelisting or enabling either one enables both, so the guideline
+  // stays consistent for legacy agents (stored 'web') and any stored 'research'.
+  const SEARCH_DEPTH_KEYS = ['web', 'research'];
+  const isSearchDepth = SEARCH_DEPTH_KEYS.includes(key);
+  if (agentWhitelist) {
+    const allowed = isSearchDepth
+      ? SEARCH_DEPTH_KEYS.some((k) => agentWhitelist.includes(k))
+      : agentWhitelist.includes(key);
+    if (!allowed) return false;
+  }
+  if (isSearchDepth) {
+    if (SEARCH_DEPTH_KEYS.every((k) => frontendToggles[k] === false)) return false;
+  } else if (frontendToggles[key] === false) {
+    return false;
+  }
   return true;
 }
 

--- a/apps/api/routes/chat/chatGraphContractRouter.ts
+++ b/apps/api/routes/chat/chatGraphContractRouter.ts
@@ -187,9 +187,22 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
 
         const forced = TOOL_PRIORITY.find((t) => forcedTools.includes(t));
         if (forced && !universalEditForced) {
-          classifiedState.intent = forced;
+          // The merged "Recherche" tool (identifier 'research', alias
+          // 'websearch') forces *search-class* without pinning a depth: keep the
+          // classifier's web↔research choice (auto-depth) and only fall back to
+          // research when it picked a non-search intent. Document search
+          // ('search') and non-search tools (image/sharepic/…) stay hard-pinned.
+          if (forced === 'research' || forced === 'web') {
+            if (classifiedState.intent !== 'web' && classifiedState.intent !== 'research') {
+              classifiedState.intent = 'research';
+            }
+          } else {
+            classifiedState.intent = forced;
+          }
           forcedTool = true;
-          log.info(`[ChatGraph] Intent forced to "${forced}" via @tool mention`);
+          log.info(
+            `[ChatGraph] Intent forced via @tool mention: forced="${forced}", resolved="${classifiedState.intent}"`
+          );
 
           // When the classifier returned a non-search intent (e.g. 'direct')
           // and the @-mention forces a search intent, the classifier never
@@ -198,7 +211,7 @@ export const chatGraphContractRouter = s.router(chatGraphContract, {
           // context. Pull the user's last message text in as the query.
           const FORCED_SEARCH_INTENTS = new Set(['research', 'web', 'search']);
           if (
-            FORCED_SEARCH_INTENTS.has(forced) &&
+            FORCED_SEARCH_INTENTS.has(classifiedState.intent) &&
             (!classifiedState.searchQuery || !classifiedState.searchQuery.trim()) &&
             lastUserMessage
           ) {

--- a/packages/chat/src/lib/composerControls.ts
+++ b/packages/chat/src/lib/composerControls.ts
@@ -45,7 +45,10 @@ export interface ComposerToolDef {
  */
 export const COMPOSER_TOOLS: ComposerToolDef[] = [
   { key: 'search', label: 'Dokumentensuche', icon: 'document' },
-  { key: 'web', label: 'Websuche', icon: 'globe' },
+  // Merged search tool: a single "Recherche" toggle gates both backend search
+  // paths (fast web + deep research). The `web` ToolKey lives on internally as a
+  // gate/back-compat key (see chatStore `toggleTool`), but is no longer a
+  // separate user-facing toggle.
   { key: 'examples', label: 'Beispiele', icon: 'idea' },
   { key: 'pressemitteilung_examples', label: 'Pressemitteilungen', icon: 'newspaper' },
   { key: 'research', label: 'Recherche', icon: 'research' },

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -1,7 +1,6 @@
 import { NOTEBOOK_ICONS } from '@gruenerator/shared/notebook-icons';
 import { NOTEBOOK_REGISTRY } from '@gruenerator/shared/notebooks';
 import {
-  PiGlobeHemisphereWest,
   PiFlask,
   PiFiles,
   PiChatCircleDots,
@@ -51,6 +50,13 @@ export interface Mentionable {
   icon?: React.ComponentType<{ className?: string }>;
   /** Locale visibility (skills/agents): de-DE / de-AT / all. Undefined ≈ all. */
   audience?: 'de-DE' | 'de-AT' | 'all';
+  /**
+   * Extra mention strings that resolve to this same mentionable but are NOT
+   * shown as separate picker entries. Used for back-compat after merging tools
+   * (e.g. the merged "Recherche" tool keeps `websearch` resolving so old
+   * @websearch mentions in existing threads still work).
+   */
+  aliases?: string[];
 }
 
 export interface CustomAgentMentionable {
@@ -164,28 +170,22 @@ export const notebookMentionables: Mentionable[] = NOTEBOOK_REGISTRY.map((nb) =>
 
 export const toolMentionables: Mentionable[] = [
   {
-    type: 'tool',
-    category: 'function',
-    trigger: '@',
-    identifier: 'web',
-    title: 'Websuche',
-    description: 'Aktuelle Infos aus dem Web',
-    avatar: '🌐',
-    icon: PiGlobeHemisphereWest,
-    backgroundColor: '#2563EB',
-    mention: 'websearch',
-  },
-  {
+    // Merged search tool (formerly two separate tools "Websuche" + "Recherche").
+    // The backend auto-scales depth: simple/news queries route to a fast web
+    // search, complex ones to deep multi-source research (see ChatGraph
+    // classifier + executeResearch complexity scaling). `websearch` stays a
+    // resolving alias so old @websearch mentions keep working.
     type: 'tool',
     category: 'function',
     trigger: '@',
     identifier: 'research',
     title: 'Recherche',
-    description: 'Tiefgehende Multi-Quellen-Recherche',
+    description: 'Web & Quellen – automatische Suchtiefe',
     avatar: '🔬',
     icon: PiFlask,
     backgroundColor: '#7C3AED',
     mention: 'recherche',
+    aliases: ['websearch'],
   },
   {
     type: 'tool',
@@ -666,6 +666,14 @@ function rebuildMentionableMap(): void {
       const key = m.mention.toLowerCase();
       if (!mentionableMap.has(key)) {
         mentionableMap.set(key, m);
+      }
+      // Back-compat aliases resolve to the same mentionable (not shown in the
+      // picker). Same first-wins dedup as the primary mention.
+      for (const alias of m.aliases ?? []) {
+        const aliasKey = alias.toLowerCase();
+        if (!mentionableMap.has(aliasKey)) {
+          mentionableMap.set(aliasKey, m);
+        }
       }
     }
   }

--- a/packages/chat/src/stores/chatStore.ts
+++ b/packages/chat/src/stores/chatStore.ts
@@ -209,12 +209,19 @@ export const useAgentStore = create<AgentState>()(
       setCurrentThreadTitle: (title) => set({ currentThreadTitle: title }),
 
       toggleTool: (tool) =>
-        set((state) => ({
-          enabledTools: {
-            ...state.enabledTools,
-            [tool]: !state.enabledTools[tool],
-          },
-        })),
+        set((state) => {
+          const next = !state.enabledTools[tool];
+          return {
+            enabledTools: {
+              ...state.enabledTools,
+              [tool]: next,
+              // The merged "Recherche" tool gates both backend search paths;
+              // keep the internal `web` gate key in lockstep so disabling the
+              // single toggle stops the auto web search too.
+              ...(tool === 'research' ? { web: next } : {}),
+            },
+          };
+        }),
 
       setAllTools: (enabled) =>
         set({

--- a/packages/shared/src/agents/userTools.ts
+++ b/packages/shared/src/agents/userTools.ts
@@ -34,14 +34,16 @@ export const USER_SELECTABLE_TOOLS: readonly UserSelectableTool[] = [
       'Durchsucht die Grünerator-Wissensdatenbank (Programme, Beschlüsse, Kommunalwiki).',
   },
   {
+    // Merged search tool (formerly "Websuche" + "Tiefenrecherche"). One picker
+    // entry; the backend auto-scales depth (fast web ↔ deep multi-source
+    // research) by query complexity. Stored under the legacy `web` key for
+    // back-compat with existing agents (default has always been ['search','web']);
+    // `research` stays a recognized key (see BACKWARD_COMPAT_TOOL_KEYS) and the
+    // backend treats the two as one capability (see `isToolEnabled`).
     key: 'web',
-    label: 'Websuche',
-    description: 'Sucht im Web nach aktuellen Informationen.',
-  },
-  {
-    key: 'research',
-    label: 'Tiefenrecherche',
-    description: 'Führt eine mehrstufige Recherche mit Quellenangaben durch.',
+    label: 'Recherche',
+    description:
+      'Sucht im Web und führt bei Bedarf eine tiefere Mehrquellen-Recherche mit Quellenangaben durch. Die Suchtiefe wird automatisch gewählt.',
   },
   {
     key: 'examples',
@@ -80,8 +82,19 @@ export const USER_SELECTABLE_TOOLS: readonly UserSelectableTool[] = [
   },
 ] as const;
 
-/** Just the keys, for membership checks. */
-export const USER_SELECTABLE_TOOL_KEYS: readonly string[] = USER_SELECTABLE_TOOLS.map((t) => t.key);
+/**
+ * Keys that are no longer shown in the picker but stay VALID so existing agent
+ * configs aren't stripped by server-side validation. `research` was merged into
+ * the single "Recherche" tool (stored under `web`); both keys still gate the
+ * merged search capability (see `isToolEnabled` in the ChatGraph system prompt).
+ */
+export const BACKWARD_COMPAT_TOOL_KEYS: readonly string[] = ['research'];
+
+/** Just the keys, for membership checks (picker keys + back-compat keys). */
+export const USER_SELECTABLE_TOOL_KEYS: readonly string[] = [
+  ...USER_SELECTABLE_TOOLS.map((t) => t.key),
+  ...BACKWARD_COMPAT_TOOL_KEYS,
+];
 
 /** Sensible default capabilities for a brand-new agent. */
 export const DEFAULT_USER_AGENT_TOOLS: readonly string[] = ['search', 'web'];


### PR DESCRIPTION
## Why

The chat composer exposed **two** near-identical search tools — **Websuche** (fast web search) and **Recherche** (deep multi-source research) — forcing users to guess which to pick. This collapses them into a **single "Recherche" tool** with **automatic search depth**.

## What

The backend keeps **both** search paths; only the user-facing *selectors* collapse to one. When the merged tool is used, the ChatGraph classifier/orchestrator picks fast web vs. deep research by query complexity (and `executeResearch` already auto-scales quick↔thorough), so depth is automatic — no manual toggle.

- **`mentionables.ts`** — merge the two `@`-tool entries into one (`identifier: research`, flask icon). New optional `aliases` field keeps **`@websearch` resolving** to the merged tool so existing threads/mentions keep working.
- **`composerControls.ts`** — drop the separate "Websuche" toggle; the single "Recherche" toggle gates both backend paths.
- **`chatStore.ts`** — `toggleTool('research')` mirrors the internal `web` gate key, so turning the tool off also stops the auto web search (gate is `enabledTools[intent] !== false`).
- **`chatGraphContractRouter.ts`** — a forced search-class mention now **soft-forces**: it keeps the classifier's web↔research choice instead of pinning a depth. Document search (`search`) and non-search tools (image/sharepic/…) stay hard-pinned.
- **Agent tools** (`userTools.ts` + `systemPrompt.ts`) — one merged picker entry ("Recherche"); `research` stays a valid back-compat key, and the system-prompt tool gate treats `web`/`research` as one capability so existing agents (default `['search','web']`) are unaffected.

Result-rendering for both `web_search` (citations) and `research` (dossier) is intentionally untouched — the classifier still emits both intents.

## Verification

- `pnpm --filter @gruenerator/{shared,chat,api} typecheck` ✅
- `pnpm --filter @gruenerator/{shared,api} lint` ✅ (0 errors)
- API tests `classifierForcedIntent` + `compoundPipeline` ✅ (49 passed)
- `@gruenerator/chat` tests ✅ (38 passed)

### Manual smoke test (suggested)
- Composer `@`-picker shows one "Recherche" tool, no separate "Websuche".
- `@recherche aktuelle Nachrichten zu …` → fast web path (`## SUCHERGEBNISSE`, citations card).
- `@recherche analysiere …` → deep research path (dossier, `researchMeta`).
- `@websearch …` (legacy alias) still resolves and behaves identically.