### PR TITLE
feat(vorlagen): redesign gallery search and uniform format cards

### DIFF
--- a/apps/web/src/components/common/Gallery/VorlagenCard.tsx
+++ b/apps/web/src/components/common/Gallery/VorlagenCard.tsx
@@ -1,0 +1,159 @@
+import { Badge } from '@gruenerator/ui';
+import { memo, type JSX, type ReactNode } from 'react';
+import { HiOutlineExternalLink, HiOutlineLink, HiOutlinePhotograph } from 'react-icons/hi';
+import { HiOutlineArrowDownTray } from 'react-icons/hi2';
+import { SiCanva } from 'react-icons/si';
+
+import { getTemplateFormat } from './templateFormat';
+
+import { cn } from '@/utils/cn';
+
+interface VorlagenCardItem {
+  id: string | number;
+  title?: string;
+  template_type?: string;
+  tags?: string[];
+  thumbnail_url?: string;
+  external_url?: string | null;
+  download_url?: string;
+  content_data?: { originalUrl?: string } | Record<string, unknown>;
+}
+
+export interface VorlagenCardProps {
+  item: VorlagenCardItem;
+  /** Top-right overlay marker (e.g. "Community"). */
+  badge?: ReactNode;
+  onOpen: () => void;
+  /** Opens the external/source URL directly (hover action). Omitted when none exists. */
+  onOpenExternal?: () => void;
+  /** Copies a shareable link to the clipboard (hover action). */
+  onCopyLink?: () => void;
+}
+
+const ToolIcon = ({ tool }: { tool: ReturnType<typeof getTemplateFormat>['tool'] }) => {
+  if (tool === 'Canva') return <SiCanva className="size-3.5 shrink-0" aria-hidden="true" />;
+  if (tool === 'Download')
+    return <HiOutlineArrowDownTray className="size-3.5 shrink-0" aria-hidden="true" />;
+  return <HiOutlineLink className="size-3.5 shrink-0" aria-hidden="true" />;
+};
+
+/**
+ * Gallery card for the Vorlagen-Datenbank. Unlike the generic IndexCard it
+ * renders each template's real format proportioned on a uniform neutral
+ * "stage" (no dead grey margins), badges the format, and exposes a compact
+ * meta row plus hover actions.
+ */
+const VorlagenCard = memo(
+  ({ item, badge, onOpen, onOpenExternal, onCopyLink }: VorlagenCardProps): JSX.Element => {
+    const format = getTemplateFormat(item);
+    const title = item.title || 'Unbenannte Vorlage';
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onOpen();
+      }
+    };
+
+    const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+    return (
+      <div
+        className={cn(
+          'group flex flex-col overflow-hidden rounded-lg border border-grey-200 bg-background text-left',
+          'shadow-card-subtle transition-all duration-200 dark:border-grey-700',
+          'cursor-pointer hover:-translate-y-0.5 hover:border-primary-500 hover:shadow-md',
+          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500'
+        )}
+        onClick={onOpen}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-label={`Vorlage ${title} öffnen`}
+      >
+        {/* Neutral stage — the real format sits centered and proportioned. */}
+        <div className="relative flex aspect-[4/5] w-full items-center justify-center overflow-hidden bg-background-alt p-3">
+          <div
+            className="flex max-h-full max-w-full items-center justify-center overflow-hidden rounded-sm bg-background shadow-sm ring-1 ring-black/5"
+            style={{ aspectRatio: format.aspectRatio, height: '100%' }}
+          >
+            {item.thumbnail_url ? (
+              <img
+                src={item.thumbnail_url}
+                alt={title}
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <HiOutlinePhotograph className="size-8 text-grey-400" aria-hidden="true" />
+            )}
+          </div>
+
+          <Badge
+            variant="secondary"
+            className="absolute left-2 top-2 bg-background/90 text-foreground shadow-sm backdrop-blur-sm"
+          >
+            {format.typeLabel}
+          </Badge>
+          {badge != null && <div className="absolute right-2 top-2">{badge}</div>}
+
+          {(onOpenExternal || onCopyLink) && (
+            <div
+              className={cn(
+                'absolute inset-x-0 bottom-0 flex items-center justify-end gap-1.5 p-2',
+                'translate-y-1 opacity-0 transition-all duration-200',
+                'group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:opacity-100'
+              )}
+            >
+              {onOpenExternal && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    stop(e);
+                    onOpenExternal();
+                  }}
+                  className="flex size-8 items-center justify-center rounded-full bg-background/95 text-foreground shadow-sm transition-colors hover:bg-primary-500 hover:text-white"
+                  aria-label="Vorlage öffnen"
+                  title="Öffnen"
+                >
+                  <HiOutlineExternalLink className="size-4" />
+                </button>
+              )}
+              {onCopyLink && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    stop(e);
+                    onCopyLink();
+                  }}
+                  className="flex size-8 items-center justify-center rounded-full bg-background/95 text-foreground shadow-sm transition-colors hover:bg-primary-500 hover:text-white"
+                  aria-label="Link kopieren"
+                  title="Link kopieren"
+                >
+                  <HiOutlineLink className="size-4" />
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Meta row: name + tool + format label. */}
+        <div className="flex flex-col gap-1 px-3 py-2.5">
+          <h3 className="truncate text-sm font-semibold text-foreground-heading" title={title}>
+            {title}
+          </h3>
+          <div className="flex items-center gap-1.5 text-xs text-grey-600 dark:text-grey-400">
+            <ToolIcon tool={format.tool} />
+            <span>{format.tool}</span>
+            <span aria-hidden="true">·</span>
+            <span className="font-medium">{format.ratioLabel}</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+VorlagenCard.displayName = 'VorlagenCard';
+
+export default VorlagenCard;

