### PR TITLE
feat(agents): concrete article links + deeper recall for Bürgeranfragen

### DIFF
--- a/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/rerankNode.ts
@@ -33,8 +33,12 @@ export async function rerankNode(state: ChatGraphState): Promise<Partial<ChatGra
   const { searchResults, searchQuery, hasTemporal, researchBrief } = state;
   const rerankCfg = vectorConfig.get('rerank');
 
+  // Includes agents bound to a notebook via `defaultNotebookId` so they get the
+  // same deeper rerank window as an explicitly selected notebook.
   const isNotebookScoped =
-    (state.notebookCollectionIds?.length ?? 0) > 0 || (state.notebookDocumentIds?.length ?? 0) > 0;
+    (state.notebookCollectionIds?.length ?? 0) > 0 ||
+    (state.defaultNotebookCollectionIds?.length ?? 0) > 0 ||
+    (state.notebookDocumentIds?.length ?? 0) > 0;
   const inputLimit = isNotebookScoped ? 20 : rerankCfg.inputLimit;
   const outputLimit = isNotebookScoped ? 12 : rerankCfg.outputLimit;
 

--- a/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/respondNode.ts
@@ -225,7 +225,10 @@ Synthese (NUR zur Orientierung — wiederhole sie nicht):
 ${synthesisPreview}`;
 }
 
-export async function formatSearchContext(state: ChatGraphState): Promise<string> {
+export async function formatSearchContext(
+  state: ChatGraphState,
+  includeSourceUrls = false
+): Promise<string> {
   // Research mode with usable synthesis: emit a wrapper-mode block so the
   // model writes a thin conversational reference, not a re-synthesis from
   // raw chunks. The tool artifact (researchMeta) is the single source of
@@ -270,8 +273,12 @@ export async function formatSearchContext(state: ChatGraphState): Promise<string
 
   // Default: budget-based truncation
   // Notebook-scoped searches get more results and higher budget for deeper answers
+  // Includes agents bound to a notebook via `defaultNotebookId` so they get the
+  // same deeper context budget as an explicitly selected notebook.
   const isNotebookScoped =
-    (state.notebookCollectionIds?.length ?? 0) > 0 || (state.notebookDocumentIds?.length ?? 0) > 0;
+    (state.notebookCollectionIds?.length ?? 0) > 0 ||
+    (state.defaultNotebookCollectionIds?.length ?? 0) > 0 ||
+    (state.notebookDocumentIds?.length ?? 0) > 0;
   const maxResults = isNotebookScoped ? 12 : MAX_SEARCH_RESULTS;
   // Group chunks → sources so each `[N]` is one source. Dedup means a wolke
   // file with 5 chunks renders as a single `[1]` block (multiple excerpts
@@ -307,7 +314,12 @@ export async function formatSearchContext(state: ChatGraphState): Promise<string
         Math.floor(((weightedRelevance[i] ?? 0) / totalWeightedRelevance) * budget)
       );
       const body = formatSourceChunks(s, charBudget);
-      return `[${i + 1}] **${s.title}**\n${body}`.trim();
+      // When the agent writes inline links (e.g. ready-to-send emails), expose
+      // the source URL to the model so it can cite the concrete article instead
+      // of falling back to a hardcoded homepage. Normal chat omits it and uses
+      // the clickable [N] cards instead.
+      const urlPart = includeSourceUrls && s.url ? `\nQuelle-URL: ${s.url}` : '';
+      return `[${i + 1}] **${s.title}**${urlPart}\n${body}`.trim();
     })
     .join('\n\n');
 
@@ -749,7 +761,7 @@ export async function buildSystemMessage(state: ChatGraphState): Promise<string>
     boardContext,
     documentMentionContext,
   } = state;
-  const searchContext = await formatSearchContext(state);
+  const searchContext = await formatSearchContext(state, !!agentConfig.inlineSourceLinks);
   const perSourceContext = formatPerSourceContext(state);
   const currentDocumentContext = formatCurrentDocument(state);
   const attachmentContext = formatAttachmentContext(state);

--- a/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
+++ b/apps/api/agents/langgraph/ChatGraph/nodes/searchNode.ts
@@ -852,8 +852,14 @@ export async function searchNode(state: ChatGraphState): Promise<Partial<ChatGra
         }
         // Deduplicate in case of overlap
         const uniqueCollections = [...new Set(collectionsToSearch)];
+        // Deep-recall path also applies to agents bound to a notebook via
+        // `defaultNotebookId` (→ defaultNotebookCollectionIds), not just to
+        // explicitly @mentioned notebooks — otherwise such agents search the
+        // right collection but with the shallow 3/8 recall, collapsing to too
+        // few distinct sources after per-article dedup.
         const isNotebookScoped =
-          state.notebookCollectionIds && state.notebookCollectionIds.length > 0;
+          (state.notebookCollectionIds?.length ?? 0) > 0 ||
+          (state.defaultNotebookCollectionIds?.length ?? 0) > 0;
 
         const query = truncateQuery(searchQuery || '');
 

--- a/apps/api/database/postgres/migrations/add_user_agents_inline_source_links.sql
+++ b/apps/api/database/postgres/migrations/add_user_agents_inline_source_links.sql
@@ -1,0 +1,7 @@
+-- Migration: add inline_source_links to user_agents
+-- When true, source URLs of search hits are injected into the model context so
+-- the agent writes concrete article links inline (e.g. ready-to-send emails).
+-- Nullable boolean: NULL/false = off (default), matching the optional field on
+-- the canonical Agent type. Idempotent.
+
+ALTER TABLE user_agents ADD COLUMN IF NOT EXISTS inline_source_links BOOLEAN;

--- a/apps/api/database/schema/userAgents.ts
+++ b/apps/api/database/schema/userAgents.ts
@@ -1,5 +1,14 @@
 import { type InferSelectModel } from 'drizzle-orm';
-import { index, jsonb, pgTable, text, timestamp, unique, uuid } from 'drizzle-orm/pg-core';
+import {
+  boolean,
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core';
 
 export const userAgents = pgTable(
   'user_agents',
@@ -28,6 +37,9 @@ export const userAgents = pgTable(
     plugins: jsonb('plugins').$type<string[]>(),
     enabled_tools: jsonb('enabled_tools').$type<string[]>(),
     skill_mentions: jsonb('skill_mentions').$type<string[]>(),
+    // When true, source URLs of search hits are injected into the model context
+    // so the agent writes concrete article links inline (e.g. ready-to-send mails).
+    inline_source_links: boolean('inline_source_links'),
     few_shot_examples:
       jsonb('few_shot_examples').$type<
         Array<{ input: string; output: string; reasoning?: string }>

--- a/apps/api/routes/chat/agents/types.ts
+++ b/apps/api/routes/chat/agents/types.ts
@@ -56,6 +56,12 @@ export interface AgentConfig {
   routeTo?: 'chat' | 'search' | undefined;
   /** Server-side default filter merged into tool calls (e.g. LV scoping). */
   defaultFilter?: AgentDefaultFilter | undefined;
+  /**
+   * When true, inject source URLs of search hits into the model's text context
+   * so the agent can write concrete article links inline (e.g. ready-to-send
+   * emails). Read by the ChatGraph respond node. Default off.
+   */
+  inlineSourceLinks?: boolean | undefined;
 }
 
 export interface Thread {

--- a/apps/api/routes/userAgents/userAgentsContractRouter.ts
+++ b/apps/api/routes/userAgents/userAgentsContractRouter.ts
@@ -117,6 +117,7 @@ export const userAgentsContractRouter = s.router(userAgentsContract, {
         ...(body.fewShotExamples != null
           ? { fewShotExamples: toFewShot(body.fewShotExamples) }
           : {}),
+        ...(body.inlineSourceLinks != null ? { inlineSourceLinks: body.inlineSourceLinks } : {}),
       };
 
       const agent = await createUserAgent(userId, input);
@@ -259,6 +260,7 @@ export const userAgentsContractRouter = s.router(userAgentsContract, {
       if (b.enabledTools != null) patch.enabledTools = b.enabledTools;
       if (b.skillMentions != null) patch.skillMentions = b.skillMentions;
       if (b.fewShotExamples != null) patch.fewShotExamples = toFewShot(b.fewShotExamples);
+      if (b.inlineSourceLinks != null) patch.inlineSourceLinks = b.inlineSourceLinks;
 
       const agent = await updateUserAgent(userId, args.params.identifier, patch);
       if (!agent) {

--- a/apps/api/services/userAgents/userAgentsRepository.ts
+++ b/apps/api/services/userAgents/userAgentsRepository.ts
@@ -34,6 +34,7 @@ export interface UserAgentInput {
   enabledTools?: string[];
   skillMentions?: string[];
   fewShotExamples?: Array<{ input: string; output: string; reasoning?: string }>;
+  inlineSourceLinks?: boolean;
 }
 
 export type UserAgentPatch = Partial<UserAgentInput>;
@@ -64,6 +65,7 @@ function rowToAgent(row: UserAgentRow): Agent {
     ...(row.enabled_tools ? { enabledTools: row.enabled_tools } : {}),
     ...(row.skill_mentions ? { skillMentions: row.skill_mentions } : {}),
     ...(row.few_shot_examples ? { fewShotExamples: row.few_shot_examples } : {}),
+    ...(row.inline_source_links != null ? { inlineSourceLinks: row.inline_source_links } : {}),
   };
 }
 
@@ -91,6 +93,7 @@ function inputToInsertValues(userId: string, input: UserAgentInput) {
     enabled_tools: input.enabledTools ?? null,
     skill_mentions: input.skillMentions ?? null,
     few_shot_examples: input.fewShotExamples ?? null,
+    inline_source_links: input.inlineSourceLinks ?? null,
   };
 }
 
@@ -116,6 +119,7 @@ function patchToUpdateValues(patch: UserAgentPatch): Record<string, unknown> {
   if (patch.enabledTools !== undefined) out.enabled_tools = patch.enabledTools;
   if (patch.skillMentions !== undefined) out.skill_mentions = patch.skillMentions;
   if (patch.fewShotExamples !== undefined) out.few_shot_examples = patch.fewShotExamples;
+  if (patch.inlineSourceLinks !== undefined) out.inline_source_links = patch.inlineSourceLinks;
   return out;
 }
 

--- a/apps/web/src/features/agents/AgentEditor.tsx
+++ b/apps/web/src/features/agents/AgentEditor.tsx
@@ -229,6 +229,22 @@ function AgentEditor({ mode, initialState, identifier, onCancel }: AgentEditorPr
             </div>
           </fieldset>
 
+          <label className="flex cursor-pointer items-start gap-sm rounded-md border border-grey-200 p-sm dark:border-grey-700">
+            <input
+              type="checkbox"
+              className="mt-1"
+              checked={form.inlineSourceLinks}
+              onChange={(e) => set('inlineSourceLinks', e.target.checked)}
+            />
+            <span>
+              <span className="block text-sm font-medium">Quell-Links direkt im Antworttext</span>
+              <span className="block text-xs text-foreground-muted">
+                Für versandfertige E-Mails/Briefe: konkrete Artikel-URLs aus der Recherche erscheinen
+                inline im Text statt nur als Quellen-Karten.
+              </span>
+            </span>
+          </label>
+
           <label className={labelCls}>
             Wissen
             <span className="text-xs font-normal text-foreground-muted">

--- a/apps/web/src/features/agents/agentFormState.ts
+++ b/apps/web/src/features/agents/agentFormState.ts
@@ -28,6 +28,8 @@ export interface FormState {
   openingQuestions: string;
   enabledTools: string[];
   skillMentions: string[];
+  /** Inject source URLs into the model context so links appear inline (e.g. emails). */
+  inlineSourceLinks: boolean;
   defaultNotebookId: string; // '' = none
   tags: string;
   model: string;
@@ -49,6 +51,7 @@ export const EMPTY_FORM: FormState = {
   openingQuestions: '',
   enabledTools: ['search', 'web'],
   skillMentions: [],
+  inlineSourceLinks: false,
   defaultNotebookId: '',
   tags: '',
   model: DEFAULT_AGENT_MODEL.model,
@@ -89,6 +92,7 @@ export function formToPayload(form: FormState) {
     locale: form.locale,
     enabledTools: form.enabledTools,
     skillMentions: form.skillMentions,
+    inlineSourceLinks: form.inlineSourceLinks,
     defaultNotebookId: form.defaultNotebookId || null,
   };
 }
@@ -110,6 +114,7 @@ export function hydrateFormState(agent: Agent): FormState {
     // doesn't silently narrow to zero tools.
     enabledTools: [...(agent.enabledTools ?? DEFAULT_USER_AGENT_TOOLS)],
     skillMentions: [...(agent.skillMentions ?? [])],
+    inlineSourceLinks: agent.inlineSourceLinks ?? false,
     defaultNotebookId: agent.defaultNotebookId ?? '',
     tags: agent.tags.join(', '),
     model: agent.model,

--- a/packages/contracts/src/schemas/userAgents.ts
+++ b/packages/contracts/src/schemas/userAgents.ts
@@ -73,6 +73,7 @@ export const userAgentSchema = z.object({
   enabledTools: z.array(z.string()).readonly().optional(),
   skillMentions: z.array(z.string()).readonly().optional(),
   fewShotExamples: z.array(agentFewShotExampleSchema).readonly().optional(),
+  inlineSourceLinks: z.boolean().optional(),
 });
 
 export type UserAgent = z.infer<typeof userAgentSchema>;
@@ -101,6 +102,7 @@ export const createUserAgentBodySchema = z.object({
   enabledTools: z.array(z.string()).nullish(),
   skillMentions: z.array(z.string()).nullish(),
   fewShotExamples: z.array(agentFewShotExampleSchema).nullish(),
+  inlineSourceLinks: z.boolean().nullish(),
 });
 
 export type CreateUserAgentBody = z.infer<typeof createUserAgentBodySchema>;

--- a/packages/shared/src/agents/lvBuergerAgents.ts
+++ b/packages/shared/src/agents/lvBuergerAgents.ts
@@ -67,8 +67,8 @@ Schritt 3: Schreibe die Antwort-E-Mail. Die recherchierten Quellen werden dem*de
 2. **Dank:** Ein bis zwei Sätze Dank, z.B. \`vielen Dank für deine/Ihre E-Mail an ${partyName} und dein/Ihr Interesse an unserer Politik.\`
 3. **Inhaltliche Antwort:** Die eigentliche, recherchebasierte Antwort auf das Anliegen — klar strukturiert, in der Position des Landesverbands verankert, sachlich, freundlich und lösungsorientiert. Keine erfundenen Fakten; wenn etwas unklar ist, sage das ehrlich.
 4. **Weiterführende Links:** Schließe mit konkreten Quellen, eingeleitet z.B. mit \`Weitere Infos findest du / finden Sie hier:\`
-   - die wichtigsten 1–3 Quell-URLs aus deiner Recherche (nur real recherchierte Links, niemals erfundene)
-   - die Website des Landesverbands: ${spec.homepage}
+   - Liste **vorrangig die \`Quelle-URL\`s der relevantesten Suchtreffer (1–3)**, die du inhaltlich verwendet hast — also konkrete Artikel-, Beschluss- oder Programm-Links, nur real recherchierte URLs, niemals erfundene.
+   - Verlinke die allgemeine Landesverbands-Website (${spec.homepage}) nur ergänzend oder als Fallback, wenn keine passenden Artikel-URLs vorliegen — niemals als einzigen Link, wenn konkrete Treffer-URLs vorhanden sind.
    Danach eine freundliche Grußformel (\`Mit grünen Grüßen\`) und \`${partyName}\`.
 
 **STIL:** Freundlich, respektvoll, zugänglich. Genderstern konsequent (*innen, *in). Keine Phrasendrescherei. So lang wie nötig, so kurz wie möglich.
@@ -97,6 +97,10 @@ export const LV_BUERGER_AGENTS: Agent[] = LV_BUERGER_SPECS.map((spec) => {
     locale: isAT ? 'de-AT' : 'de-DE',
     author: 'Grünerator',
     enabledTools: ['search', 'web', 'scrape', 'memory', 'self_review'],
+    // Versandfertige E-Mail: konkrete Artikel-URLs müssen inline im Text stehen
+    // (Quellen-Karten reisen nicht mit dem kopierten Text mit). Schaltet die
+    // URL-Injektion in den Modell-Kontext frei (respondNode).
+    inlineSourceLinks: true,
     defaultNotebookId: spec.notebook,
     // AT-Korpus liegt in einer eigenen Collection ohne `landesverband`-Feld —
     // ein defaultFilter darauf liefe ins Leere. Daher nur für DE-LVs pinnen.

--- a/packages/shared/src/agents/types.ts
+++ b/packages/shared/src/agents/types.ts
@@ -180,6 +180,14 @@ export interface Agent {
    * copy per user locale without forking into two registry entries.
    */
   localized?: Partial<Record<'de-DE' | 'de-AT', AgentLocalization>>;
+  /**
+   * When true, the source URLs of search hits are injected into the model's
+   * text context, so the agent can write concrete article links inline into
+   * its answer (e.g. ready-to-send emails/letters whose copied text doesn't
+   * carry the chat UI's clickable `[N]` source cards). Default off — normal
+   * chat relies on the `[N]` cards instead. Read by the ChatGraph respond node.
+   */
+  inlineSourceLinks?: boolean;
 }
 
 export type AgentCategory = 'gruppen';


### PR DESCRIPTION
## Problem

Der per-LV **Bürger*innenanfragen**-Agent gibt gute Antworten, verlinkt aber nur die allgemeine Landesverbands-Homepage (z.B. `https://gruene.berlin`) statt konkreter Artikel — und liefert oft nur ~2 Quellen.

