### PR TITLE
feat(notebooks): single-switch enable/disable for a Landesverband (turn off Hamburg)

### DIFF
--- a/apps/api/config/notebookCollectionMap.ts
+++ b/apps/api/config/notebookCollectionMap.ts
@@ -1,17 +1,29 @@
+import { getDisabledNotebookIds } from '@gruenerator/shared/notebooks';
+
+import { COLLECTION_MAP } from './collectionMap.js';
+import { getSystemCollectionConfig } from './systemCollectionsConfig.js';
+
 /**
  * Notebook IDs that are configured but currently disabled.
  *
  * Treated as unknown by `isKnownNotebook`, so chat/notebook routes reject queries
  * against them. Keeping the entry in `NOTEBOOK_COLLECTION_MAP` means existing
  * scrape data and admin tooling still resolve collections — only end-user routing
- * is gated. Mirror in `apps/web/src/features/notebook/config/notebooksConfig.ts`
- * (`enabled: false`) to also hide from the gallery.
+ * is gated.
+ *
+ * Derived from the shared notebook registry (`enabled: false`) so a single switch
+ * cascades here automatically — no mirroring needed. Agent-only collections that
+ * live outside the registry's `NotebookId` union are listed manually below.
  */
-export const DISABLED_NOTEBOOK_IDS: ReadonlySet<string> = new Set<string>([
-  'schleswig-holstein-notebook',
-  // Agent-only (by design, not broken): reachable only via the specialized
-  // `gruenerator-ricarda-lang` agent. End-user routes reject queries against it.
+const AGENT_ONLY_DISABLED_IDS = [
+  // Reachable only via the specialized `gruenerator-ricarda-lang` agent (by
+  // design, not broken). Not a registry notebook, so it can't derive its state.
   'ricarda-lang-notebook',
+] as const;
+
+export const DISABLED_NOTEBOOK_IDS: ReadonlySet<string> = new Set<string>([
+  ...getDisabledNotebookIds(),
+  ...AGENT_ONLY_DISABLED_IDS,
 ]);
 
 /**
@@ -61,6 +73,32 @@ export function isKnownNotebook(id: string): boolean {
 
 export function isDisabledNotebook(id: string): boolean {
   return DISABLED_NOTEBOOK_IDS.has(id);
+}
+
+/**
+ * Landesverband `shortName` codes (e.g. `HH`, `TH`, `TH-F`) belonging to a
+ * disabled notebook, resolved through the existing collection chain:
+ *   notebook id → NOTEBOOK_COLLECTION_MAP → collection key → COLLECTION_MAP
+ *   → systemId → SYSTEM_COLLECTIONS.defaultFilter (`landesverband` value).
+ *
+ * Lets the scheduled scraper skip a disabled Landesverband from the SAME switch
+ * (`enabled: false`) instead of a separate manual `dormant` flag. Manual
+ * `scrapeSource(id)` calls are unaffected, so the data can still be re-scraped.
+ */
+export function getDisabledLandesverbandShortNames(): ReadonlySet<string> {
+  const codes = new Set<string>();
+  for (const notebookId of DISABLED_NOTEBOOK_IDS) {
+    for (const key of NOTEBOOK_COLLECTION_MAP[notebookId] ?? []) {
+      const systemId = COLLECTION_MAP[key]?.systemId;
+      if (!systemId) continue;
+      const filter = getSystemCollectionConfig(systemId)?.defaultFilter;
+      if (filter?.field !== 'landesverband') continue;
+      for (const value of Array.isArray(filter.value) ? filter.value : [filter.value]) {
+        codes.add(value);
+      }
+    }
+  }
+  return codes;
 }
 
 /**

--- a/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
+++ b/apps/api/services/scrapers/implementations/LandesverbandScraper/LandesverbandScraper.ts
@@ -20,6 +20,7 @@ import {
   type ContentPath,
   type LandesverbandSource,
 } from '../../../../config/landesverbaendeConfig.js';
+import { getDisabledLandesverbandShortNames } from '../../../../config/notebookCollectionMap.js';
 import { getQdrantInstance } from '../../../../database/services/QdrantService/index.js';
 import {
   scrollDocuments,
@@ -512,8 +513,14 @@ export class LandesverbandScraper extends BaseScraper {
       sources = getSourcesByLandesverband(landesverband);
     }
 
+    // Skip sources for a Landesverband whose notebook is turned off
+    // (`enabled: false`) — derived from the same single switch, so no separate
+    // `dormant` flag is needed to stop scheduled scraping. Direct
+    // `scrapeSource(id)` calls bypass this, so the data can still be re-scraped.
+    const disabledLvCodes = getDisabledLandesverbandShortNames();
     const dormantSources = sources.filter((s) => s.dormant);
-    sources = sources.filter((s) => !s.dormant);
+    const disabledLvSources = sources.filter((s) => !s.dormant && disabledLvCodes.has(s.shortName));
+    sources = sources.filter((s) => !s.dormant && !disabledLvCodes.has(s.shortName));
 
     console.log('\n╔═══════════════════════════════════════════════════════════╗');
     console.log('║       Landesverbaende Scraper - Full Crawl                ║');
@@ -521,6 +528,9 @@ export class LandesverbandScraper extends BaseScraper {
     this.log(`Sources to process: ${sources.length}`);
     if (dormantSources.length > 0) {
       this.log(`Dormant sources skipped: ${dormantSources.map((s) => s.id).join(', ')}`);
+    }
+    if (disabledLvSources.length > 0) {
+      this.log(`Disabled-LV sources skipped: ${disabledLvSources.map((s) => s.id).join(', ')}`);
     }
     if (sourceType) this.log(`Filter by type: ${sourceType}`);
     if (landesverband) this.log(`Filter by LV: ${landesverband}`);

--- a/packages/chat/src/lib/agents.ts
+++ b/packages/chat/src/lib/agents.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SYSTEM_AGENT_ID,
   SKILLS,
+  getSystemAgent,
   getVisibleSystemAgentsForLocale,
   resolveSkillMention,
   type Skill,
@@ -17,7 +18,14 @@ export {
 
 type ResolvedSkill = Skill & { icon: SkillIcon };
 
-export const agentsList: ResolvedSkill[] = SKILLS.map((skill) => ({
+// Drop skills whose owning agent is hidden from inventory (e.g. a Landesverband
+// turned off via `enabled: false` hides its presse-/insta-<lv> skills). The
+// generated SKILLS carry no agent metadata, so resolve the agent by identifier.
+// Resolution maps in `skills/index.ts` are untouched, so historical `/presse-<lv>`
+// mentions still resolve.
+export const agentsList: ResolvedSkill[] = SKILLS.filter(
+  (skill) => getSystemAgent(skill.identifier)?.hiddenFromInventory !== true
+).map((skill) => ({
   ...skill,
   icon: resolveSkillIcon(skill.iconKey),
 }));

--- a/packages/chat/src/lib/mentionables.ts
+++ b/packages/chat/src/lib/mentionables.ts
@@ -1,5 +1,5 @@
 import { NOTEBOOK_ICONS } from '@gruenerator/shared/notebook-icons';
-import { NOTEBOOK_REGISTRY } from '@gruenerator/shared/notebooks';
+import { NOTEBOOK_REGISTRY, isNotebookEnabled } from '@gruenerator/shared/notebooks';
 import {
   PiFlask,
   PiFiles,
@@ -153,7 +153,12 @@ export function getCustomAgentMentionables(): Mentionable[] {
 // Derived from the shared notebook registry so the @-mention picker always matches the
 // web/mobile galleries. Adding a notebook to `@gruenerator/shared/notebooks` surfaces it
 // here automatically; the icon is resolved by id from the shared NOTEBOOK_ICONS map.
-export const notebookMentionables: Mentionable[] = NOTEBOOK_REGISTRY.map((nb) => ({
+//
+// Two views: `allNotebookMentionables` (incl. disabled) backs `resolveMentionable`
+// so old `@hamburg`/`@sh` tokens in existing threads still resolve, while the
+// exported `notebookMentionables` (enabled only) is what the picker offers — so a
+// notebook turned off via `enabled: false` disappears from discovery.
+const allNotebookMentionables: Mentionable[] = NOTEBOOK_REGISTRY.map((nb) => ({
   type: 'notebook',
   category: 'function',
   trigger: '@',
@@ -165,6 +170,10 @@ export const notebookMentionables: Mentionable[] = NOTEBOOK_REGISTRY.map((nb) =>
   backgroundColor: nb.mention.backgroundColor,
   mention: nb.mention.alias,
 }));
+
+export const notebookMentionables: Mentionable[] = allNotebookMentionables.filter((m) =>
+  isNotebookEnabled(m.identifier)
+);
 
 export const toolMentionables: Mentionable[] = [
   {
@@ -636,7 +645,8 @@ function rebuildMentionableMap(): void {
     agentMentionables,
     customAgentMentionables,
     dynamicUserNotebookMentionables,
-    notebookMentionables,
+    // Full set (incl. disabled) so historical `@hamburg`/`@sh` tokens still resolve.
+    allNotebookMentionables,
     toolMentionables,
     boardToolMentionables,
     dynamicBoardMentionables,

--- a/packages/shared/src/agents/landesverbandHubs.ts
+++ b/packages/shared/src/agents/landesverbandHubs.ts
@@ -1,4 +1,4 @@
-import { type NotebookId } from '../notebooks/index.js';
+import { type NotebookId, isNotebookEnabled } from '../notebooks/index.js';
 
 import { type SystemAgentId } from './system.js';
 import { type AgentAudience } from './types.js';
@@ -129,7 +129,7 @@ export function getLandesverbandHubBySlug(slug: string): (typeof LV_HUBS)[number
  * for German users) — so unlike agents, a hub never has an `'all'` audience.
  */
 export function getLandesverbandHubs(userLocale: string): readonly (typeof LV_HUBS)[number][] {
-  return LV_HUBS.filter((hub) => hub.audience === userLocale);
+  return LV_HUBS.filter((hub) => hub.audience === userLocale && isNotebookEnabled(hub.notebookId));
 }
 
 /**

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -1,4 +1,7 @@
+import { getDisabledNotebookIds } from '../notebooks/index.js';
+
 import { CORE_AGENTS } from './coreAgents.js';
+import { LV_HUBS } from './landesverbandHubs.js';
 import { LV_BUERGER_AGENTS, type LV_BUERGER_SPECS } from './lvBuergerAgents.js';
 import { LV_PR_AGENTS, type LV_PR_SPECS } from './lvPrAgents.js';
 import { OEFFENTLICHKEITSARBEIT_AGENTS } from './oeffentlichkeitsarbeitAgents.js';
@@ -13,13 +16,31 @@ import type { Agent } from './types.js';
 //   lvPrAgents.ts                   — generated per-LV "Öffentlichkeitsarbeit" agents
 //   lvBuergerAgents.ts              — generated per-LV "Bürger*innenanfragen" agents
 // This file only assembles them into the registry and resolves identifiers.
-export const SYSTEM_AGENTS: readonly Agent[] = [
+const RAW_SYSTEM_AGENTS: readonly Agent[] = [
   ...CORE_AGENTS,
   ...OEFFENTLICHKEITSARBEIT_AGENTS,
   ...PERSONA_AGENTS,
   ...LV_PR_AGENTS,
   ...LV_BUERGER_AGENTS,
 ];
+
+// A Landesverband's two specialist agents (PR + Bürger*innenanfragen) are owned by
+// its hub, which pins the LV notebook. When that notebook is turned off
+// (`enabled: false`), hide both agents from discovery — same single switch, no
+// per-agent flag. LV_HUBS is the authoritative notebook→agents map; the
+// hand-written PR agents carry no `defaultNotebookId`, so we can't derive from that.
+const disabledLvAgentIds = new Set<string>(
+  LV_HUBS.filter((hub) => getDisabledNotebookIds().has(hub.notebookId)).flatMap((hub) => [
+    hub.prAgentId,
+    hub.buergerAgentId,
+  ])
+);
+
+// Identifiers stay live (legacy threads + backend fallbacks keep resolving via
+// `getSystemAgent`); only `hiddenFromInventory` flips so no UI surface offers them.
+export const SYSTEM_AGENTS: readonly Agent[] = RAW_SYSTEM_AGENTS.map((agent) =>
+  disabledLvAgentIds.has(agent.identifier) ? { ...agent, hiddenFromInventory: true } : agent
+);
 
 /** SYSTEM_AGENTS minus those marked `hiddenFromInventory` — shared between
  *  every agent-inventory render (sidebar modal, /agents page). */

--- a/packages/shared/src/notebooks/index.ts
+++ b/packages/shared/src/notebooks/index.ts
@@ -171,6 +171,11 @@ export const NOTEBOOK_REGISTRY = [
     order: 4,
     category: 'landesebene',
     audience: 'de-DE',
+    // LV Hamburg decided against keeping their notebook. Turned off here (the
+    // single switch): hidden from galleries, chat picker, hub and agents, and
+    // skipped by scheduled scraping — while the data stays intact and links stay
+    // routable. To re-enable, delete this one line.
+    enabled: false,
     defaultAgent: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
     mention: {
       alias: 'hamburg',
@@ -392,6 +397,25 @@ const isEnabled = (nb: NotebookDefinition): boolean => nb.enabled !== false;
 
 export const getNotebookDefinition = (id: string): NotebookDefinition | undefined =>
   NOTEBOOK_REGISTRY.find((nb) => nb.id === id);
+
+/**
+ * Whether a notebook is enabled, by id. Unknown ids are treated as enabled so
+ * non-registry notebooks (user notebooks, agent-only collections) aren't
+ * accidentally gated. The single switch for a Landesverband is `enabled: false`
+ * on its registry entry — every discovery surface derives its gating from here.
+ */
+export const isNotebookEnabled = (id: string): boolean => {
+  const nb = getNotebookDefinition(id);
+  return nb ? isEnabled(nb) : true;
+};
+
+/**
+ * Ids of notebooks explicitly disabled via `enabled: false`. The single cascade
+ * source: backend chat routing, the chat mention picker, LV hub discovery, the
+ * agent inventory, and scheduled scraping all derive their gating from this set.
+ */
+export const getDisabledNotebookIds = (): ReadonlySet<string> =>
+  new Set(NOTEBOOK_REGISTRY.filter((nb) => nb.enabled === false).map((nb) => nb.id));
 
 /**
  * Enabled notebooks, sorted by `order`. `devOnly` notebooks are excluded unless


### PR DESCRIPTION
## Why

LV Hamburg decided against keeping their notebook. We want to **turn it off but keep all data as backup** (Qdrant `landesverbaende_documents` rows tagged `landesverband: 'HH'`, plus Postgres). Rather than a one-off Hamburg hack, this introduces a **reusable on/off switch** so any Landesverband can be toggled later.

## The switch

A notebook's existing `enabled?: boolean` flag in `packages/shared/src/notebooks/index.ts` becomes the **single source of truth**. Setting `enabled: false` now cascades to every discovery surface **and** scheduled scraping — while data, routes, and historical `@`/`/` mentions stay intact. Re-enabling is deleting one line.

This also closes pre-existing gaps where Schleswig-Holstein (already `enabled: false`) still appeared in the chat `@`-mention picker.

## What derives from it now

| Surface | Before | After |
|---|---|---|
| Web/mobile gallery | already derived | unchanged |
| Backend chat routing (`DISABLED_NOTEBOOK_IDS`) | hardcoded, manually mirrored | derived from registry |
| `@`-mention notebook picker | showed disabled notebooks | hides them (old tokens still resolve) |
| LV hub discovery (`getLandesverbandHubs`) | always listed | skips disabled LVs |
| LV specialist agents (PR + Bürger\*innen) | always visible | auto-hidden from inventory |
| `presse-/insta-<lv>` skills | always in picker | drop when their agent is hidden |
| Scheduled scraping (`scrapeAllSources`) | needed a manual `dormant` flag | skips a disabled LV's sources |

Manual `scrapeSource(id)` still works, so disabled-LV data can be re-scraped on demand.

## This PR also flips Hamburg off

`hamburg-notebook` gets `enabled: false`. The `gruene-hamburg` hub, both Hamburg agents, `@hamburg`, and `presse-/insta-hamburg` disappear from discovery; scheduled sync skips `hamburg-lv-presse` + `hamburg-lv-beschluesse`. Deep links to `/notebooks/hamburg` and `/agents/gruene-hamburg` still resolve (data preserved).

## Verification

- `pnpm typecheck` ✅ (watched the `system.ts ↔ landesverbandHubs.ts` import — back-edge is type-only, so no runtime cycle)
- `pnpm lint` ✅ for all changed packages (the only failure is pre-existing in `apps/mobile`, untouched here)
- Prettier clean
- Re-enable smoke test: removing the one `enabled: false` line restores every surface with no other edit.