### PR TITLE
feat(agents): make agent creator public with experimental warning

### DIFF
--- a/apps/web/src/features/agents/AgentEditor.tsx
+++ b/apps/web/src/features/agents/AgentEditor.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { formToPayload, type FormState, type Locale } from './agentFormState';
 import { AgentPreview } from './AgentPreview';
 import { useCreateUserAgent, useUpdateUserAgent } from './api';
+import { ExperimentalAgentBanner } from './experimentalWarning';
 import { AgentAvatar } from './icons/AgentAvatar';
 import { IconPicker } from './icons/IconPicker';
 
@@ -161,6 +162,8 @@ function AgentEditor({ mode, initialState, identifier, onCancel }: AgentEditorPr
         </div>
       </header>
 
+      <ExperimentalAgentBanner className="mb-md" />
+
       {error && <p className="mb-md text-sm text-destructive">{error}</p>}
 
       <div className="grid grid-cols-1 gap-lg lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
@@ -239,8 +242,8 @@ function AgentEditor({ mode, initialState, identifier, onCancel }: AgentEditorPr
             <span>
               <span className="block text-sm font-medium">Quell-Links direkt im Antworttext</span>
               <span className="block text-xs text-foreground-muted">
-                Für versandfertige E-Mails/Briefe: konkrete Artikel-URLs aus der Recherche erscheinen
-                inline im Text statt nur als Quellen-Karten.
+                Für versandfertige E-Mails/Briefe: konkrete Artikel-URLs aus der Recherche
+                erscheinen inline im Text statt nur als Quellen-Karten.
               </span>
             </span>
           </label>

--- a/apps/web/src/features/agents/AgentStartScreen.tsx
+++ b/apps/web/src/features/agents/AgentStartScreen.tsx
@@ -3,6 +3,7 @@ import { useVoxtralDictation } from '@gruenerator/voice';
 
 import AgentCard from './AgentCard';
 import { useUserAgents } from './api';
+import { ExperimentalAgentBanner } from './experimentalWarning';
 
 import PageContainer from '@/components/common/PageContainer';
 
@@ -51,6 +52,7 @@ function AgentStartScreen({
       title="Was für einen Agent möchtest du bauen?"
       subtitle="Beschreibe Zweck, Ton und Fähigkeiten — daraus entsteht ein Entwurf, den du vor dem Anlegen noch anpassen kannst."
     >
+      <ExperimentalAgentBanner className="mx-auto mb-md max-w-3xl" />
       <div className="mx-auto flex max-w-3xl flex-col gap-sm">
         <AIPromptInput
           useDictation={useVoxtralDictation}

--- a/apps/web/src/features/agents/experimentalWarning.tsx
+++ b/apps/web/src/features/agents/experimentalWarning.tsx
@@ -1,0 +1,24 @@
+import { DismissableBanner } from '@gruenerator/ui';
+
+/** Shared dismiss key so the warning stays hidden across the creator entry
+ *  (AgentStartScreen) and the editor (AgentEditor) once dismissed. */
+export const AGENT_CREATOR_EXPERIMENTAL_KEY = 'agent-creator-experimental-warning';
+
+/**
+ * Experimental-feature notice shown on every surface where users build their
+ * own agents. The creator is public but still in active development, so this
+ * sets expectations and points people at the team for bug reports.
+ */
+export function ExperimentalAgentBanner({ className }: { className?: string }) {
+  return (
+    <DismissableBanner
+      storageKey={AGENT_CREATOR_EXPERIMENTAL_KEY}
+      variant="warning"
+      className={className}
+    >
+      <strong>Experimentelles Feature</strong> — Eigene Agent*innen sind noch in der Erprobung.
+      Verhalten und Funktionen können sich ändern, und nicht alles funktioniert schon zuverlässig.
+      Bitte melde Probleme dem Team.
+    </DismissableBanner>
+  );
+}

--- a/apps/web/src/features/agentura/AgentDetailPage.tsx
+++ b/apps/web/src/features/agentura/AgentDetailPage.tsx
@@ -167,7 +167,7 @@ function AgentDetailPage() {
             <PiChatCircleText />
             Im Chat öffnen
           </Button>
-          {isUserAgent && import.meta.env.DEV && (
+          {isUserAgent && (
             <Button
               variant="outline"
               size="icon"

--- a/apps/web/src/features/agentura/AgenturaPage.tsx
+++ b/apps/web/src/features/agentura/AgenturaPage.tsx
@@ -100,7 +100,8 @@ function AgenturaPage() {
   const agentFavorites = useAgentFavoritesStore((s) => s.favoriteIdentifiers);
   const toggleAgentFavorite = useAgentFavoritesStore((s) => s.toggle);
 
-  const showCreateAgentCta = import.meta.env.DEV;
+  // Public, but still experimental — the creator flow carries a warning banner.
+  const showCreateAgentCta = true;
   const q = search.toLowerCase();
 
   const isSkillFav = (s: AgentListItem) => favorites.includes(s.mention.toLowerCase());


### PR DESCRIPTION
## Was

Macht die Option, eigene Agent*innen zu erstellen, auf **/agentura** öffentlich (vorher nur in `import.meta.env.DEV` sichtbar) — mit einem deutlichen **„Experimentelles Feature"**-Hinweis.

## Warum

Die Routen (`/agents/new`, `/agents/:id/edit`) waren über `SHOW_AGENT_CREATOR` bereits öffentlich; nur die UI-Einstiegspunkte waren dev-only versteckt. Das Feature ist nutzbar, soll aber als experimentell gekennzeichnet sein.

## Änderungen

- **AgenturaPage** — „Neuer Agent"-CTA und die Bearbeiten/Löschen-Aktionen pro Karte sind jetzt immer sichtbar (`showCreateAgentCta = true`).
- **AgentDetailPage** — Bearbeiten-Stift für eigene Agent*innen ist nicht mehr dev-gated.
- **Experimentelles-Feature-Banner** — ein dismissbares Warn-Banner (`variant="warning"`, etablierter `DismissableBanner`-Idiom wie bei Verbindungen/Docs) auf allen Build-Oberflächen (Creator-Startscreen + Editor). Text und Dismiss-Key sind über eine gemeinsame `ExperimentalAgentBanner`-Komponente einzeln gepflegt, damit sie nicht auseinanderlaufen; einmal weggeklickt bleibt es auf beiden Oberflächen verborgen.

## Test

- `pnpm --filter @gruenerator/web typecheck` ✅
- eslint auf den geänderten Dateien: 0 Errors (nur vorbestehende Warnings).