### PR TITLE
feat(notifications): merge read/dismiss action, un-nest account menu list

### DIFF
--- a/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
+++ b/apps/web/src/components/layout/Sidebar/SidebarAccount.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from '@gruenerator/ui';
 import { LogOut } from 'lucide-react';
-import { type MutableRefObject, type ReactNode, memo, useEffect, useState } from 'react';
+import { type MutableRefObject, type ReactNode, Fragment, memo, useEffect, useState } from 'react';
 import { PiDesktop, PiMoon, PiQuestion, PiSun } from 'react-icons/pi';
 
 import { RobotAvatar } from '../../../components/common/RobotAvatar';
@@ -31,10 +31,10 @@ interface SidebarAccountProps {
 
 // Bottom-of-sidebar account block. The avatar is the single trigger for one
 // unified account menu — identical whether the sidebar is expanded or collapsed.
-// The menu carries notifications inline at the top (they're infrequent), then
-// the nav targets, theme toggle and logout. Mirrors the ChatGPT/Gemini account
-// anchor; replaces the standalone footer theme-toggle and the removed top-right
-// ProfileButton.
+// The menu lists the nav targets, with notifications inline just above
+// Einstellungen, then the theme toggle and logout. Mirrors the ChatGPT/Gemini
+// account anchor; replaces the standalone footer theme-toggle and the removed
+// top-right ProfileButton.
 const SidebarAccount = memo(function SidebarAccount({
   sidebarExpanded,
   openRef,
@@ -90,19 +90,21 @@ const SidebarAccount = memo(function SidebarAccount({
       className="w-80"
     >
       {NAV_ITEMS.map((item) => (
-        <DropdownMenuItem key={item.key} onClick={() => onNavigate(item.path, item.label)}>
-          <item.icon className="size-4" />
-          <span>{item.label}</span>
-        </DropdownMenuItem>
+        <Fragment key={item.key}>
+          {/* Notifications render inline just above Einstellungen; NotificationList
+              returns null (and its bounding separators with it) when nothing is
+              pending, so the menu reads as a plain list when empty. */}
+          {item.key === 'einstellungen' && <NotificationList />}
+          <DropdownMenuItem onClick={() => onNavigate(item.path, item.label)}>
+            <item.icon className="size-4" />
+            <span>{item.label}</span>
+          </DropdownMenuItem>
+        </Fragment>
       ))}
       <DropdownMenuItem onClick={() => onNavigate('/support', 'Support')}>
         <PiQuestion className="size-4" />
         <span>Support</span>
       </DropdownMenuItem>
-      {/* Notifications sit in their own bounded card between the nav targets and the
-          theme/logout row; NotificationList renders null when empty, so nothing shows
-          here when nothing is pending. */}
-      <NotificationList unreadCount={unreadCount} />
       <DropdownMenuSeparator />
       {/* Theme + logout share one row to save vertical space. */}
       <div className="flex items-center gap-1">

--- a/apps/web/src/features/notifications/components/NotificationList.tsx
+++ b/apps/web/src/features/notifications/components/NotificationList.tsx
@@ -1,4 +1,4 @@
-import { Button, ItemGroup, ItemSeparator, ScrollArea, Separator } from '@gruenerator/ui';
+import { Button, ItemGroup, ItemSeparator, Separator } from '@gruenerator/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { CheckCheck } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
@@ -7,109 +7,26 @@ import { useNavigate } from 'react-router-dom';
 import {
   useNotifications,
   useMarkAsRead,
-  useMarkAllAsRead,
   useDismissNotification,
   useDismissAll,
 } from '../hooks/useNotifications';
-import { getNotificationConfig } from '../notificationConfig';
-import { NOTIFICATION_GROUPS } from '../types';
+import {
+  groupByCategory,
+  groupNotifications,
+  formatShortTime,
+} from '../utils/notificationGrouping';
 
 import NotificationGroupComponent from './NotificationGroup';
 import NotificationItem from './NotificationItem';
 
-import type { Notification, NotificationGroup as NotificationGroupType } from '../types';
-
-type GroupedEntry =
-  | { kind: 'single'; notification: Notification }
-  | { kind: 'group'; key: string; items: Notification[] };
-
-interface CategorySection {
-  category: NotificationGroupType;
-  label: string;
-  entries: GroupedEntry[];
-}
-
-function groupNotifications(notifications: Notification[]): GroupedEntry[] {
-  const groups = new Map<string, Notification[]>();
-  const order: (string | Notification)[] = [];
-
-  for (const n of notifications) {
-    if (n.group_key) {
-      if (!groups.has(n.group_key)) {
-        groups.set(n.group_key, []);
-        order.push(n.group_key);
-      }
-      groups.get(n.group_key)!.push(n);
-    } else {
-      order.push(n);
-    }
-  }
-
-  return order.map((item) => {
-    if (typeof item === 'string') {
-      const items = groups.get(item)!;
-      if (items.length === 1) {
-        return { kind: 'single' as const, notification: items[0] };
-      }
-      return { kind: 'group' as const, key: item, items };
-    }
-    return { kind: 'single' as const, notification: item };
-  });
-}
-
-function getNotificationCategory(entry: GroupedEntry): NotificationGroupType {
-  const type = entry.kind === 'group' ? entry.items[0].type : entry.notification.type;
-  return (getNotificationConfig(type).group ?? 'system') as NotificationGroupType;
-}
-
-function groupByCategory(entries: GroupedEntry[]): CategorySection[] {
-  const categoryMap = new Map<NotificationGroupType, GroupedEntry[]>();
-
-  for (const entry of entries) {
-    const cat = getNotificationCategory(entry);
-    const existing = categoryMap.get(cat) ?? [];
-    existing.push(entry);
-    categoryMap.set(cat, existing);
-  }
-
-  return Array.from(categoryMap.entries())
-    .map(([category, catEntries]) => ({
-      category,
-      label: NOTIFICATION_GROUPS[category]?.label ?? 'Sonstige',
-      entries: catEntries,
-    }))
-    .sort(
-      (a, b) =>
-        (NOTIFICATION_GROUPS[a.category]?.order ?? 99) -
-        (NOTIFICATION_GROUPS[b.category]?.order ?? 99)
-    );
-}
-
-function formatShortTime(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const min = Math.floor(diff / 60000);
-  if (min < 1) return 'jetzt';
-  if (min < 60) return `${min}m`;
-  const hrs = Math.floor(min / 60);
-  if (hrs < 24) return `${hrs}h`;
-  const days = Math.floor(hrs / 24);
-  if (days < 30) return `${days}d`;
-  return new Date(dateStr).toLocaleDateString('de-DE', { day: 'numeric', month: 'short' });
-}
-
-interface NotificationListProps {
-  unreadCount: number;
-}
-
-const NotificationList = ({ unreadCount }: NotificationListProps) => {
+const NotificationList = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { data: notifData, hasNextPage, fetchNextPage, isFetchingNextPage } = useNotifications();
   const markAsRead = useMarkAsRead();
-  const markAllAsRead = useMarkAllAsRead();
   const dismissNotification = useDismissNotification();
   const dismissAll = useDismissAll();
-  const notifications = notifData?.pages.flat() ?? [];
+  const notifications = useMemo(() => notifData?.pages.flat() ?? [], [notifData]);
 
   const grouped = useMemo(() => groupNotifications(notifications), [notifications]);
   const sections = useMemo(() => groupByCategory(grouped), [grouped]);
@@ -128,35 +45,26 @@ const NotificationList = ({ unreadCount }: NotificationListProps) => {
 
   if (notifications.length === 0) return null;
 
+  // Rendered inline inside the account dropdown (not a nested card): bounding
+  // separators set it apart, and the list scrolls natively so the menu items
+  // below (Einstellungen, Support, …) stay reachable when many are pending.
   return (
-    <div className="mx-1 my-1 overflow-hidden rounded-lg border border-grey-200 dark:border-grey-700 bg-background-alt">
-      <div className="flex items-center justify-between px-md pt-xs pb-0">
+    <div className="my-1">
+      <Separator className="mb-1" />
+      <div className="flex items-center justify-between px-md pb-xs">
         <span className="text-xs font-medium text-foreground">Benachrichtigungen</span>
-        <div className="flex gap-xs">
-          {unreadCount > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-auto px-1.5 py-0.5 text-[0.65rem] text-foreground font-normal"
-              onClick={() => markAllAsRead.mutate()}
-            >
-              <CheckCheck className="mr-0.5 size-3" />
-              Alle gelesen
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto px-1.5 py-0.5 text-[0.65rem] text-foreground font-normal"
-            onClick={() => dismissAll.mutate()}
-          >
-            <CheckCheck className="mr-0.5 size-3" />
-            Alle erledigt
-          </Button>
-        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-auto px-1.5 py-0.5 text-[0.65rem] text-foreground font-normal"
+          onClick={() => dismissAll.mutate()}
+        >
+          <CheckCheck className="mr-0.5 size-3" />
+          Alle erledigt
+        </Button>
       </div>
 
-      <ScrollArea className="max-h-[260px]">
+      <div className="max-h-[260px] overflow-y-auto">
         {sections.map((section, sectionIdx) => (
           <div key={section.category}>
             {sectionIdx > 0 && <Separator />}
@@ -212,7 +120,8 @@ const NotificationList = ({ unreadCount }: NotificationListProps) => {
             </div>
           </>
         )}
-      </ScrollArea>
+      </div>
+      <Separator className="mt-1" />
     </div>
   );
 };

--- a/apps/web/src/features/notifications/hooks/useNotifications.ts
+++ b/apps/web/src/features/notifications/hooks/useNotifications.ts
@@ -4,7 +4,6 @@ import {
   fetchNotificationsPage,
   fetchUnreadCount,
   markNotificationAsRead,
-  markAllNotificationsAsRead,
   dismissNotificationById,
   dismissAllNotificationsClient,
 } from '../../../hooks/useNotificationsTyped';
@@ -63,21 +62,6 @@ export function useMarkAsRead() {
     },
     onSuccess: () => {
       decrementUnreadCount();
-      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
-    },
-  });
-}
-
-export function useMarkAllAsRead() {
-  const queryClient = useQueryClient();
-  const setUnreadCount = useNotificationStore((s) => s.setUnreadCount);
-
-  return useMutation({
-    mutationFn: async () => {
-      await markAllNotificationsAsRead();
-    },
-    onSuccess: () => {
-      setUnreadCount(0);
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
     },
   });

--- a/apps/web/src/features/notifications/utils/notificationGrouping.ts
+++ b/apps/web/src/features/notifications/utils/notificationGrouping.ts
@@ -1,0 +1,85 @@
+import { getNotificationConfig } from '../notificationConfig';
+import { NOTIFICATION_GROUPS } from '../types';
+
+import type { Notification, NotificationGroup as NotificationGroupType } from '../types';
+
+export type GroupedEntry =
+  | { kind: 'single'; notification: Notification }
+  | { kind: 'group'; key: string; items: Notification[] };
+
+export interface CategorySection {
+  category: NotificationGroupType;
+  label: string;
+  entries: GroupedEntry[];
+}
+
+// Collapse consecutive notifications sharing a group_key into one entry; keep
+// singletons (and single-item groups) as standalone entries, preserving order.
+export function groupNotifications(notifications: Notification[]): GroupedEntry[] {
+  const groups = new Map<string, Notification[]>();
+  const order: (string | Notification)[] = [];
+
+  for (const n of notifications) {
+    if (n.group_key) {
+      if (!groups.has(n.group_key)) {
+        groups.set(n.group_key, []);
+        order.push(n.group_key);
+      }
+      groups.get(n.group_key)!.push(n);
+    } else {
+      order.push(n);
+    }
+  }
+
+  return order.map((item) => {
+    if (typeof item === 'string') {
+      const items = groups.get(item)!;
+      if (items.length === 1) {
+        return { kind: 'single' as const, notification: items[0] };
+      }
+      return { kind: 'group' as const, key: item, items };
+    }
+    return { kind: 'single' as const, notification: item };
+  });
+}
+
+function getNotificationCategory(entry: GroupedEntry): NotificationGroupType {
+  const type = entry.kind === 'group' ? entry.items[0].type : entry.notification.type;
+  return (getNotificationConfig(type).group ?? 'system') as NotificationGroupType;
+}
+
+// Bucket grouped entries by their category and sort by the category order.
+export function groupByCategory(entries: GroupedEntry[]): CategorySection[] {
+  const categoryMap = new Map<NotificationGroupType, GroupedEntry[]>();
+
+  for (const entry of entries) {
+    const cat = getNotificationCategory(entry);
+    const existing = categoryMap.get(cat) ?? [];
+    existing.push(entry);
+    categoryMap.set(cat, existing);
+  }
+
+  return Array.from(categoryMap.entries())
+    .map(([category, catEntries]) => ({
+      category,
+      label: NOTIFICATION_GROUPS[category]?.label ?? 'Sonstige',
+      entries: catEntries,
+    }))
+    .sort(
+      (a, b) =>
+        (NOTIFICATION_GROUPS[a.category]?.order ?? 99) -
+        (NOTIFICATION_GROUPS[b.category]?.order ?? 99)
+    );
+}
+
+export function formatShortTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return 'jetzt';
+  if (min < 60) return `${min}m`;
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d`;
+  return new Date(dateStr).toLocaleDateString('de-DE', { day: 'numeric', month: 'short' });
+}

--- a/apps/web/src/hooks/useNotificationsTyped.ts
+++ b/apps/web/src/hooks/useNotificationsTyped.ts
@@ -43,14 +43,6 @@ export async function markNotificationAsRead(notificationId: string): Promise<vo
   }
 }
 
-export async function markAllNotificationsAsRead(): Promise<void> {
-  const client = getContractsClient();
-  const result = await client.notifications.markAllAsRead({ body: {} });
-  if (result.status !== 200) {
-    throw new Error(`Failed to mark all as read (HTTP ${result.status})`);
-  }
-}
-
 export async function dismissNotificationById(notificationId: string): Promise<void> {
   const client = getContractsClient();
   const result = await client.notifications.dismiss({


### PR DESCRIPTION
## Summary

Reworks the notifications block in the sidebar account menu per feedback:

- **Merged the two actions into one.** The separate **Alle gelesen** (mark all read) and **Alle erledigt** (dismiss all) buttons are now a single **Alle erledigt** button that dismisses (deletes) all notifications — dismissing already clears the unread state, so the mark-read button was redundant. Dropped the now-dead web `useMarkAllAsRead` hook and `markAllNotificationsAsRead` client. The backend `markAllAsRead` contract/endpoint is **kept** because mobile still uses it.
- **Un-nested the list.** It no longer renders inside a bordered card; it now sits inline in the dropdown with bounding separators.
- **Moved it above Einstellungen** (previously below Support).
- **Scrollable.** The list scrolls natively (`max-h` + `overflow-y-auto`) so the menu items below (Einstellungen, Support, theme, logout) stay reachable when many notifications are pending.
- **Maintainability.** Extracted the pure grouping/formatting helpers into `features/notifications/utils/notificationGrouping.ts`.

## Notes
- "Erledigt" permanently deletes notifications (no soft "done" flag exists in the data model) — same as the prior "Alle erledigt" behavior, just now the only action.

## Test plan
- [x] `pnpm --filter @gruenerator/web typecheck`
- [x] `eslint` on changed files (clean)
- [ ] Manual: open account menu, confirm notifications appear above Einstellungen, scroll with many items, "Alle erledigt" clears them and badge resets.