### PR TITLE
feat(chat): read pasted links as context (wire up scrape_url)

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
+++ b/apps/api/agents/langgraph/ChatGraph/ChatGraph.ts
@@ -226,6 +226,10 @@ const ChatStateAnnotation = Annotation.Root({
   subQueries: Annotation<string[] | null>({
     reducer: (x, y) => y ?? x,
   }),
+  detectedUrls: Annotation<string[]>({
+    reducer: (x, y) => y ?? x ?? [],
+    default: () => [],
+  }),
   reasoning: Annotation<string>({
     reducer: (x, y) => y ?? x,
   }),
@@ -482,6 +486,7 @@ function routeAfterClassification(
     search: 'search',
     // person: 'person', // DISABLED: Person search not production ready
     web: 'web',
+    scrape_url: 'scrape',
     examples: 'examples',
     pressemitteilung_examples: 'pressemitteilung_examples',
     image: 'image',
@@ -768,6 +773,7 @@ export async function initializeChatState(input: ChatGraphInput): Promise<ChatSt
     searchSources: [],
     searchQuery: null,
     subQueries: null,
+    detectedUrls: [],
     reasoning: '',
     hasTemporal: false,
     complexity: 'moderate' as const,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
@@ -33,6 +33,8 @@ export const INTENT_KEYWORDS: Record<
     | 'edit_current_board'
     | 'share_doc'
     | 'pressemitteilung_examples'
+    // scrape_url is detected by URL presence in the message (extractUrls), not keywords.
+    | 'scrape_url'
   >,
   string[]
 > = {
@@ -156,6 +158,28 @@ export function extractMessageText(content: unknown): string {
       .join('');
   }
   return String(content || '');
+}
+
+/**
+ * Detect http(s) URLs in user-typed text. Ported from the frontend's
+ * `urlDetection.ts` regex (web/api boundary forbids a cross-import). Used by the
+ * classifier to route pasted links to the `scrape_url` intent so their page
+ * content becomes chat context. Strips trailing sentence punctuation and dedupes.
+ */
+const URL_PATTERN =
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gi;
+
+export function extractUrls(text: string): string[] {
+  if (!text) return [];
+  const matches = text.match(URL_PATTERN);
+  if (!matches) return [];
+  const seen = new Set<string>();
+  for (const raw of matches) {
+    // Trim trailing punctuation that commonly follows a URL in prose.
+    const cleaned = raw.replace(/[.,;:!?)\]}'"]+$/, '');
+    if (cleaned) seen.add(cleaned);
+  }
+  return [...seen];
 }
 
 /**

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierHeuristics.ts
@@ -167,7 +167,7 @@ export function extractMessageText(content: unknown): string {
  * content becomes chat context. Strips trailing sentence punctuation and dedupes.
  */
 const URL_PATTERN =
-  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/gi;
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/gi;
 
 export function extractUrls(text: string): string[] {
   if (!text) return [];

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.ts
@@ -26,6 +26,7 @@ import {
   heuristicClassify,
   extractSearchTopic,
   extractMessageText,
+  extractUrls,
   formatConversationHistory,
   hasImageEditVerb,
   mentionsImageNoun,
@@ -97,11 +98,40 @@ export async function classifierNode(state: ChatGraphState): Promise<Partial<Cha
     intent = 'compare';
   }
 
+  // ── URL context: pasted link(s) → additive scrape_url step ──
+  // When the active agent has scraping enabled and the message contains URL(s),
+  // crawl them so the page content becomes context. Additive, not exclusive:
+  // a pure link paste (or a creative task whose only "search" is the link) takes
+  // the scrape_url slot directly; otherwise it rides as the secondary intent so
+  // "schreib einen Tweet zu <url>" both crawls the page AND drafts the tweet.
+  let secondaryIntent = result.secondaryIntent ?? null;
+  // Agent must allow scraping (whitelist holds 'scrape'; one agent uses the tool
+  // name 'scrape_url') and the user must not have toggled it off in the composer.
+  const scrapeWhitelist = state.agentConfig?.enabledTools;
+  const agentAllowsScrape =
+    !scrapeWhitelist ||
+    scrapeWhitelist.includes('scrape') ||
+    scrapeWhitelist.includes('scrape_url');
+  const scrapeEnabled = agentAllowsScrape && state.enabledTools?.['scrape'] !== false;
+  const detectedUrls = scrapeEnabled ? extractUrls(userText) : [];
+  if (detectedUrls.length > 0) {
+    if (!intent || intent === 'direct') {
+      intent = 'scrape_url';
+    } else if (!secondaryIntent && intent !== 'scrape_url') {
+      secondaryIntent = 'scrape_url';
+    }
+    log.info(
+      `[Classifier] Detected ${detectedUrls.length} URL(s) → scrape_url (intent=${intent}, secondary=${secondaryIntent ?? 'none'})`
+    );
+  }
+
   const synthesisMode = pickSynthesisMode(intent ?? 'direct', documentSources.length);
 
   return {
     ...result,
     intent: intent ?? result.intent,
+    secondaryIntent,
+    detectedUrls,
     documentSources,
     synthesisMode,
   };

--- a/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.vitest.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/classifierNode.vitest.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
+import { extractUrls } from './classifierHeuristics.js';
 import {
   extractSearchTopic,
   parseClassifierResponse,
@@ -54,6 +55,36 @@ describe('extractSearchTopic', () => {
     expect(extractSearchTopic('Erstelle eine kurze Zusammenfassung über den Atomausstieg')).toBe(
       'den Atomausstieg'
     );
+  });
+});
+
+// ─── extractUrls (scrape_url detection) ───────────────────────────────────
+
+describe('extractUrls', () => {
+  it('returns [] when no URL present', () => {
+    expect(extractUrls('Schreib einen Tweet über Klimapolitik')).toEqual([]);
+  });
+
+  it('detects a single pasted URL', () => {
+    expect(extractUrls('Lies das: https://gruene.de/programm')).toEqual([
+      'https://gruene.de/programm',
+    ]);
+  });
+
+  it('strips trailing sentence punctuation', () => {
+    expect(extractUrls('Quelle ist https://example.com/artikel.')).toEqual([
+      'https://example.com/artikel',
+    ]);
+  });
+
+  it('detects multiple URLs and dedupes', () => {
+    expect(
+      extractUrls('Vergleiche https://a.de und https://b.de sowie nochmal https://a.de')
+    ).toEqual(['https://a.de', 'https://b.de']);
+  });
+
+  it('ignores bare domains without http(s) scheme', () => {
+    expect(extractUrls('Schau auf gruene.de nach')).toEqual([]);
   });
 });
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragImprovements.test.ts
@@ -206,6 +206,7 @@ async function testExpandedContextWindow() {
     secondaryIntent: null,
     searchQuery: 'test query',
     subQueries: null,
+    detectedUrls: [],
     reasoning: 'test',
     contentType: null,
     documentSubtype: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/ragQualityEval.test.ts
@@ -247,6 +247,7 @@ async function evaluateBudgetAllocation() {
     secondaryIntent: null,
     searchQuery: 'Klimapolitik der Grünen',
     subQueries: null,
+    detectedUrls: [],
     reasoning: 'test',
     contentType: null,
     documentSubtype: null,

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -1060,6 +1060,45 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         break;
       }
 
+      case 'scrape_url': {
+        // User pasted URL(s) into their message. The classifier detected them
+        // deterministically (state.detectedUrls); crawl the pages and inject the
+        // content as context. Unlike `web`, there's no search step — the URLs are
+        // user-chosen, so give them a longer per-URL timeout. First link ranks highest.
+        const urls = state.detectedUrls ?? [];
+        if (urls.length === 0) {
+          log.warn('[Search] scrape_url intent reached with no detectedUrls');
+          break;
+        }
+        const seeds: CrawlableResult[] = urls.map((url, idx) => ({
+          url,
+          title: url,
+          content: '',
+          relevance: 1 - idx * 0.1,
+        }));
+        try {
+          const crawled = await selectAndCrawlTopUrls(seeds, searchQuery || '', {
+            maxUrls: 3,
+            timeout: 8000,
+          });
+          results = crawled
+            .filter((r) => r.crawled && (r.fullContent || r.content))
+            .map((r) => ({
+              ...r,
+              content: r.fullContent || r.content || '',
+              source: 'web',
+              title: r.title || r.url || '',
+            }));
+          log.info(`[Search] scrape_url crawled ${results.length}/${urls.length} pasted URL(s)`);
+        } catch (err: unknown) {
+          log.warn(
+            `[Search] scrape_url crawling failed: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+        citations = buildCitations(results);
+        break;
+      }
+
       case 'pressemitteilung_examples':
       case 'examples': {
         // Build kinds from intent + secondaryIntent. The dual SearchIntent

--- a/apps/api/agents/langgraph/ChatGraph/types.ts
+++ b/apps/api/agents/langgraph/ChatGraph/types.ts
@@ -46,6 +46,7 @@ export type SearchIntent =
   | 'search' // Gruenerator document search (party programs, positions)
   // | 'person' // DISABLED: Person search not production ready (only searches 80 cached MPs)
   | 'web' // Web search (current events, external facts)
+  | 'scrape_url' // Crawl URL(s) pasted in the user message and use the page content as context
   | 'examples' // Social media examples/templates
   | 'pressemitteilung_examples' // Real LV press releases as templates (landesverbaende_documents, content_type=presse)
   | 'image' // Image generation ("erstelle bild", "generiere", "visualisiere")
@@ -446,6 +447,10 @@ export interface ChatGraphState {
   searchSources: SearchSource[];
   searchQuery: string | null;
   subQueries: string[] | null;
+  // URLs the user pasted into the message. Set by the classifier when the active
+  // agent has 'scrape' enabled; consumed by searchNode's 'scrape_url' case to crawl
+  // the pages and inject their content as context/citations.
+  detectedUrls: string[];
   reasoning: string;
   contentType: string | null;
   documentSubtype: string | null;

--- a/apps/api/routes/chat/services/postResponseService.ts
+++ b/apps/api/routes/chat/services/postResponseService.ts
@@ -43,6 +43,7 @@ export const INTENT_TO_TOOL: Record<string, string> = {
   image: 'image_generate',
   image_edit: 'image_edit',
   sharepic: 'sharepic',
+  scrape_url: 'scrape_url',
 };
 
 /**
@@ -68,16 +69,22 @@ interface SharepicToolCallResult {
   variants: SharepicVariant[];
 }
 
+/** Shape the frontend `parseScrapeResult` reads for the link-preview card. */
+interface ScrapeToolCallResult {
+  content: string;
+}
+
 type ToolCallResult =
   | SearchToolCallResult
   | ResearchToolResult
   | ImageToolCallResult
-  | SharepicToolCallResult;
+  | SharepicToolCallResult
+  | ScrapeToolCallResult;
 
 interface PersistedToolCall {
   toolCallId: string;
   toolName: string;
-  args: { query: string };
+  args: { query?: string; url?: string };
   result: ToolCallResult;
 }
 
@@ -135,6 +142,20 @@ function buildToolCalls(
 ): PersistedToolCall[] | undefined {
   const toolName = INTENT_TO_TOOL[finalState.intent];
   if (!toolName) return undefined;
+
+  // scrape_url renders a link-preview card per crawled page. The frontend parser
+  // reads `args.url` + `result.content`, so emit one tool call per result rather
+  // than the generic {query}/{results} shape.
+  if (toolName === 'scrape_url') {
+    const crawled = (finalState.searchResults || []).filter((r) => r.url);
+    if (crawled.length === 0) return undefined;
+    return crawled.slice(0, 5).map((r, idx) => ({
+      toolCallId: `tc_${Date.now()}_${idx}`,
+      toolName: 'scrape_url',
+      args: { url: r.url as string },
+      result: { content: r.content || '' },
+    }));
+  }
 
   const subQueries = classifiedState.subQueries;
   const searchSources: SearchSource[] = classifiedState.searchSources || [];

--- a/apps/api/routes/chat/services/sseHelpers.ts
+++ b/apps/api/routes/chat/services/sseHelpers.ts
@@ -264,6 +264,7 @@ export const INTENT_MESSAGE_POOLS: Record<SearchIntent, string[]> = {
   search: ['Durchsuche...', 'Stöbere...', 'Wälze...'],
   // person: 'Suche Informationen zur Person...', // DISABLED: Person search not production ready
   web: ['Surfe...', 'Suche im Netz...', 'Recherchiere online...'],
+  scrape_url: ['Lese Webseite...', 'Öffne den Link...', 'Rufe die Seite ab...'],
   examples: ['Krame...', 'Hole Beispiele...', 'Suche Inspiration...'],
   pressemitteilung_examples: ['Suche Pressemitteilungen...', 'Blättere...', 'Hole Vorlagen...'],
   image: ['Generiere...', 'Male...', 'Zeichne...'],


### PR DESCRIPTION
## Problem

Adding a link as context in chat **didn't work**. The chat advertised a `scrape_url` tool (system prompt + frontend `link-preview` card + `scrape` in many agents' `enabledTools`), but it was never executed — the classifier-driven pipeline (classifier → search → respond) had no `scrape_url` intent, `searchNode` had no case for it, and nothing detected URLs in the message. The system-prompt mention was a dead reference.

## What this does

When a user pastes a URL in a chat message **and** the active agent has scraping enabled, the chat now deterministically detects it, crawls it as a visible `scrape_url` step, and feeds the page content to the respond node as context/citations. So *"fasse https://… zusammen"* and *"schreib einen Tweet zu https://…"* both work.

Decisions: **auto-detect** pasted URLs (no new composer UI), executed as a **visible classifier intent**, **additive** — a pure link paste takes the `scrape_url` slot; a link alongside another request rides as the secondary intent so the page is crawled *and* the answer drafted.

## Changes (backend only)

- **types.ts** — `'scrape_url'` `SearchIntent` + `detectedUrls` state field
- **classifierHeuristics.ts** — `extractUrls()` (regex ported from the frontend `urlDetection.ts`; web/api boundary forbids a cross-import) + unit tests
- **classifierNode.ts** — deterministic URL detection gated on the agent's `scrape` whitelist (and respecting a frontend toggle-off); additive intent routing
- **searchNode.ts** — new `scrape_url` case reusing the SSRF-safe `selectAndCrawlTopUrls` (the same crawl primitive the `web` intent uses), 8s timeout, graceful fallback
- **postResponseService.ts** — persists a `link-preview` tool card per crawled page (`args.url` + `result.content`, the shape the frontend `parseScrapeResult` expects)
- **ChatGraph.ts / sseHelpers.ts** — intent→tool-key maps + German progress messages

No frontend changes: `toolRegistry.ts` already maps `scrape_url` → `link-preview`.

## Reuse

Builds entirely on existing infra — `selectAndCrawlTopUrls` (`services/search/CrawlingService.ts`), `buildCitations`, and the frontend link-preview card. The pattern mirrors the text generator's existing auto-detect-and-crawl behaviour (`useGenerator.ts`).

## Verification

- `pnpm --filter @gruenerator/api typecheck` ✅, eslint clean, `classifierNode.vitest.ts` (78 tests incl. 5 new `extractUrls`) ✅
- Manual: send a chat message with a public URL on a `scrape`-enabled agent → logs show `[ChatGraph:Classifier] … → scrape_url` and `[Crawl] Success: <url>`; the "Webseite lesen" link-preview card renders and the answer uses the page content.