### PR TITLE
feat(workplace): add Grünerator newsletter as first favorite

### DIFF
--- a/apps/web/src/features/workplace/components/ToolsSection.tsx
+++ b/apps/web/src/features/workplace/components/ToolsSection.tsx
@@ -81,7 +81,16 @@ const MAIN_TOOLS: ToolItem[] = [
   },
 ];
 
+const NEWSLETTER_URL =
+  'https://896ca129.sibforms.com/serve/MUIFAFnH3lov98jrw3d75u_DFByChA39XRS6JkBKqjTsN9gx0MxCvDn1FMnkvHLgzxEh1JBcEOiyHEkyzRC-XUO2DffKsVccZ4r7CCaYiugoiLf1a-yoTxDwoctxuzCsmDuodwrVwEwnofr7K42jQc-saIKeVuB_8UxrwS18QIaahZml1qMExNno2sEC7HyMy9Nz4f2f8-UJ4QmW';
+
 const FAVORITES: FavoriteItem[] = [
+  {
+    id: 'newsletter',
+    title: 'Newsletter',
+    href: NEWSLETTER_URL,
+    icon: getIcon('navigation', 'presse-social')!,
+  },
   {
     id: 'verdigado',
     title: 'Verdigado',


### PR DESCRIPTION
Adds the Grünerator newsletter as the **first item** in the "Grünerators Favoriten" section of the workplace.

- New favorite `id: 'newsletter'` (title "Newsletter") linking to the same signup URL used by the startpage hero button (`Home.tsx`).
- Uses the newspaper icon (`navigation`/`presse-social`) since the icon registry has no mail icon.
- Inlined the URL to match the existing convention (all other favorites hardcode their URLs).

Per-request feature change only; no other files touched.