### PR TITLE
docs(newsletter): add June 2026 issue on building your own agent

### DIFF
--- a/documentation/docs/newsletter/2025-03-gruugo.md
+++ b/documentation/docs/newsletter/2025-03-gruugo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: 'März 2025: Kennst du schon Gruugo?'
 ---
 

--- a/documentation/docs/newsletter/2025-05-testlabor.md
+++ b/documentation/docs/newsletter/2025-05-testlabor.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: 'Mai 2025: Komm ins Testlabor!'
 ---
 

--- a/documentation/docs/newsletter/2025-10-reimagined.md
+++ b/documentation/docs/newsletter/2025-10-reimagined.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: 'Oktober 2025: Grünerator Reimagined'
 ---
 

--- a/documentation/docs/newsletter/2025-12-weihnachtszeit.md
+++ b/documentation/docs/newsletter/2025-12-weihnachtszeit.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: 'Dezember 2025: Grünerator zur Weihnachtszeit'
 ---
 

--- a/documentation/docs/newsletter/2026-01-jahr-der-daten.md
+++ b/documentation/docs/newsletter/2026-01-jahr-der-daten.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: 'Januar 2026: Jahr der Daten'
 ---
 

--- a/documentation/docs/newsletter/2026-03-ki-chat-launch.md
+++ b/documentation/docs/newsletter/2026-03-ki-chat-launch.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: 'März 2026: Grünerator Chat'
 ---
 

--- a/documentation/docs/newsletter/2026-04-work-update.md
+++ b/documentation/docs/newsletter/2026-04-work-update.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 title: 'April 2026: Das große Work-Update'
 ---
 

--- a/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
+++ b/documentation/docs/newsletter/2026-05-erstelle-dein-notebook.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 0
+sidebar_position: 1
 title: 'Mai 2026: Das Notebook-Update'
 ---
 

