### PR TITLE
fix(agents): pin all LV agents to their notebooks via a single registry

### DIFF
--- a/packages/chat/src/lib/landesverbandAgents.vitest.ts
+++ b/packages/chat/src/lib/landesverbandAgents.vitest.ts
@@ -1,0 +1,40 @@
+import { LANDESVERBAENDE, LV_HUBS, getSystemAgent } from '@gruenerator/shared/agents';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the LV registry ↔ agents contract from the consumer side (chat already
+ * runs vitest; @gruenerator/shared does not). The notebook page lists an agent
+ * only when `agent.defaultNotebookId === notebookId` — so a hub agent that loses
+ * its notebook pin silently vanishes from its Landesverband notebook. That is
+ * exactly the bug that hid the hand-tuned Öffentlichkeitsarbeit agents for 8 LVs.
+ * These assertions fail the build the moment the pin is dropped again.
+ */
+describe('LV registry agents stay pinned to their notebook', () => {
+  for (const lv of LANDESVERBAENDE) {
+    describe(lv.title, () => {
+      it(`PR agent (${lv.prAgentId}) resolves and pins ${lv.notebookId}`, () => {
+        const agent = getSystemAgent(lv.prAgentId);
+        expect(agent, `PR agent ${lv.prAgentId} must resolve`).toBeDefined();
+        expect(agent?.defaultNotebookId).toBe(lv.notebookId);
+      });
+
+      it(`Bürger agent (${lv.buergerAgentId}) resolves and pins ${lv.notebookId}`, () => {
+        const agent = getSystemAgent(lv.buergerAgentId);
+        expect(agent, `Bürger agent ${lv.buergerAgentId} must resolve`).toBeDefined();
+        expect(agent?.defaultNotebookId).toBe(lv.notebookId);
+      });
+    });
+  }
+});
+
+describe('every hub derives from its registry entry', () => {
+  for (const hub of LV_HUBS) {
+    it(`${hub.name} hub matches its registry entry`, () => {
+      const lv = LANDESVERBAENDE.find((entry) => entry.id === hub.lvId);
+      expect(lv, `hub ${hub.slug} must have a registry entry`).toBeDefined();
+      expect(hub.notebookId).toBe(lv?.notebookId);
+      expect(hub.prAgentId).toBe(lv?.prAgentId);
+      expect(hub.buergerAgentId).toBe(lv?.buergerAgentId);
+    });
+  }
+});

