### PR TITLE
fix(mobile): ignore Expo config plugins in eslint to fix CI

### DIFF
--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -22,6 +22,6 @@ export default [
     },
   },
   {
-    ignores: ['.expo/**', 'android/**', 'ios/**', 'metro.config.js', 'shims/**'],
+    ignores: ['.expo/**', 'android/**', 'ios/**', 'metro.config.js', 'shims/**', 'plugins/**'],
   },
 ];


### PR DESCRIPTION
## Summary
Master's CI is currently **red** on every push: the mobile `eslint` step fails with 3 parsing errors because the Expo config plugins in `apps/mobile/plugins/*.js` (added in the reel commit) aren't covered by any tsconfig, so the typed linter can't resolve them:

```
error  Parsing error: apps/mobile/plugins/withLargeHeap.js was not found by the project service
error  Parsing error: apps/mobile/plugins/withMediaCapabilities.js ...
error  Parsing error: apps/mobile/plugins/withNoSourcemapAssets.js ...
```

These are CommonJS build-time config plugins, like `metro.config.js` and `shims/**` which are already ignored. This adds `plugins/**` to the mobile eslint `ignores`.

## Test plan
- [ ] CI Quality Checks green (mobile lint now 0 errors)