--- a/documentation/docs/newsletter/2026-06-baue-deinen-agenten.md
+++ b/documentation/docs/newsletter/2026-06-baue-deinen-agenten.md
@@ -1,0 +1,80 @@
+---
+sidebar_position: 0
+title: 'Juni 2026: Bau dir deinen eigenen Agenten'
+---
+
+# Bau dir deinen eigenen Agenten
+
+_Newsletter Juni 2026_
+
+---
+
+Hallo {{ contact.VORNAME | default : " " }},
+
+im Mai hast du die ersten Spezialist\*innen im Chat kennengelernt – den Öffentlichkeitsarbeit-Agenten, den Kommunalpolitik-Assistenten. Die Idee dahinter war immer größer, als sie damals aussah. Heute löse ich das Versprechen ein:
+
+Ab sofort kannst du **deine eigenen Agent\*innen bauen**. Keine Vorkenntnisse, kein Code, kein Promptengineering-Studium. Du beschreibst in einem Satz, was dein Agent können soll – den Rest macht der Grünerator.
+
+## Was ist ein Agent überhaupt?
+
+Ein Agent ist ein auf eine Aufgabe spezialisierter Grünerator. Statt jedes Mal neu zu erklären, in welchem Ton, mit welchem Wissen und mit welchen Werkzeugen die KI arbeiten soll, packst du das einmal in einen Agenten – und rufst ihn danach mit einem Klick auf.
+
+Ein paar Beispiele, was möglich ist:
+
+- Ein **Pressestellen-Agent** für deinen Kreisverband, der in eurem Ton schreibt.
+- Ein **Antrags-Agent**, der die Formvorgaben deiner Fraktion schon kennt.
+- Ein **Bürger\*innenanfragen-Agent**, der auf ein bestimmtes Notebook zugreift und nur aus euren echten Beschlüssen antwortet.
+
+## Wie baue ich einen?
+
+Am einfachsten im Gespräch. Du gehst auf [Zu den Agent\*innen](https://gruenerator.eu/agents), klickst auf **„Neue\*r Agent\*in"** und erzählst dem Grünerator einfach, was du brauchst. Daraus entsteht ein fertiger Entwurf, den du direkt nutzen oder im geführten Baukasten weiter anpassen kannst – Persönlichkeit, Region, Werkzeuge und ein eigenes Wissens-Notebook inklusive.
+
+Das Beste: Du kannst deine Agent\*innen an **deine eigenen Notebooks** binden. So antwortet dein Agent ausschließlich aus den Quellen, die du ihm gibst – nachprüfbar, mit Zitaten.
+
+:::tip Auch deine eigenen Quellen
+Beim Bauen kannst du unter „Wissen" nicht nur die Grünerator-Notebooks, sondern auch **deine eigenen** auswählen. Lege dir vorher unter „Notebooks" eines an, lade eure Dokumente hoch – und dein Agent kennt euren Verband.
+:::
+
+Das Feature ist neu, und ich konnte noch nicht jede Kombination aus Werkzeugen, Notebooks und Sichtbarkeit durchtesten. Wenn etwas hakt: schreib mir.
+
+## Willkommen in der Agentura
+
+Damit man die wachsende Zahl an Agent\*innen und Skills auch findet, habe ich die alte „Skills & Agents"-Seite komplett neu gebaut – als kleinen Marktplatz: die **Agentura**.
+
+Du findest dort eine empfohlene Auswahl, kannst nach Region und Typ filtern, suchen und sortieren. Jede\*r Agent\*in und jeder Skill hat jetzt eine eigene Detailseite mit Beispielen, Fähigkeiten und einem „Im Chat öffnen"-Knopf. Schau einfach mal rein: [Zur Agentura](https://gruenerator.eu/agentura).
+
+## Boards können jetzt mitdenken
+
+Im April habe ich die **Grünerator Boards** (unser grünes Trello) gestartet. Seitdem ist viel passiert – vor allem werden sie jetzt richtig schlau.
+
+- **KI-Assistent direkt im Board:** Unten rechts findest du einen Knopf, über den du dem Board Anweisungen geben kannst. „Erstelle drei Karten für die Pressearbeit nächste Woche", „Was ist überfällig?", „Fass mir das Board zusammen" – die KI plant und setzt es direkt um, live und für alle Mitarbeitenden sichtbar.
+- **Aufgaben an den Grünerator delegieren:** Schreibe in einem Kommentar auf einer Karte `@gruenerator <Aufgabe>` – etwa „@gruenerator recherchiere die aktuelle Beschlusslage zu Tempo 30". Der Grünerator übernimmt die Aufgabe im Hintergrund, legt ein fertiges Dokument an, verknüpft es mit der Karte und benachrichtigt dich, sobald er fertig ist. Du musst dafür nicht mal im Board bleiben.
+- **Grünerator-Spalten („Mini-n8n"):** Für alle, die gerne automatisieren: Eine neue Spaltenart, die einen kleinen Ablauf abbildet. **Quelle** (Karteninhalt, eine Website oder Social Media) → **KI-Schritt** (Recherche, Tiefenrecherche, Dokumentensuche oder eine eigene Anweisung) → **Ergebnis** (Kommentar, Dokument oder E-Mail). Karten lassen sich so per Klick durch einen festen Arbeitsablauf schicken.
+
+Dazu kamen viele kleinere, lang gewünschte Dinge: mehrere Zuständige pro Karte, Checklisten, Datei-Anhänge, Aktivitätsverläufe, wiederkehrende Karten, Board-Vorlagen, Volltextsuche und WIP-Limits. Boards arbeiten weiterhin kollaborativ – diese Features sind genau die, die in der gemeinsamen Arbeit am schwersten zu testen sind. Auch hier: dein Feedback hilft enorm.
+
+## Vorlagen und Canva
+
+Viele von euch arbeiten mit Canva. Deshalb kann der Grünerator jetzt direkt mit eurem **Canva**-Konto sprechen – ihr könnt Vorlagen verbinden und nutzen, ohne ständig Dateien hin- und herzuschieben.
+
+Außerdem gibt es eine überarbeitete **Vorlagen**-Sammlung: Du kannst eigene Vorlagen hochladen und verwalten, sie auf Wunsch öffentlich teilen, andere als Favorit markieren und Community-Vorlagen mit Urheber\*innen-Angabe entdecken.
+
+## Neue Landesverbände, neue Daten
+
+Das **Jahr der Daten** geht weiter. Neu mit eigenem Notebook und eigenen, handgetunten Agent\*innen sind diesen Monat **Hessen**, **Sachsen-Anhalt** und **Bayern** dazugekommen. Damit wächst die Datenbank stetig weiter – gespeist aus öffentlichen Beschlüssen und Pressemitteilungen, automatisch aktuell gehalten.
+
+Wenn das für deinen Landesverband (in Österreich der Bundesverband) interessant ist: melde dich gern. So bleibt das Feature für uns als Basis dauerhaft kostenfrei.
+
+## Jetzt brauche ich deine Hilfe
+
+Der rote Faden hinter all dem: Die Werkzeuge gehören in die Hände der Basis, nicht nur einiger weniger. Wer einen Agenten bauen kann, ist nicht mehr darauf angewiesen, dass jemand anderes das passende Tool baut. Genau das ist mir wichtig.
+
+Der Grünerator befindet sich gerade in besonders aktiver Entwicklung, es können also vermehrt Fehler auftreten. Probier die neuen Agent\*innen aus, bau dir einen eigenen, und schreib mir, was funktioniert und was nicht. Jede Rückmeldung zählt.
+
+---
+
+Bei Fragen oder Problemen, insbesondere beim Login, wende dich gerne jederzeit an den Support-Chat (Deutschland) oder an das Helpdesk (Österreich). Du kannst diesen Newsletter gerne weiterleiten, etwa in deinem Orts- oder Kreisverband. Interessierte können sich jederzeit unter [fax.gruenerator.de](https://fax.gruenerator.de) anmelden.
+
+Viel Spaß beim Grünerieren!
+
+_Moritz_


### PR DESCRIPTION
## Summary
Adds the June 2026 newsletter `2026-06-baue-deinen-agenten.md` at `sidebar_position: 0` and bumps the 8 existing newsletters down one slot to keep reverse-chronological order.

## Test plan
- [ ] docs build renders the new entry at the top