--- a/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
+++ b/apps/web/src/components/common/Gallery/VorlagenGallery.tsx
@@ -2,16 +2,17 @@ import { Badge, Button, Popover, PopoverContent, PopoverTrigger } from '@gruener
 import { useQuery } from '@tanstack/react-query';
 import { memo, useCallback, useEffect, useMemo, useState, type JSX } from 'react';
 import { HiPlus } from 'react-icons/hi';
-import { HiCog6Tooth } from 'react-icons/hi2';
+import { HiOutlineAdjustmentsHorizontal, HiMagnifyingGlass } from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 
 import { useEntityFavorites } from '../../../features/favorites/hooks/useEntityFavorites';
 import { useEntityLikes } from '../../../features/likes/hooks/useEntityLikes';
-import SearchBar from '../../../features/search/components/SearchBar';
 import apiClient from '../../utils/apiClient';
 import AddTemplateModal from '../AddTemplateModal/AddTemplateModal';
-import IndexCard from '../IndexCard';
 import TemplatePreviewModal from '../TemplatePreviewModal';
+
+import VorlagenCard from './VorlagenCard';
 
 import { cn } from '@/utils/cn';
 
@@ -30,11 +31,16 @@ interface VorlageItem {
   tags?: string[];
   thumbnail_url?: string;
   external_url?: string;
+  download_url?: string;
   content_data?: { originalUrl?: string };
   metadata?: { author_name?: string; contact_email?: string };
   source?: 'community' | 'system';
   [key: string]: unknown;
 }