Zwei zusammenwirkende Ursachen, beide behoben.

## 1. Keine konkreten Links → URLs waren nie im Modell-Kontext

`respondNode` formatiert Suchtreffer für das Modell nur als `[N] **Titel**` ohne URL (die URL ist für die klickbaren `[N]`-Karten im UI reserviert). Der Agent soll aber laut Prompt konkrete Artikel-URLs **inline** in die E-Mail schreiben — die UI-Karten reisen nicht mit dem kopierten Text mit.

**Fix:** Neues opt-in Agent-Flag `inlineSourceLinks`. Wenn gesetzt, wird die `Quelle-URL:` der Treffer in den Modell-Kontext injiziert. Aktiviert auf den 10 LV-Bürger-Agenten; Prompt priorisiert jetzt recherchierte Artikel-URLs, Homepage nur als Fallback. Zusätzlich als **Toggle im Agent-Creator** verfügbar (durchgängig: FormState → Zod → Drizzle-Spalte + Migration → Repository → Runtime-`AgentConfig`).

## 2. Zu wenige Quellen → falscher Recall-Pfad

`isNotebookScoped` prüfte nur `notebookCollectionIds` (explizit gewählte Notebooks), nicht `defaultNotebookCollectionIds` (die `defaultNotebookId`-Bindung des Agenten). Folge: notebook-gebundene Agenten durchsuchten die richtige Collection, aber auf dem flachen Recall-Pfad (`perCollectionLimit=3`, `resultsCap=8`, `maxResults=8`) → nach Dedup-pro-Artikel oft nur 2 distinkte Quellen.

**Fix:** `isNotebookScoped` zählt jetzt auch `defaultNotebookCollectionIds` (in `searchNode`/`rerankNode`/`respondNode`) → Tiefen-Recall 10/20/12. Normaler Chat (kein Notebook gebunden) bleibt unverändert.

## Verifikation
- `pnpm typecheck` (20/20) + ESLint auf allen geänderten Dateien grün (im Hauptbaum gefahren; Worktree ohne node_modules).
- Migration `add_user_agents_inline_source_links.sql` läuft beim Backend-Start automatisch (idempotent, `ADD COLUMN IF NOT EXISTS`).
- E2E lokal: Berlin-Bürger-Agent mit einer Anfrage testen → Logs `[Search] Using default notebook collections: berlin`, höhere `[Rerank] Reranking N results`, mehr `Insgesamt N Quelle(n)`; in der E-Mail 1–3 konkrete `gruene.berlin/...`-Artikel-Links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)