### PR TITLE
feat(agents): route LV Öffentlichkeitsarbeit agents to their notebook

### DIFF
--- a/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
+++ b/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
@@ -109,6 +109,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['BE', 'BE-F'] },
+    defaultNotebookId: 'berlin-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
@@ -150,6 +151,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: 'HH' },
+    defaultNotebookId: 'hamburg-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
@@ -191,6 +193,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['MV', 'MV-F'] },
+    defaultNotebookId: 'mecklenburg-vorpommern-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
@@ -232,6 +235,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['TH', 'TH-F'] },
+    defaultNotebookId: 'thueringen-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
@@ -273,6 +277,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: 'BB' },
+    defaultNotebookId: 'brandenburg-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-bayern',
@@ -314,6 +319,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['BY', 'BY-F'] },
+    defaultNotebookId: 'bayern-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-sachsen-anhalt',
@@ -355,6 +361,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['LSA', 'LSA-F'] },
+    defaultNotebookId: 'sachsen-anhalt-notebook',
   },
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit-hessen',
@@ -396,6 +403,7 @@ export const OEFFENTLICHKEITSARBEIT_AGENTS = [
       'self_review',
     ],
     defaultFilter: { landesverband: ['HE', 'HE-F'] },
+    defaultNotebookId: 'hessen-notebook',
   },
   // ─── Dedicated Öffentlichkeitsarbeit-Agent für Österreich ───
   // Spiegelbild zu den hand-getunten DE-LV-Agents. Verwendet gruene.at-Stil,


### PR DESCRIPTION
## Summary
Sets `defaultNotebookId` on the 8 German Landesverband Öffentlichkeitsarbeit agents so their chats land in the right LV notebook instead of falling back to the generic default:

- Berlin → `berlin-notebook`
- Hamburg → `hamburg-notebook`
- Mecklenburg-Vorpommern → `mecklenburg-vorpommern-notebook`
- Thüringen → `thueringen-notebook`
- Brandenburg → `brandenburg-notebook`
- Bayern → `bayern-notebook`
- Sachsen-Anhalt → `sachsen-anhalt-notebook`
- Hessen → `hessen-notebook`

All referenced notebook IDs exist in `packages/shared/src/notebooks/index.ts`.

## Test plan
- [ ] typecheck passes