+
+/** Resolve the openable/shareable URL for a gallery item, if any. */
+const resolveTemplateUrl = (item: VorlageItem): string | undefined =>
+  item.content_data?.originalUrl || item.external_url || item.download_url || undefined;
 
 const parseSearchQuery = (query: string): { textQuery: string; tags: string[] } => {
   const tags: string[] = [];
@@ -146,6 +152,20 @@ const VorlagenGallery = memo((): JSX.Element => {
     setInputValue((prev) => addTagToSearch(prev, tag));
   }, []);
 
+  const openExternal = useCallback((item: VorlageItem) => {
+    const url = resolveTemplateUrl(item);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  const copyLink = useCallback((item: VorlageItem) => {
+    const url = resolveTemplateUrl(item);
+    if (!url) return;
+    void navigator.clipboard
+      ?.writeText(url)
+      .then(() => toast.success('Link kopiert.'))
+      .catch(() => toast.error('Link konnte nicht kopiert werden.'));
+  }, []);
+
   useEffect(() => {
     if (categories.length === 0) return;
     if (!categories.some((c) => c.id === selectedCategory)) {
@@ -165,93 +185,89 @@ const VorlagenGallery = memo((): JSX.Element => {
           Durchsuche hier Design-Vorlagen für Canva, InDesign und mehr.
         </p>
 
-        <div className="mx-auto mb-xl flex w-full justify-center px-md box-border">
-          <div className="w-full max-w-[960px]">
-            <div className="flex items-center gap-3 max-md:flex-col max-md:items-stretch">
-              <div className="min-w-0 flex-1">
-                <SearchBar
-                  onSearch={() => {}}
-                  value={inputValue}
-                  onChange={setInputValue}
-                  placeholder="Vorlagen durchsuchen..."
-                  hideExamples
-                  hideDisclaimer
-                  settingsContent={
-                    showCategoryFilter ? (
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <button
-                            type="button"
-                            className="flex items-center justify-center rounded-full border-none bg-transparent p-2 text-foreground opacity-70 transition-colors hover:bg-background-alt hover:text-primary-500 hover:opacity-100"
-                            aria-label="Einstellungen"
-                            title="Einstellungen"
-                          >
-                            <HiCog6Tooth className="size-5" />
-                          </button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                          align="end"
-                          sideOffset={8}
-                          className="w-[16rem] space-y-3 p-3"
-                        >
-                          <div>
-                            <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
-                              Kategorie
-                            </span>
-                            <div className="flex flex-wrap gap-1.5">
-                              {categories.map((category) => (
-                                <button
-                                  key={category.id}
-                                  type="button"
-                                  className={cn(
-                                    'rounded-2xl border px-2.5 py-1 text-xs font-medium transition-colors',
-                                    selectedCategory === category.id
-                                      ? 'border-transparent bg-primary-500 text-white'
-                                      : 'border-grey-300 text-grey-700 hover:border-grey-400 dark:border-grey-600 dark:text-grey-300'
-                                  )}
-                                  onClick={() => setSelectedCategory(category.id)}
-                                >
-                                  {category.label}
-                                </button>
-                              ))}
-                            </div>
-                          </div>
-                        </PopoverContent>
-                      </Popover>
-                    ) : null
-                  }
-                />
-              </div>
-              <Button
-                variant="brand"
-                size="brand"
-                className="max-md:w-full"
-                onClick={() => setShowAddModal(true)}
-              >
-                <HiPlus className="size-5" />
-                Vorlage hinzufügen
-              </Button>
-              <Button asChild variant="brand-outline" size="brand" className="max-md:w-full">
-                <Link to="/vorlagen/meine">Meine Vorlagen</Link>
-              </Button>
-            </div>
-
-            <AddTemplateModal
-              isOpen={showAddModal}
-              onClose={() => setShowAddModal(false)}
-              onSuccess={() => dataQuery.refetch()}
+        <div className="mx-auto mb-xl flex w-full max-w-[760px] flex-wrap items-center justify-center gap-3 px-md box-border max-md:flex-col max-md:items-stretch">
+          {/* Compact, width-limited search field with leading icon. */}
+          <div className="relative h-12 min-w-0 flex-1 max-md:w-full">
+            <HiMagnifyingGlass
+              className="pointer-events-none absolute left-4 top-1/2 size-5 -translate-y-1/2 text-foreground/50"
+              aria-hidden="true"
             />
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder="Vorlagen durchsuchen..."
+              aria-label="Vorlagen durchsuchen"
+              className="h-full w-full rounded-full border-2 border-background-alt bg-background pl-11 pr-12 text-base text-foreground outline-none transition-colors placeholder:text-foreground/50 focus:border-primary-500"
+            />
+            {showCategoryFilter && (
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      'absolute right-1.5 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-full border-none bg-transparent text-foreground/60 transition-colors hover:bg-background-alt hover:text-primary-500',
+                      selectedCategory !== 'all' && 'bg-primary-500/10 text-primary-500'
+                    )}
+                    aria-label="Filter"
+                    title="Filter"
+                  >
+                    <HiOutlineAdjustmentsHorizontal className="size-5" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="end" sideOffset={8} className="w-[16rem] space-y-3 p-3">
+                  <div>
+                    <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-grey-500 dark:text-grey-400">
+                      Kategorie
+                    </span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {categories.map((category) => (
+                        <button
+                          key={category.id}
+                          type="button"
+                          className={cn(
+                            'rounded-2xl border px-2.5 py-1 text-xs font-medium transition-colors',
+                            selectedCategory === category.id
+                              ? 'border-transparent bg-primary-500 text-white'
+                              : 'border-grey-300 text-grey-700 hover:border-grey-400 dark:border-grey-600 dark:text-grey-300'
+                          )}
+                          onClick={() => setSelectedCategory(category.id)}
+                        >
+                          {category.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
           </div>
+          <Button
+            variant="brand"
+            size="brand-md"
+            className="max-md:w-full"
+            onClick={() => setShowAddModal(true)}
+          >
+            <HiPlus className="size-5" />
+            Vorlage hinzufügen
+          </Button>
+          <Button asChild variant="brand-outline" size="brand-md" className="max-md:w-full">
+            <Link to="/vorlagen/meine">Meine Vorlagen</Link>
+          </Button>
+
+          <AddTemplateModal
+            isOpen={showAddModal}
+            onClose={() => setShowAddModal(false)}
+            onSuccess={() => dataQuery.refetch()}
+          />
         </div>
       </div>
 
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-2xl max-lg:grid-cols-[repeat(auto-fill,minmax(280px,1fr))] max-md:grid-cols-[repeat(auto-fill,minmax(250px,1fr))] max-md:gap-4">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(155px,1fr))] gap-4 max-md:grid-cols-[repeat(auto-fill,minmax(140px,1fr))] max-md:gap-3">
         {dataQuery.isLoading && items.length === 0 ? (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-md col-span-full">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="animate-pulse rounded-md bg-background-alt h-[180px]" />
-            ))}
-          </div>
+          Array.from({ length: 12 }).map((_, i) => (
+            <div key={i} className="aspect-[3/4] animate-pulse rounded-lg bg-background-alt" />
+          ))
         ) : dataQuery.error ? (
           <p className="col-span-full text-center text-error">
             {dataQuery.error.message || 'Fehler beim Laden'}
@@ -259,38 +275,42 @@ const VorlagenGallery = memo((): JSX.Element => {
         ) : items.length === 0 ? (
           <p className="col-span-full text-center">Keine Vorlagen gefunden.</p>
         ) : (
-          items.map((item) => {
-            const templateType = item.template_type
-              ? item.template_type.charAt(0).toUpperCase() + item.template_type.slice(1)
-              : '';
-            // Community = user-submitted. Fall back to author presence so cards are
-            // still marked correctly if the API hasn't been redeployed with `source`.
-            const isCommunity = item.source
-              ? item.source === 'community'
-              : Boolean(item.metadata?.author_name);
-            return (
-              <IndexCard
-                key={String(item.id)}
-                title={item.title || 'Unbenannte Vorlage'}
-                description={item.description || ''}
-                meta={templateType}
-                tags={Array.isArray(item.tags) ? item.tags.slice(0, 5) : []}
-                thumbnailUrl={item.thumbnail_url || ''}
-                onTagClick={handleTagClick}
-                onClick={() => setPreviewTemplate(item)}
-                className="vorlagen-card"
-                authorName={item.metadata?.author_name || ''}
-                authorEmail={item.metadata?.contact_email || ''}
-                badge={
-                  isCommunity ? (
-                    <Badge className="border-transparent bg-primary-600 text-white shadow-sm">
-                      Community
-                    </Badge>
-                  ) : null
-                }
-              />
-            );
-          })
+          <>
+            {/* Low-friction add tile, inline in the grid. */}
+            <button
+              type="button"
+              onClick={() => setShowAddModal(true)}
+              className="group flex aspect-[4/5] flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed border-grey-300 bg-transparent text-grey-500 transition-colors hover:border-primary-500 hover:text-primary-500 dark:border-grey-600"
+            >
+              <HiPlus className="size-7" />
+              <span className="text-sm font-medium">Neue Vorlage</span>
+            </button>
+            {items.map((item) => {
+              // Community = user-submitted. Fall back to author presence so cards
+              // are still marked correctly if the API hasn't been redeployed with
+              // `source`.
+              const isCommunity = item.source
+                ? item.source === 'community'
+                : Boolean(item.metadata?.author_name);
+              const hasUrl = Boolean(resolveTemplateUrl(item));
+              return (
+                <VorlagenCard
+                  key={String(item.id)}
+                  item={item}
+                  onOpen={() => setPreviewTemplate(item)}
+                  onOpenExternal={hasUrl ? () => openExternal(item) : undefined}
+                  onCopyLink={hasUrl ? () => copyLink(item) : undefined}
+                  badge={
+                    isCommunity ? (
+                      <Badge className="border-transparent bg-primary-600 text-white shadow-sm">
+                        Community
+                      </Badge>
+                    ) : null
+                  }
+                />
+              );
+            })}
+          </>
         )}
       </div>
 

--- a/apps/web/src/components/common/Gallery/templateFormat.ts
+++ b/apps/web/src/components/common/Gallery/templateFormat.ts
@@ -70,7 +70,14 @@ const deriveTool = (item: FormatSource): TemplateFormat['tool'] => {
     (item.content_data as { originalUrl?: string } | undefined)?.originalUrl ||
     item.external_url ||
     '';
-  if (url.includes('canva.com')) return 'Canva';
+
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    if (hostname === 'canva.com' || hostname.endsWith('.canva.com')) return 'Canva';
+  } catch {
+    // Ignore invalid/relative URLs and fall through to existing fallback logic.
+  }
+
   if (item.download_url) return 'Download';
   return 'Link';
 };

--- a/apps/web/src/components/common/Gallery/templateFormat.ts
+++ b/apps/web/src/components/common/Gallery/templateFormat.ts
@@ -1,0 +1,96 @@
+/**
+ * Derives presentational format metadata for a gallery template.
+ *
+ * The Vorlagen API stores no explicit `aspectRatio`/format/tool columns — only
+ * `template_type` (e.g. "sharepic", "story"), system file types ("header",
+ * "hintergrund", "profilbild"), the `external_url` and free-form `tags`. This
+ * helper is the single source of truth that turns those into the proportions,
+ * format label and authoring tool the card UI needs, so every card renders its
+ * format on a uniform neutral stage instead of letterboxed in grey margins.
+ */
+
+export interface TemplateFormat {
+  /** CSS `aspect-ratio` value for the proportioned stage box, e.g. '1 / 1'. */
+  aspectRatio: string;
+  /** Compact ratio/size label shown in the meta row, e.g. '1:1', '9:16', 'A5'. */
+  ratioLabel: string;
+  /** Human format category shown as the stage badge, e.g. 'Sharepic', 'Story'. */
+  typeLabel: string;
+  /** Authoring tool / source, derived from the URL. */
+  tool: 'Canva' | 'Download' | 'Link';
+}
+
+interface FormatSource {
+  template_type?: string;
+  tags?: string[];
+  external_url?: string | null;
+  download_url?: string;
+  content_data?: { originalUrl?: string } | Record<string, unknown>;
+}
+
+interface FormatPreset {
+  aspectRatio: string;
+  ratioLabel: string;
+  typeLabel: string;
+}
+
+// Known template/file types → proportions. Keys are the raw `template_type`
+// (or system `file_type`) values returned by the gallery API.
+const TYPE_PRESETS: Record<string, FormatPreset> = {
+  sharepic: { aspectRatio: '1 / 1', ratioLabel: '1:1', typeLabel: 'Sharepic' },
+  story: { aspectRatio: '9 / 16', ratioLabel: '9:16', typeLabel: 'Story' },
+  reel: { aspectRatio: '9 / 16', ratioLabel: '9:16', typeLabel: 'Reel' },
+  post: { aspectRatio: '4 / 5', ratioLabel: '4:5', typeLabel: 'Post' },
+  flyer: { aspectRatio: '210 / 297', ratioLabel: 'A5', typeLabel: 'Flyer' },
+  plakat: { aspectRatio: '210 / 297', ratioLabel: 'A-Format', typeLabel: 'Plakat' },
+  header: { aspectRatio: '3 / 1', ratioLabel: 'Banner', typeLabel: 'Header' },
+  hintergrund: { aspectRatio: '16 / 9', ratioLabel: '16:9', typeLabel: 'Hintergrund' },
+  profilbild: { aspectRatio: '1 / 1', ratioLabel: '1:1', typeLabel: 'Profilbild' },
+};
+
+const DEFAULT_PRESET: FormatPreset = {
+  aspectRatio: '1 / 1',
+  ratioLabel: '1:1',
+  typeLabel: 'Vorlage',
+};
+
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+
+// Tag hints can override a type's default proportions (e.g. a "sharepic" tagged
+// "hochformat" is portrait 4:5). Checked in order; first match wins.
+const TAG_OVERRIDES: Array<{ match: string[]; aspectRatio: string; ratioLabel: string }> = [
+  { match: ['9:16', 'hochkant', 'story'], aspectRatio: '9 / 16', ratioLabel: '9:16' },
+  { match: ['4:5', 'hochformat', 'portrait'], aspectRatio: '4 / 5', ratioLabel: '4:5' },
+  { match: ['16:9', 'querformat', 'landscape'], aspectRatio: '16 / 9', ratioLabel: '16:9' },
+  { match: ['quadratisch', '1:1', 'square'], aspectRatio: '1 / 1', ratioLabel: '1:1' },
+];
+
+const deriveTool = (item: FormatSource): TemplateFormat['tool'] => {
+  const url =
+    (item.content_data as { originalUrl?: string } | undefined)?.originalUrl ||
+    item.external_url ||
+    '';
+  if (url.includes('canva.com')) return 'Canva';
+  if (item.download_url) return 'Download';
+  return 'Link';
+};
+
+export const getTemplateFormat = (item: FormatSource): TemplateFormat => {
+  const type = item.template_type?.toLowerCase() ?? '';
+  const preset = TYPE_PRESETS[type] ?? {
+    ...DEFAULT_PRESET,
+    typeLabel: type ? capitalize(type) : DEFAULT_PRESET.typeLabel,
+  };
+
+  let { aspectRatio, ratioLabel } = preset;
+  const tags = Array.isArray(item.tags) ? item.tags.map((t) => t.toLowerCase()) : [];
+  for (const override of TAG_OVERRIDES) {
+    if (override.match.some((m) => tags.includes(m))) {
+      aspectRatio = override.aspectRatio;
+      ratioLabel = override.ratioLabel;
+      break;
+    }
+  }
+
+  return { aspectRatio, ratioLabel, typeLabel: preset.typeLabel, tool: deriveTool(item) };
+};


### PR DESCRIPTION
## Was

Redesign der Vorlagen-Datenbank (`/vorlagen`) – Suchleiste und Karten.

### Suchleiste
- Kompaktes, breitenbegrenztes, mittiges Suchfeld mit **Such-Icon links** im Feld
- Zahnrad → klareres **Filter-Icon** (tönt sich ein, wenn eine Kategorie aktiv ist; verschwindet automatisch, wenn keine Kategorien existieren)
- Button-Hierarchie: „Vorlage hinzufügen" gefüllt (primär), „Meine Vorlagen" Outline – **beide gleich hoch** wie das Suchfeld
- Keine Tabs/Filter-Chips

### Cards (Uniform-Layout)
- Neue `VorlagenCard`: einheitliche Höhe, jedes Format **zentriert auf neutraler Bühne** (keine toten Grauränder)
- **Format-Badge** oben links (Sharepic/Story/Flyer …), Community-Badge oben rechts
- **Meta-Zeile**: Name + Tool (Canva-Icon / Download / Link) + Format-Label (1:1, 9:16, A5 …)
- Engeres Grid (`minmax(155px)`)
- Hover: Rahmen + leichtes Anheben, plus Hover-Aktionen (**Öffnen / Link kopieren**)
- Inline **„Neue Vorlage"**-Kachel als niedrigschwelliger Add-Einstieg

### aspectRatio
Die API hat keine `aspectRatio`/Format/Tool-Spalten. `templateFormat.ts` leitet diese aus `template_type`, `tags` und `external_url` ab – **keine DB-Migration nötig**. Einziger Seam, falls später eine echte `aspect_ratio`-Spalte gewünscht ist.

## Test
- `pnpm --filter @gruenerator/web typecheck` ✅
- ESLint sauber (nur vorbestehende Warnungen) ✅
- Lokal verifiziert (Header-Layout per Screenshot; Karten benötigen laufendes Backend)