### PR TITLE
feat(chat): merge @datei and @dokumentchat into the single @docs mention

### DIFF
--- a/packages/chat/src/lib/mentionParser.vitest.ts
+++ b/packages/chat/src/lib/mentionParser.vitest.ts
@@ -5,7 +5,14 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
 import { parseAllMentions } from './mentionParser';
-import { setBoardMentionables, setDocMentionables } from './mentionables';
+import {
+  documentMentionables,
+  filterMentionables,
+  resolveMentionable,
+  setBoardMentionables,
+  setDocMentionables,
+  toolMentionables,
+} from './mentionables';
 
 beforeAll(() => {
   // Set up some known mentionables
@@ -74,5 +81,24 @@ describe('mentionParser: unresolvedMentions', () => {
     const result = parseAllMentions('@docs browse documents');
     // @docs is registered as docs-picker-trigger in docToolMentionables
     expect(result.unresolvedMentions).toHaveLength(0);
+  });
+});
+
+describe('document mentions merged into @docs', () => {
+  it('@datei and @dokumentchat are no longer separate picker entries', () => {
+    expect(documentMentionables).toHaveLength(0);
+    expect(toolMentionables.some((m) => m.mention === 'dokumentchat')).toBe(false);
+  });
+
+  it('legacy @datei / @dokumentchat aliases redirect to the @docs entry', () => {
+    for (const alias of ['datei', 'dokumentchat']) {
+      const resolved = resolveMentionable(alias);
+      expect(resolved?.identifier).toBe('docs-picker-trigger');
+    }
+  });
+
+  it('typing an old document trigger surfaces the @docs entry in the picker', () => {
+    const docs = filterMentionables('datei').docs;
+    expect(docs.some((m) => m.identifier === 'docs-picker-trigger')).toBe(true);
   });
 });

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -3,7 +3,6 @@ import { NOTEBOOK_REGISTRY } from '@gruenerator/shared/notebooks';
 import {
   PiFlask,
   PiFiles,
-  PiChatCircleDots,
   PiNote,
   PiPaintBrush,
   PiTreeEvergreen,
@@ -11,7 +10,6 @@ import {
   PiImagesSquare,
   PiClipboardText,
   PiFileText,
-  PiPaperclip,
   PiSparkle,
   PiCloud,
   PiNotePencil,
@@ -217,18 +215,6 @@ export const toolMentionables: Mentionable[] = [
     type: 'tool',
     category: 'function',
     trigger: '@',
-    identifier: 'documentchat',
-    title: 'Dokument-Chat',
-    description: 'Mit ausgewählten Dokumenten chatten',
-    avatar: '💬',
-    icon: PiChatCircleDots,
-    backgroundColor: '#6366F1',
-    mention: 'dokumentchat',
-  },
-  {
-    type: 'tool',
-    category: 'function',
-    trigger: '@',
     identifier: 'summary',
     title: 'Zusammenfassung',
     description: 'Dokument(e) zusammenfassen',
@@ -349,16 +335,22 @@ export const docToolMentionables: Mentionable[] = [
     mention: 'dokument-erstellen',
   },
   {
+    // Single document entry point. Opens the unified file/doc browser
+    // (notebook files, uploads, saved texts, collaborative docs). Replaces the
+    // former @datei ("Datei auswählen") and @dokumentchat ("Dokument-Chat")
+    // pickers — `aliases` keep those names resolving here for back-compat and
+    // surface this entry when a user types the old triggers.
     type: 'doc',
     category: 'function',
     trigger: '@',
     identifier: 'docs-picker-trigger',
-    title: 'Dokument einfuegen',
-    description: 'Kollaboratives Dokument als Kontext hinzufuegen',
+    title: 'Dokument einfügen',
+    description: 'Dokumente, Dateien & Notizbuch-Inhalte als Kontext hinzufügen',
     avatar: '📄',
     icon: PiFileText,
     backgroundColor: '#0891B2',
     mention: 'docs',
+    aliases: ['datei', 'dokumentchat', 'document', 'dokument'],
   },
 ];
 
@@ -418,20 +410,15 @@ export function getUserNotebookMentionables(): Mentionable[] {
   return dynamicUserNotebookMentionables;
 }
 
-export const documentMentionables: Mentionable[] = [
-  {
-    type: 'document',
-    category: 'function',
-    trigger: '@',
-    identifier: 'datei-trigger',
-    title: 'Datei auswählen',
-    description: 'Dokument aus einem Notizbuch referenzieren',
-    avatar: '📎',
-    icon: PiPaperclip,
-    backgroundColor: '#6366F1',
-    mention: 'datei',
-  },
-];
+/**
+ * The legacy @datei ("Datei auswählen") and @dokumentchat ("Dokument-Chat")
+ * pickers were merged into the single @docs entry below — it opens the same
+ * unified file/doc browser (notebook files, uploads, saved texts, collab docs).
+ * This list stays empty (no separate picker entry); @datei / @dokumentchat
+ * tokens in existing threads still resolve via `mentionParser` special-cases
+ * and the `aliases` on the @docs mentionable.
+ */
+export const documentMentionables: Mentionable[] = [];
 
 // @wolke opens a sub-popover that lets the user pick files from their
 // connected Nextcloud share link(s). Selected files are inserted into the
@@ -722,7 +709,9 @@ export function filterMentionables(query: string): {
   const matchFn = (m: Mentionable) =>
     m.mention.toLowerCase().includes(q) ||
     m.title.toLowerCase().includes(q) ||
-    m.identifier.toLowerCase().includes(q);
+    m.identifier.toLowerCase().includes(q) ||
+    // Back-compat aliases (e.g. typing @datei / @dokumentchat surfaces @docs).
+    (m.aliases?.some((a) => a.toLowerCase().includes(q)) ?? false);
 
   const isNotebookCategoryQuery =
     'notebook'.startsWith(q) ||


### PR DESCRIPTION
## Why

The chat composer exposed **three overlapping document mentions**:
- **@datei** ("Datei auswählen") — pick a notebook file / upload / saved text
- **@dokumentchat** ("Dokument-Chat") — chat scoped to selected documents
- **@docs** ("Dokument einfügen") — insert a collaborative doc

In practice **@datei and @docs already opened the *same* unified picker** (`FileMentionPopover` — @docs just switches into the `datei` browser), and **@dokumentchat's separate picker is no longer wired into the composer**. Three entry points for one job. Collapse them into a single **@docs**.

## What

- **`mentionables.ts`** — remove the `@dokumentchat` tool entry; empty the `@datei` `documentMentionables` list. **@docs** becomes the one document entry point with `aliases: ['datei','dokumentchat','document','dokument']`.
- **`filterMentionables`** — match aliases so typing an old trigger (`@datei`, `@dokumentchat`) **surfaces @docs** in the live picker (the redirect).
- **@docs** description updated to reflect the unified scope (notebook files, uploads, saved texts, collaborative docs); drop now-unused icon imports.

### Back-compat (no data/behavior loss for existing threads)
`mentionParser` still special-cases `@datei`, `@datei:slug`, and `@dokumentchat` **before** resolution — so tokens in saved threads keep resolving, and `@dokumentchat` still sets `hasDocumentChat` (the document-chat backend path in ChatGraph is untouched). The `aliases` also make `resolveMentionable('datei'|'dokumentchat')` return the @docs entry for chip rendering.

## Verification
- `pnpm --filter @gruenerator/chat typecheck` ✅
- `pnpm --filter @gruenerator/chat test` ✅ (41 passed, incl. 3 new redirect tests)