### PR TITLE
fix(agents): pin LV Öffentlichkeitsarbeit agents to their notebooks

### DIFF
--- a/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
+++ b/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
@@ -109,6 +109,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['BE', 'BE-F'] },
+    defaultNotebookId: 'berlin-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
@@ -150,6 +151,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: 'HH' },
+    defaultNotebookId: 'hamburg-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
@@ -191,6 +193,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['MV', 'MV-F'] },
+    defaultNotebookId: 'mecklenburg-vorpommern-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
@@ -232,6 +235,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['TH', 'TH-F'] },
+    defaultNotebookId: 'thueringen-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
@@ -273,6 +277,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: 'BB' },
+    defaultNotebookId: 'brandenburg-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-bayern',
@@ -314,6 +319,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['BY', 'BY-F'] },
+    defaultNotebookId: 'bayern-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-sachsen-anhalt',
@@ -355,6 +361,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['LSA', 'LSA-F'] },
+    defaultNotebookId: 'sachsen-anhalt-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hessen',
@@ -396,6 +403,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['HE', 'HE-F'] },
+    defaultNotebookId: 'hessen-notebook',
   },
   // ─── Dedicated Öffentlichkeitsarbeit-Agent für Österreich ───
   // Spiegelbild zu den hand-getunten DE-LV-Agents. Verwendet gruene.at-Stil,


### PR DESCRIPTION
## Problem

Each Landesverband should show **two** agents on its notebook page (e.g. `/notebooks/berlin`): *Öffentlichkeitsarbeit* and *Bürger\*innenanfragen*. But only **Bürgeranfragen** appeared.

## Root cause

The notebook page filters system agents by `defaultNotebookId === notebookId`:

```ts
// apps/web/src/features/notebook/components/NotebookAgentsSection.tsx
getSystemAgentsForLocale(locale).filter((a) => a.defaultNotebookId === notebookId)
```

- The auto-generated **Bürger\*innenanfragen** agents set `defaultNotebookId` via their `LV_BUERGER_SPECS` (`lvBuergerAgents.ts`) → they match → shown.
- The 8 **hand-tuned Öffentlichkeitsarbeit** agents in `oeffentlichkeitsarbeitAgents.ts` only had `defaultFilter` and **no `defaultNotebookId`** → never matched → hidden.

Only Austria (and the auto-generated Schleswig-Holstein PR agent via `lvPrAgents.ts`) had it set, which is why they weren't affected.

## Fix

Add `defaultNotebookId` to each of the 8 hand-tuned agents, matching the notebook IDs already used by the Bürger specs:

| LV | notebook |
|---|---|
| Berlin | `berlin-notebook` |
| Hamburg | `hamburg-notebook` |
| Mecklenburg-Vorpommern | `mecklenburg-vorpommern-notebook` |
| Thüringen | `thueringen-notebook` |
| Brandenburg | `brandenburg-notebook` |
| Bayern | `bayern-notebook` |
| Sachsen-Anhalt | `sachsen-anhalt-notebook` |
| Hessen | `hessen-notebook` |

## Verification

- All 8 IDs cross-checked against `LV_BUERGER_SPECS` (identical).
- `pnpm --filter @gruenerator/shared typecheck` passes.

One file changed, 8 insertions.