--- a/packages/shared/src/agents/index.ts
+++ b/packages/shared/src/agents/index.ts
@@ -40,6 +40,8 @@ export {
 
 export { getAgentSlug, resolveAgentSlug } from './slug.js';
 
+export { LANDESVERBAENDE, type LandesverbandEntry } from './landesverbaende.js';
+
 export {
   LV_HUBS,
   type LvHub,

--- a/packages/shared/src/agents/landesverbaende.ts
+++ b/packages/shared/src/agents/landesverbaende.ts
@@ -1,0 +1,182 @@
+import { type NotebookId } from '../notebooks/index.js';
+
+/**
+ * Canonical registry of every Landesverband (plus Österreich). This is the
+ * SINGLE SOURCE OF TRUTH for the LV↔notebook↔agents relationship — the hub
+ * (`landesverbandHubs.ts`), the generated Bürger*innenanfragen agents
+ * (`lvBuergerAgents.ts`) and the notebook pin on the hand-tuned PR agents
+ * (`oeffentlichkeitsarbeitAgents.ts`) all DERIVE from it.
+ *
+ * Why this exists: each LV's two specialist agents must appear on the LV
+ * notebook page, which lists an agent only when `defaultNotebookId === notebookId`
+ * (`NotebookAgentsSection`). The Bürger agents always derived that pin from their
+ * spec, but the hand-tuned PR agents typed it by hand — and 8 of them silently
+ * omitted it, so only the Bürger agent showed. Deriving every pin from this one
+ * table makes that omission impossible.
+ */
+export interface LandesverbandEntry {
+  /** Internal LV id (matches the agent-spec `lv` key, e.g. `mecklenburg-vorpommern`). */
+  id: string;
+  /** Display name used in agent titles/prompts, e.g. `Berlin`. */
+  title: string;
+  /** `landesverband` metadata code(s) for `defaultFilter` / example scoping. */
+  codes: string | readonly string[];
+  /** The LV notebook both specialist agents pin (and the hub's icon source). */
+  notebookId: NotebookId;
+  /** Public homepage, surfaced in the Bürger agent's answer template. */
+  homepage: string;
+  /** Comma-separated regional themes baked into both agents' prompts. */
+  themes: string;
+  /** User-locale audience — `de-AT` for Österreich, otherwise `de-DE`. */
+  audience: 'de-DE' | 'de-AT';
+  /** Identifier of the Öffentlichkeitsarbeit agent (Österreich uses `-at`). */
+  prAgentId: string;
+  /** Identifier of the Bürger*innenanfragen agent. */
+  buergerAgentId: string;
+  /**
+   * Branded hub: `/agents/<slug>` opens a landing offering both agents. Absent
+   * when the LV has no hub yet (e.g. Schleswig-Holstein, notebook disabled).
+   * `slug` is intentionally decoupled from `id` (MV's id is
+   * `mecklenburg-vorpommern` but its shared link is `gruene-mv`).
+   */
+  hub?: { slug: string; name: string };
+}
+
+export const LANDESVERBAENDE = [
+  {
+    id: 'berlin',
+    title: 'Berlin',
+    codes: ['BE', 'BE-F'],
+    notebookId: 'berlin-notebook',
+    homepage: 'https://gruene.berlin',
+    themes:
+      'Mieten und bezahlbares Wohnen, Verkehrswende und BVG, lebenswerte Kieze, Kultur und Clubkultur, soziale Gerechtigkeit',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-berlin',
+    buergerAgentId: 'gruenerator-buergeranfragen-berlin',
+    hub: { slug: 'gruene-berlin', name: 'Grüne Berlin' },
+  },
+  {
+    id: 'hamburg',
+    title: 'Hamburg',
+    codes: 'HH',
+    notebookId: 'hamburg-notebook',
+    homepage: 'https://www.gruene-hamburg.de',
+    themes:
+      'Hafen und maritime Wirtschaft, Verkehrswende und ÖPNV (U5), Wohnen, Klimaschutz, hanseatischer Weg',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
+    buergerAgentId: 'gruenerator-buergeranfragen-hamburg',
+    hub: { slug: 'gruene-hamburg', name: 'Grüne Hamburg' },
+  },
+  {
+    id: 'mecklenburg-vorpommern',
+    title: 'Mecklenburg-Vorpommern',
+    codes: ['MV', 'MV-F'],
+    notebookId: 'mecklenburg-vorpommern-notebook',
+    homepage: 'https://gruene-mv.de',
+    themes:
+      'Energiewende und Offshore-Windkraft als Wirtschaftsfaktor, Ostsee- und Küstenschutz, ländlicher Raum, Tourismus',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
+    buergerAgentId: 'gruenerator-buergeranfragen-mecklenburg-vorpommern',
+    hub: { slug: 'gruene-mv', name: 'Grüne Mecklenburg-Vorpommern' },
+  },
+  {
+    id: 'thueringen',
+    title: 'Thüringen',
+    codes: ['TH', 'TH-F'],
+    notebookId: 'thueringen-notebook',
+    homepage: 'https://gruene-thueringen.de',
+    themes:
+      'Energiewende und Reparaturbonus, Demokratie und Schutz vor Rechtsextremismus, ländlicher Raum, Bildung',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
+    buergerAgentId: 'gruenerator-buergeranfragen-thueringen',
+    hub: { slug: 'gruene-thueringen', name: 'Grüne Thüringen' },
+  },
+  {
+    id: 'brandenburg',
+    title: 'Brandenburg',
+    codes: 'BB',
+    notebookId: 'brandenburg-notebook',
+    homepage: 'https://gruene-brandenburg.de',
+    themes:
+      'Strukturwandel in der Lausitz (Just Transition Fund), Kita und Bildung, Demokratiearbeit gegen rechte Gewalt, Mobilität (RE3)',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
+    buergerAgentId: 'gruenerator-buergeranfragen-brandenburg',
+    hub: { slug: 'gruene-brandenburg', name: 'Grüne Brandenburg' },
+  },
+  {
+    id: 'bayern',
+    title: 'Bayern',
+    codes: ['BY', 'BY-F'],
+    notebookId: 'bayern-notebook',
+    homepage: 'https://www.gruene-bayern.de',
+    themes:
+      'Erneuerbare als „Freiheitsenergie" und Wirtschaftsfaktor, Verkehrswende im ländlichen Raum, Alpen- und Naturschutz, bezahlbares Wohnen',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-bayern',
+    buergerAgentId: 'gruenerator-buergeranfragen-bayern',
+    hub: { slug: 'gruene-bayern', name: 'Grüne Bayern' },
+  },
+  {
+    id: 'sachsen-anhalt',
+    title: 'Sachsen-Anhalt',
+    codes: ['LSA', 'LSA-F'],
+    notebookId: 'sachsen-anhalt-notebook',
+    homepage: 'https://www.gruene-lsa.de',
+    themes:
+      'Energiewende und Wasserstoff (Mitteldeutsches Revier), Strukturwandel und gute Arbeit, Bildung und Kita, ländlicher Raum und Mobilität, Demokratie und Schutz vor Rechtsextremismus',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-sachsen-anhalt',
+    buergerAgentId: 'gruenerator-buergeranfragen-sachsen-anhalt',
+    hub: { slug: 'gruene-sachsen-anhalt', name: 'Grüne Sachsen-Anhalt' },
+  },
+  {
+    id: 'hessen',
+    title: 'Hessen',
+    codes: ['HE', 'HE-F'],
+    notebookId: 'hessen-notebook',
+    homepage: 'https://www.gruene-hessen.de',
+    themes:
+      'Verkehrswende und RMV im Rhein-Main-Gebiet, Energiewende und Naturschutz (Wald, Wasser), bezahlbares Wohnen in Frankfurt und den Ballungsräumen, Bildung und Kita, Demokratie und Schutz vor Rechtsextremismus',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-hessen',
+    buergerAgentId: 'gruenerator-buergeranfragen-hessen',
+    hub: { slug: 'gruene-hessen', name: 'Grüne Hessen' },
+  },
+  {
+    id: 'schleswig-holstein',
+    title: 'Schleswig-Holstein',
+    codes: 'SH',
+    notebookId: 'schleswig-holstein-notebook',
+    homepage: 'https://sh-gruene.de',
+    themes:
+      'Energiewende (Windkraft, Wasserstoff), Küstenschutz, Tourismus, Landwirtschaft, dänische Minderheit',
+    audience: 'de-DE',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-schleswig-holstein',
+    buergerAgentId: 'gruenerator-buergeranfragen-schleswig-holstein',
+    // No hub: the SH notebook is currently disabled in the frontend.
+  },
+  {
+    id: 'oesterreich',
+    title: 'Österreich',
+    codes: 'AT',
+    notebookId: 'oesterreich-notebook',
+    homepage: 'https://gruene.at',
+    themes:
+      'Klimakrise und Energiewende, leistbares Wohnen, Klimaticket und Öffis (ÖBB), Anti-Korruption und Transparenz',
+    audience: 'de-AT',
+    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-at',
+    buergerAgentId: 'gruenerator-buergeranfragen-oesterreich',
+    hub: { slug: 'gruene-oesterreich', name: 'Grüne Österreich' },
+  },
+] as const satisfies readonly LandesverbandEntry[];
+
+/** notebookId for a given PR agent id — drives the derived `defaultNotebookId`
+ *  pin on the hand-tuned Öffentlichkeitsarbeit agents. */
+export const LV_NOTEBOOK_BY_PR_AGENT_ID: ReadonlyMap<string, NotebookId> = new Map(
+  LANDESVERBAENDE.map((lv) => [lv.prAgentId, lv.notebookId])
+);

--- a/packages/shared/src/agents/landesverbandHubs.ts
+++ b/packages/shared/src/agents/landesverbandHubs.ts
@@ -1,5 +1,6 @@
 import { type NotebookId, isNotebookEnabled } from '../notebooks/index.js';
 
+import { LANDESVERBAENDE } from './landesverbaende.js';
 import { type SystemAgentId } from './system.js';
 import { type AgentAudience } from './types.js';
 
@@ -32,94 +33,33 @@ export interface LvHub {
   audience: AgentAudience;
 }
 
-export const LV_HUBS = [
-  {
-    lvId: 'berlin',
-    slug: 'gruene-berlin',
-    name: 'Grüne Berlin',
-    notebookId: 'berlin-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-berlin',
-    buergerAgentId: 'gruenerator-buergeranfragen-berlin',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'hamburg',
-    slug: 'gruene-hamburg',
-    name: 'Grüne Hamburg',
-    notebookId: 'hamburg-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-hamburg',
-    buergerAgentId: 'gruenerator-buergeranfragen-hamburg',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'mecklenburg-vorpommern',
-    slug: 'gruene-mv',
-    name: 'Grüne Mecklenburg-Vorpommern',
-    notebookId: 'mecklenburg-vorpommern-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-mecklenburg-vorpommern',
-    buergerAgentId: 'gruenerator-buergeranfragen-mecklenburg-vorpommern',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'thueringen',
-    slug: 'gruene-thueringen',
-    name: 'Grüne Thüringen',
-    notebookId: 'thueringen-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-thueringen',
-    buergerAgentId: 'gruenerator-buergeranfragen-thueringen',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'brandenburg',
-    slug: 'gruene-brandenburg',
-    name: 'Grüne Brandenburg',
-    notebookId: 'brandenburg-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-brandenburg',
-    buergerAgentId: 'gruenerator-buergeranfragen-brandenburg',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'bayern',
-    slug: 'gruene-bayern',
-    name: 'Grüne Bayern',
-    notebookId: 'bayern-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-bayern',
-    buergerAgentId: 'gruenerator-buergeranfragen-bayern',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'sachsen-anhalt',
-    slug: 'gruene-sachsen-anhalt',
-    name: 'Grüne Sachsen-Anhalt',
-    notebookId: 'sachsen-anhalt-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-sachsen-anhalt',
-    buergerAgentId: 'gruenerator-buergeranfragen-sachsen-anhalt',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'hessen',
-    slug: 'gruene-hessen',
-    name: 'Grüne Hessen',
-    notebookId: 'hessen-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-hessen',
-    buergerAgentId: 'gruenerator-buergeranfragen-hessen',
-    audience: 'de-DE',
-  },
-  {
-    lvId: 'oesterreich',
-    slug: 'gruene-oesterreich',
-    name: 'Grüne Österreich',
-    notebookId: 'oesterreich-notebook',
-    prAgentId: 'gruenerator-oeffentlichkeitsarbeit-at',
-    buergerAgentId: 'gruenerator-buergeranfragen-oesterreich',
-    audience: 'de-AT',
-  },
-] as const satisfies readonly LvHub[];
+/**
+ * Derived from the LV registry (`landesverbaende.ts`): every Landesverband that
+ * declares a `hub` becomes a hub. notebookId / agent ids / audience all come
+ * from the single registry entry, so a hub can never drift from the agents it
+ * points at. The registry types the agent ids as `string`; they are valid
+ * `SystemAgentId`s by construction, so the cast is the assertion at this boundary.
+ */
+export const LV_HUBS: readonly LvHub[] = LANDESVERBAENDE.flatMap((lv) =>
+  'hub' in lv
+    ? [
+        {
+          lvId: lv.id,
+          slug: lv.hub.slug,
+          name: lv.hub.name,
+          notebookId: lv.notebookId,
+          prAgentId: lv.prAgentId as SystemAgentId,
+          buergerAgentId: lv.buergerAgentId as SystemAgentId,
+          audience: lv.audience,
+        },
+      ]
+    : []
+);
 
-const hubBySlug = new Map<string, (typeof LV_HUBS)[number]>(LV_HUBS.map((hub) => [hub.slug, hub]));
+const hubBySlug = new Map<string, LvHub>(LV_HUBS.map((hub) => [hub.slug, hub]));
 
 /** Resolve a URL slug to its Landesverband hub, or `null` if it isn't one. */
-export function getLandesverbandHubBySlug(slug: string): (typeof LV_HUBS)[number] | null {
+export function getLandesverbandHubBySlug(slug: string): LvHub | null {
   return hubBySlug.get(slug) ?? null;
 }
 
@@ -128,7 +68,7 @@ export function getLandesverbandHubBySlug(slug: string): (typeof LV_HUBS)[number
  * locale-specific (the AT hub surfaces only for Austrian users, the rest only
  * for German users) — so unlike agents, a hub never has an `'all'` audience.
  */
-export function getLandesverbandHubs(userLocale: string): readonly (typeof LV_HUBS)[number][] {
+export function getLandesverbandHubs(userLocale: string): readonly LvHub[] {
   return LV_HUBS.filter((hub) => hub.audience === userLocale && isNotebookEnabled(hub.notebookId));
 }
 

--- a/packages/shared/src/agents/lvBuergerAgents.ts
+++ b/packages/shared/src/agents/lvBuergerAgents.ts
@@ -1,3 +1,5 @@
+import { LANDESVERBAENDE } from './landesverbaende.js';
+
 import type { Agent } from './types.js';
 
 // ─── Per-LV "Bürger*innenanfragen"-Agents ───
@@ -6,107 +8,20 @@ import type { Agent } from './types.js';
 // Treffer erscheinen als Recherche-Karten im Chat) und formuliert eine
 // versandfertige Antwort-E-Mail (Anrede → Dank → Antwort → weiterführende
 // Links). Wiederverwendet die bestehenden LV-Notebooks via defaultNotebookId.
-export const LV_BUERGER_SPECS = [
-  {
-    lv: 'berlin',
-    title: 'Berlin',
-    codes: ['BE', 'BE-F'],
-    notebook: 'berlin-notebook',
-    homepage: 'https://gruene.berlin',
-    themes:
-      'Mieten und bezahlbares Wohnen, Verkehrswende und BVG, lebenswerte Kieze, Kultur und Clubkultur, soziale Gerechtigkeit',
-  },
-  {
-    lv: 'hamburg',
-    title: 'Hamburg',
-    codes: 'HH',
-    notebook: 'hamburg-notebook',
-    homepage: 'https://www.gruene-hamburg.de',
-    themes:
-      'Hafen und maritime Wirtschaft, Verkehrswende und ÖPNV (U5), Wohnen, Klimaschutz, hanseatischer Weg',
-  },
-  {
-    lv: 'mecklenburg-vorpommern',
-    title: 'Mecklenburg-Vorpommern',
-    codes: ['MV', 'MV-F'],
-    notebook: 'mecklenburg-vorpommern-notebook',
-    homepage: 'https://gruene-mv.de',
-    themes:
-      'Energiewende und Offshore-Windkraft als Wirtschaftsfaktor, Ostsee- und Küstenschutz, ländlicher Raum, Tourismus',
-  },
-  {
-    lv: 'thueringen',
-    title: 'Thüringen',
-    codes: ['TH', 'TH-F'],
-    notebook: 'thueringen-notebook',
-    homepage: 'https://gruene-thueringen.de',
-    themes:
-      'Energiewende und Reparaturbonus, Demokratie und Schutz vor Rechtsextremismus, ländlicher Raum, Bildung',
-  },
-  {
-    lv: 'brandenburg',
-    title: 'Brandenburg',
-    codes: 'BB',
-    notebook: 'brandenburg-notebook',
-    homepage: 'https://gruene-brandenburg.de',
-    themes:
-      'Strukturwandel in der Lausitz (Just Transition Fund), Kita und Bildung, Demokratiearbeit gegen rechte Gewalt, Mobilität (RE3)',
-  },
-  {
-    lv: 'bayern',
-    title: 'Bayern',
-    codes: ['BY', 'BY-F'],
-    notebook: 'bayern-notebook',
-    homepage: 'https://www.gruene-bayern.de',
-    themes:
-      'Erneuerbare als „Freiheitsenergie" und Wirtschaftsfaktor, Verkehrswende im ländlichen Raum, Alpen- und Naturschutz, bezahlbares Wohnen',
-  },
-  {
-    lv: 'sachsen-anhalt',
-    title: 'Sachsen-Anhalt',
-    codes: ['LSA', 'LSA-F'],
-    notebook: 'sachsen-anhalt-notebook',
-    homepage: 'https://www.gruene-lsa.de',
-    themes:
-      'Energiewende und Wasserstoff (Mitteldeutsches Revier), Strukturwandel und gute Arbeit, Bildung und Kita, ländlicher Raum und Mobilität, Demokratie und Schutz vor Rechtsextremismus',
-  },
-  {
-    lv: 'hessen',
-    title: 'Hessen',
-    codes: ['HE', 'HE-F'],
-    notebook: 'hessen-notebook',
-    homepage: 'https://www.gruene-hessen.de',
-    themes:
-      'Verkehrswende und RMV im Rhein-Main-Gebiet, Energiewende und Naturschutz (Wald, Wasser), bezahlbares Wohnen in Frankfurt und den Ballungsräumen, Bildung und Kita, Demokratie und Schutz vor Rechtsextremismus',
-  },
-  {
-    lv: 'schleswig-holstein',
-    title: 'Schleswig-Holstein',
-    codes: 'SH',
-    notebook: 'schleswig-holstein-notebook',
-    homepage: 'https://sh-gruene.de',
-    themes:
-      'Energiewende (Windkraft, Wasserstoff), Küstenschutz, Tourismus, Landwirtschaft, dänische Minderheit',
-  },
-  {
-    lv: 'oesterreich',
-    title: 'Österreich',
-    codes: 'AT',
-    notebook: 'oesterreich-notebook',
-    homepage: 'https://gruene.at',
-    themes:
-      'Klimakrise und Energiewende, leistbares Wohnen, Klimaticket und Öffis (ÖBB), Anti-Korruption und Transparenz',
-    audience: 'de-AT',
-  },
-] as const satisfies ReadonlyArray<{
-  lv: string;
-  title: string;
-  codes: string | readonly string[];
-  notebook: string;
-  homepage: string;
-  themes: string;
-  audience?: 'de-AT';
-}>;
+//
+// Die Specs werden aus der LV-Registry (`landesverbaende.ts`) abgeleitet — der
+// einen Quelle der Wahrheit für notebookId, codes, homepage und themes pro LV.
+// `audience` wird nur für Österreich gesetzt (mirror der früheren Inline-Specs),
+// damit `'audience' in spec` im Builder weiterhin DE von AT unterscheidet.
+export const LV_BUERGER_SPECS = LANDESVERBAENDE.map((lv) => ({
+  lv: lv.id,
+  title: lv.title,
+  codes: lv.codes,
+  notebook: lv.notebookId,
+  homepage: lv.homepage,
+  themes: lv.themes,
+  ...(lv.audience === 'de-AT' ? { audience: 'de-AT' as const } : {}),
+}));
 
 // Splits a comma-separated `themes` string into individual topics, ignoring
 // commas inside parentheses (e.g. Hessen's "Naturschutz (Wald, Wasser)") and

--- a/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
+++ b/packages/shared/src/agents/oeffentlichkeitsarbeitAgents.ts
@@ -1,6 +1,14 @@
+import { LV_NOTEBOOK_BY_PR_AGENT_ID } from './landesverbaende.js';
+
 import type { Agent } from './types.js';
 
-export const OEFFENTLICHKEITSARBEIT_AGENTS = [
+// Hand-tuned PR agents: the general Öffentlichkeitsarbeit agent plus one
+// corpus-derived variant per Landesverband. Editorial content (systemRole,
+// prompts, tone) is hand-written; the LV notebook pin is NOT — it is injected
+// from the LV registry below (see `OEFFENTLICHKEITSARBEIT_AGENTS`) so it can
+// never be forgotten. Forgetting it is exactly what hid 8 of these agents from
+// their Landesverband notebook page.
+const PR_AGENT_DEFINITIONS = [
   {
     identifier: 'gruenerator-oeffentlichkeitsarbeit',
     autoRoutingHint: 'creative',
@@ -488,9 +496,24 @@ Schritt 5: \`self_review\` prüft Stil, Vokabular (kein deutsches Vokabular!), S
       'memory_save',
       'self_review',
     ],
-    defaultNotebookId: 'oesterreich-notebook',
     toolRestrictions: {
       examplesCountry: 'AT',
     },
   },
 ] as const satisfies readonly Agent[];
+
+/** Literal union of the hand-tuned PR agent identifiers — feeds `SystemAgentId`.
+ *  Derived from the raw `as const` definitions so the union stays exact even
+ *  though the exported array below is mapped (and therefore type-widened). */
+export type OeffentlichkeitsarbeitAgentId = (typeof PR_AGENT_DEFINITIONS)[number]['identifier'];
+
+/**
+ * Public registry array. Each per-LV agent gets its `defaultNotebookId` from the
+ * LV registry by identifier, so the notebook pin is impossible to omit — the
+ * notebook page lists an agent only when `defaultNotebookId === notebookId`. The
+ * general agent has no registry entry and is passed through unchanged.
+ */
+export const OEFFENTLICHKEITSARBEIT_AGENTS: readonly Agent[] = PR_AGENT_DEFINITIONS.map((def) => {
+  const notebookId = LV_NOTEBOOK_BY_PR_AGENT_ID.get(def.identifier);
+  return notebookId ? { ...def, defaultNotebookId: notebookId } : def;
+});

--- a/packages/shared/src/agents/system.ts
+++ b/packages/shared/src/agents/system.ts
@@ -4,7 +4,10 @@ import { CORE_AGENTS } from './coreAgents.js';
 import { LV_HUBS } from './landesverbandHubs.js';
 import { LV_BUERGER_AGENTS, type LV_BUERGER_SPECS } from './lvBuergerAgents.js';
 import { LV_PR_AGENTS, type LV_PR_SPECS } from './lvPrAgents.js';
-import { OEFFENTLICHKEITSARBEIT_AGENTS } from './oeffentlichkeitsarbeitAgents.js';
+import {
+  OEFFENTLICHKEITSARBEIT_AGENTS,
+  type OeffentlichkeitsarbeitAgentId,
+} from './oeffentlichkeitsarbeitAgents.js';
 import { PERSONA_AGENTS } from './personaAgents.js';
 
 import type { Agent } from './types.js';
@@ -27,8 +30,8 @@ const RAW_SYSTEM_AGENTS: readonly Agent[] = [
 // A Landesverband's two specialist agents (PR + Bürger*innenanfragen) are owned by
 // its hub, which pins the LV notebook. When that notebook is turned off
 // (`enabled: false`), hide both agents from discovery — same single switch, no
-// per-agent flag. LV_HUBS is the authoritative notebook→agents map; the
-// hand-written PR agents carry no `defaultNotebookId`, so we can't derive from that.
+// per-agent flag. LV_HUBS (itself derived from the LV registry) is the
+// authoritative notebook→agents map, so we resolve both agent ids from it.
 const disabledLvAgentIds = new Set<string>(
   LV_HUBS.filter((hub) => getDisabledNotebookIds().has(hub.notebookId)).flatMap((hub) => [
     hub.prAgentId,
@@ -50,7 +53,7 @@ export const VISIBLE_SYSTEM_AGENTS: readonly Agent[] = SYSTEM_AGENTS.filter(
 
 type BaseSystemAgentId =
   | (typeof CORE_AGENTS)[number]['identifier']
-  | (typeof OEFFENTLICHKEITSARBEIT_AGENTS)[number]['identifier']
+  | OeffentlichkeitsarbeitAgentId
   | (typeof PERSONA_AGENTS)[number]['identifier'];
 type LvPrAgentId = `gruenerator-oeffentlichkeitsarbeit-${(typeof LV_PR_SPECS)[number]['lv']}`;
 type LvBuergerAgentId = `gruenerator-buergeranfragen-${(typeof LV_BUERGER_SPECS)[number]['lv']}`;


### PR DESCRIPTION
## Problem

Each Landesverband should show **two** agents on its notebook page (e.g. `/notebooks/berlin`): *Öffentlichkeitsarbeit* and *Bürger\*innenanfragen*. Only **Bürgeranfragen** appeared for Berlin, Hamburg, Mecklenburg-Vorpommern, Thüringen, Brandenburg, Bayern, Sachsen-Anhalt and Hessen.

## Root cause

The notebook page lists a system agent only when its `defaultNotebookId` matches the notebook:

```ts
// apps/web/src/features/notebook/components/NotebookAgentsSection.tsx
getSystemAgentsForLocale(locale).filter((a) => a.defaultNotebookId === notebookId)
```

The generated **Bürger** agents derived that pin from their spec. The 8 hand-tuned **Öffentlichkeitsarbeit** agents typed it by hand — and every one omitted it. `system.ts` even documented the gap: *"the hand-written PR agents carry no `defaultNotebookId`, so we can't derive from that."*

## Fix — single source of truth

Rather than re-type 8 pins (which can be forgotten again), introduce **`landesverbaende.ts`**: the canonical registry for the LV↔notebook↔agents relationship. Everything derives from it, so the pin is impossible to omit.

- **New `LANDESVERBAENDE`** — id, title, codes, notebookId, homepage, themes, audience, agent ids, optional hub. Exported from `@gruenerator/shared/agents`.
- **`LV_HUBS`** and **`LV_BUERGER_SPECS`** are now derived from it (large net deletions — the data lived in 3 places, now 1).
- **Hand-tuned PR agents** keep all editorial content (systemRole, prompts, tone); only `defaultNotebookId` is injected from the registry by identifier. `OeffentlichkeitsarbeitAgentId` is exported so `SystemAgentId` stays a literal union despite the array now being mapped.
- `lvPrAgents.ts` (generated SH agent) left untouched.

## Guardrail

A new test in `packages/chat` (which already runs vitest — `@gruenerator/shared` has no test runner, and wiring one in would have churned the lockfile) asserts that **every registry agent resolves and pins its notebook**, and **every hub matches its registry entry**. It fails the build the moment a pin is dropped again.

## Verification

- **Behavior-preserving:** a sorted-key snapshot of all **31 `SYSTEM_AGENTS` is byte-identical** before/after (relative to the corrected, pinned state) — the refactor changes structure, not output.
- `typecheck` passes for **shared, chat, web, api**.
- `shared` lint clean (only pre-existing warnings elsewhere); chat test suite **70 passed** (incl. 29 new).
- **No dependency or `pnpm-lock.yaml` changes.**

Supersedes #1275 (the minimal 8-pin hotfix) and folds in the guardrail test.